### PR TITLE
Fix deploy credential validation for Bash token parsing

### DIFF
--- a/ops/deploy/sitbank-container-deploy
+++ b/ops/deploy/sitbank-container-deploy
@@ -338,7 +338,6 @@ fi
 registry_user="${registry_credentials[0]}"
 registry_token="${registry_credentials[1]}"
 if [[ -z "${registry_user}" || -z "${registry_token}" \
-    || "${registry_user}" == *$'\0'* || "${registry_token}" == *$'\0'* \
     || "${registry_user}" == *$'\r'* || "${registry_token}" == *$'\r'* ]]; then
     echo "Registry credentials are malformed" >&2
     exit 2


### PR DESCRIPTION
## Summary

This PR fixes production deploy wrapper validation that was incorrectly rejecting valid GitHub Actions registry credentials.

## Root cause

The previous patch checked for NUL bytes inside Bash variables using:

```bash
$'\0'
```

Bash variables cannot safely contain NUL bytes, so this pattern can behave like an always-match condition and reject valid credentials.

## Changes

* Keep validation for empty registry credential values
* Keep validation for carriage return characters
* Remove the unsafe Bash NUL-byte validation pattern
* Avoid rejecting valid GitHub-generated registry tokens
* Preserve registry credential sanity checks without breaking GitHub Actions deploys

## Verification

* `python -m pytest -q`: 183 passed, 1 skipped
* `git diff --check`: passed