### PR TITLE
Use file-backed secrets in production compose

### DIFF
--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -97,16 +97,16 @@ services:
 
 secrets:
   secret_key:
-    environment: SITBANK_SECRET_KEY
+    file: /etc/sitbank/secrets/secret_key
   wtf_csrf_secret_key:
-    environment: SITBANK_WTF_CSRF_SECRET_KEY
+    file: /etc/sitbank/secrets/wtf_csrf_secret_key
   session_hmac_keys_json:
-    environment: SITBANK_SESSION_HMAC_KEYS_JSON
+    file: /etc/sitbank/secrets/session_hmac_keys_json
   database_url:
-    environment: SITBANK_DATABASE_URL
+    file: /etc/sitbank/secrets/database_url
   redis_url:
-    environment: SITBANK_REDIS_URL
+    file: /etc/sitbank/secrets/redis_url
   mfa_aes256_gcm_key_b64:
-    environment: SITBANK_MFA_AES256_GCM_KEY_B64
+    file: /etc/sitbank/secrets/mfa_aes256_gcm_key_b64
   password_pepper_b64:
-    environment: SITBANK_PASSWORD_PEPPER_B64
+    file: /etc/sitbank/secrets/password_pepper_b64


### PR DESCRIPTION
## Summary

This PR fixes the production deployment failure caused by unsupported environment-backed Compose secrets.

## Root cause

Production deployment failed with:

```text
cannot create secret "sitbank_secret_key" in read-only service app: `file` is the sole supported option
```

The production deploy wrapper already installs runtime secrets into:

```text
/etc/sitbank/secrets
```

However, `compose.prod.yml` was still trying to use environment-backed Compose secrets instead of consuming the root-managed secret files directly.

## Changes

* Update `compose.prod.yml` to use file-backed runtime secrets
* Consume root-managed secret files from `/etc/sitbank/secrets`
* Remove reliance on environment-backed Compose secrets for production runtime secrets
* Keep production secrets managed by the deploy wrapper
* Preserve the existing read-only service model

## Verification

* `python -m pytest -q`: 183 passed, 1 skipped
* `git diff --check`: passed