### PR TITLE
Allow app container to read runtime secret files

### DIFF
--- a/ops/deploy/sitbank-container-deploy
+++ b/ops/deploy/sitbank-container-deploy
@@ -195,7 +195,7 @@ install_runtime_bundle() {
         "${staging_dir}/container.env" "${CONTAINER_ENV}"
     install -d -o root -g root -m 0700 "${SECRET_DIR}"
     for relative_path in "${required[@]:1}"; do
-        install -o root -g root -m 0400 \
+        install -o root -g 10001 -m 0440 \
             "${staging_dir}/${relative_path}" \
             "${SECRET_DIR}/$(basename "${relative_path}")"
     done


### PR DESCRIPTION
## Summary

This PR fixes the production deployment failure caused by unreadable Docker secret files.

## Root cause

Production deployment failed with:

```text
PermissionError: [Errno 13] Permission denied: '/run/secrets/secret_key'
```

Docker Compose v5 ignores `uid`, `gid`, and `mode` settings on secrets in this setup, so the container receives the mounted secret using the source file permissions.

The deploy wrapper was installing runtime secret files as `root:root 0400`, which prevented the app running as UID/GID `10001` from reading them.

## Changes

* Update runtime secret files from `root:root 0400` to `root:10001 0440`
* Allow the non-root app container running as UID/GID `10001` to read mounted secrets
* Keep runtime secrets inaccessible to other users
* Account for Docker Compose v5 using source-file permissions for mounted secrets

## Verification

* `python -m pytest -q`: 183 passed, 1 skipped
* `git diff --check`: passed
