### PR TITLE
Split staging and production CI/CD deployment

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -6,12 +6,28 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      target_environment:
+        description: Deployment target for manual release runs.
+        type: choice
+        options:
+          - staging
+          - production
+        default: staging
+      deploy:
+        description: Deploy the verified digest after release verification.
+        type: boolean
+        default: false
+      run_dast:
+        description: Run the authenticated DAST smoke crawl during release verification.
+        type: boolean
+        default: true
 
 permissions: {}
 
 concurrency:
-  group: production-${{ github.ref }}
-  cancel-in-progress: false
+  group: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('release-{0}', github.ref) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   PYTHON_VERSION: "3.12"
@@ -19,7 +35,48 @@ env:
   PYTHONDONTWRITEBYTECODE: "1"
 
 jobs:
+  workflow-security:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+
+      - name: Install workflow security tools
+        run: |
+          go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
+          python -m pip install --user zizmor==1.25.2
+          echo "${HOME}/go/bin" >> "${GITHUB_PATH}"
+          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+
+      - name: Validate GitHub Actions workflows
+        run: |
+          actionlint
+          zizmor .github/workflows/ci-deploy.yml
+
+  dependency-review:
+    if: >-
+      github.event_name == 'pull_request' &&
+      (github.event.repository.visibility == 'public' ||
+        vars.ENABLE_GITHUB_CODE_SECURITY == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48
+
   test:
+    needs: workflow-security
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -41,6 +98,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
@@ -71,11 +130,14 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Validate deployment shell scripts
         run: |
           shellcheck \
             ops/container/smoke-test.sh \
+            ops/container/dast-smoke.sh \
             ops/deploy/bootstrap-container-ec2 \
             ops/deploy/sitbank-container-deploy \
             ops/deploy/sitbank-container-runtime \
@@ -98,6 +160,18 @@ jobs:
 
       - name: Run PostgreSQL and Redis container smoke test
         run: bash ops/container/smoke-test.sh sitbank:smoke
+
+      - name: Run authenticated DAST smoke crawl
+        run: bash ops/container/dast-smoke.sh sitbank:smoke
+
+      - name: Scan all critical vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          image-ref: sitbank:smoke
+          format: table
+          exit-code: "1"
+          ignore-unfixed: false
+          severity: CRITICAL
 
       - name: Scan fixable high and critical vulnerabilities
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
@@ -148,14 +222,69 @@ jobs:
           SITBANK_PASSWORD_PEPPER_B64: smoke
         run: docker compose --file compose.prod.yml config --quiet
 
+  deployment-preflight:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      TARGET_ENVIRONMENT: ${{ inputs.target_environment || 'staging' }}
+      DEPLOY_REQUESTED: ${{ inputs.deploy || false }}
+      STAGING_DEPLOY_ENABLED: ${{ vars.STAGING_DEPLOY_ENABLED }}
+      PROD_DEPLOY_ENABLED: ${{ vars.PROD_DEPLOY_ENABLED }}
+    steps:
+      - name: Validate release request
+        shell: bash
+        run: |
+          case "${TARGET_ENVIRONMENT}" in
+            staging|production) ;;
+            *)
+              echo "::error::Invalid target_environment '${TARGET_ENVIRONMENT}'."
+              exit 1
+              ;;
+          esac
+
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            echo "::error::Pull request events must never reach deployment preflight."
+            exit 1
+          fi
+
+          if [[ "${TARGET_ENVIRONMENT}" == "production" \
+              && "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "::error::Manual production deployment is allowed only from refs/heads/main."
+            exit 1
+          fi
+
+          if [[ "${DEPLOY_REQUESTED}" == "true" \
+              && "${TARGET_ENVIRONMENT}" == "staging" \
+              && "${STAGING_DEPLOY_ENABLED}" != "true" ]]; then
+            echo "::notice::Staging deployment requested, but STAGING_DEPLOY_ENABLED is not true. The digest will be verified and deployment will be skipped."
+          fi
+
+          if [[ "${DEPLOY_REQUESTED}" == "true" \
+              && "${TARGET_ENVIRONMENT}" == "production" \
+              && "${PROD_DEPLOY_ENABLED}" != "true" ]]; then
+            echo "::notice::Production deployment requested, but PROD_DEPLOY_ENABLED is not true. The digest will be verified and deployment will be skipped."
+          fi
+
+          if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            if [[ "${STAGING_DEPLOY_ENABLED}" != "true" ]]; then
+              echo "::notice::STAGING_DEPLOY_ENABLED is not true. Automatic staging deployment will be skipped."
+            fi
+            if [[ "${PROD_DEPLOY_ENABLED}" != "true" ]]; then
+              echo "::notice::PROD_DEPLOY_ENABLED is not true. Automatic production deployment will be skipped."
+            fi
+          fi
+
   publish:
-    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-    needs: image-test
+    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch')
+    needs:
+      - image-test
+      - deployment-preflight
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-      id-token: write
       attestations: write
     outputs:
       digest: ${{ steps.push.outputs.digest }}
@@ -163,6 +292,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
 
       - name: Resolve lowercase GHCR repository
         id: image
@@ -170,6 +301,24 @@ jobs:
         run: |
           repository="ghcr.io/${GITHUB_REPOSITORY,,}"
           echo "repository=${repository}" >> "${GITHUB_OUTPUT}"
+
+      - name: Resolve immutable image tags
+        id: tags
+        shell: bash
+        env:
+          REPOSITORY: ${{ steps.image.outputs.repository }}
+          TARGET_ENVIRONMENT: ${{ inputs.target_environment || 'staging' }}
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            {
+              echo "tags<<EOF"
+              printf '%s\n' "${REPOSITORY}:manual-${GITHUB_RUN_ID}"
+              printf '%s\n' "${REPOSITORY}:${TARGET_ENVIRONMENT}-${GITHUB_RUN_ID}"
+              echo "EOF"
+            } >> "${GITHUB_OUTPUT}"
+          else
+            echo "tags=${REPOSITORY}:${GITHUB_SHA}" >> "${GITHUB_OUTPUT}"
+          fi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
@@ -181,14 +330,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
-      - name: Build and push signed release candidate
+      - name: Build and push release candidate
         id: push
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
           context: .
           platforms: linux/amd64
           push: true
-          tags: ${{ steps.image.outputs.repository }}:${{ github.sha }}
+          tags: ${{ steps.tags.outputs.tags }}
           build-args: |
             VCS_REF=${{ github.sha }}
             SOURCE_URL=${{ github.server_url }}/${{ github.repository }}
@@ -197,25 +346,289 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  release-verify:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      id-token: write
+    outputs:
+      digest: ${{ steps.image.outputs.digest }}
+      repository: ${{ steps.image.outputs.repository }}
+      image: ${{ steps.image.outputs.image }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+
+      - name: Resolve verified image reference
+        id: image
+        shell: bash
+        env:
+          IMAGE_DIGEST: ${{ needs.publish.outputs.digest }}
+          IMAGE_REPOSITORY: ${{ needs.publish.outputs.repository }}
+        run: |
+          if [[ ! "${IMAGE_REPOSITORY}" =~ ^ghcr\.io/[a-z0-9._-]+/[a-z0-9._-]+$ ]]; then
+            echo "::error::Publish emitted an invalid GHCR repository."
+            exit 1
+          fi
+          if [[ ! "${IMAGE_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::Publish emitted an invalid image digest."
+            exit 1
+          fi
+          image="${IMAGE_REPOSITORY}@${IMAGE_DIGEST}"
+          echo "repository=${IMAGE_REPOSITORY}" >> "${GITHUB_OUTPUT}"
+          echo "digest=${IMAGE_DIGEST}" >> "${GITHUB_OUTPUT}"
+          echo "image=${image}" >> "${GITHUB_OUTPUT}"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Pull and verify image revision label
+        env:
+          IMAGE: ${{ steps.image.outputs.image }}
+        run: |
+          docker pull "${IMAGE}"
+          revision="$(
+            docker image inspect \
+              --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' \
+              "${IMAGE}"
+          )"
+          if [[ "${revision}" != "${GITHUB_SHA}" ]]; then
+            echo "::error::Image revision label does not match the workflow commit."
+            exit 1
+          fi
+
+      - name: Validate Compose model for exact digest
+        env:
+          SITBANK_IMAGE: ${{ steps.image.outputs.image }}
+        run: |
+          docker compose --file compose.prod.yml config --quiet
+          docker compose --file compose.prod.yml config \
+            | grep -F "${SITBANK_IMAGE}" >/dev/null
+
+      - name: Run release smoke test against exact digest
+        env:
+          IMAGE: ${{ steps.image.outputs.image }}
+        run: bash ops/container/smoke-test.sh "${IMAGE}"
+
+      - name: Run authenticated DAST smoke crawl
+        if: github.event_name != 'workflow_dispatch' || inputs.run_dast == true
+        env:
+          IMAGE: ${{ steps.image.outputs.image }}
+        run: bash ops/container/dast-smoke.sh "${IMAGE}"
+
+      - name: Scan all critical vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          image-ref: ${{ steps.image.outputs.image }}
+          format: table
+          exit-code: "1"
+          ignore-unfixed: false
+          severity: CRITICAL
+
+      - name: Scan fixable high and critical vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+        with:
+          image-ref: ${{ steps.image.outputs.image }}
+          format: table
+          exit-code: "1"
+          ignore-unfixed: true
+          severity: HIGH,CRITICAL
+
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6
 
-      - name: Sign and verify the immutable digest
+      - name: Sign and verify immutable digest
         env:
-          IMAGE: ${{ steps.image.outputs.repository }}@${{ steps.push.outputs.digest }}
+          IMAGE: ${{ steps.image.outputs.image }}
         run: |
           cosign sign --yes "${IMAGE}"
           cosign verify \
-            --certificate-identity "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/.github/workflows/ci-deploy.yml@refs/heads/main" \
+            --certificate-identity "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/.github/workflows/ci-deploy.yml@${GITHUB_REF}" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
             "${IMAGE}" >/dev/null
 
-  deploy:
+  deploy-staging:
     if: >-
+      needs.release-verify.result == 'success' &&
+      (
+        (
+          github.event_name == 'push' &&
+          github.ref == 'refs/heads/main' &&
+          vars.STAGING_DEPLOY_ENABLED == 'true'
+        ) ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          inputs.target_environment == 'staging' &&
+          inputs.deploy == true &&
+          vars.STAGING_DEPLOY_ENABLED == 'true'
+        )
+      )
+    needs: release-verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    environment:
+      name: staging
+      url: https://${{ vars.STAGING_PUBLIC_HOST }}
+    env:
+      RELEASE_SHA: ${{ github.sha }}
+      IMAGE_DIGEST: ${{ needs.release-verify.outputs.digest }}
+      REMOTE_HOST: ${{ vars.STAGING_EC2_HOST }}
+      REMOTE_PORT: ${{ vars.STAGING_EC2_PORT }}
+      REMOTE_USER: ${{ vars.STAGING_EC2_DEPLOY_USER }}
+      STAGING_PUBLIC_HOST: ${{ vars.STAGING_PUBLIC_HOST }}
+      STAGING_SESSION_HMAC_ACTIVE_KEY_ID: ${{ vars.STAGING_SESSION_HMAC_ACTIVE_KEY_ID }}
+      STAGING_SESSION_HMAC_PREVIOUS_KEY_ID: ${{ vars.STAGING_SESSION_HMAC_PREVIOUS_KEY_ID }}
+      STAGING_PASSWORD_PBKDF2_ITERATIONS: ${{ vars.STAGING_PASSWORD_PBKDF2_ITERATIONS }}
+      STAGING_MFA_ISSUER_NAME: ${{ vars.STAGING_MFA_ISSUER_NAME }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+
+      - name: Verify staging deployment configuration
+        env:
+          STAGING_EC2_KNOWN_HOSTS: ${{ secrets.STAGING_EC2_KNOWN_HOSTS }}
+          STAGING_EC2_SSH_PRIVATE_KEY: ${{ secrets.STAGING_EC2_SSH_PRIVATE_KEY }}
+          STAGING_DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+          STAGING_MFA_AES256_GCM_KEY_B64: ${{ secrets.STAGING_MFA_AES256_GCM_KEY_B64 }}
+          STAGING_PASSWORD_PEPPER_B64: ${{ secrets.STAGING_PASSWORD_PEPPER_B64 }}
+          STAGING_REDIS_URL: ${{ secrets.STAGING_REDIS_URL }}
+          STAGING_SECRET_KEY: ${{ secrets.STAGING_SECRET_KEY }}
+          STAGING_SESSION_HMAC_ACTIVE_KEY_B64: ${{ secrets.STAGING_SESSION_HMAC_ACTIVE_KEY_B64 }}
+          STAGING_WTF_CSRF_SECRET_KEY: ${{ secrets.STAGING_WTF_CSRF_SECRET_KEY }}
+        run: |
+          required=(
+            IMAGE_DIGEST
+            REMOTE_HOST
+            REMOTE_PORT
+            REMOTE_USER
+            STAGING_PUBLIC_HOST
+            STAGING_SESSION_HMAC_ACTIVE_KEY_ID
+            STAGING_PASSWORD_PBKDF2_ITERATIONS
+            STAGING_MFA_ISSUER_NAME
+            STAGING_EC2_KNOWN_HOSTS
+            STAGING_EC2_SSH_PRIVATE_KEY
+            STAGING_DATABASE_URL
+            STAGING_MFA_AES256_GCM_KEY_B64
+            STAGING_PASSWORD_PEPPER_B64
+            STAGING_REDIS_URL
+            STAGING_SECRET_KEY
+            STAGING_SESSION_HMAC_ACTIVE_KEY_B64
+            STAGING_WTF_CSRF_SECRET_KEY
+          )
+          missing=0
+          for name in "${required[@]}"; do
+            if [[ -z "${!name}" ]]; then
+              echo "::error::Missing required staging deployment setting: ${name}"
+              missing=1
+            fi
+          done
+          if [[ ! "${IMAGE_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::Verified image digest is invalid."
+            missing=1
+          fi
+          if [[ ! "${REMOTE_PORT}" =~ ^[0-9]+$ ]]; then
+            echo "::error::STAGING_EC2_PORT must be numeric."
+            missing=1
+          fi
+          exit "${missing}"
+
+      - name: Render protected Compose runtime bundle
+        run: |
+          umask 077
+          python ops/deploy/render_container_bundle.py \
+            --prefix STAGING \
+            --output "runtime-${RELEASE_SHA}"
+          tar --create --file "runtime-${RELEASE_SHA}.tar" \
+            --directory "runtime-${RELEASE_SHA}" .
+          sha256sum "runtime-${RELEASE_SHA}.tar" \
+            > "runtime-${RELEASE_SHA}.sha256"
+          printf '%s\n%s\n' "${GITHUB_ACTOR}" "${GITHUB_TOKEN}" \
+            > "registry-${RELEASE_SHA}.credentials"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          STAGING_SECRET_KEY: ${{ secrets.STAGING_SECRET_KEY }}
+          STAGING_WTF_CSRF_SECRET_KEY: ${{ secrets.STAGING_WTF_CSRF_SECRET_KEY }}
+          STAGING_SESSION_HMAC_ACTIVE_KEY_B64: ${{ secrets.STAGING_SESSION_HMAC_ACTIVE_KEY_B64 }}
+          STAGING_SESSION_HMAC_PREVIOUS_KEY_B64: ${{ secrets.STAGING_SESSION_HMAC_PREVIOUS_KEY_B64 }}
+          STAGING_DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+          STAGING_REDIS_URL: ${{ secrets.STAGING_REDIS_URL }}
+          STAGING_MFA_AES256_GCM_KEY_B64: ${{ secrets.STAGING_MFA_AES256_GCM_KEY_B64 }}
+          STAGING_PASSWORD_PEPPER_B64: ${{ secrets.STAGING_PASSWORD_PEPPER_B64 }}
+
+      - name: Configure verified SSH
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.STAGING_EC2_SSH_PRIVATE_KEY }}
+          SSH_KNOWN_HOSTS: ${{ secrets.STAGING_EC2_KNOWN_HOSTS }}
+        run: |
+          install -d -m 0700 ~/.ssh
+          printf '%s\n' "${SSH_PRIVATE_KEY}" > ~/.ssh/id_ed25519
+          chmod 0600 ~/.ssh/id_ed25519
+          printf '%s\n' "${SSH_KNOWN_HOSTS}" > ~/.ssh/known_hosts
+          chmod 0600 ~/.ssh/known_hosts
+
+      - name: Upload private deployment inputs
+        run: |
+          scp -P "${REMOTE_PORT}" -i ~/.ssh/id_ed25519 \
+            -o BatchMode=yes -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=yes -o ConnectTimeout=15 \
+            "runtime-${RELEASE_SHA}.tar" \
+            "runtime-${RELEASE_SHA}.sha256" \
+            "registry-${RELEASE_SHA}.credentials" \
+            "${REMOTE_USER}@${REMOTE_HOST}:incoming/"
+
+      - name: Deploy verified image digest
+        run: |
+          ssh -p "${REMOTE_PORT}" -i ~/.ssh/id_ed25519 \
+            -o BatchMode=yes -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=yes -o ConnectTimeout=15 \
+            "${REMOTE_USER}@${REMOTE_HOST}" \
+            "sudo /usr/local/sbin/sitbank-container-deploy '${RELEASE_SHA}' '${IMAGE_DIGEST}'"
+
+      - name: Remove deployment credentials and bundles
+        if: always()
+        run: |
+          rm -rf ~/.ssh/id_ed25519 \
+            "runtime-${RELEASE_SHA}" \
+            "runtime-${RELEASE_SHA}.tar" \
+            "runtime-${RELEASE_SHA}.sha256" \
+            "registry-${RELEASE_SHA}.credentials"
+
+  deploy-production:
+    if: >-
+      always() &&
+      needs.release-verify.result == 'success' &&
       github.event_name != 'pull_request' &&
       github.ref == 'refs/heads/main' &&
-      vars.PROD_DEPLOY_ENABLED == 'true'
-    needs: publish
+      vars.PROD_DEPLOY_ENABLED == 'true' &&
+      (
+        (
+          github.event_name == 'push' &&
+          (
+            vars.STAGING_DEPLOY_ENABLED != 'true' ||
+            needs.deploy-staging.result == 'success'
+          )
+        ) ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          inputs.target_environment == 'production' &&
+          inputs.deploy == true
+        )
+      )
+    needs:
+      - release-verify
+      - deploy-staging
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -225,23 +638,74 @@ jobs:
       url: https://${{ vars.PROD_PUBLIC_HOST }}
     env:
       RELEASE_SHA: ${{ github.sha }}
-      IMAGE_DIGEST: ${{ needs.publish.outputs.digest }}
-      EC2_HOST: ${{ vars.EC2_HOST }}
-      EC2_PORT: ${{ vars.EC2_PORT || '22' }}
-      EC2_DEPLOY_USER: ${{ vars.EC2_DEPLOY_USER || 'sitbank-deploy' }}
+      IMAGE_DIGEST: ${{ needs.release-verify.outputs.digest }}
+      REMOTE_HOST: ${{ vars.PROD_EC2_HOST }}
+      REMOTE_PORT: ${{ vars.PROD_EC2_PORT }}
+      REMOTE_USER: ${{ vars.PROD_EC2_DEPLOY_USER }}
       PROD_PUBLIC_HOST: ${{ vars.PROD_PUBLIC_HOST }}
       PROD_SESSION_HMAC_ACTIVE_KEY_ID: ${{ vars.PROD_SESSION_HMAC_ACTIVE_KEY_ID }}
       PROD_SESSION_HMAC_PREVIOUS_KEY_ID: ${{ vars.PROD_SESSION_HMAC_PREVIOUS_KEY_ID }}
-      PROD_PASSWORD_PBKDF2_ITERATIONS: ${{ vars.PROD_PASSWORD_PBKDF2_ITERATIONS || '600000' }}
-      PROD_MFA_ISSUER_NAME: ${{ vars.PROD_MFA_ISSUER_NAME || 'SITBank' }}
+      PROD_PASSWORD_PBKDF2_ITERATIONS: ${{ vars.PROD_PASSWORD_PBKDF2_ITERATIONS }}
+      PROD_MFA_ISSUER_NAME: ${{ vars.PROD_MFA_ISSUER_NAME }}
     steps:
       - name: Check out repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+
+      - name: Verify production deployment configuration
+        env:
+          PROD_EC2_KNOWN_HOSTS: ${{ secrets.PROD_EC2_KNOWN_HOSTS }}
+          PROD_EC2_SSH_PRIVATE_KEY: ${{ secrets.PROD_EC2_SSH_PRIVATE_KEY }}
+          PROD_DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
+          PROD_MFA_AES256_GCM_KEY_B64: ${{ secrets.PROD_MFA_AES256_GCM_KEY_B64 }}
+          PROD_PASSWORD_PEPPER_B64: ${{ secrets.PROD_PASSWORD_PEPPER_B64 }}
+          PROD_REDIS_URL: ${{ secrets.PROD_REDIS_URL }}
+          PROD_SECRET_KEY: ${{ secrets.PROD_SECRET_KEY }}
+          PROD_SESSION_HMAC_ACTIVE_KEY_B64: ${{ secrets.PROD_SESSION_HMAC_ACTIVE_KEY_B64 }}
+          PROD_WTF_CSRF_SECRET_KEY: ${{ secrets.PROD_WTF_CSRF_SECRET_KEY }}
+        run: |
+          required=(
+            IMAGE_DIGEST
+            REMOTE_HOST
+            REMOTE_PORT
+            REMOTE_USER
+            PROD_PUBLIC_HOST
+            PROD_SESSION_HMAC_ACTIVE_KEY_ID
+            PROD_PASSWORD_PBKDF2_ITERATIONS
+            PROD_MFA_ISSUER_NAME
+            PROD_EC2_KNOWN_HOSTS
+            PROD_EC2_SSH_PRIVATE_KEY
+            PROD_DATABASE_URL
+            PROD_MFA_AES256_GCM_KEY_B64
+            PROD_PASSWORD_PEPPER_B64
+            PROD_REDIS_URL
+            PROD_SECRET_KEY
+            PROD_SESSION_HMAC_ACTIVE_KEY_B64
+            PROD_WTF_CSRF_SECRET_KEY
+          )
+          missing=0
+          for name in "${required[@]}"; do
+            if [[ -z "${!name}" ]]; then
+              echo "::error::Missing required production deployment setting: ${name}"
+              missing=1
+            fi
+          done
+          if [[ ! "${IMAGE_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::Verified image digest is invalid."
+            missing=1
+          fi
+          if [[ ! "${REMOTE_PORT}" =~ ^[0-9]+$ ]]; then
+            echo "::error::PROD_EC2_PORT must be numeric."
+            missing=1
+          fi
+          exit "${missing}"
 
       - name: Render protected Compose runtime bundle
         run: |
           umask 077
           python ops/deploy/render_container_bundle.py \
+            --prefix PROD \
             --output "runtime-${RELEASE_SHA}"
           tar --create --file "runtime-${RELEASE_SHA}.tar" \
             --directory "runtime-${RELEASE_SHA}" .
@@ -262,31 +726,31 @@ jobs:
 
       - name: Configure verified SSH
         env:
-          EC2_SSH_PRIVATE_KEY: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
-          EC2_KNOWN_HOSTS: ${{ secrets.EC2_KNOWN_HOSTS }}
+          SSH_PRIVATE_KEY: ${{ secrets.PROD_EC2_SSH_PRIVATE_KEY }}
+          SSH_KNOWN_HOSTS: ${{ secrets.PROD_EC2_KNOWN_HOSTS }}
         run: |
           install -d -m 0700 ~/.ssh
-          printf '%s\n' "${EC2_SSH_PRIVATE_KEY}" > ~/.ssh/id_ed25519
+          printf '%s\n' "${SSH_PRIVATE_KEY}" > ~/.ssh/id_ed25519
           chmod 0600 ~/.ssh/id_ed25519
-          printf '%s\n' "${EC2_KNOWN_HOSTS}" > ~/.ssh/known_hosts
+          printf '%s\n' "${SSH_KNOWN_HOSTS}" > ~/.ssh/known_hosts
           chmod 0600 ~/.ssh/known_hosts
 
       - name: Upload private deployment inputs
         run: |
-          scp -P "${EC2_PORT}" -i ~/.ssh/id_ed25519 \
+          scp -P "${REMOTE_PORT}" -i ~/.ssh/id_ed25519 \
             -o BatchMode=yes -o IdentitiesOnly=yes \
             -o StrictHostKeyChecking=yes -o ConnectTimeout=15 \
             "runtime-${RELEASE_SHA}.tar" \
             "runtime-${RELEASE_SHA}.sha256" \
             "registry-${RELEASE_SHA}.credentials" \
-            "${EC2_DEPLOY_USER}@${EC2_HOST}:incoming/"
+            "${REMOTE_USER}@${REMOTE_HOST}:incoming/"
 
       - name: Deploy verified image digest
         run: |
-          ssh -p "${EC2_PORT}" -i ~/.ssh/id_ed25519 \
+          ssh -p "${REMOTE_PORT}" -i ~/.ssh/id_ed25519 \
             -o BatchMode=yes -o IdentitiesOnly=yes \
             -o StrictHostKeyChecking=yes -o ConnectTimeout=15 \
-            "${EC2_DEPLOY_USER}@${EC2_HOST}" \
+            "${REMOTE_USER}@${REMOTE_HOST}" \
             "sudo /usr/local/sbin/sitbank-container-deploy '${RELEASE_SHA}' '${IMAGE_DIGEST}'"
 
       - name: Remove deployment credentials and bundles

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -379,9 +379,11 @@ jobs:
             exit 1
           fi
           image="${IMAGE_REPOSITORY}@${IMAGE_DIGEST}"
-          echo "repository=${IMAGE_REPOSITORY}" >> "${GITHUB_OUTPUT}"
-          echo "digest=${IMAGE_DIGEST}" >> "${GITHUB_OUTPUT}"
-          echo "image=${image}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "repository=${IMAGE_REPOSITORY}"
+            echo "digest=${IMAGE_DIGEST}"
+            echo "image=${image}"
+          } >> "${GITHUB_OUTPUT}"
 
       - name: Log in to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee

--- a/README.md
+++ b/README.md
@@ -111,64 +111,126 @@ development, tests, and the one-time protected legacy import only.
 
 `.github/workflows/ci-deploy.yml`:
 
-1. Runs pytest, compilation, package checks, Bandit, dependency auditing, and
-   repository secret scanning.
-2. Builds a `linux/amd64` image from hash-locked dependencies.
-3. Runs migrations, `production-check`, and `/health/ready` against temporary
-   PostgreSQL and Redis containers.
-4. Scans fixable high and critical image vulnerabilities with Trivy.
-5. Pushes the private GHCR image using the job-scoped `GITHUB_TOKEN`.
-6. Generates SBOM and provenance attestations.
-7. Signs the immutable digest with Cosign keyless GitHub OIDC.
-8. Passes only the commit SHA and `sha256:` digest to the protected deployment
-   job.
+1. Pull requests run workflow security checks, pytest, compilation, package
+   checks, Bandit, dependency auditing, repository secret scanning, local image
+   build, smoke tests, authenticated DAST smoke crawl, Compose validation, and
+   both Trivy gates. Pull requests do not publish, sign, or deploy release
+   images, and they do not reference staging or production secrets.
+2. Manual `workflow_dispatch` runs can publish and verify an immutable release
+   candidate digest. Use `target_environment=staging` and `deploy=false` for
+   a staging release verification only run.
+3. Manual staging deployment requires `target_environment=staging`,
+   `deploy=true`, and `STAGING_DEPLOY_ENABLED=true`.
+4. Pushes to `main` publish one immutable GHCR image, verify the exact digest,
+   and deploy to staging only when `STAGING_DEPLOY_ENABLED=true`.
+5. Production deployment is restricted to `main`, uses the `production`
+   environment, and runs only when `PROD_DEPLOY_ENABLED=true`. On automatic
+   `main` runs, production waits for staging when staging deployment is enabled.
+6. Release verification validates the exact digest from `publish`, checks the
+   image revision label, validates the Compose model against that digest, runs
+   smoke and DAST checks, keeps both Trivy gates, and signs/verifies the digest
+   with Cosign keyless GitHub OIDC.
+7. Deployment passes only the commit SHA and verified `sha256:` digest to the
+   protected EC2 wrapper. It never deploys `latest` and never rebuilds for
+   staging or production.
 
 Every third-party action is pinned to a full commit SHA. Publishing remains
-available while production deployment is disabled, allowing an administrator
-to deploy the same signed digest manually.
+available while deployment is disabled, allowing the same signed digest to be
+verified without changing EC2.
 
-### Production Environment
+### GitHub Environments
 
-Ask a repository administrator to create the `production` environment:
+Create separate `staging` and `production` environments. Restrict production
+deployment branches to `main`, add required reviewers, prevent self-review
+where supported, and protect `main` with pull-request approval, required CI
+checks, and disabled force pushes.
 
-- Restrict deployment branches to `main`.
-- Add required reviewers and prevent self-review where supported.
-- Protect `main` with pull-request approval, required CI checks, and disabled
-  force pushes.
+Set these repository Actions variables before the first merge:
 
-Add these environment secrets:
+- `STAGING_DEPLOY_ENABLED=false`
+- `PROD_DEPLOY_ENABLED=false`
 
-- `EC2_SSH_PRIVATE_KEY`
-- `EC2_KNOWN_HOSTS`
-- `PROD_SECRET_KEY`
-- `PROD_WTF_CSRF_SECRET_KEY`
-- `PROD_SESSION_HMAC_ACTIVE_KEY_B64`
-- `PROD_SESSION_HMAC_PREVIOUS_KEY_B64` during a rotation only
+The enable flags are repository variables because the workflow evaluates them
+before environment-scoped variables are loaded. With both disabled, a `main`
+run still builds, scans, signs, and release-verifies the digest, then skips
+deployment clearly.
+
+#### Staging Environment
+
+Add these staging environment secrets:
+
+- `STAGING_EC2_KNOWN_HOSTS`
+- `STAGING_EC2_SSH_PRIVATE_KEY`
+- `STAGING_DATABASE_URL`
+- `STAGING_MFA_AES256_GCM_KEY_B64`
+- `STAGING_PASSWORD_PEPPER_B64`
+- `STAGING_REDIS_URL`
+- `STAGING_SECRET_KEY`
+- `STAGING_SESSION_HMAC_ACTIVE_KEY_B64`
+- `STAGING_WTF_CSRF_SECRET_KEY`
+
+Add these staging environment variables:
+
+- `STAGING_EC2_DEPLOY_USER`
+- `STAGING_EC2_HOST`
+- `STAGING_EC2_PORT`
+- `STAGING_MFA_ISSUER_NAME`
+- `STAGING_PASSWORD_PBKDF2_ITERATIONS`
+- `STAGING_PUBLIC_HOST`
+- `STAGING_SESSION_HMAC_ACTIVE_KEY_ID`
+
+#### Production Environment
+
+Add these production environment secrets:
+
+- `PROD_EC2_KNOWN_HOSTS`
+- `PROD_EC2_SSH_PRIVATE_KEY`
 - `PROD_DATABASE_URL`
-- `PROD_REDIS_URL`
 - `PROD_MFA_AES256_GCM_KEY_B64`
 - `PROD_PASSWORD_PEPPER_B64`
+- `PROD_REDIS_URL`
+- `PROD_SECRET_KEY`
+- `PROD_SESSION_HMAC_ACTIVE_KEY_B64`
+- `PROD_WTF_CSRF_SECRET_KEY`
 
-Add these environment variables:
+Add these production environment variables:
 
-- `EC2_HOST`
-- `EC2_PORT`, normally `22`
-- `EC2_DEPLOY_USER`, normally `sitbank-deploy`
+- `PROD_EC2_DEPLOY_USER`
+- `PROD_EC2_HOST`
+- `PROD_EC2_PORT`
+- `PROD_MFA_ISSUER_NAME`
+- `PROD_PASSWORD_PBKDF2_ITERATIONS`
 - `PROD_PUBLIC_HOST`, currently `sitbank.duckdns.org`
 - `PROD_SESSION_HMAC_ACTIVE_KEY_ID`
-- `PROD_SESSION_HMAC_PREVIOUS_KEY_ID` during a rotation only
-- `PROD_PASSWORD_PBKDF2_ITERATIONS`, normally `600000`
-- `PROD_MFA_ISSUER_NAME`, normally `SITBank`
 
-Set the repository Actions variable `PROD_DEPLOY_ENABLED=false` during
-bootstrap. Set it to the exact value `true` only after EC2 is ready.
+The optional rotation settings are `PROD_SESSION_HMAC_PREVIOUS_KEY_ID` and
+`PROD_SESSION_HMAC_PREVIOUS_KEY_B64`; configure both together only during a
+session HMAC key rotation.
+
+#### Production EC2 Name Migration
+
+Existing unprefixed production deployment names are deprecated and are not used
+by the workflow. Rename them before enabling production deployment:
+
+| Old name | New canonical name |
+| --- | --- |
+| `EC2_KNOWN_HOSTS` | `PROD_EC2_KNOWN_HOSTS` |
+| `EC2_SSH_PRIVATE_KEY` | `PROD_EC2_SSH_PRIVATE_KEY` |
+| `EC2_DEPLOY_USER` | `PROD_EC2_DEPLOY_USER` |
+| `EC2_HOST` | `PROD_EC2_HOST` |
+| `EC2_PORT` | `PROD_EC2_PORT` |
 
 Configuration names and non-secret defaults are safe to document. Their values
-must never be committed. Verify `EC2_KNOWN_HOSTS` through a trusted channel;
-never accept an unexpected SSH host-key change merely to make deployment pass.
+must never be committed. Verify known hosts through a trusted channel; never
+accept an unexpected SSH host-key change merely to make deployment pass.
 
 The production database and Redis URLs must use `127.0.0.1`, because both
 services remain bound to EC2 loopback and the app uses host networking.
+
+The active production runtime is Docker Compose under
+`sitbank-container.service`, using `/opt/sitbank/compose.yml`. The legacy
+`sitbank.service`, old service names, and `/var/www` application directories
+are not the active runtime.
 
 ## One-Time EC2 Transition
 
@@ -286,15 +348,16 @@ with:
 restrict ssh-ed25519 AAAA... github-actions-sitbank
 ```
 
-Store the private key only as `EC2_SSH_PRIVATE_KEY`. Verify the server host-key
-fingerprint through the EC2 console or another trusted channel:
+Store the private key only as `PROD_EC2_SSH_PRIVATE_KEY` in the `production`
+environment. Verify the server host-key fingerprint through the EC2 console or
+another trusted channel:
 
 ```bash
 sudo ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub -E sha256
 ```
 
 Store the verified complete `ssh-keyscan -H -t ed25519
-sitbank.duckdns.org` result as `EC2_KNOWN_HOSTS`.
+sitbank.duckdns.org` result as `PROD_EC2_KNOWN_HOSTS`.
 
 ### 6. Seed Container Secrets for a Manual First Deployment
 

--- a/ops/container/dast-smoke.sh
+++ b/ops/container/dast-smoke.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+readonly IMAGE="${1:-sitbank:smoke}"
+readonly POSTGRES_IMAGE="postgres:16.9-alpine@sha256:7c688148e5e156d0e86df7ba8ae5a05a2386aaec1e2ad8e6d11bdf10504b1fb7"
+readonly REDIS_IMAGE="redis:7.4.5-alpine@sha256:bb186d083732f669da90be8b0f975a37812b15e913465bb14d845db72a4e3e08"
+readonly PUBLIC_HOST="sitbank.duckdns.org"
+
+work_dir="$(mktemp -d)"
+chmod 2770 "${work_dir}"
+
+# shellcheck disable=SC2317
+cleanup() {
+    docker rm -f sitbank-dast dast-postgres dast-redis >/dev/null 2>&1 || true
+    rm -rf -- "${work_dir}"
+}
+trap cleanup EXIT
+
+runner_gid="$(id -g)"
+docker run --detach --name dast-postgres \
+    --group-add "${runner_gid}" \
+    --publish 127.0.0.1:55433:5432 \
+    --env POSTGRES_USER=ci \
+    --env POSTGRES_PASSWORD=ci-password \
+    --env POSTGRES_DB=ci \
+    "${POSTGRES_IMAGE}" >/dev/null
+docker run --detach --name dast-redis \
+    --group-add "${runner_gid}" \
+    --publish 127.0.0.1:56380:6379 \
+    "${REDIS_IMAGE}" \
+    redis-server --requirepass ci-password >/dev/null
+
+for _ in $(seq 1 30); do
+    if docker exec dast-postgres pg_isready --username ci --dbname ci >/dev/null 2>&1 \
+        && docker exec dast-redis redis-cli -a ci-password ping 2>/dev/null \
+            | grep -q PONG; then
+        break
+    fi
+    sleep 1
+done
+docker exec dast-postgres pg_isready --username ci --dbname ci >/dev/null
+docker exec dast-redis redis-cli -a ci-password ping 2>/dev/null | grep -q PONG
+
+install -d -m 0770 "${work_dir}/secrets" "${work_dir}/config"
+printf '%s' 'ci-secret-key-that-is-long-enough-for-dast-tests' \
+    > "${work_dir}/secrets/secret_key"
+printf '%s' 'ci-csrf-key-that-is-long-enough-for-dast-tests' \
+    > "${work_dir}/secrets/wtf_csrf_secret_key"
+printf '%s' '{"ci":"MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjI="}' \
+    > "${work_dir}/secrets/session_hmac_keys_json"
+printf '%s' 'postgresql+psycopg2://ci:ci-password@127.0.0.1:55433/ci' \
+    > "${work_dir}/secrets/database_url"
+printf '%s' 'redis://:ci-password@127.0.0.1:56380/15' \
+    > "${work_dir}/secrets/redis_url"
+printf '%s' 'MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=' \
+    > "${work_dir}/secrets/mfa_aes256_gcm_key_b64"
+printf '%s' 'MTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTE=' \
+    > "${work_dir}/secrets/password_pepper_b64"
+chmod 0444 "${work_dir}"/secrets/*
+
+seq -f 'blocked-password-%06g' 1 100000 \
+    > "${work_dir}/config/common-passwords.txt"
+cp tests/fixtures/fido-approved-aaguids.json \
+    "${work_dir}/config/fido-approved-aaguids.json"
+cp tests/fixtures/fido-mds-cache.json \
+    "${work_dir}/config/fido-mds-cache.json"
+chmod 0444 "${work_dir}"/config/*
+
+docker_args=(
+    --network host
+    --user 10001:10001
+    --group-add "${runner_gid}"
+    --read-only
+    --tmpfs "/tmp:rw,noexec,nosuid,nodev,size=64m,uid=10001,gid=10001,mode=1770"
+    --cap-drop ALL
+    --security-opt no-new-privileges:true
+    --env APP_ENV=production
+    --env SECRET_KEY_FILE=/run/secrets/secret_key
+    --env WTF_CSRF_SECRET_KEY_FILE=/run/secrets/wtf_csrf_secret_key
+    --env SESSION_HMAC_ACTIVE_KEY_ID=ci
+    --env SESSION_HMAC_KEYS_JSON_FILE=/run/secrets/session_hmac_keys_json
+    --env DATABASE_URL_FILE=/run/secrets/database_url
+    --env REDIS_URL_FILE=/run/secrets/redis_url
+    --env MFA_AES256_GCM_KEY_B64_FILE=/run/secrets/mfa_aes256_gcm_key_b64
+    --env PASSWORD_PEPPER_B64_FILE=/run/secrets/password_pepper_b64
+    --env PASSWORD_PBKDF2_ITERATIONS=600000
+    --env COMMON_PASSWORDS_PATH=/run/config/common-passwords.txt
+    --env COMMON_PASSWORDS_MIN_ENTRIES=100000
+    --env WEBAUTHN_RP_ID="${PUBLIC_HOST}"
+    --env WEBAUTHN_RP_ORIGIN="https://${PUBLIC_HOST}"
+    --env WEBAUTHN_APPROVED_AAGUIDS_PATH=/run/config/fido-approved-aaguids.json
+    --env WEBAUTHN_MDS_CACHE_PATH=/run/config/fido-mds-cache.json
+    --env TRUSTED_PROXY_COUNT=1
+    --volume "${work_dir}/secrets:/run/secrets:ro"
+    --volume "${work_dir}/config:/run/config:ro"
+)
+
+docker run --rm "${docker_args[@]}" "${IMAGE}" \
+    python -m flask --app wsgi:app db upgrade
+docker run --detach --name sitbank-dast \
+    "${docker_args[@]}" "${IMAGE}" >/dev/null
+for _ in $(seq 1 20); do
+    if curl --fail --silent \
+        --header "Host: ${PUBLIC_HOST}" \
+        --header "X-Forwarded-Proto: https" \
+        http://127.0.0.1:5000/health/ready >/dev/null; then
+        break
+    fi
+    sleep 1
+done
+curl --fail --silent \
+    --header "Host: ${PUBLIC_HOST}" \
+    --header "X-Forwarded-Proto: https" \
+    http://127.0.0.1:5000/health/ready >/dev/null
+
+cookie_jar="${work_dir}/dast.cookies"
+: > "${cookie_jar}"
+chmod 0640 "${cookie_jar}"
+
+python - "${cookie_jar}" "${PUBLIC_HOST}" <<'PY'
+from __future__ import annotations
+
+import http.cookies
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+
+cookie_path = sys.argv[1]
+public_host = sys.argv[2]
+base_url = "http://127.0.0.1:5000"
+cookies: dict[str, str] = {}
+
+
+def update_cookies(headers) -> None:
+    for raw_cookie in headers.get_all("Set-Cookie", []):
+        parsed = http.cookies.SimpleCookie()
+        parsed.load(raw_cookie)
+        for name, morsel in parsed.items():
+            cookies[name] = morsel.value
+        if "__Host-sitbank_session" in raw_cookie:
+            lowered = raw_cookie.casefold()
+            required = ("secure", "httponly", "samesite=strict")
+            missing = [flag for flag in required if flag not in lowered]
+            if missing:
+                raise RuntimeError(f"Session cookie is missing flags: {', '.join(missing)}")
+
+
+def save_cookie_names() -> None:
+    with open(cookie_path, "w", encoding="utf-8", newline="\n") as handle:
+        for name in sorted(cookies):
+            handle.write(f"{name}\n")
+    os.chmod(cookie_path, 0o640)
+
+
+def request_json(path: str, payload: dict | None = None, csrf: str | None = None):
+    headers = {
+        "Accept": "application/json",
+        "Host": public_host,
+        "User-Agent": "sitbank-dast-smoke",
+        "X-Forwarded-Host": public_host,
+        "X-Forwarded-Proto": "https",
+    }
+    if cookies:
+        headers["Cookie"] = "; ".join(f"{name}={value}" for name, value in cookies.items())
+    body = None
+    method = "GET"
+    if payload is not None:
+        method = "POST"
+        body = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+        headers["Referer"] = f"https://{public_host}{path}"
+    if csrf is not None:
+        headers["X-CSRFToken"] = csrf
+    req = urllib.request.Request(
+        f"{base_url}{path}",
+        data=body,
+        headers=headers,
+        method=method,
+    )
+    try:
+        response = urllib.request.urlopen(req, timeout=10)
+    except urllib.error.HTTPError as exc:
+        response = exc
+    update_cookies(response.headers)
+    save_cookie_names()
+    return response
+
+
+def read_json(response):
+    payload = response.read().decode("utf-8")
+    return json.loads(payload)
+
+
+index = request_json("/")
+csp = index.headers.get("Content-Security-Policy", "")
+if index.status != 200:
+    raise RuntimeError(f"Unexpected index status: {index.status}")
+if "default-src 'self'" not in csp or "script-src 'self'" not in csp:
+    raise RuntimeError("CSP header is missing required self directives")
+if index.headers.get("X-Frame-Options", "").casefold() != "sameorigin":
+    raise RuntimeError("Frame restriction header is missing")
+
+csrf = read_json(request_json("/auth/csrf-token"))["csrf_token"]
+register = request_json(
+    "/auth/register",
+    {
+        "username": "dastuser",
+        "email": "dast@example.test",
+        "password": "correct horse battery staple 2026",
+        "confirm_password": "correct horse battery staple 2026",
+    },
+    csrf,
+)
+if register.status != 201:
+    raise RuntimeError(f"Unexpected register status: {register.status}")
+
+csrf = read_json(request_json("/auth/csrf-token"))["csrf_token"]
+login = request_json(
+    "/auth/login",
+    {"identifier": "dastuser", "password": "correct horse battery staple 2026"},
+    csrf,
+)
+login_payload = read_json(login)
+if login.status != 200 or not login_payload.get("mfa_setup_required"):
+    raise RuntimeError("Login did not create an authenticated MFA setup session")
+
+mfa_setup = request_json("/mfa/setup")
+page = mfa_setup.read().decode("utf-8", errors="replace")
+if mfa_setup.status != 200 or "Authenticator MFA" not in page:
+    raise RuntimeError("Authenticated MFA setup page was not reachable")
+if mfa_setup.headers.get("Cache-Control", "").casefold().find("no-store") < 0:
+    raise RuntimeError("Authenticated page is missing no-store cache control")
+PY

--- a/ops/deploy/render_container_bundle.py
+++ b/ops/deploy/render_container_bundle.py
@@ -11,12 +11,12 @@ from pathlib import Path
 
 
 SECRET_INPUTS = {
-    "PROD_DATABASE_URL": "database_url",
-    "PROD_MFA_AES256_GCM_KEY_B64": "mfa_aes256_gcm_key_b64",
-    "PROD_PASSWORD_PEPPER_B64": "password_pepper_b64",
-    "PROD_REDIS_URL": "redis_url",
-    "PROD_SECRET_KEY": "secret_key",
-    "PROD_WTF_CSRF_SECRET_KEY": "wtf_csrf_secret_key",
+    "DATABASE_URL": "database_url",
+    "MFA_AES256_GCM_KEY_B64": "mfa_aes256_gcm_key_b64",
+    "PASSWORD_PEPPER_B64": "password_pepper_b64",
+    "REDIS_URL": "redis_url",
+    "SECRET_KEY": "secret_key",
+    "WTF_CSRF_SECRET_KEY": "wtf_csrf_secret_key",
 }
 
 NON_SECRET_DEFAULTS = {
@@ -54,51 +54,62 @@ def _quote_environment_value(name: str, value: str) -> str:
     return f"'{value}'"
 
 
-def _session_keyring() -> tuple[str, str]:
-    active_id = _value("PROD_SESSION_HMAC_ACTIVE_KEY_ID")
+def _prefixed(prefix: str, name: str) -> str:
+    return f"{prefix}_{name}"
+
+
+def _session_keyring(prefix: str) -> tuple[str, str]:
+    active_id_name = _prefixed(prefix, "SESSION_HMAC_ACTIVE_KEY_ID")
+    active_id = _value(active_id_name)
     if not re.fullmatch(r"[A-Za-z0-9._-]{1,32}", active_id):
-        raise RuntimeError("PROD_SESSION_HMAC_ACTIVE_KEY_ID is invalid")
+        raise RuntimeError(f"{active_id_name} is invalid")
+    active_key_name = _prefixed(prefix, "SESSION_HMAC_ACTIVE_KEY_B64")
     active_key = _validate_b64_key(
-        "PROD_SESSION_HMAC_ACTIVE_KEY_B64",
-        _value("PROD_SESSION_HMAC_ACTIVE_KEY_B64"),
+        active_key_name,
+        _value(active_key_name),
     )
     keyring = {active_id: active_key}
 
-    previous_id = os.environ.get("PROD_SESSION_HMAC_PREVIOUS_KEY_ID", "").strip()
-    previous_key = os.environ.get("PROD_SESSION_HMAC_PREVIOUS_KEY_B64", "").strip()
+    previous_id_name = _prefixed(prefix, "SESSION_HMAC_PREVIOUS_KEY_ID")
+    previous_key_name = _prefixed(prefix, "SESSION_HMAC_PREVIOUS_KEY_B64")
+    previous_id = os.environ.get(previous_id_name, "").strip()
+    previous_key = os.environ.get(previous_key_name, "").strip()
     if bool(previous_id) != bool(previous_key):
         raise RuntimeError(
-            "PROD_SESSION_HMAC_PREVIOUS_KEY_ID and "
-            "PROD_SESSION_HMAC_PREVIOUS_KEY_B64 must be configured together"
+            f"{previous_id_name} and {previous_key_name} must be configured together"
         )
     if previous_id:
         if not re.fullmatch(r"[A-Za-z0-9._-]{1,32}", previous_id):
-            raise RuntimeError("PROD_SESSION_HMAC_PREVIOUS_KEY_ID is invalid")
+            raise RuntimeError(f"{previous_id_name} is invalid")
         if previous_id == active_id:
             raise RuntimeError("Session HMAC key identifiers must be unique")
         keyring[previous_id] = _validate_b64_key(
-            "PROD_SESSION_HMAC_PREVIOUS_KEY_B64",
+            previous_key_name,
             previous_key,
         )
     return active_id, json.dumps(keyring, separators=(",", ":"), sort_keys=True)
 
 
-def build_container_bundle() -> tuple[dict[str, str], dict[str, str]]:
-    public_host = _value("PROD_PUBLIC_HOST")
+def build_container_bundle(prefix: str = "PROD") -> tuple[dict[str, str], dict[str, str]]:
+    if prefix not in {"PROD", "STAGING"}:
+        raise RuntimeError("Deployment prefix must be PROD or STAGING")
+
+    public_host_name = _prefixed(prefix, "PUBLIC_HOST")
+    public_host = _value(public_host_name)
     if not re.fullmatch(r"[A-Za-z0-9.-]+", public_host):
-        raise RuntimeError("PROD_PUBLIC_HOST must be a bare hostname")
-    active_key_id, keyring = _session_keyring()
+        raise RuntimeError(f"{public_host_name} must be a bare hostname")
+    active_key_id, keyring = _session_keyring(prefix)
 
     secrets = {
-        target: _value(source)
+        target: _value(_prefixed(prefix, source))
         for source, target in SECRET_INPUTS.items()
     }
     _validate_b64_key(
-        "PROD_MFA_AES256_GCM_KEY_B64",
+        _prefixed(prefix, "MFA_AES256_GCM_KEY_B64"),
         secrets["mfa_aes256_gcm_key_b64"],
     )
     _validate_b64_key(
-        "PROD_PASSWORD_PEPPER_B64",
+        _prefixed(prefix, "PASSWORD_PEPPER_B64"),
         secrets["password_pepper_b64"],
     )
     secrets["session_hmac_keys_json"] = keyring
@@ -106,7 +117,7 @@ def build_container_bundle() -> tuple[dict[str, str], dict[str, str]]:
     environment = {
         "APP_ENV": "production",
         "COMMON_PASSWORDS_PATH": "/run/config/common-passwords.txt",
-        "MFA_ISSUER_NAME": _value("PROD_MFA_ISSUER_NAME", default="SITBank"),
+        "MFA_ISSUER_NAME": _value(_prefixed(prefix, "MFA_ISSUER_NAME"), default="SITBank"),
         "SESSION_HMAC_ACTIVE_KEY_ID": active_key_id,
         "WEBAUTHN_APPROVED_AAGUIDS_PATH": "/run/config/fido-approved-aaguids.json",
         "WEBAUTHN_MDS_CACHE_PATH": "/run/config/fido-mds-cache.json",
@@ -114,12 +125,12 @@ def build_container_bundle() -> tuple[dict[str, str], dict[str, str]]:
         "WEBAUTHN_RP_ORIGIN": f"https://{public_host}",
     }
     for name, default in NON_SECRET_DEFAULTS.items():
-        environment[name] = _value(f"PROD_{name}", default=default)
+        environment[name] = _value(_prefixed(prefix, name), default=default)
     return environment, secrets
 
 
-def write_container_bundle(output_dir: Path) -> None:
-    environment, secrets = build_container_bundle()
+def write_container_bundle(output_dir: Path, prefix: str = "PROD") -> None:
+    environment, secrets = build_container_bundle(prefix)
     output_dir.mkdir(mode=0o700, parents=True, exist_ok=False)
     secret_dir = output_dir / "secrets"
     secret_dir.mkdir(mode=0o700)
@@ -141,8 +152,9 @@ def write_container_bundle(output_dir: Path) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--prefix", choices=("PROD", "STAGING"), default="PROD")
     args = parser.parse_args()
-    write_container_bundle(args.output)
+    write_container_bundle(args.output, args.prefix)
 
 
 if __name__ == "__main__":

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -32,6 +32,14 @@ def _set_deployment_values(monkeypatch):
         monkeypatch.setenv(name, value)
 
 
+def _set_prefixed_deployment_values(monkeypatch, prefix: str, public_host: str):
+    for name, value in DEPLOYMENT_VALUES.items():
+        target_name = name.replace("PROD_", f"{prefix}_", 1)
+        if name == "PROD_PUBLIC_HOST":
+            value = public_host
+        monkeypatch.setenv(target_name, value)
+
+
 def test_container_bundle_separates_secrets_from_non_secret_environment(monkeypatch):
     _set_deployment_values(monkeypatch)
 
@@ -46,6 +54,23 @@ def test_container_bundle_separates_secrets_from_non_secret_environment(monkeypa
     assert secrets["secret_key"] == DEPLOYMENT_VALUES["PROD_SECRET_KEY"]
     assert secrets["database_url"] == DEPLOYMENT_VALUES["PROD_DATABASE_URL"]
     assert '"2026-06":"MjIy' in secrets["session_hmac_keys_json"]
+
+
+def test_container_bundle_accepts_staging_prefix(monkeypatch):
+    _set_prefixed_deployment_values(
+        monkeypatch,
+        "STAGING",
+        "staging.sitbank.example",
+    )
+
+    environment, secrets = build_container_bundle("STAGING")
+
+    assert environment["APP_ENV"] == "production"
+    assert environment["WEBAUTHN_RP_ID"] == "staging.sitbank.example"
+    assert environment["WEBAUTHN_RP_ORIGIN"] == "https://staging.sitbank.example"
+    assert environment["SESSION_HMAC_ACTIVE_KEY_ID"] == "2026-06"
+    assert secrets["secret_key"] == DEPLOYMENT_VALUES["PROD_SECRET_KEY"]
+    assert secrets["database_url"] == DEPLOYMENT_VALUES["PROD_DATABASE_URL"]
 
 
 def test_container_bundle_rejects_missing_multiline_and_partial_rotation(monkeypatch):
@@ -174,17 +199,44 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
         "ops/deploy/bootstrap-container-ec2"
     ).read_text(encoding="utf-8")
 
-    assert set(workflow["jobs"]) == {"test", "image-test", "publish", "deploy"}
+    assert set(workflow["jobs"]) == {
+        "workflow-security",
+        "dependency-review",
+        "test",
+        "image-test",
+        "deployment-preflight",
+        "publish",
+        "release-verify",
+        "deploy-staging",
+        "deploy-production",
+    }
     assert workflow["permissions"] == {}
+    assert workflow["jobs"]["workflow-security"]["permissions"]["contents"] == "read"
     assert workflow["jobs"]["publish"]["permissions"]["packages"] == "write"
-    assert workflow["jobs"]["publish"]["permissions"]["id-token"] == "write"
-    assert workflow["jobs"]["deploy"]["permissions"]["packages"] == "read"
+    assert workflow["jobs"]["release-verify"]["permissions"]["id-token"] == "write"
+    assert workflow["jobs"]["deploy-staging"]["permissions"]["packages"] == "read"
+    assert workflow["jobs"]["deploy-production"]["permissions"]["packages"] == "read"
     assert "vars.PROD_DEPLOY_ENABLED == 'true'" in workflow_text
+    assert "vars.STAGING_DEPLOY_ENABLED == 'true'" in workflow_text
+    assert "workflow_dispatch" in workflow_text
+    assert "target_environment" in workflow_text
+    assert "deploy-staging" in workflow_text
+    assert "deploy-production" in workflow_text
+    assert "PROD_EC2_HOST" in workflow_text
+    assert "PROD_EC2_SSH_PRIVATE_KEY" in workflow_text
+    assert "STAGING_EC2_HOST" in workflow_text
+    assert "STAGING_EC2_SSH_PRIVATE_KEY" in workflow_text
+    assert "vars.EC2_" not in workflow_text
+    assert "secrets.EC2_" not in workflow_text
     assert "provenance: mode=max" in workflow_text
     assert "sbom: true" in workflow_text
+    assert "ignore-unfixed: false" in workflow_text
     assert "ignore-unfixed: true" in workflow_text
     assert "cosign sign --yes" in workflow_text
+    assert "zizmor==1.25.2" in workflow_text
+    assert "actionlint" in workflow_text
     assert "shellcheck" in workflow_text
+    assert "dast-smoke.sh" in workflow_text
     assert "scan_repository_secrets.py" in workflow_text
     assert "IMAGE_DIGEST" in workflow_text
     assert "StrictHostKeyChecking=no" not in workflow_text


### PR DESCRIPTION
## Summary

- Added workflow_dispatch controls for staging and production release runs
- Added automatic staging deployment gate after release verification on main
- Split staging and production deployment jobs
- Normalized deployment variables and secrets to STAGING_* and PROD_*
- Updated deployment documentation for GitHub environment configuration
- Added DAST smoke helper script
- Preserved digest-based deployment, release verification, Trivy gates, Zizmor, ShellCheck, and existing CI hardening

## Safe rollout

Before merging, repository variables should be:

- STAGING_DEPLOY_ENABLED=false
- PROD_DEPLOY_ENABLED=false

The first main run after merge should publish and verify the image digest, then skip staging and production deployment.

## Production variable migration

The old production EC2 names must be renamed/copied before production deployment is enabled:

- EC2_KNOWN_HOSTS -> PROD_EC2_KNOWN_HOSTS
- EC2_SSH_PRIVATE_KEY -> PROD_EC2_SSH_PRIVATE_KEY
- EC2_DEPLOY_USER -> PROD_EC2_DEPLOY_USER
- EC2_HOST -> PROD_EC2_HOST
- EC2_PORT -> PROD_EC2_PORT