### PR TITLE
Add staging deployment and enhance site verification

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,12 +6,15 @@
 /.github/dependabot.yml @WenJiangggg
 /Dockerfile @WenJiangggg
 /compose.prod.yml @WenJiangggg
+/compose.staging.yml @WenJiangggg
 /requirements.in @WenJiangggg
 /requirements-dev.in @WenJiangggg
 /requirements.lock @WenJiangggg
 /requirements-dev.lock @WenJiangggg
 /ops/container/ @WenJiangggg
 /ops/deploy/ @WenJiangggg
+/ops/nginx/ @WenJiangggg
+/ops/nginx-proxy-headers.conf @WenJiangggg
 /ops/security/ @WenJiangggg
 /ops/sudoers/ @WenJiangggg
 /ops/systemd/ @WenJiangggg

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -575,16 +575,16 @@ jobs:
           python ops/deploy/render_container_bundle.py \
             --prefix STAGING \
             --environment-only \
-            --output "runtime-${RELEASE_SHA}"
-          tar --create --file "runtime-${RELEASE_SHA}.tar" \
-            --directory "runtime-${RELEASE_SHA}" .
-          sha256sum "runtime-${RELEASE_SHA}.tar" \
-            > "runtime-${RELEASE_SHA}.sha256"
+            --output "runtime-staging-${RELEASE_SHA}"
+          tar --create --file "runtime-staging-${RELEASE_SHA}.tar" \
+            --directory "runtime-staging-${RELEASE_SHA}" .
+          sha256sum "runtime-staging-${RELEASE_SHA}.tar" \
+            > "runtime-staging-${RELEASE_SHA}.sha256"
           cosign sign-blob --yes \
-            --bundle "runtime-${RELEASE_SHA}.sigstore.json" \
-            "runtime-${RELEASE_SHA}.tar"
+            --bundle "runtime-staging-${RELEASE_SHA}.sigstore.json" \
+            "runtime-staging-${RELEASE_SHA}.tar"
           printf '%s\n%s\n' "${GITHUB_ACTOR}" "${GITHUB_TOKEN}" \
-            > "registry-${RELEASE_SHA}.credentials"
+            > "registry-staging-${RELEASE_SHA}.credentials"
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
@@ -604,10 +604,10 @@ jobs:
           scp -P "${REMOTE_PORT}" -i ~/.ssh/id_ed25519 \
             -o BatchMode=yes -o IdentitiesOnly=yes \
             -o StrictHostKeyChecking=yes -o ConnectTimeout=15 \
-            "runtime-${RELEASE_SHA}.tar" \
-            "runtime-${RELEASE_SHA}.sha256" \
-            "runtime-${RELEASE_SHA}.sigstore.json" \
-            "registry-${RELEASE_SHA}.credentials" \
+            "runtime-staging-${RELEASE_SHA}.tar" \
+            "runtime-staging-${RELEASE_SHA}.sha256" \
+            "runtime-staging-${RELEASE_SHA}.sigstore.json" \
+            "registry-staging-${RELEASE_SHA}.credentials" \
             "${REMOTE_USER}@${REMOTE_HOST}:incoming/"
 
       - name: Deploy verified image digest
@@ -616,17 +616,17 @@ jobs:
             -o BatchMode=yes -o IdentitiesOnly=yes \
             -o StrictHostKeyChecking=yes -o ConnectTimeout=15 \
             "${REMOTE_USER}@${REMOTE_HOST}" \
-            "sudo /usr/local/sbin/sitbank-container-deploy '${RELEASE_SHA}' '${IMAGE_DIGEST}'"
+            "sudo /usr/local/sbin/sitbank-container-deploy staging '${RELEASE_SHA}' '${IMAGE_DIGEST}'"
 
       - name: Remove deployment credentials and bundles
         if: always()
         run: |
           rm -rf ~/.ssh/id_ed25519 \
-            "runtime-${RELEASE_SHA}" \
-            "runtime-${RELEASE_SHA}.tar" \
-            "runtime-${RELEASE_SHA}.sha256" \
-            "runtime-${RELEASE_SHA}.sigstore.json" \
-            "registry-${RELEASE_SHA}.credentials"
+            "runtime-staging-${RELEASE_SHA}" \
+            "runtime-staging-${RELEASE_SHA}.tar" \
+            "runtime-staging-${RELEASE_SHA}.sha256" \
+            "runtime-staging-${RELEASE_SHA}.sigstore.json" \
+            "registry-staging-${RELEASE_SHA}.credentials"
 
   deploy-production:
     if: >-

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -198,7 +198,7 @@ jobs:
           RUN_ZAP_DAST: "true"
         run: bash ops/container/smoke-test.sh sitbank:pr
 
-      - name: Validate the production Compose model
+      - name: Validate production and staging Compose models
         run: bash ops/container/validate-compose.sh sitbank:pr
 
       # zizmor: ignore[unpinned-tools] Trivy action is SHA-pinned; the action installs a pinned Trivy tool version.
@@ -428,7 +428,7 @@ jobs:
           )"
           test "${revision}" = "${RELEASE_SHA}"
 
-      - name: Validate the production Compose model for the exact digest
+      - name: Validate production and staging Compose models for the exact digest
         env:
           SITBANK_IMAGE: ${{ steps.image.outputs.image }}
         run: bash ops/container/validate-compose.sh "${SITBANK_IMAGE}"

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -295,7 +295,10 @@ jobs:
           fi
 
   publish:
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    if: >-
+      github.event_name != 'pull_request' &&
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     needs: [test, workflow-security, deployment-preflight]
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -363,13 +366,16 @@ jobs:
           cache-to: type=gha,mode=max
 
   release-verify:
+    if: >-
+      github.event_name != 'pull_request' &&
+      github.ref == 'refs/heads/main'
     needs: publish
     runs-on: ubuntu-latest
     timeout-minutes: 40
     permissions:
       contents: read
       id-token: write
-      packages: read
+      packages: write
     outputs:
       digest: ${{ steps.image.outputs.digest }}
       repository: ${{ steps.image.outputs.repository }}

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -14,7 +14,6 @@ on:
         type: choice
         options:
           - staging
-          - production
         default: staging
       deploy:
         description: Deploy the verified digest after release verification.
@@ -255,7 +254,7 @@ jobs:
         shell: bash
         run: |
           case "${TARGET_ENVIRONMENT}" in
-            staging|production) ;;
+            staging) ;;
             *)
               echo "::error::Invalid target_environment '${TARGET_ENVIRONMENT}'."
               exit 1
@@ -267,22 +266,10 @@ jobs:
             exit 1
           fi
 
-          if [[ "${TARGET_ENVIRONMENT}" == "production" \
-              && "${GITHUB_REF}" != "refs/heads/main" ]]; then
-            echo "::error::Manual production deployment is allowed only from refs/heads/main."
-            exit 1
-          fi
-
           if [[ "${DEPLOY_REQUESTED}" == "true" \
               && "${TARGET_ENVIRONMENT}" == "staging" \
               && "${STAGING_DEPLOY_ENABLED}" != "true" ]]; then
             echo "::notice::Staging deployment requested, but STAGING_DEPLOY_ENABLED is not true. The digest will be verified and deployment will be skipped."
-          fi
-
-          if [[ "${DEPLOY_REQUESTED}" == "true" \
-              && "${TARGET_ENVIRONMENT}" == "production" \
-              && "${PROD_DEPLOY_ENABLED}" != "true" ]]; then
-            echo "::notice::Production deployment requested, but PROD_DEPLOY_ENABLED is not true. The digest will be verified and deployment will be skipped."
           fi
 
           if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == "refs/heads/main" ]]; then
@@ -297,8 +284,16 @@ jobs:
   publish:
     if: >-
       github.event_name != 'pull_request' &&
-      github.ref == 'refs/heads/main' &&
-      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+      (
+        (
+          github.event_name == 'push' &&
+          github.ref == 'refs/heads/main'
+        ) ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          inputs.target_environment == 'staging'
+        )
+      )
     needs: [test, workflow-security, deployment-preflight]
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -368,7 +363,16 @@ jobs:
   release-verify:
     if: >-
       github.event_name != 'pull_request' &&
-      github.ref == 'refs/heads/main'
+      (
+        (
+          github.event_name == 'push' &&
+          github.ref == 'refs/heads/main'
+        ) ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          inputs.target_environment == 'staging'
+        )
+      )
     needs: publish
     runs-on: ubuntu-latest
     timeout-minutes: 40
@@ -492,6 +496,7 @@ jobs:
 
   deploy-staging:
     if: >-
+      github.event_name != 'pull_request' &&
       needs.release-verify.result == 'success' &&
       (
         (
@@ -632,23 +637,10 @@ jobs:
     if: >-
       always() &&
       needs.release-verify.result == 'success' &&
-      github.event_name != 'pull_request' &&
+      needs.deploy-staging.result == 'success' &&
+      github.event_name == 'push' &&
       github.ref == 'refs/heads/main' &&
-      vars.PROD_DEPLOY_ENABLED == 'true' &&
-      (
-        (
-          github.event_name == 'push' &&
-          (
-            vars.STAGING_DEPLOY_ENABLED != 'true' ||
-            needs.deploy-staging.result == 'success'
-          )
-        ) ||
-        (
-          github.event_name == 'workflow_dispatch' &&
-          inputs.target_environment == 'production' &&
-          inputs.deploy == true
-        )
-      )
+      vars.PROD_DEPLOY_ENABLED == 'true'
     needs:
       - release-verify
       - deploy-staging

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -9,18 +9,25 @@ on:
     - cron: "17 18 * * 1"
   workflow_dispatch:
     inputs:
+      source_ref:
+        description: Branch, tag, or commit SHA to build and deploy to staging.
+        required: true
+        type: string
       target_environment:
-        description: Deployment target for manual release runs.
+        description: Deployment target.
+        required: true
         type: choice
         options:
           - staging
         default: staging
       deploy:
         description: Deploy the verified digest after release verification.
+        required: true
         type: boolean
         default: false
       run_dast:
-        description: Run the authenticated DAST smoke crawl during release verification.
+        description: Run authenticated DAST smoke crawl during release verification.
+        required: true
         type: boolean
         default: true
 
@@ -36,6 +43,101 @@ env:
   PYTHONDONTWRITEBYTECODE: "1"
 
 jobs:
+  resolve-source:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      source_ref_display: ${{ steps.resolve.outputs.source_ref_display }}
+      source_sha: ${{ steps.resolve.outputs.source_sha }}
+    steps:
+      - name: Check out trusted workflow repository state
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.workflow_sha }}
+
+      - name: Resolve candidate source to an immutable commit
+        id: resolve
+        shell: bash
+        env:
+          SOURCE_REF_INPUT: ${{ inputs.source_ref }}
+          SOURCE_REF_HINT: ${{ github.head_ref || github.ref }}
+          SOURCE_SHA_HINT: ${{ github.sha }}
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
+              echo "::error::Manual staging must be dispatched from refs/heads/main."
+              exit 1
+            fi
+            source_ref="${SOURCE_REF_INPUT}"
+            if [[ -z "${source_ref}" || "${#source_ref}" -gt 255 \
+                || "${source_ref}" == -* \
+                || "${source_ref}" =~ [[:cntrl:]] ]]; then
+              echo "::error::source_ref is empty or invalid."
+              exit 1
+            fi
+
+            resolved=""
+            if [[ "${source_ref}" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
+              resolved="${source_ref}"
+            elif [[ "${source_ref}" == refs/heads/* ]]; then
+              branch="${source_ref#refs/heads/}"
+              git check-ref-format --branch "${branch}" >/dev/null
+              resolved="refs/remotes/origin/${branch}"
+            elif [[ "${source_ref}" == refs/tags/* ]]; then
+              tag="${source_ref#refs/tags/}"
+              git check-ref-format "refs/tags/${tag}"
+              resolved="refs/tags/${tag}"
+            else
+              branch_exists=0
+              tag_exists=0
+              if git check-ref-format --branch "${source_ref}" >/dev/null 2>&1 \
+                  && git show-ref --verify --quiet \
+                    "refs/remotes/origin/${source_ref}"; then
+                branch_exists=1
+              fi
+              if git check-ref-format "refs/tags/${source_ref}" >/dev/null 2>&1 \
+                  && git show-ref --verify --quiet "refs/tags/${source_ref}"; then
+                tag_exists=1
+              fi
+              if [[ "${branch_exists}" -eq 1 && "${tag_exists}" -eq 1 ]]; then
+                echo "::error::source_ref is ambiguous; use refs/heads/ or refs/tags/."
+                exit 1
+              elif [[ "${branch_exists}" -eq 1 ]]; then
+                resolved="refs/remotes/origin/${source_ref}"
+              elif [[ "${tag_exists}" -eq 1 ]]; then
+                resolved="refs/tags/${source_ref}"
+              else
+                echo "::error::source_ref does not identify a repository branch, tag, or commit."
+                exit 1
+              fi
+            fi
+
+            if ! source_sha="$(git rev-parse --verify "${resolved}^{commit}")" \
+                || [[ ! "${source_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "::error::source_ref did not resolve to an immutable commit."
+              exit 1
+            fi
+          else
+            source_ref="${SOURCE_REF_HINT}"
+            source_sha="${SOURCE_SHA_HINT}"
+            if [[ ! "${source_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "::error::GitHub did not provide a valid source commit."
+              exit 1
+            fi
+          fi
+
+          source_ref_display="$(
+            printf '%s' "${source_ref}" | tr -c 'A-Za-z0-9._/@+-' '_'
+          )"
+          {
+            echo "source_ref_display=${source_ref_display}"
+            echo "source_sha=${source_sha}"
+          } >> "${GITHUB_OUTPUT}"
+
   workflow-security:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -101,7 +203,7 @@ jobs:
           fail-on-severity: high
 
   test:
-    needs: workflow-security
+    needs: [workflow-security, resolve-source]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -127,6 +229,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+          ref: ${{ needs.resolve-source.outputs.source_sha }}
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
@@ -284,17 +387,15 @@ jobs:
   publish:
     if: >-
       github.event_name != 'pull_request' &&
+      github.ref == 'refs/heads/main' &&
       (
-        (
-          github.event_name == 'push' &&
-          github.ref == 'refs/heads/main'
-        ) ||
+        github.event_name == 'push' ||
         (
           github.event_name == 'workflow_dispatch' &&
           inputs.target_environment == 'staging'
         )
       )
-    needs: [test, workflow-security, deployment-preflight]
+    needs: [test, workflow-security, deployment-preflight, resolve-source]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -303,11 +404,13 @@ jobs:
     outputs:
       digest: ${{ steps.push.outputs.digest }}
       repository: ${{ steps.image.outputs.repository }}
+      revision: ${{ needs.resolve-source.outputs.source_sha }}
     steps:
       - name: Check out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
+          ref: ${{ needs.resolve-source.outputs.source_sha }}
 
       - name: Resolve lowercase GHCR repository
         id: image
@@ -353,7 +456,7 @@ jobs:
           push: true
           tags: ${{ steps.tags.outputs.tags }}
           build-args: |
-            VCS_REF=${{ github.sha }}
+            VCS_REF=${{ needs.resolve-source.outputs.source_sha }}
             SOURCE_URL=${{ github.server_url }}/${{ github.repository }}
           provenance: mode=max
           sbom: true
@@ -363,11 +466,9 @@ jobs:
   release-verify:
     if: >-
       github.event_name != 'pull_request' &&
+      github.ref == 'refs/heads/main' &&
       (
-        (
-          github.event_name == 'push' &&
-          github.ref == 'refs/heads/main'
-        ) ||
+        github.event_name == 'push' ||
         (
           github.event_name == 'workflow_dispatch' &&
           inputs.target_environment == 'staging'
@@ -384,11 +485,13 @@ jobs:
       digest: ${{ steps.image.outputs.digest }}
       repository: ${{ steps.image.outputs.repository }}
       image: ${{ steps.image.outputs.image }}
+      revision: ${{ steps.image.outputs.revision }}
     steps:
       - name: Check out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
+          ref: ${{ github.workflow_sha }}
 
       - name: Resolve verified image reference
         id: image
@@ -396,6 +499,7 @@ jobs:
         env:
           IMAGE_DIGEST: ${{ needs.publish.outputs.digest }}
           IMAGE_REPOSITORY: ${{ needs.publish.outputs.repository }}
+          RELEASE_SHA: ${{ needs.publish.outputs.revision }}
         run: |
           if [[ ! "${IMAGE_REPOSITORY}" =~ ^ghcr\.io/[a-z0-9._-]+/[a-z0-9._-]+$ ]]; then
             echo "::error::Publish emitted an invalid GHCR repository."
@@ -410,6 +514,7 @@ jobs:
             echo "repository=${IMAGE_REPOSITORY}"
             echo "digest=${IMAGE_DIGEST}"
             echo "image=${image}"
+            echo "revision=${RELEASE_SHA}"
           } >> "${GITHUB_OUTPUT}"
 
       - name: Log in to GHCR
@@ -422,7 +527,7 @@ jobs:
       - name: Pull and verify release identity
         env:
           IMAGE: ${{ steps.image.outputs.image }}
-          RELEASE_SHA: ${{ github.sha }}
+          RELEASE_SHA: ${{ steps.image.outputs.revision }}
         run: |
           docker pull "${IMAGE}"
           revision="$(
@@ -506,6 +611,7 @@ jobs:
         ) ||
         (
           github.event_name == 'workflow_dispatch' &&
+          github.ref == 'refs/heads/main' &&
           inputs.target_environment == 'staging' &&
           inputs.deploy == true &&
           vars.STAGING_DEPLOY_ENABLED == 'true'
@@ -522,7 +628,7 @@ jobs:
       name: staging
       url: https://${{ vars.STAGING_PUBLIC_HOST }}
     env:
-      RELEASE_SHA: ${{ github.sha }}
+      RELEASE_SHA: ${{ needs.release-verify.outputs.revision }}
       IMAGE_DIGEST: ${{ needs.release-verify.outputs.digest }}
       REMOTE_HOST: ${{ vars.STAGING_EC2_HOST }}
       REMOTE_PORT: ${{ vars.STAGING_EC2_PORT }}
@@ -536,6 +642,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
+          ref: ${{ github.workflow_sha }}
 
       - name: Verify staging deployment configuration
         env:
@@ -654,7 +761,7 @@ jobs:
       name: production
       url: https://${{ vars.PROD_PUBLIC_HOST }}
     env:
-      RELEASE_SHA: ${{ github.sha }}
+      RELEASE_SHA: ${{ needs.release-verify.outputs.revision }}
       IMAGE_DIGEST: ${{ needs.release-verify.outputs.digest }}
       REMOTE_HOST: ${{ vars.PROD_EC2_HOST }}
       REMOTE_PORT: ${{ vars.PROD_EC2_PORT }}
@@ -668,6 +775,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           persist-credentials: false
+          ref: ${{ github.workflow_sha }}
 
       - name: Verify production deployment configuration
         env:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ the WSL2 Linux-container backend when changing the Dockerfile, Compose model,
 or container deployment scripts. GitHub Actions remains the authoritative
 `linux/amd64` build and security test environment.
 
-## Production Architecture
+## Production and Staging Architecture
 
 - Nginx terminates TLS and proxies to `127.0.0.1:5000`.
 - The application container uses host networking to reach the existing
@@ -68,6 +68,20 @@ or container deployment scripts. GitHub Actions remains the authoritative
   layers, labels, or the container environment.
 - The SSH deployment user is not a member of the `docker` group and can run
   only the validated root deployment wrapper.
+
+Staging runs beside production without sharing its Compose project, paths,
+containers, secrets, or data:
+
+- `staging-sitbank.duckdns.org` proxies to `127.0.0.1:5001`.
+- The staging Compose project is `sitbank-staging`.
+- Its app, PostgreSQL, and Redis containers are `sitbank-staging-app`,
+  `sitbank-staging-postgres`, and `sitbank-staging-redis`.
+- Its named data volumes are `sitbank-staging-postgres-data` and
+  `sitbank-staging-redis-data`.
+- Its configuration and state live under `/etc/sitbank-staging`,
+  `/opt/sitbank-staging`, and `/var/lib/sitbank-staging-container`.
+- Only the staging app publishes a loopback host port. PostgreSQL and Redis
+  remain on the private staging Docker network.
 
 The active deployment uses:
 
@@ -99,11 +113,12 @@ secret files must resolve beneath `/run/secrets`, must not be symlinks, and
 must contain one non-empty UTF-8 line without NUL, CR, or embedded LF
 characters.
 
-Root-owned host copies live under `/etc/sitbank/secrets`. Compose mounts those
+Root-owned production copies live under `/etc/sitbank/secrets`; staging uses
+the separate `/etc/sitbank-staging/secrets` directory. Compose mounts these
 files directly beneath `/run/secrets`; the deployment and runtime helpers do
 not copy their values into process environment variables. Non-secret settings
-live in `/etc/sitbank/container.env`. The container does not load a production
-`.env` file.
+live in each environment's `container.env`. Containers do not load a
+production `.env` file.
 
 The complete production configuration surface is:
 
@@ -239,9 +254,10 @@ Add these staging environment variables:
 - `STAGING_PUBLIC_HOST`
 - `STAGING_SESSION_HMAC_ACTIVE_KEY_ID`
 
-Staging application runtime secrets remain root-managed on the staging host
-under `/etc/sitbank/secrets`. Do not copy database URLs, Redis URLs, Flask
-keys, password peppers, MFA encryption keys, or session HMAC key material into
+Staging application runtime secrets remain root-managed under
+`/etc/sitbank-staging/secrets`. They must be generated independently and must
+not reuse production values. Do not copy database URLs, Redis URLs, Flask keys,
+password peppers, MFA encryption keys, or session HMAC key material into
 GitHub Actions secrets.
 
 #### Production Environment
@@ -354,6 +370,7 @@ sudo install -d -m 0755 /opt/sitbank-bootstrap
 sudo tar -xzf /tmp/sitbank-bootstrap.tar.gz -C /opt/sitbank-bootstrap
 cd /opt/sitbank-bootstrap
 sudo bash ops/deploy/bootstrap-container-ec2 \
+  production \
   WenJiangggg/SITBank \
   sitbank.duckdns.org \
   <current-service> \
@@ -364,6 +381,118 @@ Use `-` for either legacy argument when no old service or directory exists.
 The bootstrap installs Docker Engine and Compose, checksum-verified Cosign,
 the SITBank service and restricted wrappers, and the root-owned deployment
 configuration. It does not add `sitbank-deploy` to the Docker group.
+
+### 4. Bootstrap Isolated Staging on the Existing EC2 Host
+
+Run this from the same reviewed bootstrap checkout. It installs only staging
+Compose/config/state assets plus the shared restricted wrapper; it does not
+restart or migrate production:
+
+```bash
+cd /opt/sitbank-bootstrap
+sudo bash ops/deploy/bootstrap-container-ec2 \
+  staging \
+  WenJiangggg/SITBank \
+  staging-sitbank.duckdns.org
+```
+
+Copy the non-secret policy data into separate staging paths:
+
+```bash
+sudo install -o root -g 10001 -m 0640 \
+  /etc/sitbank/common-passwords.txt \
+  /etc/sitbank-staging/common-passwords.txt
+sudo install -o root -g 10001 -m 0640 \
+  /etc/sitbank/fido-approved-aaguids.json \
+  /etc/sitbank-staging/fido-approved-aaguids.json
+sudo install -o root -g 10001 -m 0640 \
+  /etc/sitbank/fido-mds-cache.json \
+  /etc/sitbank-staging/fido-mds-cache.json
+```
+
+Generate independent staging application and data-service secrets without
+printing them. Set the same non-secret key identifier as the GitHub
+`STAGING_SESSION_HMAC_ACTIVE_KEY_ID` variable:
+
+```bash
+sudo STAGING_SESSION_HMAC_ACTIVE_KEY_ID=2026-06-staging python3 - <<'PY'
+import base64
+import json
+import os
+import secrets
+from pathlib import Path
+from urllib.parse import quote
+
+root = Path("/etc/sitbank-staging/secrets")
+root.mkdir(mode=0o700, parents=True, exist_ok=True)
+os.chown(root, 0, 0)
+
+def write(name, value, mode=0o440, gid=10001):
+    path = root / name
+    path.write_text(value, encoding="utf-8", newline="")
+    os.chown(path, 0, gid)
+    os.chmod(path, mode)
+
+active_id = os.environ["STAGING_SESSION_HMAC_ACTIVE_KEY_ID"]
+postgres_password = secrets.token_urlsafe(32)
+redis_password = secrets.token_urlsafe(32)
+
+write("secret_key", secrets.token_urlsafe(48))
+write("wtf_csrf_secret_key", secrets.token_urlsafe(48))
+write(
+    "session_hmac_keys_json",
+    json.dumps(
+        {active_id: base64.b64encode(secrets.token_bytes(32)).decode("ascii")},
+        separators=(",", ":"),
+    ),
+)
+write("mfa_aes256_gcm_key_b64", base64.b64encode(secrets.token_bytes(32)).decode("ascii"))
+write("password_pepper_b64", base64.b64encode(secrets.token_bytes(32)).decode("ascii"))
+write(
+    "database_url",
+    "postgresql+psycopg2://sitbank_staging:"
+    f"{quote(postgres_password, safe='')}@postgres:5432/sitbank_staging",
+)
+write("redis_url", f"redis://:{quote(redis_password, safe='')}@redis:6379/0")
+write("postgres_password", postgres_password, mode=0o444, gid=0)
+write(
+    "redis.conf",
+    "appendonly yes\n"
+    "appendfsync everysec\n"
+    "protected-mode yes\n"
+    "bind 0.0.0.0\n"
+    f"requirepass {redis_password}\n",
+    mode=0o444,
+    gid=0,
+)
+PY
+```
+
+Install the staging TLS certificate before the first deployment, because the
+deployment wrapper verifies public HTTPS readiness:
+
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+sudo certbot --nginx -d staging-sitbank.duckdns.org
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+Verify that staging assets are separate and production remains healthy:
+
+```bash
+sudo systemctl is-active sitbank-container.service
+sudo test -r /etc/sitbank-staging/deploy.conf
+sudo test -r /opt/sitbank-staging/compose.yml
+sudo -u sitbank-container test -r /etc/sitbank-staging/common-passwords.txt
+curl --fail https://sitbank.duckdns.org/health/ready
+```
+
+Set `STAGING_PUBLIC_HOST=staging-sitbank.duckdns.org`,
+`STAGING_EC2_HOST=sitbank.duckdns.org` or the EC2 address, and the matching
+staging key identifier in the GitHub `staging` environment. Enable
+`STAGING_DEPLOY_ENABLED=true` only after these checks pass.
 
 The workflow intentionally cannot update its own privileged EC2 validator.
 Whenever `ops/deploy/sitbank-container-deploy`, the Compose file, sudoers
@@ -386,7 +515,7 @@ COSIGN_CERTIFICATE_IDENTITY=https://github.com/WenJiangggg/SITBank/.github/workf
 The private GHCR package must grant Actions access to `WenJiangggg/SITBank`
 before enabling production deployment.
 
-### 4. Prepare Host Policy Files
+### 5. Prepare Host Policy Files
 
 Keep reviewed production copies outside the image:
 
@@ -408,7 +537,7 @@ sudo -u sitbank-container test -r /etc/sitbank/fido-mds-cache.json
 Do not replace production FIDO policy files with checked-in fail-closed
 placeholders.
 
-### 5. Configure the Restricted Deployment Key
+### 6. Configure the Restricted Deployment Key
 
 Generate a dedicated Ed25519 key. Do not reuse a personal EC2 key:
 
@@ -436,7 +565,7 @@ sudo ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub -E sha256
 Store the verified complete `ssh-keyscan -H -t ed25519
 sitbank.duckdns.org` result as `PROD_EC2_KNOWN_HOSTS`.
 
-### 6. Seed Root-Managed Container Secrets
+### 7. Seed Root-Managed Container Secrets
 
 This step is mandatory. Automated deployments do not transmit long-lived
 application secrets. Keep the root-owned files under `/etc/sitbank/secrets`
@@ -465,7 +594,7 @@ non-empty output directories. After import, confirm that every file is
 root-owned, unreadable by the SSH deploy user, and readable by container UID
 `10001` only through the Compose secret mount.
 
-### 7. Rename the PostgreSQL Database and Role
+### 8. Rename the PostgreSQL Database and Role
 
 Generate a new URL-safe password on an administrator workstation and send the
 password and complete database URL directly to root-only EC2 files without
@@ -521,7 +650,7 @@ After successful readiness it removes the former role with:
 sudo /usr/local/sbin/sitbank-database-cutover finalize
 ```
 
-### 8. Deploy and Verify
+### 9. Deploy and Verify
 
 Set the two SSH environment secrets and documented non-secret variables, then
 set `PROD_DEPLOY_ENABLED=true` and run the workflow from `main`.

--- a/README.md
+++ b/README.md
@@ -161,13 +161,15 @@ development, tests, and the one-time protected legacy import only.
    and a blocking fixable High/Critical Trivy gate. Pull requests do not
    publish, sign, or deploy release images, and they do not reference staging
    or production secrets.
-2. Manual `workflow_dispatch` runs from a trusted feature branch may publish,
-   scan, sign, and verify one immutable staging candidate. Use
-   `target_environment=staging` and `deploy=false` for verification only.
-3. Manual pre-merge staging deployment requires
+2. Manual `workflow_dispatch` staging runs must be started from `main`. Set
+   `source_ref` to the candidate branch, tag, or commit SHA. The trusted
+   workflow resolves it to an immutable `source_sha`, then tests, builds,
+   scans, signs, and verifies that candidate digest.
+3. Manual pre-merge staging deployment requires the workflow ref `main`,
    `target_environment=staging`, `deploy=true`, and
    `STAGING_DEPLOY_ENABLED=true`. It deploys only the exact digest emitted by
-   `publish`; it cannot trigger production.
+   `publish`; it cannot trigger production. Use `deploy=false` for candidate
+   verification without deployment.
 4. Pushes to `main` publish one immutable GHCR image with SBOM and provenance
    attestations, verify the exact digest, and deploy to staging only when
    `STAGING_DEPLOY_ENABLED=true`.
@@ -203,8 +205,14 @@ Pull request:
   tests and validation only
 
 Manual pre-merge staging:
-  trusted branch -> workflow_dispatch -> publish -> release-verify -> staging
-  -> manual verification -> merge pull request
+  run trusted workflow from main
+  -> source_ref = candidate branch, tag, or SHA
+  -> resolve immutable source_sha
+  -> test/build/publish candidate source_sha
+  -> release-verify exact digest using trusted main scripts
+  -> deploy staging using trusted main scripts
+  -> manual verification
+  -> merge pull request
 
 Automatic main release:
   main push -> publish -> release-verify -> staging -> production
@@ -213,6 +221,15 @@ Automatic main release:
 Manual production deployment is disabled. A production deployment requires
 the protected `main` push path and a successful staging deployment in that
 same workflow run.
+
+Candidate code is checked out only in jobs that test or build the candidate.
+Jobs that render signed runtime bundles, access staging or production
+environment secrets, upload over SSH, or invoke the EC2 deployment wrapper
+explicitly check out `github.workflow_sha`, the trusted commit containing the
+workflow selected from `main`. Feature-branch workflow and deployment scripts
+therefore do not execute with staging or production secrets. The candidate
+application itself receives only the isolated staging application secrets when
+it is intentionally deployed to staging.
 
 ### Temporary Trivy Exception
 
@@ -233,10 +250,12 @@ gate, and blocks fixable High/Critical findings with no ignore file.
 
 ### GitHub Environments
 
-Create separate `staging` and `production` environments. Restrict production
-deployment branches to `main`, add required reviewers, prevent self-review
-where supported, and protect `main` with pull-request approval, required CI
-checks, and disabled force pushes.
+Create separate `staging` and `production` environments. Restrict both
+environment deployment branches to `main`; manual staging still tests a
+feature branch because the candidate is supplied through `source_ref`, while
+the secret-bearing job runs trusted workflow code from `main`. Add required
+reviewers, prevent self-review where supported, and protect `main` with
+pull-request approval, required CI checks, and disabled force pushes.
 
 Set these repository Actions variables before the first merge:
 
@@ -280,6 +299,17 @@ Staging application runtime secrets remain root-managed under
 not reuse production values. Do not copy database URLs, Redis URLs, Flask keys,
 password peppers, MFA encryption keys, or session HMAC key material into
 GitHub Actions secrets.
+
+To test a candidate before merge, open **Actions**, select the CI workflow,
+choose **Run workflow**, and set:
+
+```text
+Use workflow from: main
+source_ref: <feature branch, tag, or full/short commit SHA>
+target_environment: staging
+deploy: true
+run_dast: true
+```
 
 #### Production Environment
 
@@ -533,15 +563,9 @@ GHCR_REPOSITORY=ghcr.io/wenjiangggg/sitbank
 COSIGN_CERTIFICATE_IDENTITY=https://github.com/WenJiangggg/SITBank/.github/workflows/ci-deploy.yml@refs/heads/main
 ```
 
-Staging uses a separate, repository-scoped branch identity regular expression
-in `/etc/sitbank-staging/deploy.conf`:
-
-```text
-COSIGN_CERTIFICATE_IDENTITY_REGEXP=^https://github[.]com/WenJiangggg/SITBank/[.]github/workflows/ci-deploy[.]yml@refs/heads/[A-Za-z0-9._/-]+$
-```
-
-Production must retain the exact `main` identity. Do not replace its
-`COSIGN_CERTIFICATE_IDENTITY` with the staging regular expression.
+Staging and production both retain the exact trusted `main` workflow identity.
+The candidate image revision label and deployment revision use the resolved
+candidate `source_sha`, not `github.sha`.
 
 The private GHCR package must grant Actions access to `WenJiangggg/SITBank`
 before enabling production deployment.

--- a/README.md
+++ b/README.md
@@ -161,17 +161,20 @@ development, tests, and the one-time protected legacy import only.
    and a blocking fixable High/Critical Trivy gate. Pull requests do not
    publish, sign, or deploy release images, and they do not reference staging
    or production secrets.
-2. Manual `workflow_dispatch` runs can publish and verify an immutable release
-   candidate digest. Use `target_environment=staging` and `deploy=false` for a
-   staging release verification only run.
-3. Manual staging deployment requires `target_environment=staging`,
-   `deploy=true`, and `STAGING_DEPLOY_ENABLED=true`.
+2. Manual `workflow_dispatch` runs from a trusted feature branch may publish,
+   scan, sign, and verify one immutable staging candidate. Use
+   `target_environment=staging` and `deploy=false` for verification only.
+3. Manual pre-merge staging deployment requires
+   `target_environment=staging`, `deploy=true`, and
+   `STAGING_DEPLOY_ENABLED=true`. It deploys only the exact digest emitted by
+   `publish`; it cannot trigger production.
 4. Pushes to `main` publish one immutable GHCR image with SBOM and provenance
    attestations, verify the exact digest, and deploy to staging only when
    `STAGING_DEPLOY_ENABLED=true`.
 5. Production deployment is restricted to `main`, uses the `production`
-   environment, and runs only when `PROD_DEPLOY_ENABLED=true`. On automatic
-   `main` runs, production waits for staging when staging deployment is enabled.
+   environment, and runs automatically only on a push when
+   `PROD_DEPLOY_ENABLED=true` and staging succeeded in the same workflow.
+   Production never skips disabled, skipped, or failed staging.
 6. Release verification validates the exact digest from `publish`, checks the
    image revision label, validates the Compose model against that digest, runs
    migrations, `production-check`, Redis compatibility checks, `/health/ready`,
@@ -192,6 +195,24 @@ packages visible without permitting scheduled publish or deployment.
 Every third-party action is pinned to a full commit SHA. Publishing remains
 available while deployment is disabled, allowing the same signed digest to be
 verified without changing EC2.
+
+The release flows are:
+
+```text
+Pull request:
+  tests and validation only
+
+Manual pre-merge staging:
+  trusted branch -> workflow_dispatch -> publish -> release-verify -> staging
+  -> manual verification -> merge pull request
+
+Automatic main release:
+  main push -> publish -> release-verify -> staging -> production
+```
+
+Manual production deployment is disabled. A production deployment requires
+the protected `main` push path and a successful staging deployment in that
+same workflow run.
 
 ### Temporary Trivy Exception
 
@@ -511,6 +532,16 @@ GITHUB_REPOSITORY=WenJiangggg/SITBank
 GHCR_REPOSITORY=ghcr.io/wenjiangggg/sitbank
 COSIGN_CERTIFICATE_IDENTITY=https://github.com/WenJiangggg/SITBank/.github/workflows/ci-deploy.yml@refs/heads/main
 ```
+
+Staging uses a separate, repository-scoped branch identity regular expression
+in `/etc/sitbank-staging/deploy.conf`:
+
+```text
+COSIGN_CERTIFICATE_IDENTITY_REGEXP=^https://github[.]com/WenJiangggg/SITBank/[.]github/workflows/ci-deploy[.]yml@refs/heads/[A-Za-z0-9._/-]+$
+```
+
+Production must retain the exact `main` identity. Do not replace its
+`COSIGN_CERTIFICATE_IDENTITY` with the staging regular expression.
 
 The private GHCR package must grant Actions access to `WenJiangggg/SITBank`
 before enabling production deployment.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -70,12 +70,14 @@ that ignore file.
 ## Deployment and Rollback
 
 Only a protected `main` workflow may produce a trusted production signature.
-Staging may trust this repository's release workflow on a selected
-`refs/heads/*` branch, but production trusts only the exact
-`refs/heads/main` workflow identity. The tested, scanned, signed, and deployed
-image digest must be identical. Deployment accepts only the configured GHCR
-repository, environment-specific workflow identity policy, a 40-character
-commit SHA, and an immutable SHA-256 digest.
+Manual staging also runs the trusted workflow from `main`; its `source_ref`
+input is resolved to an immutable candidate commit without executing
+feature-branch workflow or deployment scripts with environment secrets.
+Staging and production both trust only the exact `refs/heads/main` workflow
+identity. The tested, scanned, signed, and deployed image digest must be
+identical. Deployment accepts only the configured GHCR repository, exact
+workflow identity, a 40-character candidate commit SHA, and an immutable
+SHA-256 digest.
 
 Production deployment is automatic on a protected `main` push only. It must
 not run unless staging succeeded in the same workflow; disabled, skipped, or

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,9 @@ log.
 
 1. Revoke the exposed credential at its source.
 2. Create a replacement using a cryptographically secure generator.
-3. Install it into the appropriate root-owned file under
-   `/etc/sitbank/secrets`.
+3. Install it into the appropriate root-owned environment directory:
+   `/etc/sitbank/secrets` for production or
+   `/etc/sitbank-staging/secrets` for staging.
 4. Restart through the restricted deployment/runtime command and run
    `production-check`.
 5. Revoke active sessions when rotating session-signing, Flask, CSRF, MFA
@@ -25,6 +26,11 @@ Session HMAC rotation must keep the old key in
 `session_hmac_keys_json` only for the approved overlap period, set the new
 `SESSION_HMAC_ACTIVE_KEY_ID`, then remove the previous key after all sessions
 signed by it have expired.
+
+Staging secrets must never be copied from production. The staging deployment
+wrapper rejects identical application secret files when production secrets are
+present and requires database and Redis URLs to resolve only to the staging
+Compose service names.
 
 ## Dependency Response
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -70,9 +70,16 @@ that ignore file.
 ## Deployment and Rollback
 
 Only a protected `main` workflow may produce a trusted production signature.
-The tested, scanned, signed, and deployed image digest must be identical.
-Deployment accepts only the configured GHCR repository, the protected
-workflow identity, a 40-character commit SHA, and an immutable SHA-256 digest.
+Staging may trust this repository's release workflow on a selected
+`refs/heads/*` branch, but production trusts only the exact
+`refs/heads/main` workflow identity. The tested, scanned, signed, and deployed
+image digest must be identical. Deployment accepts only the configured GHCR
+repository, environment-specific workflow identity policy, a 40-character
+commit SHA, and an immutable SHA-256 digest.
+
+Production deployment is automatic on a protected `main` push only. It must
+not run unless staging succeeded in the same workflow; disabled, skipped, or
+failed staging blocks production.
 
 Migrations must remain backward-compatible with the previous image. If
 readiness fails, the wrapper restores the previous digest and non-secret

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="google-site-verification" content="TdWqsa4Ln9t_GIYl4Devi4rrU48Z7XNSue_PiImREJs">
     <title>{% block title %}SITBank{% endblock %}</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
     <script src="{{ url_for('static', filename='js/theme.js') }}" defer></script>
@@ -205,8 +206,7 @@
       <div class="footer-inner">
         <section class="footer-brand" aria-label="Service information">
           <h2 class="footer-heading">SITBank</h2>
-          <p>Simulated online banking portal for secure account-access practice. This is not a real bank, payment service, or licensed financial institution.</p>
-          <p>Use only self-created sample accounts. Do not enter real banking credentials or financial data.</p>
+          <p>SITBank is a student cybersecurity project and demonstration site. Do not enter real banking credentials, card numbers, phone numbers, or personal financial information.</p>
         </section>
 
         <section class="footer-column" aria-label="Sitemap">

--- a/compose.staging.yml
+++ b/compose.staging.yml
@@ -1,0 +1,207 @@
+name: sitbank-staging
+
+services:
+  postgres:
+    image: postgres:16.9-alpine@sha256:7c688148e5e156d0e86df7ba8ae5a05a2386aaec1e2ad8e6d11bdf10504b1fb7
+    container_name: sitbank-staging-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: sitbank_staging
+      POSTGRES_USER: sitbank_staging
+      POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
+    secrets:
+      - postgres_password
+    volumes:
+      - sitbank-staging-postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - pg_isready --username sitbank_staging --dbname sitbank_staging
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+    networks:
+      - sitbank-staging
+    logging:
+      driver: local
+      options:
+        max-size: 10m
+        max-file: "5"
+
+  redis:
+    image: redis:7.4.5-alpine@sha256:bb186d083732f669da90be8b0f975a37812b15e913465bb14d845db72a4e3e08
+    container_name: sitbank-staging-redis
+    restart: unless-stopped
+    command:
+      - redis-server
+      - /run/secrets/redis.conf
+    secrets:
+      - source: redis_conf
+        target: redis.conf
+    volumes:
+      - sitbank-staging-redis-data:/data
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - redis-cli ping 2>&1 | grep -Eq 'PONG|NOAUTH'
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 5s
+    networks:
+      - sitbank-staging
+    logging:
+      driver: local
+      options:
+        max-size: 10m
+        max-file: "5"
+
+  app:
+    image: ${SITBANK_IMAGE:?SITBANK_IMAGE must be an immutable digest reference}
+    container_name: sitbank-staging-app
+    user: "10001:10001"
+    read_only: true
+    init: true
+    restart: unless-stopped
+    stop_grace_period: 35s
+    command:
+      - python
+      - -m
+      - gunicorn
+      - --workers
+      - "3"
+      - --bind
+      - 0.0.0.0:5000
+      - --access-logfile
+      - "-"
+      - --error-logfile
+      - "-"
+      - --timeout
+      - "30"
+      - --graceful-timeout
+      - "30"
+      - wsgi:app
+    ports:
+      - 127.0.0.1:5001:5000
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 256
+    mem_limit: 768m
+    mem_reservation: 256m
+    cpus: 1.5
+    ulimits:
+      nofile:
+        soft: 4096
+        hard: 8192
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,nodev,size=64m,uid=10001,gid=10001,mode=1770
+    env_file:
+      - /etc/sitbank-staging/container.env
+    environment:
+      SECRET_KEY_FILE: /run/secrets/secret_key
+      WTF_CSRF_SECRET_KEY_FILE: /run/secrets/wtf_csrf_secret_key
+      SESSION_HMAC_KEYS_JSON_FILE: /run/secrets/session_hmac_keys_json
+      DATABASE_URL_FILE: /run/secrets/database_url
+      REDIS_URL_FILE: /run/secrets/redis_url
+      MFA_AES256_GCM_KEY_B64_FILE: /run/secrets/mfa_aes256_gcm_key_b64
+      PASSWORD_PEPPER_B64_FILE: /run/secrets/password_pepper_b64
+    secrets:
+      - source: secret_key
+        target: secret_key
+        uid: "10001"
+        gid: "10001"
+        mode: 0400
+      - source: wtf_csrf_secret_key
+        target: wtf_csrf_secret_key
+        uid: "10001"
+        gid: "10001"
+        mode: 0400
+      - source: session_hmac_keys_json
+        target: session_hmac_keys_json
+        uid: "10001"
+        gid: "10001"
+        mode: 0400
+      - source: database_url
+        target: database_url
+        uid: "10001"
+        gid: "10001"
+        mode: 0400
+      - source: redis_url
+        target: redis_url
+        uid: "10001"
+        gid: "10001"
+        mode: 0400
+      - source: mfa_aes256_gcm_key_b64
+        target: mfa_aes256_gcm_key_b64
+        uid: "10001"
+        gid: "10001"
+        mode: 0400
+      - source: password_pepper_b64
+        target: password_pepper_b64
+        uid: "10001"
+        gid: "10001"
+        mode: 0400
+    volumes:
+      - type: bind
+        source: /etc/sitbank-staging/common-passwords.txt
+        target: /run/config/common-passwords.txt
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: /etc/sitbank-staging/fido-approved-aaguids.json
+        target: /run/config/fido-approved-aaguids.json
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: /etc/sitbank-staging/fido-mds-cache.json
+        target: /run/config/fido-mds-cache.json
+        read_only: true
+        bind:
+          create_host_path: false
+    networks:
+      - sitbank-staging
+    logging:
+      driver: local
+      options:
+        max-size: 10m
+        max-file: "5"
+
+secrets:
+  secret_key:
+    file: /etc/sitbank-staging/secrets/secret_key
+  wtf_csrf_secret_key:
+    file: /etc/sitbank-staging/secrets/wtf_csrf_secret_key
+  session_hmac_keys_json:
+    file: /etc/sitbank-staging/secrets/session_hmac_keys_json
+  database_url:
+    file: /etc/sitbank-staging/secrets/database_url
+  redis_url:
+    file: /etc/sitbank-staging/secrets/redis_url
+  mfa_aes256_gcm_key_b64:
+    file: /etc/sitbank-staging/secrets/mfa_aes256_gcm_key_b64
+  password_pepper_b64:
+    file: /etc/sitbank-staging/secrets/password_pepper_b64
+  postgres_password:
+    file: /etc/sitbank-staging/secrets/postgres_password
+  redis_conf:
+    file: /etc/sitbank-staging/secrets/redis.conf
+
+volumes:
+  sitbank-staging-postgres-data:
+    name: sitbank-staging-postgres-data
+  sitbank-staging-redis-data:
+    name: sitbank-staging-redis-data
+
+networks:
+  sitbank-staging:
+    name: sitbank-staging-network

--- a/ops/container/compose-validation.override.yml
+++ b/ops/container/compose-validation.override.yml
@@ -1,0 +1,3 @@
+services:
+  app:
+    env_file: !reset []

--- a/ops/container/validate-compose.sh
+++ b/ops/container/validate-compose.sh
@@ -1,40 +1,31 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-readonly IMAGE="${1:?Usage: validate-compose.sh IMAGE}"
+readonly IMAGE="${1:?Usage: validate-compose.sh IMAGE [production|staging|all]}"
+readonly TARGET="${2:-all}"
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
-sudo install -d -m 0755 /etc/sitbank
-sudo install -d -m 0700 /etc/sitbank/secrets
-sudo tee /etc/sitbank/container.env > /dev/null <<'EOF'
-APP_ENV=production
-COMMON_PASSWORDS_MIN_ENTRIES=100000
-COMMON_PASSWORDS_PATH=/run/config/common-passwords.txt
-HIBP_CIRCUIT_FAILURE_THRESHOLD=3
-HIBP_CIRCUIT_OPEN_SECONDS=300
-HIBP_PASSWORD_CHECK_TIMEOUT_SECONDS=2.0
-MFA_ISSUER_NAME=SITBank
-PASSWORD_PBKDF2_ITERATIONS=600000
-SESSION_HMAC_ACTIVE_KEY_ID=smoke
-TRUSTED_PROXY_COUNT=1
-WEBAUTHN_APPROVED_AAGUIDS_PATH=/run/config/fido-approved-aaguids.json
-WEBAUTHN_MDS_CACHE_PATH=/run/config/fido-mds-cache.json
-WEBAUTHN_RP_ID=sitbank.duckdns.org
-WEBAUTHN_RP_ORIGIN=https://sitbank.duckdns.org
-EOF
-for name in \
-    secret_key \
-    wtf_csrf_secret_key \
-    session_hmac_keys_json \
-    database_url \
-    redis_url \
-    mfa_aes256_gcm_key_b64 \
-    password_pepper_b64; do
-    printf '%s' 'compose-validation-placeholder' \
-        | sudo tee "/etc/sitbank/secrets/${name}" > /dev/null
-    sudo chmod 0400 "/etc/sitbank/secrets/${name}"
-done
-sudo chmod 0600 /etc/sitbank/container.env
+case "${TARGET}" in
+    production|staging|all)
+        ;;
+    *)
+        echo "Compose validation target must be production, staging, or all" >&2
+        exit 2
+        ;;
+esac
 
-sudo env SITBANK_IMAGE="${IMAGE}" \
-    docker compose --file "${repo_root}/compose.prod.yml" config --quiet
+validate_model() {
+    local project_name="$1"
+    local compose_file="$2"
+    SITBANK_IMAGE="${IMAGE}" docker compose \
+        --project-name "${project_name}" \
+        --file "${compose_file}" \
+        config --quiet --no-env-resolution --no-path-resolution
+}
+
+if [[ "${TARGET}" == "production" || "${TARGET}" == "all" ]]; then
+    validate_model sitbank "${repo_root}/compose.prod.yml"
+fi
+if [[ "${TARGET}" == "staging" || "${TARGET}" == "all" ]]; then
+    validate_model sitbank-staging "${repo_root}/compose.staging.yml"
+fi

--- a/ops/container/validate-compose.sh
+++ b/ops/container/validate-compose.sh
@@ -4,6 +4,7 @@ set -Eeuo pipefail
 readonly IMAGE="${1:?Usage: validate-compose.sh IMAGE [production|staging|all]}"
 readonly TARGET="${2:-all}"
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly VALIDATION_OVERRIDE="${repo_root}/ops/container/compose-validation.override.yml"
 
 case "${TARGET}" in
     production|staging|all)
@@ -20,6 +21,7 @@ validate_model() {
     SITBANK_IMAGE="${IMAGE}" docker compose \
         --project-name "${project_name}" \
         --file "${compose_file}" \
+        --file "${VALIDATION_OVERRIDE}" \
         config --quiet --no-env-resolution --no-path-resolution
 }
 

--- a/ops/deploy/bootstrap-container-ec2
+++ b/ops/deploy/bootstrap-container-ec2
@@ -79,7 +79,6 @@ esac
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 repository_lower="${github_repository,,}"
-github_repository_regexp="${github_repository//./[.]}"
 
 if [[ "$(dpkg --print-architecture)" != "amd64" ]]; then
     echo "This deployment is pinned to linux/amd64" >&2
@@ -183,16 +182,10 @@ install -o root -g root -m 0440 \
     "${repo_root}/ops/sudoers/sitbank-container-deploy" \
     /etc/sudoers.d/sitbank-container-deploy
 
-if [[ "${target}" == "staging" ]]; then
-    cosign_identity_setting="COSIGN_CERTIFICATE_IDENTITY_REGEXP='^https://github[.]com/${github_repository_regexp}/[.]github/workflows/ci-deploy[.]yml@refs/heads/[A-Za-z0-9._/-]+$'"
-else
-    cosign_identity_setting="COSIGN_CERTIFICATE_IDENTITY=https://github.com/${github_repository}/.github/workflows/ci-deploy.yml@refs/heads/main"
-fi
-
 cat > "${config_root}/deploy.conf" <<EOF
 GITHUB_REPOSITORY=${github_repository}
 GHCR_REPOSITORY=ghcr.io/${repository_lower}
-${cosign_identity_setting}
+COSIGN_CERTIFICATE_IDENTITY=https://github.com/${github_repository}/.github/workflows/ci-deploy.yml@refs/heads/main
 PUBLIC_HOST=${public_host}
 LEGACY_SERVICE=${legacy_service}
 LEGACY_APP_ROOT=${legacy_app_root}

--- a/ops/deploy/bootstrap-container-ec2
+++ b/ops/deploy/bootstrap-container-ec2
@@ -79,6 +79,7 @@ esac
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 repository_lower="${github_repository,,}"
+github_repository_regexp="${github_repository//./[.]}"
 
 if [[ "$(dpkg --print-architecture)" != "amd64" ]]; then
     echo "This deployment is pinned to linux/amd64" >&2
@@ -182,10 +183,16 @@ install -o root -g root -m 0440 \
     "${repo_root}/ops/sudoers/sitbank-container-deploy" \
     /etc/sudoers.d/sitbank-container-deploy
 
+if [[ "${target}" == "staging" ]]; then
+    cosign_identity_setting="COSIGN_CERTIFICATE_IDENTITY_REGEXP='^https://github[.]com/${github_repository_regexp}/[.]github/workflows/ci-deploy[.]yml@refs/heads/[A-Za-z0-9._/-]+$'"
+else
+    cosign_identity_setting="COSIGN_CERTIFICATE_IDENTITY=https://github.com/${github_repository}/.github/workflows/ci-deploy.yml@refs/heads/main"
+fi
+
 cat > "${config_root}/deploy.conf" <<EOF
 GITHUB_REPOSITORY=${github_repository}
 GHCR_REPOSITORY=ghcr.io/${repository_lower}
-COSIGN_CERTIFICATE_IDENTITY=https://github.com/${github_repository}/.github/workflows/ci-deploy.yml@refs/heads/main
+${cosign_identity_setting}
 PUBLIC_HOST=${public_host}
 LEGACY_SERVICE=${legacy_service}
 LEGACY_APP_ROOT=${legacy_app_root}

--- a/ops/deploy/bootstrap-container-ec2
+++ b/ops/deploy/bootstrap-container-ec2
@@ -12,16 +12,34 @@ if [[ "${EUID}" -ne 0 ]]; then
     exit 1
 fi
 
+target="production"
+if [[ "${1:-}" == "production" || "${1:-}" == "staging" ]]; then
+    target="$1"
+    shift
+fi
+
 github_repository="${1:-}"
-public_host="${2:-sitbank.duckdns.org}"
+public_host="${2:-}"
 legacy_service="${3:--}"
 legacy_app_root="${4:--}"
 if [[ ! "${github_repository}" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
-    echo "Usage: bootstrap-container-ec2 OWNER/REPOSITORY [PUBLIC_HOST] [LEGACY_SERVICE|-] [LEGACY_APP_ROOT|-]" >&2
+    echo "Usage: bootstrap-container-ec2 [production|staging] OWNER/REPOSITORY PUBLIC_HOST [LEGACY_SERVICE|-] [LEGACY_APP_ROOT|-]" >&2
     exit 2
+fi
+if [[ -z "${public_host}" ]]; then
+    if [[ "${target}" == "production" ]]; then
+        public_host="sitbank.duckdns.org"
+    else
+        public_host="staging-sitbank.duckdns.org"
+    fi
 fi
 if [[ ! "${public_host}" =~ ^[A-Za-z0-9.-]+$ ]]; then
     echo "PUBLIC_HOST must be a bare hostname" >&2
+    exit 2
+fi
+if [[ "${target}" == "staging" \
+    && ( "${legacy_service}" != "-" || "${legacy_app_root}" != "-" ) ]]; then
+    echo "Staging bootstrap does not accept legacy production migration inputs" >&2
     exit 2
 fi
 if [[ "${legacy_service}" != "-" \
@@ -38,6 +56,27 @@ if [[ "${legacy_app_root}" != "-" ]]; then
     fi
 fi
 
+case "${target}" in
+    production)
+        config_root="/etc/sitbank"
+        compose_dir="/opt/sitbank"
+        state_dir="/var/lib/sitbank-container"
+        backup_dir="/var/backups/sitbank"
+        compose_source="compose.prod.yml"
+        systemd_source="ops/systemd/sitbank-container.service"
+        systemd_service="sitbank-container.service"
+        ;;
+    staging)
+        config_root="/etc/sitbank-staging"
+        compose_dir="/opt/sitbank-staging"
+        state_dir="/var/lib/sitbank-staging-container"
+        backup_dir="/var/backups/sitbank-staging"
+        compose_source="compose.staging.yml"
+        systemd_source="ops/systemd/sitbank-staging-container.service"
+        systemd_service="sitbank-staging-container.service"
+        ;;
+esac
+
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 repository_lower="${github_repository,,}"
 
@@ -48,18 +87,21 @@ fi
 
 apt-get update
 apt-get install -y ca-certificates curl gnupg
-install -m 0755 -d /etc/apt/keyrings
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
-    | gpg --dearmor --yes -o /etc/apt/keyrings/docker.gpg
-chmod a+r /etc/apt/keyrings/docker.gpg
-# shellcheck disable=SC1091
-. /etc/os-release
-printf '%s\n' \
-    "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu ${VERSION_CODENAME} stable" \
-    > /etc/apt/sources.list.d/docker.list
-apt-get update
-apt-get install -y docker-ce docker-ce-cli containerd.io \
-    docker-buildx-plugin docker-compose-plugin
+if ! command -v docker >/dev/null 2>&1 \
+    || ! docker compose version >/dev/null 2>&1; then
+    install -m 0755 -d /etc/apt/keyrings
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+        | gpg --dearmor --yes -o /etc/apt/keyrings/docker.gpg
+    chmod a+r /etc/apt/keyrings/docker.gpg
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    printf '%s\n' \
+        "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu ${VERSION_CODENAME} stable" \
+        > /etc/apt/sources.list.d/docker.list
+    apt-get update
+    apt-get install -y docker-ce docker-ce-cli containerd.io \
+        docker-buildx-plugin docker-compose-plugin
+fi
 systemctl enable --now docker.service
 
 cosign_tmp="$(mktemp)"
@@ -112,13 +154,13 @@ chown "${DEPLOY_USER}:${DEPLOY_USER}" \
     "/home/${DEPLOY_USER}/.ssh/authorized_keys"
 chmod 0600 "/home/${DEPLOY_USER}/.ssh/authorized_keys"
 
-install -d -o root -g root -m 0755 /opt/sitbank
-install -d -o root -g "${CONTAINER_GID}" -m 0750 /etc/sitbank
+install -d -o root -g root -m 0755 "${compose_dir}"
+install -d -o root -g "${CONTAINER_GID}" -m 0750 "${config_root}"
 install -d -o root -g root -m 0700 \
-    /etc/sitbank/secrets /var/lib/sitbank-container /var/backups/sitbank
+    "${config_root}/secrets" "${state_dir}" "${backup_dir}"
 
 install -o root -g root -m 0644 \
-    "${repo_root}/compose.prod.yml" /opt/sitbank/compose.yml
+    "${repo_root}/${compose_source}" "${compose_dir}/compose.yml"
 install -o root -g root -m 0755 \
     "${repo_root}/ops/deploy/sitbank-container-deploy" \
     /usr/local/sbin/sitbank-container-deploy
@@ -128,17 +170,19 @@ install -o root -g root -m 0755 \
 install -o root -g root -m 0755 \
     "${repo_root}/ops/deploy/sitbank-database-cutover" \
     /usr/local/sbin/sitbank-database-cutover
-install -o root -g root -m 0600 \
-    "${repo_root}/ops/deploy/import_legacy_env.py" \
-    /opt/sitbank/import_legacy_env.py
+if [[ "${target}" == "production" ]]; then
+    install -o root -g root -m 0600 \
+        "${repo_root}/ops/deploy/import_legacy_env.py" \
+        /opt/sitbank/import_legacy_env.py
+fi
 install -o root -g root -m 0644 \
-    "${repo_root}/ops/systemd/sitbank-container.service" \
-    /etc/systemd/system/sitbank-container.service
+    "${repo_root}/${systemd_source}" \
+    "/etc/systemd/system/${systemd_service}"
 install -o root -g root -m 0440 \
     "${repo_root}/ops/sudoers/sitbank-container-deploy" \
     /etc/sudoers.d/sitbank-container-deploy
 
-cat > /etc/sitbank/deploy.conf <<EOF
+cat > "${config_root}/deploy.conf" <<EOF
 GITHUB_REPOSITORY=${github_repository}
 GHCR_REPOSITORY=ghcr.io/${repository_lower}
 COSIGN_CERTIFICATE_IDENTITY=https://github.com/${github_repository}/.github/workflows/ci-deploy.yml@refs/heads/main
@@ -146,18 +190,34 @@ PUBLIC_HOST=${public_host}
 LEGACY_SERVICE=${legacy_service}
 LEGACY_APP_ROOT=${legacy_app_root}
 EOF
-chown root:root /etc/sitbank/deploy.conf
-chmod 0644 /etc/sitbank/deploy.conf
+chown root:root "${config_root}/deploy.conf"
+chmod 0644 "${config_root}/deploy.conf"
 
 for policy_file in \
     common-passwords.txt \
     fido-approved-aaguids.json \
     fido-mds-cache.json; do
-    if [[ -f "/etc/sitbank/${policy_file}" ]]; then
-        chown root:"${CONTAINER_GID}" "/etc/sitbank/${policy_file}"
-        chmod 0640 "/etc/sitbank/${policy_file}"
+    if [[ -f "${config_root}/${policy_file}" ]]; then
+        chown root:"${CONTAINER_GID}" "${config_root}/${policy_file}"
+        chmod 0640 "${config_root}/${policy_file}"
     fi
 done
+
+if [[ "${target}" == "staging" ]]; then
+    install -d -o root -g root -m 0755 /etc/nginx/snippets
+    install -o root -g root -m 0644 \
+        "${repo_root}/ops/nginx-proxy-headers.conf" \
+        /etc/nginx/snippets/sitbank-proxy-headers.conf
+    if [[ ! -e /etc/nginx/sites-available/sitbank-staging ]]; then
+        install -o root -g root -m 0644 \
+            "${repo_root}/ops/nginx/sitbank-staging.conf" \
+            /etc/nginx/sites-available/sitbank-staging
+    fi
+    ln -sfn /etc/nginx/sites-available/sitbank-staging \
+        /etc/nginx/sites-enabled/sitbank-staging
+    nginx -t
+    systemctl reload nginx
+fi
 
 if [[ -S /var/run/docker.sock ]]; then
     chmod 0660 /var/run/docker.sock
@@ -169,7 +229,7 @@ fi
 
 visudo -cf /etc/sudoers.d/sitbank-container-deploy
 systemctl daemon-reload
-systemctl enable sitbank-container.service
+systemctl enable "${systemd_service}"
 
-echo "Docker bootstrap complete; the existing Gunicorn service was not changed."
-echo "Add a restricted SSH key for ${DEPLOY_USER}, then deploy a signed digest."
+echo "${target^} container bootstrap complete; existing production containers were not restarted."
+echo "Seed ${config_root} with unique runtime secrets and policy files before deployment."

--- a/ops/deploy/render_container_bundle.py
+++ b/ops/deploy/render_container_bundle.py
@@ -30,6 +30,43 @@ NON_SECRET_DEFAULTS = {
 
 DEPLOYMENT_PREFIXES = {"PROD", "STAGING"}
 
+DEPLOYMENT_PROFILES = {
+    "PROD": {
+        "APP_BIND_HOST": "127.0.0.1",
+        "APP_BIND_PORT": "5000",
+        "APP_CONTAINER_NAME": "sitbank-app",
+        "COMPOSE_DIR": "/opt/sitbank",
+        "COMPOSE_FILE": "/opt/sitbank/compose.yml",
+        "COMPOSE_PROJECT_NAME": "sitbank",
+        "CONFIG_ROOT": "/etc/sitbank",
+        "DEPLOYMENT_TARGET": "production",
+        "POSTGRES_CONTAINER_NAME": "none",
+        "POSTGRES_VOLUME_NAME": "none",
+        "REDIS_CONTAINER_NAME": "none",
+        "REDIS_VOLUME_NAME": "none",
+        "SECRET_ROOT": "/etc/sitbank/secrets",
+        "STATE_DIR": "/var/lib/sitbank-container",
+        "SYSTEMD_SERVICE": "sitbank-container.service",
+    },
+    "STAGING": {
+        "APP_BIND_HOST": "127.0.0.1",
+        "APP_BIND_PORT": "5001",
+        "APP_CONTAINER_NAME": "sitbank-staging-app",
+        "COMPOSE_DIR": "/opt/sitbank-staging",
+        "COMPOSE_FILE": "/opt/sitbank-staging/compose.yml",
+        "COMPOSE_PROJECT_NAME": "sitbank-staging",
+        "CONFIG_ROOT": "/etc/sitbank-staging",
+        "DEPLOYMENT_TARGET": "staging",
+        "POSTGRES_CONTAINER_NAME": "sitbank-staging-postgres",
+        "POSTGRES_VOLUME_NAME": "sitbank-staging-postgres-data",
+        "REDIS_CONTAINER_NAME": "sitbank-staging-redis",
+        "REDIS_VOLUME_NAME": "sitbank-staging-redis-data",
+        "SECRET_ROOT": "/etc/sitbank-staging/secrets",
+        "STATE_DIR": "/var/lib/sitbank-staging-container",
+        "SYSTEMD_SERVICE": "sitbank-staging-container.service",
+    },
+}
+
 
 def _value(name: str, *, default: str | None = None) -> str:
     value = os.environ.get(name, default or "")
@@ -124,6 +161,13 @@ def build_container_environment(prefix: str = "PROD") -> dict[str, str]:
     return environment
 
 
+def build_deployment_environment(prefix: str = "PROD") -> dict[str, str]:
+    _validate_prefix(prefix)
+    environment = dict(DEPLOYMENT_PROFILES[prefix])
+    environment["PUBLIC_HOST"] = _value(_prefixed(prefix, "PUBLIC_HOST"))
+    return environment
+
+
 def build_container_bundle(
     prefix: str = "PROD",
 ) -> tuple[dict[str, str], dict[str, str]]:
@@ -169,6 +213,14 @@ def write_container_bundle(
     environment_path = output_dir / "container.env"
     environment_path.write_text(environment_text, encoding="utf-8", newline="\n")
     environment_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+    deployment_text = "".join(
+        f"{name}={_quote_environment_value(name, value)}\n"
+        for name, value in sorted(build_deployment_environment(prefix).items())
+    )
+    deployment_path = output_dir / "deployment.env"
+    deployment_path.write_text(deployment_text, encoding="utf-8", newline="\n")
+    deployment_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
 
     if secrets:
         secret_dir = output_dir / "secrets"

--- a/ops/deploy/sitbank-container-deploy
+++ b/ops/deploy/sitbank-container-deploy
@@ -1,12 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-readonly DEPLOY_CONFIG="/etc/sitbank/deploy.conf"
-readonly COMPOSE_FILE="/opt/sitbank/compose.yml"
-readonly SECRET_DIR="/etc/sitbank/secrets"
-readonly CONTAINER_ENV="/etc/sitbank/container.env"
-readonly STATE_DIR="/var/lib/sitbank-container"
-readonly STATE_FILE="${STATE_DIR}/current"
 readonly DEPLOY_USER="sitbank-deploy"
 readonly INCOMING_DIR="/home/${DEPLOY_USER}/incoming"
 
@@ -14,18 +8,78 @@ if [[ "${EUID}" -ne 0 ]]; then
     echo "Deployment wrapper must run as root" >&2
     exit 1
 fi
-if [[ ! -r "${DEPLOY_CONFIG}" ]]; then
-    echo "Missing root-owned deployment configuration" >&2
+
+target="production"
+if [[ "$#" -eq 3 ]]; then
+    target="${1:-}"
+    shift
+elif [[ "$#" -ne 2 ]]; then
+    echo "Usage: sitbank-container-deploy [staging|production] COMMIT_SHA SHA256_DIGEST" >&2
+    exit 2
+fi
+
+case "${target}" in
+    production)
+        readonly DEPLOY_CONFIG="/etc/sitbank/deploy.conf"
+        readonly CONFIG_ROOT="/etc/sitbank"
+        readonly COMPOSE_DIR="/opt/sitbank"
+        readonly COMPOSE_FILE="/opt/sitbank/compose.yml"
+        readonly SECRET_DIR="/etc/sitbank/secrets"
+        readonly CONTAINER_ENV="/etc/sitbank/container.env"
+        readonly STATE_DIR="/var/lib/sitbank-container"
+        readonly STATE_FILE="${STATE_DIR}/current"
+        readonly SYSTEMD_SERVICE="sitbank-container.service"
+        readonly COMPOSE_PROJECT="sitbank"
+        readonly APP_CONTAINER="sitbank-app"
+        readonly APP_BIND_HOST="127.0.0.1"
+        readonly APP_BIND_PORT="5000"
+        readonly POSTGRES_CONTAINER="none"
+        readonly POSTGRES_VOLUME="none"
+        readonly REDIS_CONTAINER="none"
+        readonly REDIS_VOLUME="none"
+        readonly LOCK_FILE="/var/lock/sitbank-container-deploy.lock"
+        readonly INPUT_PREFIX=""
+        readonly AUDIT_TAG="sitbank-deploy"
+        readonly DATABASE_CUTOVER="/var/lib/sitbank-container/database-cutover/state"
+        ;;
+    staging)
+        readonly DEPLOY_CONFIG="/etc/sitbank-staging/deploy.conf"
+        readonly CONFIG_ROOT="/etc/sitbank-staging"
+        readonly COMPOSE_DIR="/opt/sitbank-staging"
+        readonly COMPOSE_FILE="/opt/sitbank-staging/compose.yml"
+        readonly SECRET_DIR="/etc/sitbank-staging/secrets"
+        readonly CONTAINER_ENV="/etc/sitbank-staging/container.env"
+        readonly STATE_DIR="/var/lib/sitbank-staging-container"
+        readonly STATE_FILE="${STATE_DIR}/current"
+        readonly SYSTEMD_SERVICE="sitbank-staging-container.service"
+        readonly COMPOSE_PROJECT="sitbank-staging"
+        readonly APP_CONTAINER="sitbank-staging-app"
+        readonly APP_BIND_HOST="127.0.0.1"
+        readonly APP_BIND_PORT="5001"
+        readonly POSTGRES_CONTAINER="sitbank-staging-postgres"
+        readonly POSTGRES_VOLUME="sitbank-staging-postgres-data"
+        readonly REDIS_CONTAINER="sitbank-staging-redis"
+        readonly REDIS_VOLUME="sitbank-staging-redis-data"
+        readonly LOCK_FILE="/var/lock/sitbank-staging-container-deploy.lock"
+        readonly INPUT_PREFIX="staging-"
+        readonly AUDIT_TAG="sitbank-staging-deploy"
+        readonly DATABASE_CUTOVER=""
+        ;;
+    *)
+        echo "Deployment target must be staging or production" >&2
+        exit 2
+        ;;
+esac
+
+if [[ ! -f "${DEPLOY_CONFIG}" || -L "${DEPLOY_CONFIG}" \
+    || "$(stat -c '%U' -- "${DEPLOY_CONFIG}")" != "root" ]]; then
+    echo "Missing trusted root-owned deployment configuration" >&2
     exit 1
 fi
 
 # shellcheck disable=SC1090
 source "${DEPLOY_CONFIG}"
 
-if [[ "$#" -ne 2 ]]; then
-    echo "Usage: sitbank-container-deploy COMMIT_SHA SHA256_DIGEST" >&2
-    exit 2
-fi
 release_sha="${1:-}"
 image_digest="${2:-}"
 if [[ ! "${release_sha}" =~ ^[0-9a-f]{40}$ ]]; then
@@ -46,14 +100,15 @@ if [[ ! "${PUBLIC_HOST}" =~ ^[A-Za-z0-9.-]+$ ]]; then
 fi
 
 readonly image="${GHCR_REPOSITORY}@${image_digest}"
-readonly credential_path="${INCOMING_DIR}/registry-${release_sha}.credentials"
-readonly bundle_path="${INCOMING_DIR}/runtime-${release_sha}.tar"
-readonly checksum_path="${INCOMING_DIR}/runtime-${release_sha}.sha256"
-readonly signature_path="${INCOMING_DIR}/runtime-${release_sha}.sigstore.json"
+readonly input_stem="${INPUT_PREFIX}${release_sha}"
+readonly credential_path="${INCOMING_DIR}/registry-${input_stem}.credentials"
+readonly bundle_path="${INCOMING_DIR}/runtime-${input_stem}.tar"
+readonly checksum_path="${INCOMING_DIR}/runtime-${input_stem}.sha256"
+readonly signature_path="${INCOMING_DIR}/runtime-${input_stem}.sigstore.json"
 
-exec 9>/var/lock/sitbank-container-deploy.lock
+exec 9>"${LOCK_FILE}"
 if ! flock -n 9; then
-    echo "Another deployment is already running" >&2
+    echo "Another ${target} deployment is already running" >&2
     exit 1
 fi
 
@@ -63,6 +118,7 @@ runtime_backup="$(mktemp -d "${STATE_DIR}/runtime-backup.XXXXXX")"
 runtime_replaced=0
 service_switched=0
 legacy_was_active=0
+dependencies_prepared=0
 previous_image=""
 if [[ -r "${STATE_FILE}" ]]; then
     previous_image="$(awk -F= '$1 == "IMAGE" { print $2 }' "${STATE_FILE}")"
@@ -78,7 +134,7 @@ cleanup() {
 }
 
 audit_log() {
-    logger --tag sitbank-deploy -- "$1" || true
+    logger --tag "${AUDIT_TAG}" -- "$1" || true
 }
 
 validate_input_file() {
@@ -107,6 +163,37 @@ restore_runtime() {
     fi
 }
 
+validate_deployment_profile() {
+    local deployment_file="$1"
+    local expected
+    expected="$(
+        cat <<EOF
+APP_BIND_HOST='${APP_BIND_HOST}'
+APP_BIND_PORT='${APP_BIND_PORT}'
+APP_CONTAINER_NAME='${APP_CONTAINER}'
+COMPOSE_DIR='${COMPOSE_DIR}'
+COMPOSE_FILE='${COMPOSE_FILE}'
+COMPOSE_PROJECT_NAME='${COMPOSE_PROJECT}'
+CONFIG_ROOT='${CONFIG_ROOT}'
+DEPLOYMENT_TARGET='${target}'
+POSTGRES_CONTAINER_NAME='${POSTGRES_CONTAINER}'
+POSTGRES_VOLUME_NAME='${POSTGRES_VOLUME}'
+PUBLIC_HOST='${PUBLIC_HOST}'
+REDIS_CONTAINER_NAME='${REDIS_CONTAINER}'
+REDIS_VOLUME_NAME='${REDIS_VOLUME}'
+SECRET_ROOT='${SECRET_DIR}'
+STATE_DIR='${STATE_DIR}'
+SYSTEMD_SERVICE='${SYSTEMD_SERVICE}'
+EOF
+    )"
+    if ! diff -u \
+        <(printf '%s\n' "${expected}" | sort) \
+        <(sort "${deployment_file}") >/dev/null; then
+        echo "Signed runtime deployment profile does not match ${target}" >&2
+        exit 1
+    fi
+}
+
 install_runtime_bundle() {
     if [[ ! -e "${bundle_path}" \
         && ! -e "${checksum_path}" \
@@ -127,7 +214,7 @@ install_runtime_bundle() {
     fi
     expected_checksum="$(awk 'NR == 1 { print $1 }' "${checksum_path}")"
     expected_filename="$(awk 'NR == 1 { print $2 }' "${checksum_path}")"
-    actual_checksum="$(sha256sum "${bundle_path}" | awk '{ print $1 }')"
+    actual_checksum="$(sha256sum "${bundle_path}" | awk '{ print $1}')"
     if [[ ! "${expected_checksum}" =~ ^[0-9a-f]{64}$ \
         || "${expected_filename}" != "$(basename "${bundle_path}")" \
         || "${actual_checksum}" != "${expected_checksum}" ]]; then
@@ -149,7 +236,7 @@ install_runtime_bundle() {
         exit 1
     fi
 
-    local required=(container.env)
+    local required=(container.env deployment.env)
     local relative_path
     for relative_path in "${required[@]}"; do
         if [[ ! -s "${staging_dir}/${relative_path}" ]]; then
@@ -188,6 +275,14 @@ install_runtime_bundle() {
         echo "Runtime environment contains missing or unsupported settings" >&2
         exit 1
     fi
+    if ! grep -Fqx "WEBAUTHN_RP_ID='${PUBLIC_HOST}'" \
+        "${staging_dir}/container.env" \
+        || ! grep -Fqx "WEBAUTHN_RP_ORIGIN='https://${PUBLIC_HOST}'" \
+            "${staging_dir}/container.env"; then
+        echo "Runtime WebAuthn host does not match the deployment target" >&2
+        exit 1
+    fi
+    validate_deployment_profile "${staging_dir}/deployment.env"
 
     backup_runtime
     install -o root -g root -m 0600 \
@@ -199,10 +294,13 @@ compose() {
     local selected_image="$1"
     shift
     SITBANK_IMAGE="${selected_image}" docker compose \
-        --project-name sitbank --file "${COMPOSE_FILE}" "$@"
+        --project-name "${COMPOSE_PROJECT}" --file "${COMPOSE_FILE}" "$@"
 }
 
 validate_legacy_configuration() {
+    if [[ "${target}" != "production" ]]; then
+        return
+    fi
     if [[ "${LEGACY_SERVICE:-"-"}" != "-" \
         && ! "${LEGACY_SERVICE}" =~ ^[A-Za-z0-9_.@-]+\.service$ ]]; then
         echo "Configured legacy service name is invalid" >&2
@@ -222,6 +320,9 @@ remove_legacy_runtime() {
     local fragment_path=""
     local resolved_root=""
 
+    if [[ "${target}" != "production" ]]; then
+        return
+    fi
     if [[ "${LEGACY_SERVICE:-"-"}" != "-" ]]; then
         systemctl disable --now "${LEGACY_SERVICE}" >/dev/null 2>&1 || true
         fragment_path="$(
@@ -246,11 +347,86 @@ remove_legacy_runtime() {
     fi
 }
 
+validate_staging_isolation() {
+    local secret_file
+    local production_secret
+    if [[ "${target}" != "staging" ]]; then
+        return
+    fi
+    for secret_file in \
+        secret_key \
+        wtf_csrf_secret_key \
+        session_hmac_keys_json \
+        database_url \
+        redis_url \
+        mfa_aes256_gcm_key_b64 \
+        password_pepper_b64; do
+        production_secret="/etc/sitbank/secrets/${secret_file}"
+        if [[ -r "${production_secret}" ]] \
+            && cmp -s "${SECRET_DIR}/${secret_file}" "${production_secret}"; then
+            echo "Staging secret must not reuse the production ${secret_file}" >&2
+            exit 1
+        fi
+    done
+
+    python3 - \
+        "${SECRET_DIR}/database_url" \
+        "${SECRET_DIR}/postgres_password" \
+        "${SECRET_DIR}/redis_url" \
+        "${SECRET_DIR}/redis.conf" <<'PY'
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+import sys
+
+database_url = Path(sys.argv[1]).read_text(encoding="utf-8")
+postgres_password = Path(sys.argv[2]).read_text(encoding="utf-8")
+redis_url = Path(sys.argv[3]).read_text(encoding="utf-8")
+redis_config = Path(sys.argv[4]).read_text(encoding="utf-8")
+
+database = urlsplit(database_url)
+if (
+    database.scheme != "postgresql+psycopg2"
+    or database.hostname != "postgres"
+    or database.port != 5432
+    or unquote(database.username or "") != "sitbank_staging"
+    or database.path != "/sitbank_staging"
+    or unquote(database.password or "") != postgres_password
+):
+    raise SystemExit("Staging database URL must target only the staging PostgreSQL service")
+
+redis = urlsplit(redis_url)
+if (
+    redis.scheme != "redis"
+    or redis.hostname != "redis"
+    or redis.port != 6379
+    or redis.path not in {"", "/", "/0"}
+):
+    raise SystemExit("Staging Redis URL must target only the staging Redis service")
+
+password_lines = [
+    line.split(None, 1)[1]
+    for line in redis_config.splitlines()
+    if line.strip() and not line.lstrip().startswith("#")
+    and line.split(None, 1)[0].casefold() == "requirepass"
+]
+if len(password_lines) != 1 or unquote(redis.password or "") != password_lines[0]:
+    raise SystemExit("Staging Redis URL and protected Redis configuration do not match")
+PY
+}
+
+prepare_dependencies() {
+    if [[ "${target}" == "staging" ]]; then
+        compose "${image}" up --detach --pull always --wait postgres redis
+        dependencies_prepared=1
+    fi
+}
+
 wait_until_ready() {
     curl --fail --silent --show-error \
         --retry 15 --retry-delay 2 --retry-connrefused \
+        --header "Host: ${PUBLIC_HOST}" \
         --header "X-Forwarded-Proto: https" \
-        "http://127.0.0.1:5000/health/ready" >/dev/null
+        "http://${APP_BIND_HOST}:${APP_BIND_PORT}/health/ready" >/dev/null
     curl --fail --silent --show-error \
         --retry 8 --retry-delay 2 --retry-connrefused \
         --resolve "${PUBLIC_HOST}:443:127.0.0.1" \
@@ -264,11 +440,15 @@ rollback() {
     set +e
     if [[ "${service_switched}" -eq 1 ]]; then
         compose "${image}" down --remove-orphans
+    elif [[ "${target}" == "staging" \
+        && "${dependencies_prepared}" -eq 1 \
+        && -z "${previous_image}" ]]; then
+        compose "${image}" down --remove-orphans
     fi
     if [[ "${runtime_replaced}" -eq 1 ]]; then
         restore_runtime
     fi
-    if [[ -r "${STATE_DIR}/database-cutover/state" ]]; then
+    if [[ -n "${DATABASE_CUTOVER}" && -r "${DATABASE_CUTOVER}" ]]; then
         if ! /usr/local/sbin/sitbank-database-cutover rollback; then
             database_rollback_ok=0
             echo "Database rollback requires administrator intervention" >&2
@@ -283,15 +463,15 @@ rollback() {
         systemctl enable "${LEGACY_SERVICE}" >/dev/null 2>&1
         systemctl start "${LEGACY_SERVICE}"
     fi
-    audit_log "result=failure revision=${release_sha} digest=${image_digest}"
-    echo "Deployment failed; the previous application runtime was restored" >&2
+    audit_log "environment=${target} result=failure revision=${release_sha} digest=${image_digest}"
+    echo "Deployment failed; the previous ${target} runtime was restored" >&2
     exit "${exit_code}"
 }
 
 trap cleanup EXIT
 trap rollback ERR
 
-audit_log "result=started revision=${release_sha} digest=${image_digest}"
+audit_log "environment=${target} result=started revision=${release_sha} digest=${image_digest}"
 validate_legacy_configuration
 if ss -lnt | grep -Eq ':(2375|2376)\b'; then
     echo "Docker API must not be exposed over TCP" >&2
@@ -335,35 +515,43 @@ if [[ "${image_revision}" != "${release_sha}" ]]; then
 fi
 
 for host_file in \
-    /etc/sitbank/common-passwords.txt \
-    /etc/sitbank/fido-approved-aaguids.json \
-    /etc/sitbank/fido-mds-cache.json; do
+    "${CONFIG_ROOT}/common-passwords.txt" \
+    "${CONFIG_ROOT}/fido-approved-aaguids.json" \
+    "${CONFIG_ROOT}/fido-mds-cache.json"; do
     if [[ ! -r "${host_file}" || -L "${host_file}" ]]; then
         echo "Missing required root-managed policy file: ${host_file}" >&2
         exit 1
     fi
 done
-for secret_file in \
-    secret_key \
-    wtf_csrf_secret_key \
-    session_hmac_keys_json \
-    database_url \
-    redis_url \
-    mfa_aes256_gcm_key_b64 \
-    password_pepper_b64; do
+required_secrets=(
+    secret_key
+    wtf_csrf_secret_key
+    session_hmac_keys_json
+    database_url
+    redis_url
+    mfa_aes256_gcm_key_b64
+    password_pepper_b64
+)
+if [[ "${target}" == "staging" ]]; then
+    required_secrets+=(postgres_password redis.conf)
+fi
+for secret_file in "${required_secrets[@]}"; do
     if [[ ! -r "${SECRET_DIR}/${secret_file}" \
         || -L "${SECRET_DIR}/${secret_file}" ]]; then
         echo "Missing required root-managed secret file: ${secret_file}" >&2
         exit 1
     fi
 done
+validate_staging_isolation
+prepare_dependencies
 
 compose "${image}" run --rm --no-deps app \
     python -m flask --app wsgi:app production-check
 compose "${image}" run --rm --no-deps app \
     python -m flask --app wsgi:app db upgrade
 
-if [[ "${LEGACY_SERVICE:-"-"}" != "-" ]] \
+if [[ "${target}" == "production" \
+    && "${LEGACY_SERVICE:-"-"}" != "-" ]] \
     && systemctl is-active --quiet "${LEGACY_SERVICE}"; then
     legacy_was_active=1
 fi
@@ -393,19 +581,19 @@ printf 'IMAGE=%s\nREVISION=%s\nDEPLOYED_AT=%s\n' \
     > "${STATE_FILE}"
 chmod 0600 "${STATE_FILE}"
 
-systemctl enable sitbank-container.service >/dev/null
-systemctl start sitbank-container.service
+systemctl enable "${SYSTEMD_SERVICE}" >/dev/null
+systemctl start "${SYSTEMD_SERVICE}"
 service_switched=0
 runtime_replaced=0
 trap - ERR
 if ! remove_legacy_runtime; then
     echo "Warning: SITBank is healthy, but the former application files require manual cleanup" >&2
 fi
-if [[ -r "${STATE_DIR}/database-cutover/state" ]]; then
+if [[ -n "${DATABASE_CUTOVER}" && -r "${DATABASE_CUTOVER}" ]]; then
     if ! /usr/local/sbin/sitbank-database-cutover finalize; then
         echo "Warning: SITBank is healthy, but the former database role still requires manual cleanup" >&2
     fi
 fi
 
-audit_log "result=success revision=${release_sha} digest=${image_digest}"
-echo "Deployed ${release_sha} as ${image}"
+audit_log "environment=${target} result=success revision=${release_sha} digest=${image_digest}"
+echo "Deployed ${release_sha} to ${target} as ${image}"

--- a/ops/deploy/sitbank-container-deploy
+++ b/ops/deploy/sitbank-container-deploy
@@ -103,27 +103,10 @@ if [[ ! "${PUBLIC_HOST}" =~ ^[A-Za-z0-9.-]+$ ]]; then
     exit 1
 fi
 
-if [[ "${target}" == "staging" ]]; then
-    github_repository_regexp="${GITHUB_REPOSITORY//./[.]}"
-    expected_identity_regexp="^https://github[.]com/${github_repository_regexp}/[.]github/workflows/ci-deploy[.]yml@refs/heads/[A-Za-z0-9._/-]+$"
-    if [[ "${COSIGN_CERTIFICATE_IDENTITY_REGEXP:-}" != "${expected_identity_regexp}" ]]; then
-        echo "Invalid configured staging Cosign workflow identity" >&2
-        exit 1
-    fi
-    cosign_identity_args=(
-        --certificate-identity-regexp
-        "${COSIGN_CERTIFICATE_IDENTITY_REGEXP}"
-    )
-else
-    expected_identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/ci-deploy.yml@refs/heads/main"
-    if [[ "${COSIGN_CERTIFICATE_IDENTITY:-}" != "${expected_identity}" ]]; then
-        echo "Invalid configured production Cosign workflow identity" >&2
-        exit 1
-    fi
-    cosign_identity_args=(
-        --certificate-identity
-        "${COSIGN_CERTIFICATE_IDENTITY}"
-    )
+expected_identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/ci-deploy.yml@refs/heads/main"
+if [[ "${COSIGN_CERTIFICATE_IDENTITY:-}" != "${expected_identity}" ]]; then
+    echo "Invalid configured Cosign workflow identity" >&2
+    exit 1
 fi
 
 readonly image="${GHCR_REPOSITORY}@${image_digest}"
@@ -232,7 +215,7 @@ install_runtime_bundle() {
     validate_input_file "${signature_path}"
     cosign verify-blob \
         --bundle "${signature_path}" \
-        "${cosign_identity_args[@]}" \
+        --certificate-identity "${COSIGN_CERTIFICATE_IDENTITY}" \
         --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
         "${bundle_path}" >/dev/null
     if [[ "$(wc -l < "${checksum_path}")" -ne 1 ]]; then
@@ -526,7 +509,7 @@ printf '%s' "${registry_token}" | docker login ghcr.io \
 unset registry_token
 
 cosign verify \
-    "${cosign_identity_args[@]}" \
+    --certificate-identity "${COSIGN_CERTIFICATE_IDENTITY}" \
     --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
     "${image}" >/dev/null
 docker pull "${image}" >/dev/null

--- a/ops/deploy/sitbank-container-deploy
+++ b/ops/deploy/sitbank-container-deploy
@@ -94,9 +94,36 @@ if [[ ! "${GHCR_REPOSITORY}" =~ ^ghcr\.io/[a-z0-9._-]+/[a-z0-9._-]+$ ]]; then
     echo "Invalid configured GHCR repository" >&2
     exit 1
 fi
+if [[ ! "${GITHUB_REPOSITORY}" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+    echo "Invalid configured GitHub repository" >&2
+    exit 1
+fi
 if [[ ! "${PUBLIC_HOST}" =~ ^[A-Za-z0-9.-]+$ ]]; then
     echo "Invalid configured public host" >&2
     exit 1
+fi
+
+if [[ "${target}" == "staging" ]]; then
+    github_repository_regexp="${GITHUB_REPOSITORY//./[.]}"
+    expected_identity_regexp="^https://github[.]com/${github_repository_regexp}/[.]github/workflows/ci-deploy[.]yml@refs/heads/[A-Za-z0-9._/-]+$"
+    if [[ "${COSIGN_CERTIFICATE_IDENTITY_REGEXP:-}" != "${expected_identity_regexp}" ]]; then
+        echo "Invalid configured staging Cosign workflow identity" >&2
+        exit 1
+    fi
+    cosign_identity_args=(
+        --certificate-identity-regexp
+        "${COSIGN_CERTIFICATE_IDENTITY_REGEXP}"
+    )
+else
+    expected_identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/ci-deploy.yml@refs/heads/main"
+    if [[ "${COSIGN_CERTIFICATE_IDENTITY:-}" != "${expected_identity}" ]]; then
+        echo "Invalid configured production Cosign workflow identity" >&2
+        exit 1
+    fi
+    cosign_identity_args=(
+        --certificate-identity
+        "${COSIGN_CERTIFICATE_IDENTITY}"
+    )
 fi
 
 readonly image="${GHCR_REPOSITORY}@${image_digest}"
@@ -205,7 +232,7 @@ install_runtime_bundle() {
     validate_input_file "${signature_path}"
     cosign verify-blob \
         --bundle "${signature_path}" \
-        --certificate-identity "${COSIGN_CERTIFICATE_IDENTITY}" \
+        "${cosign_identity_args[@]}" \
         --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
         "${bundle_path}" >/dev/null
     if [[ "$(wc -l < "${checksum_path}")" -ne 1 ]]; then
@@ -499,7 +526,7 @@ printf '%s' "${registry_token}" | docker login ghcr.io \
 unset registry_token
 
 cosign verify \
-    --certificate-identity "${COSIGN_CERTIFICATE_IDENTITY}" \
+    "${cosign_identity_args[@]}" \
     --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
     "${image}" >/dev/null
 docker pull "${image}" >/dev/null

--- a/ops/deploy/sitbank-container-runtime
+++ b/ops/deploy/sitbank-container-runtime
@@ -1,20 +1,41 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-readonly DEPLOY_CONFIG="/etc/sitbank/deploy.conf"
-readonly COMPOSE_FILE="/opt/sitbank/compose.yml"
-readonly STATE_FILE="/var/lib/sitbank-container/current"
-
 if [[ "${EUID}" -ne 0 ]]; then
     echo "Container runtime helper must run as root" >&2
     exit 1
 fi
-if [[ "$#" -ne 1 ]]; then
-    echo "Usage: sitbank-container-runtime up|down" >&2
+
+target="production"
+if [[ "$#" -eq 2 ]]; then
+    target="${1:-}"
+    shift
+elif [[ "$#" -ne 1 ]]; then
+    echo "Usage: sitbank-container-runtime [staging|production] up|down" >&2
     exit 2
 fi
+
+case "${target}" in
+    production)
+        readonly DEPLOY_CONFIG="/etc/sitbank/deploy.conf"
+        readonly COMPOSE_FILE="/opt/sitbank/compose.yml"
+        readonly STATE_FILE="/var/lib/sitbank-container/current"
+        readonly COMPOSE_PROJECT="sitbank"
+        ;;
+    staging)
+        readonly DEPLOY_CONFIG="/etc/sitbank-staging/deploy.conf"
+        readonly COMPOSE_FILE="/opt/sitbank-staging/compose.yml"
+        readonly STATE_FILE="/var/lib/sitbank-staging-container/current"
+        readonly COMPOSE_PROJECT="sitbank-staging"
+        ;;
+    *)
+        echo "Runtime target must be staging or production" >&2
+        exit 2
+        ;;
+esac
+
 if [[ ! -r "${DEPLOY_CONFIG}" || ! -r "${STATE_FILE}" ]]; then
-    echo "Container deployment state is not initialized" >&2
+    echo "${target} container deployment state is not initialized" >&2
     exit 1
 fi
 
@@ -30,15 +51,16 @@ export SITBANK_IMAGE="${image}"
 
 case "${1:-}" in
     up)
-        exec docker compose --project-name sitbank --file "${COMPOSE_FILE}" \
+        exec docker compose --project-name "${COMPOSE_PROJECT}" \
+            --file "${COMPOSE_FILE}" \
             up --detach --no-build --pull never --remove-orphans
         ;;
     down)
-        exec docker compose --project-name sitbank --file "${COMPOSE_FILE}" \
-            down --remove-orphans
+        exec docker compose --project-name "${COMPOSE_PROJECT}" \
+            --file "${COMPOSE_FILE}" down --remove-orphans
         ;;
     *)
-        echo "Usage: sitbank-container-runtime up|down" >&2
+        echo "Usage: sitbank-container-runtime [staging|production] up|down" >&2
         exit 2
         ;;
 esac

--- a/ops/nginx/sitbank-staging.conf
+++ b/ops/nginx/sitbank-staging.conf
@@ -1,0 +1,10 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name staging-sitbank.duckdns.org;
+
+    location / {
+        proxy_pass http://127.0.0.1:5001;
+        include /etc/nginx/snippets/sitbank-proxy-headers.conf;
+    }
+}

--- a/ops/systemd/sitbank-staging-container.service
+++ b/ops/systemd/sitbank-staging-container.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=SITBank staging Docker Compose application
+Requires=docker.service
+After=docker.service network-online.target
+Wants=network-online.target
+ConditionPathExists=/var/lib/sitbank-staging-container/current
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+Environment=HOME=/tmp
+ExecStart=/usr/local/sbin/sitbank-container-runtime staging up
+ExecStop=/usr/local/sbin/sitbank-container-runtime staging down
+TimeoutStartSec=180
+TimeoutStopSec=90
+
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ReadWritePaths=/run/docker.sock
+
+[Install]
+WantedBy=multi-user.target
+

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -419,6 +419,7 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     ).read_text(encoding="utf-8")
 
     assert set(workflow["jobs"]) == {
+        "resolve-source",
         "workflow-security",
         "dependency-review",
         "test",
@@ -444,6 +445,44 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
         assert "github.event_name == 'push'" in condition
         assert "github.event_name == 'workflow_dispatch'" in condition
         assert "inputs.target_environment == 'staging'" in condition
+    source_job = workflow["jobs"]["resolve-source"]
+    source_step = next(
+        step
+        for step in source_job["steps"]
+        if step["name"] == "Resolve candidate source to an immutable commit"
+    )
+    assert source_job["permissions"] == {"contents": "read"}
+    assert source_job["outputs"]["source_sha"] == (
+        "${{ steps.resolve.outputs.source_sha }}"
+    )
+    assert source_step["env"]["SOURCE_REF_INPUT"] == "${{ inputs.source_ref }}"
+    assert "git rev-parse --verify" in source_step["run"]
+    assert "refs/remotes/origin/" in source_step["run"]
+    assert "refs/tags/" in source_step["run"]
+    assert "source_ref_display" in source_step["run"]
+    assert "refs/heads/main" in source_step["run"]
+    dispatch_inputs = workflow[True]["workflow_dispatch"]["inputs"]
+    assert dispatch_inputs["source_ref"]["required"] is True
+    assert dispatch_inputs["source_ref"]["type"] == "string"
+    assert dispatch_inputs["target_environment"]["options"] == ["staging"]
+    candidate_jobs = ("test", "publish")
+    for job_name in candidate_jobs:
+        checkout = next(
+            step
+            for step in workflow["jobs"][job_name]["steps"]
+            if step["name"] == "Check out repository"
+        )
+        assert checkout["with"]["ref"] == (
+            "${{ needs.resolve-source.outputs.source_sha }}"
+        )
+    trusted_jobs = ("release-verify", "deploy-staging", "deploy-production")
+    for job_name in trusted_jobs:
+        checkout = next(
+            step
+            for step in workflow["jobs"][job_name]["steps"]
+            if step["name"] == "Check out repository"
+        )
+        assert checkout["with"]["ref"] == "${{ github.workflow_sha }}"
     assert workflow["jobs"]["release-verify"]["needs"] == "publish"
     release_verify_steps = [
         step["name"] for step in workflow["jobs"]["release-verify"]["steps"]
@@ -468,6 +507,10 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     assert release_smoke_step["env"]["RUN_ZAP_DAST"] == (
         "${{ github.event_name != 'workflow_dispatch' || inputs.run_dast == true }}"
     )
+    assert (
+        release_image_step["env"]["RELEASE_SHA"]
+        == "${{ needs.publish.outputs.revision }}"
+    )
     assert workflow["jobs"]["deploy-staging"]["permissions"]["packages"] == "read"
     assert workflow["jobs"]["deploy-staging"]["permissions"]["id-token"] == "write"
     assert workflow["jobs"]["deploy-production"]["permissions"]["packages"] == "read"
@@ -479,6 +522,7 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     assert "github.event_name == 'push'" in staging_condition
     assert "github.ref == 'refs/heads/main'" in staging_condition
     assert "github.event_name == 'workflow_dispatch'" in staging_condition
+    assert "github.ref == 'refs/heads/main'" in staging_condition
     assert "inputs.target_environment == 'staging'" in staging_condition
     assert "inputs.deploy == true" in staging_condition
     assert "vars.STAGING_DEPLOY_ENABLED == 'true'" in staging_condition
@@ -491,8 +535,6 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     assert "needs.deploy-staging.result == 'success'" in production_condition
     assert "vars.STAGING_DEPLOY_ENABLED != 'true'" not in production_condition
     assert "inputs.deploy == true" not in production_condition
-    dispatch_inputs = workflow[True]["workflow_dispatch"]["inputs"]
-    assert dispatch_inputs["target_environment"]["options"] == ["staging"]
     assert (
         workflow["jobs"]["deploy-staging"]["env"]["IMAGE_DIGEST"]
         == "${{ needs.release-verify.outputs.digest }}"
@@ -505,6 +547,7 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
         "test",
         "workflow-security",
         "deployment-preflight",
+        "resolve-source",
     ]
     assert (
         workflow["jobs"]["image-test"]["if"]
@@ -556,12 +599,12 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     assert "check_dependency_locks.py" in workflow_text
     assert "IMAGE_DIGEST" in workflow_text
     assert "StrictHostKeyChecking=no" not in workflow_text
-    assert workflow_text.count("persist-credentials: false") == 8
+    assert workflow_text.count("persist-credentials: false") == 9
     assert (
         workflow_text.count(
             "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10"
         )
-        == 8
+        == 9
     )
     assert (
         "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405"
@@ -569,6 +612,15 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     )
     assert "sitbank:pr" in workflow_text
     assert "SITBANK_IMAGE" in workflow_text
+    assert "source_ref" in workflow_text
+    assert "source_sha" in workflow_text
+    assert "VCS_REF=${{ needs.resolve-source.outputs.source_sha }}" in workflow_text
+    assert "RELEASE_SHA: ${{ needs.publish.outputs.revision }}" in workflow_text
+    assert workflow_text.count("ref: ${{ github.workflow_sha }}") == 4
+    assert workflow_text.count(
+        "ref: ${{ needs.resolve-source.outputs.source_sha }}"
+    ) == 2
+    assert "RELEASE_SHA: ${{ github.sha }}" not in workflow_text
     assert "SITBANK_SECRET_KEY" not in workflow_text
     assert "STAGING_SECRET_KEY" not in workflow_text
     assert "STAGING_DATABASE_URL" not in workflow_text
@@ -590,16 +642,9 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     )
     assert "sha256:[0-9a-f]{64}" in deploy_script
     assert "COSIGN_CERTIFICATE_IDENTITY" in deploy_script
-    assert "COSIGN_CERTIFICATE_IDENTITY_REGEXP" in deploy_script
-    assert "--certificate-identity-regexp" in deploy_script
-    assert (
-        "ci-deploy[.]yml@refs/heads/[A-Za-z0-9._/-]+$"
-        in deploy_script
-    )
-    assert (
-        "ci-deploy.yml@refs/heads/main"
-        in deploy_script
-    )
+    assert "COSIGN_CERTIFICATE_IDENTITY_REGEXP" not in deploy_script
+    assert "--certificate-identity-regexp" not in deploy_script
+    assert "ci-deploy.yml@refs/heads/main" in deploy_script
     assert "org.opencontainers.image.revision" in deploy_script
     assert "production-check" in deploy_script
     assert "db upgrade" in deploy_script
@@ -626,11 +671,7 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     assert "gpasswd --delete" in bootstrap
     assert "docker.sock" in bootstrap
     assert "COSIGN_SHA256" in bootstrap
-    assert "COSIGN_CERTIFICATE_IDENTITY_REGEXP" in bootstrap
-    assert (
-        "ci-deploy[.]yml@refs/heads/[A-Za-z0-9._/-]+$"
-        in bootstrap
-    )
+    assert "COSIGN_CERTIFICATE_IDENTITY_REGEXP" not in bootstrap
     assert "ci-deploy.yml@refs/heads/main" in bootstrap
     assert "/opt/sitbank" in bootstrap
     assert "/etc/sitbank" in bootstrap
@@ -644,10 +685,14 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
 
     readme = Path("README.md").read_text(encoding="utf-8")
     assert "Manual pre-merge staging:" in readme
-    assert "trusted branch -> workflow_dispatch -> publish -> release-verify -> staging" in readme
+    assert "run trusted workflow from main" in readme
+    assert "source_ref = candidate branch, tag, or SHA" in readme
+    assert "resolve immutable source_sha" in readme
+    assert "deploy staging using trusted main scripts" in readme
     assert "main push -> publish -> release-verify -> staging -> production" in readme
     assert "Manual production deployment is disabled." in readme
     assert "Production never skips disabled, skipped, or failed staging." in readme
+    assert "Feature-branch workflow and deployment scripts" in readme
 
 
 def test_trivy_exception_is_narrow_documented_and_temporary():

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -441,7 +441,9 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     for condition in (publish_condition, release_verify_condition):
         assert "github.event_name != 'pull_request'" in condition
         assert "github.ref == 'refs/heads/main'" in condition
-    assert "github.event_name == 'workflow_dispatch'" in publish_condition
+        assert "github.event_name == 'push'" in condition
+        assert "github.event_name == 'workflow_dispatch'" in condition
+        assert "inputs.target_environment == 'staging'" in condition
     assert workflow["jobs"]["release-verify"]["needs"] == "publish"
     release_verify_steps = [
         step["name"] for step in workflow["jobs"]["release-verify"]["steps"]
@@ -449,10 +451,56 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     assert release_verify_steps.index("Log in to GHCR") < release_verify_steps.index(
         "Sign and verify the tested immutable digest"
     )
+    release_image_step = next(
+        step
+        for step in workflow["jobs"]["release-verify"]["steps"]
+        if step["name"] == "Resolve verified image reference"
+    )
+    assert (
+        release_image_step["env"]["IMAGE_DIGEST"]
+        == "${{ needs.publish.outputs.digest }}"
+    )
+    release_smoke_step = next(
+        step
+        for step in workflow["jobs"]["release-verify"]["steps"]
+        if step["name"] == "Smoke-test and DAST-scan the exact published digest"
+    )
+    assert release_smoke_step["env"]["RUN_ZAP_DAST"] == (
+        "${{ github.event_name != 'workflow_dispatch' || inputs.run_dast == true }}"
+    )
     assert workflow["jobs"]["deploy-staging"]["permissions"]["packages"] == "read"
     assert workflow["jobs"]["deploy-staging"]["permissions"]["id-token"] == "write"
     assert workflow["jobs"]["deploy-production"]["permissions"]["packages"] == "read"
     assert workflow["jobs"]["deploy-production"]["permissions"]["id-token"] == "write"
+    staging_condition = workflow["jobs"]["deploy-staging"]["if"]
+    production_condition = workflow["jobs"]["deploy-production"]["if"]
+    assert "github.event_name != 'pull_request'" in staging_condition
+    assert "needs.release-verify.result == 'success'" in staging_condition
+    assert "github.event_name == 'push'" in staging_condition
+    assert "github.ref == 'refs/heads/main'" in staging_condition
+    assert "github.event_name == 'workflow_dispatch'" in staging_condition
+    assert "inputs.target_environment == 'staging'" in staging_condition
+    assert "inputs.deploy == true" in staging_condition
+    assert "vars.STAGING_DEPLOY_ENABLED == 'true'" in staging_condition
+    assert "always()" in production_condition
+    assert "github.event_name == 'push'" in production_condition
+    assert "github.event_name == 'workflow_dispatch'" not in production_condition
+    assert "github.ref == 'refs/heads/main'" in production_condition
+    assert "vars.PROD_DEPLOY_ENABLED == 'true'" in production_condition
+    assert "needs.release-verify.result == 'success'" in production_condition
+    assert "needs.deploy-staging.result == 'success'" in production_condition
+    assert "vars.STAGING_DEPLOY_ENABLED != 'true'" not in production_condition
+    assert "inputs.deploy == true" not in production_condition
+    dispatch_inputs = workflow[True]["workflow_dispatch"]["inputs"]
+    assert dispatch_inputs["target_environment"]["options"] == ["staging"]
+    assert (
+        workflow["jobs"]["deploy-staging"]["env"]["IMAGE_DIGEST"]
+        == "${{ needs.release-verify.outputs.digest }}"
+    )
+    assert (
+        workflow["jobs"]["deploy-production"]["env"]["IMAGE_DIGEST"]
+        == "${{ needs.release-verify.outputs.digest }}"
+    )
     assert workflow["jobs"]["publish"]["needs"] == [
         "test",
         "workflow-security",
@@ -492,6 +540,8 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     assert "no-cache: ${{ github.event_name == 'schedule' }}" in workflow_text
     assert "cosign sign --yes" in workflow_text
     assert "cosign sign-blob --yes" in workflow_text
+    assert workflow_text.count("Build and push the release candidate once") == 1
+    assert ":latest" not in workflow_text
     assert "cosign verify-blob" in deploy_script
     assert "runtime-${RELEASE_SHA}.sigstore.json" in workflow_text
     assert "RUN_ZAP_DAST" in workflow_text
@@ -540,6 +590,16 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     )
     assert "sha256:[0-9a-f]{64}" in deploy_script
     assert "COSIGN_CERTIFICATE_IDENTITY" in deploy_script
+    assert "COSIGN_CERTIFICATE_IDENTITY_REGEXP" in deploy_script
+    assert "--certificate-identity-regexp" in deploy_script
+    assert (
+        "ci-deploy[.]yml@refs/heads/[A-Za-z0-9._/-]+$"
+        in deploy_script
+    )
+    assert (
+        "ci-deploy.yml@refs/heads/main"
+        in deploy_script
+    )
     assert "org.opencontainers.image.revision" in deploy_script
     assert "production-check" in deploy_script
     assert "db upgrade" in deploy_script
@@ -566,6 +626,12 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     assert "gpasswd --delete" in bootstrap
     assert "docker.sock" in bootstrap
     assert "COSIGN_SHA256" in bootstrap
+    assert "COSIGN_CERTIFICATE_IDENTITY_REGEXP" in bootstrap
+    assert (
+        "ci-deploy[.]yml@refs/heads/[A-Za-z0-9._/-]+$"
+        in bootstrap
+    )
+    assert "ci-deploy.yml@refs/heads/main" in bootstrap
     assert "/opt/sitbank" in bootstrap
     assert "/etc/sitbank" in bootstrap
     assert "/var/lib/sitbank-container" in bootstrap
@@ -575,6 +641,13 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     assert "sitbank-deploy" in bootstrap
     assert "sitbank-container.service" in bootstrap
     assert "sitbank-staging-container.service" in bootstrap
+
+    readme = Path("README.md").read_text(encoding="utf-8")
+    assert "Manual pre-merge staging:" in readme
+    assert "trusted branch -> workflow_dispatch -> publish -> release-verify -> staging" in readme
+    assert "main push -> publish -> release-verify -> staging -> production" in readme
+    assert "Manual production deployment is disabled." in readme
+    assert "Production never skips disabled, skipped, or failed staging." in readme
 
 
 def test_trivy_exception_is_narrow_documented_and_temporary():

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -280,6 +280,18 @@ def test_dockerfile_and_compose_enforce_hardened_runtime():
     compose_validation = Path(
         "ops/container/validate-compose.sh"
     ).read_text(encoding="utf-8")
+    compose_validation_override = Path(
+        "ops/container/compose-validation.override.yml"
+    ).read_text(encoding="utf-8")
+    bootstrap = Path("ops/deploy/bootstrap-container-ec2").read_text(
+        encoding="utf-8"
+    )
+    deploy_script = Path("ops/deploy/sitbank-container-deploy").read_text(
+        encoding="utf-8"
+    )
+    runtime_script = Path("ops/deploy/sitbank-container-runtime").read_text(
+        encoding="utf-8"
+    )
     compose = yaml.safe_load(compose_text)
     app = compose["services"]["app"]
     staging_compose = yaml.safe_load(staging_compose_text)
@@ -335,6 +347,11 @@ def test_dockerfile_and_compose_enforce_hardened_runtime():
     assert "production|staging|all" in compose_validation
     assert "--no-env-resolution" in compose_validation
     assert "--no-path-resolution" in compose_validation
+    assert "compose-validation.override.yml" in compose_validation
+    assert "env_file: !reset []" in compose_validation_override
+    assert "compose-validation.override.yml" not in bootstrap
+    assert "compose-validation.override.yml" not in deploy_script
+    assert "compose-validation.override.yml" not in runtime_script
     assert "sudo" not in compose_validation
     assert "/etc/sitbank" not in compose_validation
     assert "docker port" in smoke_test

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -13,6 +13,7 @@ from ops.deploy.import_legacy_env import import_legacy_environment
 from ops.deploy.render_container_bundle import (
     build_container_bundle,
     build_container_environment,
+    build_deployment_environment,
     write_container_bundle,
 )
 
@@ -76,6 +77,53 @@ def test_container_bundle_accepts_staging_prefix(monkeypatch):
     assert secrets["database_url"] == DEPLOYMENT_VALUES["PROD_DATABASE_URL"]
 
 
+def test_deployment_profiles_keep_production_and_staging_isolated(monkeypatch):
+    _set_deployment_values(monkeypatch)
+    _set_prefixed_deployment_values(
+        monkeypatch,
+        "STAGING",
+        "staging-sitbank.duckdns.org",
+    )
+
+    production = build_deployment_environment("PROD")
+    staging = build_deployment_environment("STAGING")
+
+    assert production["DEPLOYMENT_TARGET"] == "production"
+    assert production["CONFIG_ROOT"] == "/etc/sitbank"
+    assert production["COMPOSE_DIR"] == "/opt/sitbank"
+    assert production["SYSTEMD_SERVICE"] == "sitbank-container.service"
+    assert production["COMPOSE_PROJECT_NAME"] == "sitbank"
+    assert production["APP_CONTAINER_NAME"] == "sitbank-app"
+    assert production["APP_BIND_PORT"] == "5000"
+    assert production["POSTGRES_VOLUME_NAME"] == "none"
+    assert production["REDIS_VOLUME_NAME"] == "none"
+
+    assert staging["DEPLOYMENT_TARGET"] == "staging"
+    assert staging["CONFIG_ROOT"] == "/etc/sitbank-staging"
+    assert staging["SECRET_ROOT"] == "/etc/sitbank-staging/secrets"
+    assert staging["COMPOSE_DIR"] == "/opt/sitbank-staging"
+    assert staging["SYSTEMD_SERVICE"] == "sitbank-staging-container.service"
+    assert staging["COMPOSE_PROJECT_NAME"] == "sitbank-staging"
+    assert staging["APP_CONTAINER_NAME"] == "sitbank-staging-app"
+    assert staging["APP_BIND_PORT"] == "5001"
+    assert staging["POSTGRES_CONTAINER_NAME"] == "sitbank-staging-postgres"
+    assert staging["REDIS_CONTAINER_NAME"] == "sitbank-staging-redis"
+    assert staging["POSTGRES_VOLUME_NAME"] == "sitbank-staging-postgres-data"
+    assert staging["REDIS_VOLUME_NAME"] == "sitbank-staging-redis-data"
+    assert staging["PUBLIC_HOST"] == "staging-sitbank.duckdns.org"
+
+    for key in (
+        "CONFIG_ROOT",
+        "SECRET_ROOT",
+        "COMPOSE_DIR",
+        "SYSTEMD_SERVICE",
+        "COMPOSE_PROJECT_NAME",
+        "APP_CONTAINER_NAME",
+        "APP_BIND_PORT",
+    ):
+        assert production[key] != staging[key]
+
+
 def test_container_bundle_rejects_unknown_prefix(monkeypatch):
     _set_deployment_values(monkeypatch)
 
@@ -137,6 +185,7 @@ def test_environment_only_bundle_does_not_export_long_lived_secrets(
 
     assert environment["SESSION_HMAC_ACTIVE_KEY_ID"] == "2026-06"
     assert (output / "container.env").is_file()
+    assert (output / "deployment.env").is_file()
     assert not (output / "secrets").exists()
 
 
@@ -161,7 +210,11 @@ def test_environment_only_bundle_accepts_staging_prefix(monkeypatch, tmp_path):
     write_container_bundle(output, "STAGING", include_secrets=False)
 
     environment = (output / "container.env").read_text(encoding="utf-8")
+    deployment = (output / "deployment.env").read_text(encoding="utf-8")
     assert "WEBAUTHN_RP_ID='staging.sitbank.example'" in environment
+    assert "APP_BIND_PORT='5001'" in deployment
+    assert "COMPOSE_PROJECT_NAME='sitbank-staging'" in deployment
+    assert "CONFIG_ROOT='/etc/sitbank-staging'" in deployment
     assert not (output / "secrets").exists()
 
 
@@ -222,12 +275,16 @@ def test_legacy_environment_import_seeds_root_runtime_without_printing_values(
 def test_dockerfile_and_compose_enforce_hardened_runtime():
     dockerfile = Path("Dockerfile").read_text(encoding="utf-8")
     compose_text = Path("compose.prod.yml").read_text(encoding="utf-8")
+    staging_compose_text = Path("compose.staging.yml").read_text(encoding="utf-8")
     smoke_test = Path("ops/container/smoke-test.sh").read_text(encoding="utf-8")
     compose_validation = Path(
         "ops/container/validate-compose.sh"
     ).read_text(encoding="utf-8")
     compose = yaml.safe_load(compose_text)
     app = compose["services"]["app"]
+    staging_compose = yaml.safe_load(staging_compose_text)
+    staging_services = staging_compose["services"]
+    staging_app = staging_services["app"]
 
     assert compose["name"] == "sitbank"
     assert (
@@ -273,9 +330,51 @@ def test_dockerfile_and_compose_enforce_hardened_runtime():
     assert "create_dast_session.py" in smoke_test
     assert "docker compose" in compose_validation
     assert "SITBANK_IMAGE" in compose_validation
+    assert "compose.prod.yml" in compose_validation
+    assert "compose.staging.yml" in compose_validation
+    assert "production|staging|all" in compose_validation
+    assert "--no-env-resolution" in compose_validation
+    assert "--no-path-resolution" in compose_validation
+    assert "sudo" not in compose_validation
+    assert "/etc/sitbank" not in compose_validation
     assert "docker port" in smoke_test
     assert "55432" not in smoke_test
     assert "56379" not in smoke_test
+
+    assert staging_compose["name"] == "sitbank-staging"
+    assert set(staging_services) == {"app", "postgres", "redis"}
+    assert staging_app["container_name"] == "sitbank-staging-app"
+    assert staging_app["ports"] == ["127.0.0.1:5001:5000"]
+    assert "network_mode" not in staging_app
+    assert staging_app["read_only"] is True
+    assert staging_app["user"] == "10001:10001"
+    assert staging_app["cap_drop"] == ["ALL"]
+    assert "no-new-privileges:true" in staging_app["security_opt"]
+    assert staging_app["env_file"] == ["/etc/sitbank-staging/container.env"]
+    assert all(
+        volume["source"].startswith("/etc/sitbank-staging/")
+        for volume in staging_app["volumes"]
+    )
+    assert all(
+        secret["file"].startswith("/etc/sitbank-staging/secrets/")
+        for secret in staging_compose["secrets"].values()
+    )
+    assert staging_services["postgres"]["container_name"] == (
+        "sitbank-staging-postgres"
+    )
+    assert staging_services["redis"]["container_name"] == "sitbank-staging-redis"
+    assert "ports" not in staging_services["postgres"]
+    assert "ports" not in staging_services["redis"]
+    assert staging_compose["volumes"]["sitbank-staging-postgres-data"]["name"] == (
+        "sitbank-staging-postgres-data"
+    )
+    assert staging_compose["volumes"]["sitbank-staging-redis-data"]["name"] == (
+        "sitbank-staging-redis-data"
+    )
+    assert "/etc/sitbank-staging" not in compose_text
+    assert "/etc/sitbank/" not in staging_compose_text
+    assert "sitbank-staging-postgres-data" not in compose_text
+    assert "sitbank-staging-redis-data" not in compose_text
 
     app_python = "\n".join(
         path.read_text(encoding="utf-8")
@@ -412,6 +511,16 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     assert "--prefix STAGING" in workflow_text
     assert "--prefix PROD" in workflow_text
     assert "sitbank-container-deploy" in workflow_text
+    assert "runtime-staging-${RELEASE_SHA}" in workflow_text
+    assert "registry-staging-${RELEASE_SHA}.credentials" in workflow_text
+    assert (
+        "sitbank-container-deploy staging '${RELEASE_SHA}' '${IMAGE_DIGEST}'"
+        in workflow_text
+    )
+    assert (
+        "sitbank-container-deploy '${RELEASE_SHA}' '${IMAGE_DIGEST}'"
+        in workflow_text
+    )
     assert "sha256:[0-9a-f]{64}" in deploy_script
     assert "COSIGN_CERTIFICATE_IDENTITY" in deploy_script
     assert "org.opencontainers.image.revision" in deploy_script
@@ -424,14 +533,31 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     assert "load_runtime_secrets" not in deploy_script
     assert "SITBANK_SECRET_KEY" not in deploy_script
     assert "SITBANK_SECRET_KEY" not in runtime_script
+    assert "/etc/sitbank-staging/deploy.conf" in deploy_script
+    assert "/opt/sitbank-staging/compose.yml" in deploy_script
+    assert "/var/lib/sitbank-staging-container" in deploy_script
+    assert "sitbank-staging-container.service" in deploy_script
+    assert "sitbank-staging-postgres-data" in deploy_script
+    assert "sitbank-staging-redis-data" in deploy_script
+    assert "Staging secret must not reuse the production" in deploy_script
+    assert "hostname != \"postgres\"" in deploy_script
+    assert "hostname != \"redis\"" in deploy_script
+    assert "sitbank-container-runtime staging up" in Path(
+        "ops/systemd/sitbank-staging-container.service"
+    ).read_text(encoding="utf-8")
+    assert "--project-name \"${COMPOSE_PROJECT}\"" in runtime_script
     assert "gpasswd --delete" in bootstrap
     assert "docker.sock" in bootstrap
     assert "COSIGN_SHA256" in bootstrap
     assert "/opt/sitbank" in bootstrap
     assert "/etc/sitbank" in bootstrap
     assert "/var/lib/sitbank-container" in bootstrap
+    assert "/opt/sitbank-staging" in bootstrap
+    assert "/etc/sitbank-staging" in bootstrap
+    assert "/var/lib/sitbank-staging-container" in bootstrap
     assert "sitbank-deploy" in bootstrap
     assert "sitbank-container.service" in bootstrap
+    assert "sitbank-staging-container.service" in bootstrap
 
 
 def test_trivy_exception_is_narrow_documented_and_temporary():
@@ -493,9 +619,12 @@ def test_codeowners_and_codeql_cover_security_sensitive_changes():
         "/.github/workflows/",
         "/Dockerfile",
         "/compose.prod.yml",
+        "/compose.staging.yml",
         "/requirements.lock",
         "/requirements-dev.lock",
         "/ops/deploy/",
+        "/ops/nginx/",
+        "/ops/nginx-proxy-headers.conf",
         "/ops/security/",
     ):
         assert protected_path in codeowners
@@ -523,7 +652,17 @@ def test_only_sitbank_container_deployment_units_are_active():
     assert Path("ops/deploy/sitbank-container-runtime").exists()
     assert Path("ops/deploy/sitbank-database-cutover").exists()
     assert Path("ops/systemd/sitbank-container.service").exists()
+    assert Path("ops/systemd/sitbank-staging-container.service").exists()
     assert Path("ops/sudoers/sitbank-container-deploy").exists()
+
+
+def test_staging_nginx_routes_only_to_the_staging_loopback_port():
+    nginx = Path("ops/nginx/sitbank-staging.conf").read_text(encoding="utf-8")
+
+    assert "server_name staging-sitbank.duckdns.org;" in nginx
+    assert "proxy_pass http://127.0.0.1:5001;" in nginx
+    assert "127.0.0.1:5000" not in nginx
+    assert "server_name sitbank.duckdns.org;" not in nginx
 
 
 def test_dependency_manifests_have_one_hashed_lockfile_source_of_truth():

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -319,6 +319,20 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     assert "id-token" not in workflow["jobs"]["publish"]["permissions"]
     assert "attestations" not in workflow["jobs"]["publish"]["permissions"]
     assert workflow["jobs"]["release-verify"]["permissions"]["id-token"] == "write"
+    assert workflow["jobs"]["release-verify"]["permissions"]["packages"] == "write"
+    publish_condition = workflow["jobs"]["publish"]["if"]
+    release_verify_condition = workflow["jobs"]["release-verify"]["if"]
+    for condition in (publish_condition, release_verify_condition):
+        assert "github.event_name != 'pull_request'" in condition
+        assert "github.ref == 'refs/heads/main'" in condition
+    assert "github.event_name == 'workflow_dispatch'" in publish_condition
+    assert workflow["jobs"]["release-verify"]["needs"] == "publish"
+    release_verify_steps = [
+        step["name"] for step in workflow["jobs"]["release-verify"]["steps"]
+    ]
+    assert release_verify_steps.index("Log in to GHCR") < release_verify_steps.index(
+        "Sign and verify the tested immutable digest"
+    )
     assert workflow["jobs"]["deploy-staging"]["permissions"]["packages"] == "read"
     assert workflow["jobs"]["deploy-staging"]["permissions"]["id-token"] == "write"
     assert workflow["jobs"]["deploy-production"]["permissions"]["packages"] == "read"

--- a/tests/test_owasp_regressions.py
+++ b/tests/test_owasp_regressions.py
@@ -14,6 +14,25 @@ def test_security_headers_are_present(client):
     assert "default-src 'self'" in response.headers["Content-Security-Policy"]
 
 
+def test_public_homepage_exposes_verification_and_student_disclaimer(client):
+    response = client.get("/")
+    html = response.get_data(as_text=True)
+    verification_tag = (
+        '<meta name="google-site-verification" '
+        'content="TdWqsa4Ln9t_GIYl4Devi4rrU48Z7XNSue_PiImREJs">'
+    )
+    disclaimer = (
+        "SITBank is a student cybersecurity project and demonstration site. "
+        "Do not enter real banking credentials, card numbers, phone numbers, "
+        "or personal financial information."
+    )
+
+    assert response.status_code == 200
+    assert verification_tag in html
+    assert html.index(verification_tag) < html.index("</head>")
+    assert html.count(disclaimer) == 1
+
+
 def test_external_next_parameter_cannot_create_an_open_redirect(client):
     register = client.post(
         "/register",


### PR DESCRIPTION
## Summary

This PR hardens the staging and release workflow while adding the public Safe Browsing/Search Console updates.

## Changes

* Add isolated staging deployment stack with separate config, services, volumes, and Nginx routing
* Add Google Search Console verification metadata
* Add visible student-project disclaimer to public pages
* Harden Cosign signing and release verification gates
* Add trusted manual staging flow using `source_ref` and immutable `source_sha`
* Restrict production deployment to `main` after successful staging
* Remove feature-branch deployment trust for secret-handling jobs
* Update staging bootstrap, deployment docs, README, and SECURITY guidance
* Add regression tests for staging isolation, workflow gates, metadata, and release safety

## Security notes

* Candidate branch code is used only for test/build/release candidate generation
* Secret-handling deployment steps use trusted `main` workflow/deployment scripts
* Manual production deployment is removed
* Production can only run from a `main` push after staging succeeds
* Both staging and production verify the exact trusted main Cosign workflow identity
* The published, verified, signed, and deployed digest remains identical

## Operational note

After this is merged, staging bootstrap must be refreshed once so the EC2 staging policy trusts the exact main workflow identity instead of the older branch-regex Cosign policy.

```bash
cd /path/to/SITBank
sudo bash ops/deploy/bootstrap-container-ec2 \
  staging WenJiangggg/SITBank staging-sitbank.duckdns.org
```

## Verification

* Full suite: 201 passed, 1 skipped
* Deployment tests: 24 passed
* `git diff --check`: passed
* Actionlint, Zizmor, and ShellCheck should be treated as final GitHub Actions gates because they could not be rerun locally after the final edits due execution approval quota
