### PR TITLE
Fix SSH formatting and DAST configuration

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -295,9 +295,9 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Run container smoke and authenticated DAST tests
+      - name: Run container smoke test and scheduled authenticated DAST
         env:
-          RUN_ZAP_DAST: "true"
+          RUN_ZAP_DAST: ${{ github.event_name == 'schedule' && 'true' || 'false' }}
         run: bash ops/container/smoke-test.sh sitbank:pr
 
       - name: Validate production and staging Compose models

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -647,7 +647,7 @@ jobs:
       - name: Verify staging deployment configuration
         env:
           STAGING_EC2_KNOWN_HOSTS: ${{ secrets.STAGING_EC2_KNOWN_HOSTS }}
-          STAGING_EC2_SSH_PRIVATE_KEY: ${{ secrets.STAGING_EC2_SSH_PRIVATE_KEY }}
+          STAGING_EC2_SSH_PRIVATE_KEY_B64: ${{ secrets.STAGING_EC2_SSH_PRIVATE_KEY_B64 }}
         run: |
           required=(
             IMAGE_DIGEST
@@ -659,7 +659,7 @@ jobs:
             STAGING_PASSWORD_PBKDF2_ITERATIONS
             STAGING_MFA_ISSUER_NAME
             STAGING_EC2_KNOWN_HOSTS
-            STAGING_EC2_SSH_PRIVATE_KEY
+            STAGING_EC2_SSH_PRIVATE_KEY_B64
           )
           missing=0
           for name in "${required[@]}"; do
@@ -702,39 +702,24 @@ jobs:
 
       - name: Configure verified SSH
         env:
-          SSH_PRIVATE_KEY: ${{ secrets.STAGING_EC2_SSH_PRIVATE_KEY }}
+          SSH_PRIVATE_KEY_B64: ${{ secrets.STAGING_EC2_SSH_PRIVATE_KEY_B64 }}
           SSH_KNOWN_HOSTS: ${{ secrets.STAGING_EC2_KNOWN_HOSTS }}
         run: |
           umask 077
           install -d -m 0700 ~/.ssh
 
-          if [[ "${SSH_PRIVATE_KEY}" == *'\n'* ]]; then
-            printf '%s\n' \
-              '::error::STAGING_EC2_SSH_PRIVATE_KEY contains literal \n text. Store the raw multiline private key instead.'
+          if [[ ! "${SSH_PRIVATE_KEY_B64}" =~ ^[A-Za-z0-9+/]+={0,2}$ ]]; then
+            echo "::error::STAGING_EC2_SSH_PRIVATE_KEY_B64 is not valid single-line Base64."
             exit 1
           fi
-          python3 - <<'PY'
-          import os
-          from pathlib import Path
-
-          value = os.environ["SSH_PRIVATE_KEY"].replace("\r\n", "\n").replace("\r", "\n")
-          value = value.lstrip("\ufeff")
-          lines = value.split("\n")
-          while lines and not lines[0].strip():
-              lines.pop(0)
-          while lines and not lines[-1].strip():
-              lines.pop()
-          if not lines or "\x00" in value:
-              raise SystemExit("STAGING_EC2_SSH_PRIVATE_KEY is empty or malformed")
-          Path.home().joinpath(".ssh", "deploy_key").write_text(
-              "\n".join(lines) + "\n",
-              encoding="utf-8",
-              newline="\n",
-          )
-          PY
+          if ! printf '%s' "${SSH_PRIVATE_KEY_B64}" \
+              | base64 --decode > ~/.ssh/deploy_key; then
+            echo "::error::STAGING_EC2_SSH_PRIVATE_KEY_B64 could not be decoded."
+            exit 1
+          fi
           chmod 0600 ~/.ssh/deploy_key
           if ! ssh-keygen -y -P "" -f ~/.ssh/deploy_key >/dev/null 2>&1; then
-            echo "::error::STAGING_EC2_SSH_PRIVATE_KEY could not be parsed. Use an unencrypted OpenSSH private key and preserve its multiline formatting."
+            echo "::error::Decoded staging SSH key could not be parsed. Store Base64 of an unencrypted OpenSSH private key."
             exit 1
           fi
 
@@ -815,7 +800,7 @@ jobs:
       - name: Verify production deployment configuration
         env:
           PROD_EC2_KNOWN_HOSTS: ${{ secrets.PROD_EC2_KNOWN_HOSTS }}
-          PROD_EC2_SSH_PRIVATE_KEY: ${{ secrets.PROD_EC2_SSH_PRIVATE_KEY }}
+          PROD_EC2_SSH_PRIVATE_KEY_B64: ${{ secrets.PROD_EC2_SSH_PRIVATE_KEY_B64 }}
         run: |
           required=(
             IMAGE_DIGEST
@@ -827,7 +812,7 @@ jobs:
             PROD_PASSWORD_PBKDF2_ITERATIONS
             PROD_MFA_ISSUER_NAME
             PROD_EC2_KNOWN_HOSTS
-            PROD_EC2_SSH_PRIVATE_KEY
+            PROD_EC2_SSH_PRIVATE_KEY_B64
           )
           missing=0
           for name in "${required[@]}"; do
@@ -870,39 +855,24 @@ jobs:
 
       - name: Configure verified SSH
         env:
-          SSH_PRIVATE_KEY: ${{ secrets.PROD_EC2_SSH_PRIVATE_KEY }}
+          SSH_PRIVATE_KEY_B64: ${{ secrets.PROD_EC2_SSH_PRIVATE_KEY_B64 }}
           SSH_KNOWN_HOSTS: ${{ secrets.PROD_EC2_KNOWN_HOSTS }}
         run: |
           umask 077
           install -d -m 0700 ~/.ssh
 
-          if [[ "${SSH_PRIVATE_KEY}" == *'\n'* ]]; then
-            printf '%s\n' \
-              '::error::PROD_EC2_SSH_PRIVATE_KEY contains literal \n text. Store the raw multiline private key instead.'
+          if [[ ! "${SSH_PRIVATE_KEY_B64}" =~ ^[A-Za-z0-9+/]+={0,2}$ ]]; then
+            echo "::error::PROD_EC2_SSH_PRIVATE_KEY_B64 is not valid single-line Base64."
             exit 1
           fi
-          python3 - <<'PY'
-          import os
-          from pathlib import Path
-
-          value = os.environ["SSH_PRIVATE_KEY"].replace("\r\n", "\n").replace("\r", "\n")
-          value = value.lstrip("\ufeff")
-          lines = value.split("\n")
-          while lines and not lines[0].strip():
-              lines.pop(0)
-          while lines and not lines[-1].strip():
-              lines.pop()
-          if not lines or "\x00" in value:
-              raise SystemExit("PROD_EC2_SSH_PRIVATE_KEY is empty or malformed")
-          Path.home().joinpath(".ssh", "deploy_key").write_text(
-              "\n".join(lines) + "\n",
-              encoding="utf-8",
-              newline="\n",
-          )
-          PY
+          if ! printf '%s' "${SSH_PRIVATE_KEY_B64}" \
+              | base64 --decode > ~/.ssh/deploy_key; then
+            echo "::error::PROD_EC2_SSH_PRIVATE_KEY_B64 could not be decoded."
+            exit 1
+          fi
           chmod 0600 ~/.ssh/deploy_key
           if ! ssh-keygen -y -P "" -f ~/.ssh/deploy_key >/dev/null 2>&1; then
-            echo "::error::PROD_EC2_SSH_PRIVATE_KEY could not be parsed. Use an unencrypted OpenSSH private key and preserve its multiline formatting."
+            echo "::error::Decoded production SSH key could not be parsed. Store Base64 of an unencrypted OpenSSH private key."
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ deployment clearly.
 Add these staging environment secrets:
 
 - `STAGING_EC2_KNOWN_HOSTS`
-- `STAGING_EC2_SSH_PRIVATE_KEY`
+- `STAGING_EC2_SSH_PRIVATE_KEY_B64`
 
 Add these staging environment variables:
 
@@ -316,7 +316,7 @@ run_dast: true
 Add these production environment secrets:
 
 - `PROD_EC2_KNOWN_HOSTS`
-- `PROD_EC2_SSH_PRIVATE_KEY`
+- `PROD_EC2_SSH_PRIVATE_KEY_B64`
 
 Add these production environment variables:
 
@@ -341,7 +341,7 @@ by the workflow. Rename them before enabling production deployment:
 | Old name | New canonical name |
 | --- | --- |
 | `EC2_KNOWN_HOSTS` | `PROD_EC2_KNOWN_HOSTS` |
-| `EC2_SSH_PRIVATE_KEY` | `PROD_EC2_SSH_PRIVATE_KEY` |
+| `EC2_SSH_PRIVATE_KEY` | `PROD_EC2_SSH_PRIVATE_KEY_B64` |
 | `EC2_DEPLOY_USER` | `PROD_EC2_DEPLOY_USER` |
 | `EC2_HOST` | `PROD_EC2_HOST` |
 | `EC2_PORT` | `PROD_EC2_PORT` |
@@ -617,19 +617,25 @@ with `restrict`. The staging entry, for example, is:
 restrict ssh-ed25519 AAAA... github-actions-sitbank-staging
 ```
 
-Store the complete raw private-key contents as:
+Encode each private key as single-line Base64 and store the result as:
 
-- `STAGING_EC2_SSH_PRIVATE_KEY` in the `staging` environment.
-- `PROD_EC2_SSH_PRIVATE_KEY` in the `production` environment.
+- `STAGING_EC2_SSH_PRIVATE_KEY_B64` in the `staging` environment.
+- `PROD_EC2_SSH_PRIVATE_KEY_B64` in the `production` environment.
 
-The secret must start with `-----BEGIN OPENSSH PRIVATE KEY-----` and end with
-`-----END OPENSSH PRIVATE KEY-----`. Paste the multiline contents, not the
-`.pub` key, a filesystem path, a PuTTY `.ppk`, or text containing literal
-`\n` sequences. On Windows, copy it without changing its formatting:
+Base64 is transport encoding, not encryption; confidentiality still comes from
+the GitHub environment secret. Encode the private file bytes directly. Do not
+encode the `.pub` key, a filesystem path, or a PuTTY `.ppk`:
 
 ```powershell
-Get-Content -Raw "$HOME\.ssh\sitbank_github_actions_staging" | Set-Clipboard
+$keyBytes = [System.IO.File]::ReadAllBytes(
+  "$HOME\.ssh\sitbank_github_actions_staging"
+)
+[Convert]::ToBase64String($keyBytes) | Set-Clipboard
 ```
+
+The copied value must be one uninterrupted line. Delete the obsolete raw
+`STAGING_EC2_SSH_PRIVATE_KEY` or `PROD_EC2_SSH_PRIVATE_KEY` secret after the
+corresponding Base64 deployment succeeds.
 
 Verify that the corresponding public key is the one installed for
 `sitbank-deploy`:

--- a/README.md
+++ b/README.md
@@ -41,8 +41,10 @@ ignored until a deliberate runtime migration is approved.
 
 Docker base images remain pinned by digest in the Dockerfile. Dependabot is
 configured to propose Dockerfile base-image updates as pull requests, and those
-PRs must run the same tests, Trivy scans, smoke test, authenticated DAST,
-actionlint, zizmor, and shellcheck checks as application changes.
+PRs must run the same tests, Trivy scans, container smoke test, Compose
+validation, actionlint, zizmor, and shellcheck checks as application changes.
+Ordinary pull requests skip the full authenticated DAST crawl; scheduled scans
+and release verification retain that coverage.
 Base-image updates must not be auto-merged.
 
 Docker Desktop is optional for ordinary Python development. Install it with
@@ -194,6 +196,15 @@ validation, and Trivy checks. This keeps the pinned Debian/Python base image
 under regular review and makes fixed upstream base digests or fixed Debian
 packages visible without permitting scheduled publish or deployment.
 
+Normal pull requests run the container smoke test, Compose validation, and
+both Trivy gates without pulling the ZAP image. This keeps feedback fast while
+preserving the full Python, SAST, dependency, secret, container, and image
+security checks. Authenticated DAST still runs during `release-verify` for
+every push to `main`. For manual staging, maintainers control it with the
+`run_dast` input; `true` runs DAST before staging deployment and `false` is the
+only manual opt-out. Scheduled runs continue to execute authenticated DAST for
+regular deeper coverage.
+
 Every third-party action is pinned to a full commit SHA. Publishing remains
 available while deployment is disabled, allowing the same signed digest to be
 verified without changing EC2.
@@ -202,7 +213,7 @@ The release flows are:
 
 ```text
 Pull request:
-  tests and validation only
+  tests, container smoke, Compose validation, and Trivy; no full ZAP DAST
 
 Manual pre-merge staging:
   run trusted workflow from main

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,7 +37,10 @@ Compose service names.
 Dependabot pull requests are never auto-merged. Review release notes and
 transitive changes, update the reviewed manifest, regenerate the applicable
 hash-locked files, and require the full test, SAST, dependency review,
-container, DAST, and image scan checks.
+container smoke, Compose validation, and image scan checks. Full authenticated
+DAST is intentionally reserved for scheduled scans and release verification;
+ordinary pull requests skip it to keep feedback timely without weakening the
+release gate.
 
 Critical advisories require immediate triage. High advisories require an owner
 and target date. A runtime upgrade is kept separate from ordinary package

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -116,5 +116,5 @@ Manager Run Command:
 - retain the same root deployment wrapper, Cosign checks, and environment
   approval.
 
-Remove `EC2_SSH_PRIVATE_KEY` only after the OIDC/SSM path has passed rollback
-and incident-response testing.
+Remove the Base64-encoded EC2 SSH private-key secrets only after the OIDC/SSM
+path has passed rollback and incident-response testing.

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -564,15 +564,14 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     assert "deploy-staging" in workflow_text
     assert "deploy-production" in workflow_text
     assert "PROD_EC2_HOST" in workflow_text
-    assert "PROD_EC2_SSH_PRIVATE_KEY" in workflow_text
+    assert "PROD_EC2_SSH_PRIVATE_KEY_B64" in workflow_text
     assert "STAGING_EC2_HOST" in workflow_text
-    assert "STAGING_EC2_SSH_PRIVATE_KEY" in workflow_text
+    assert "STAGING_EC2_SSH_PRIVATE_KEY_B64" in workflow_text
     assert workflow_text.count("ssh-keygen -y -P") == 2
-    assert workflow_text.count('value.lstrip("\\ufeff")') == 2
-    assert workflow_text.count('replace("\\r\\n", "\\n")') == 2
-    assert workflow_text.count('while lines and not lines[0].strip()') == 2
-    assert workflow_text.count('while lines and not lines[-1].strip()') == 2
-    assert workflow_text.count(r"contains literal \n text") == 2
+    assert workflow_text.count("base64 --decode > ~/.ssh/deploy_key") == 2
+    assert workflow_text.count("^[A-Za-z0-9+/]+={0,2}$") == 2
+    assert "STAGING_EC2_SSH_PRIVATE_KEY:" not in workflow_text
+    assert "PROD_EC2_SSH_PRIVATE_KEY:" not in workflow_text
     assert workflow_text.count("-i ~/.ssh/deploy_key") == 4
     assert "~/.ssh/id_ed25519" not in workflow_text
     assert "vars.EC2_" not in workflow_text

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -465,6 +465,9 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     assert dispatch_inputs["source_ref"]["required"] is True
     assert dispatch_inputs["source_ref"]["type"] == "string"
     assert dispatch_inputs["target_environment"]["options"] == ["staging"]
+    assert dispatch_inputs["run_dast"]["required"] is True
+    assert dispatch_inputs["run_dast"]["type"] == "boolean"
+    assert dispatch_inputs["run_dast"]["default"] is True
     candidate_jobs = ("test", "publish")
     for job_name in candidate_jobs:
         checkout = next(
@@ -504,9 +507,27 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
         for step in workflow["jobs"]["release-verify"]["steps"]
         if step["name"] == "Smoke-test and DAST-scan the exact published digest"
     )
-    assert release_smoke_step["env"]["RUN_ZAP_DAST"] == (
+    release_dast_policy = (
         "${{ github.event_name != 'workflow_dispatch' || inputs.run_dast == true }}"
     )
+    assert release_smoke_step["env"]["RUN_ZAP_DAST"] == release_dast_policy
+    assert "github.event_name != 'workflow_dispatch'" in release_dast_policy
+    assert "inputs.run_dast == true" in release_dast_policy
+    image_smoke_step = next(
+        step
+        for step in workflow["jobs"]["image-test"]["steps"]
+        if step["name"] == "Run container smoke test and scheduled authenticated DAST"
+    )
+    assert image_smoke_step["run"] == (
+        "bash ops/container/smoke-test.sh sitbank:pr"
+    )
+    assert image_smoke_step["env"]["RUN_ZAP_DAST"] == (
+        "${{ github.event_name == 'schedule' && 'true' || 'false' }}"
+    )
+    assert image_smoke_step["env"]["RUN_ZAP_DAST"] != "true"
+    assert 'if [[ "${RUN_ZAP_DAST:-false}" == "true" ]]' in Path(
+        "ops/container/smoke-test.sh"
+    ).read_text(encoding="utf-8")
     assert (
         release_image_step["env"]["RELEASE_SHA"]
         == "${{ needs.publish.outputs.revision }}"
@@ -750,7 +771,10 @@ def test_dependabot_tracks_docker_base_images_without_automerge():
     ]
     assert "Dependabot updates are review-only" in readme
     assert "Base-image updates must not be auto-merged" in readme
-    assert "tests, Trivy scans, smoke test, authenticated DAST" in readme
+    assert "container smoke test, Compose" in readme
+    assert "Ordinary pull requests skip the full authenticated DAST crawl" in readme
+    assert "scheduled scans" in readme
+    assert "release verification retain that coverage" in readme
 
 
 def test_codeowners_and_codeql_cover_security_sensitive_changes():


### PR DESCRIPTION
## Summary

This PR improves CI deployment SSH key handling and tunes DAST coverage to make PR validation faster while preserving release security checks.

## Changes

- Update CI SSH key handling to use Base64-encoded private key secrets
- Decode and validate SSH private keys before deployment steps run
- Reduce deployment failures caused by multiline secret formatting issues
- Skip authenticated ZAP DAST during normal PR image tests
- Keep PR validation focused on smoke tests, Compose validation, and security gates
- Keep authenticated DAST enabled for scheduled runs
- Keep authenticated DAST required during release verification before deployment
- Update documentation for SSH key setup and DAST execution rules
- Update regression tests for Base64 SSH secrets and DAST workflow behavior

## Security notes

- Private keys remain stored only in GitHub environment secrets
- The workflow validates SSH key usability without printing private key material
- SSH host verification and `StrictHostKeyChecking` remain enabled
- PRs still run fast security checks without receiving deployment secrets
- Authenticated DAST still runs before staging and production deployment paths
- Production remains gated on successful release verification and staging

## Verification

- Updated CI workflow tests for SSH key handling
- Updated DAST regression tests
- Confirmed documentation reflects the new SSH secret and DAST behavior