### PR TITLE
Add verification for trusted staging and production deployment wrappers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,17 @@
-﻿* text=auto eol=lf
+* text=auto eol=lf
+
+Dockerfile text eol=lf
+*.sh text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.conf text eol=lf
+*.service text eol=lf
+
+ops/deploy/bootstrap-container-ec2 text eol=lf
+ops/deploy/sitbank-container-deploy text eol=lf
+ops/deploy/sitbank-container-runtime text eol=lf
+ops/deploy/sitbank-database-cutover text eol=lf
+ops/sudoers/* text eol=lf
 
 *.bat text eol=crlf
 *.cmd text eol=crlf

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -731,6 +731,28 @@ jobs:
             exit 1
           fi
 
+      - name: Verify trusted staging deployment wrapper
+        run: |
+          expected_hash="$(
+            sha256sum ops/deploy/sitbank-container-deploy | awk '{print $1}'
+          )"
+          if ! remote_output="$(
+              ssh -p "${REMOTE_PORT}" -i ~/.ssh/deploy_key \
+              -o BatchMode=yes -o IdentitiesOnly=yes \
+              -o StrictHostKeyChecking=yes -o ConnectTimeout=15 \
+              "${REMOTE_USER}@${REMOTE_HOST}" \
+              "sha256sum /usr/local/sbin/sitbank-container-deploy"
+            )"; then
+            echo "::error::The EC2 staging deployment wrapper is unavailable. Rerun the trusted staging bootstrap before deployment."
+            exit 1
+          fi
+          remote_hash="${remote_output%% *}"
+          if [[ ! "${remote_hash}" =~ ^[0-9a-f]{64}$ \
+              || "${remote_hash}" != "${expected_hash}" ]]; then
+            echo "::error::The EC2 staging deployment wrapper is missing or stale. Rerun the trusted staging bootstrap before deployment."
+            exit 1
+          fi
+
       - name: Upload authenticated deployment inputs
         run: |
           scp -P "${REMOTE_PORT}" -i ~/.ssh/deploy_key \
@@ -881,6 +903,28 @@ jobs:
           chmod 0600 ~/.ssh/known_hosts
           if [[ ! -s ~/.ssh/known_hosts ]]; then
             echo "::error::PROD_EC2_KNOWN_HOSTS is empty."
+            exit 1
+          fi
+
+      - name: Verify trusted production deployment wrapper
+        run: |
+          expected_hash="$(
+            sha256sum ops/deploy/sitbank-container-deploy | awk '{print $1}'
+          )"
+          if ! remote_output="$(
+              ssh -p "${REMOTE_PORT}" -i ~/.ssh/deploy_key \
+              -o BatchMode=yes -o IdentitiesOnly=yes \
+              -o StrictHostKeyChecking=yes -o ConnectTimeout=15 \
+              "${REMOTE_USER}@${REMOTE_HOST}" \
+              "sha256sum /usr/local/sbin/sitbank-container-deploy"
+            )"; then
+            echo "::error::The EC2 production deployment wrapper is unavailable. Rerun the trusted production bootstrap before deployment."
+            exit 1
+          fi
+          remote_hash="${remote_output%% *}"
+          if [[ ! "${remote_hash}" =~ ^[0-9a-f]{64}$ \
+              || "${remote_hash}" != "${expected_hash}" ]]; then
+            echo "::error::The EC2 production deployment wrapper is missing or stale. Rerun the trusted production bootstrap before deployment."
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -242,6 +242,13 @@ therefore do not execute with staging or production secrets. The candidate
 application itself receives only the isolated staging application secrets when
 it is intentionally deployed to staging.
 
+Before uploading a runtime bundle, each deployment job compares the SHA-256 of
+the trusted checked-out `sitbank-container-deploy` wrapper with the root-owned
+copy installed at `/usr/local/sbin/sitbank-container-deploy`. A mismatch fails
+closed. After any reviewed change to the wrapper, rerun the matching EC2
+bootstrap as an administrator before enabling that environment's next
+deployment.
+
 ### Temporary Trivy Exception
 
 `.trivyignore` contains a narrow temporary exception for only

--- a/README.md
+++ b/README.md
@@ -426,11 +426,24 @@ This archive installs root-owned deployment assets. It is not an application
 release:
 
 ```powershell
+git ls-files --eol -- ops/deploy ops/container ops/nginx ops/sudoers ops/systemd
 git archive --format=tar.gz --output=".\sitbank-bootstrap.tar.gz" HEAD
 scp -i "C:\path\to\existing-ec2-key.pem" `
   ".\sitbank-bootstrap.tar.gz" `
   "student12@sitbank.duckdns.org:/tmp/"
 ```
+
+The listed Linux files must report `i/lf` and `w/lf`. Commit the reviewed
+renormalization before creating the archive. On EC2, verify that the archived
+Linux scripts use LF endings before running them:
+
+```bash
+tar -xOf /tmp/sitbank-bootstrap.tar.gz \
+  ops/deploy/bootstrap-container-ec2 | sed -n '1,3l'
+```
+
+The displayed lines must not end in `\r$`. The bootstrap also refuses to
+install CRLF-formatted Compose, systemd, sudoers, Nginx, or deployment files.
 
 On EC2:
 

--- a/ops/deploy/bootstrap-container-ec2
+++ b/ops/deploy/bootstrap-container-ec2
@@ -80,6 +80,28 @@ esac
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 repository_lower="${github_repository,,}"
 
+linux_runtime_files=(
+    "${repo_root}/${compose_source}"
+    "${repo_root}/${systemd_source}"
+    "${repo_root}/ops/deploy/sitbank-container-deploy"
+    "${repo_root}/ops/deploy/sitbank-container-runtime"
+    "${repo_root}/ops/deploy/sitbank-database-cutover"
+    "${repo_root}/ops/sudoers/sitbank-container-deploy"
+)
+if [[ "${target}" == "staging" ]]; then
+    linux_runtime_files+=(
+        "${repo_root}/ops/nginx-proxy-headers.conf"
+        "${repo_root}/ops/nginx/sitbank-staging.conf"
+    )
+fi
+for runtime_file in "${linux_runtime_files[@]}"; do
+    if grep -q $'\r$' "${runtime_file}"; then
+        echo "Refusing to install CRLF-formatted Linux file: ${runtime_file}" >&2
+        echo "Recreate the bootstrap archive from a checkout honoring .gitattributes." >&2
+        exit 1
+    fi
+done
+
 if [[ "$(dpkg --print-architecture)" != "amd64" ]]; then
     echo "This deployment is pinned to linux/amd64" >&2
     exit 1
@@ -204,6 +226,24 @@ for policy_file in \
 done
 
 if [[ "${target}" == "staging" ]]; then
+    nginx_conflict=0
+    while IFS= read -r enabled_site; do
+        if [[ "$(readlink -f "${enabled_site}")" \
+            != "/etc/nginx/sites-available/sitbank-staging" ]]; then
+            echo "Conflicting Nginx staging site is already enabled: ${enabled_site}" >&2
+            nginx_conflict=1
+        fi
+    done < <(
+        grep -RlF \
+            "server_name ${public_host};" \
+            /etc/nginx/sites-enabled /etc/nginx/conf.d \
+            2>/dev/null || true
+    )
+    if [[ "${nginx_conflict}" -ne 0 ]]; then
+        echo "Disable the duplicate staging server block, then rerun bootstrap." >&2
+        exit 1
+    fi
+
     install -d -o root -g root -m 0755 /etc/nginx/snippets
     install -o root -g root -m 0644 \
         "${repo_root}/ops/nginx-proxy-headers.conf" \

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -593,7 +593,31 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     assert workflow_text.count("^[A-Za-z0-9+/]+={0,2}$") == 2
     assert "STAGING_EC2_SSH_PRIVATE_KEY:" not in workflow_text
     assert "PROD_EC2_SSH_PRIVATE_KEY:" not in workflow_text
-    assert workflow_text.count("-i ~/.ssh/deploy_key") == 4
+    assert workflow_text.count("-i ~/.ssh/deploy_key") == 6
+    assert workflow_text.count(
+        "sha256sum ops/deploy/sitbank-container-deploy"
+    ) == 2
+    assert workflow_text.count(
+        "sha256sum /usr/local/sbin/sitbank-container-deploy"
+    ) == 2
+    assert "EC2 staging deployment wrapper is missing or stale" in workflow_text
+    assert "EC2 production deployment wrapper is missing or stale" in workflow_text
+    for job_name, wrapper_step_name, upload_step_name in (
+        (
+            "deploy-staging",
+            "Verify trusted staging deployment wrapper",
+            "Upload authenticated deployment inputs",
+        ),
+        (
+            "deploy-production",
+            "Verify trusted production deployment wrapper",
+            "Upload authenticated deployment inputs",
+        ),
+    ):
+        step_names = [
+            step["name"] for step in workflow["jobs"][job_name]["steps"]
+        ]
+        assert step_names.index(wrapper_step_name) < step_names.index(upload_step_name)
     assert "~/.ssh/id_ed25519" not in workflow_text
     assert "vars.EC2_" not in workflow_text
     assert "secrets.EC2_" not in workflow_text

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -846,13 +846,51 @@ def test_only_sitbank_container_deployment_units_are_active():
     assert Path("ops/sudoers/sitbank-container-deploy").exists()
 
 
+def test_linux_deployment_artifacts_are_forced_to_lf_and_reject_crlf():
+    attributes = Path(".gitattributes").read_text(encoding="utf-8")
+    bootstrap = Path("ops/deploy/bootstrap-container-ec2").read_text(
+        encoding="utf-8"
+    )
+    linux_files = (
+        Path("Dockerfile"),
+        Path("compose.prod.yml"),
+        Path("compose.staging.yml"),
+        Path("ops/deploy/bootstrap-container-ec2"),
+        Path("ops/deploy/sitbank-container-deploy"),
+        Path("ops/deploy/sitbank-container-runtime"),
+        Path("ops/deploy/sitbank-database-cutover"),
+        Path("ops/nginx-proxy-headers.conf"),
+        Path("ops/nginx/sitbank-staging.conf"),
+        Path("ops/sudoers/sitbank-container-deploy"),
+        Path("ops/systemd/sitbank-container.service"),
+        Path("ops/systemd/sitbank-staging-container.service"),
+    )
+
+    assert "*.sh text eol=lf" in attributes
+    assert "*.yml text eol=lf" in attributes
+    assert "*.conf text eol=lf" in attributes
+    assert "*.service text eol=lf" in attributes
+    assert "ops/deploy/bootstrap-container-ec2 text eol=lf" in attributes
+    assert "ops/sudoers/* text eol=lf" in attributes
+    for path in linux_files:
+        assert b"\r\n" not in path.read_bytes(), f"{path} must use LF line endings"
+
+    assert "Refusing to install CRLF-formatted Linux file" in bootstrap
+    assert "grep -q $'\\r$'" in bootstrap
+
+
 def test_staging_nginx_routes_only_to_the_staging_loopback_port():
     nginx = Path("ops/nginx/sitbank-staging.conf").read_text(encoding="utf-8")
+    bootstrap = Path("ops/deploy/bootstrap-container-ec2").read_text(
+        encoding="utf-8"
+    )
 
     assert "server_name staging-sitbank.duckdns.org;" in nginx
     assert "proxy_pass http://127.0.0.1:5001;" in nginx
     assert "127.0.0.1:5000" not in nginx
     assert "server_name sitbank.duckdns.org;" not in nginx
+    assert "Conflicting Nginx staging site is already enabled" in bootstrap
+    assert "Disable the duplicate staging server block" in bootstrap
 
 
 def test_dependency_manifests_have_one_hashed_lockfile_source_of_truth():


### PR DESCRIPTION
## Summary

This PR adds trusted deployment wrapper verification for both staging and production deployment paths.

## Changes

- Add SHA-256 verification for the installed staging deployment wrapper
- Add SHA-256 verification for the installed production deployment wrapper
- Compare the EC2 root-owned wrapper hash against the expected repository wrapper hash
- Fail deployment early if the EC2 wrapper is missing, stale, or modified
- Prevent bundle and credential uploads when the host deployment wrapper does not match the trusted version
- Update documentation with the required bootstrap refresh process
- Add test coverage for deployment wrapper verification logic

## Security notes

- Deployment jobs no longer blindly trust the EC2-installed wrapper
- Stale or unexpected host-side deployment logic is detected before sensitive deployment inputs are uploaded
- The check helps prevent mismatches between the GitHub Actions workflow and the root-owned EC2 deployment scripts
- Staging and production both verify the trusted wrapper before deployment proceeds

## Verification

- Added regression tests for wrapper hash verification
- Confirmed staging and production deployment paths require the expected wrapper SHA-256
- Confirmed documentation explains how to refresh bootstrap when the wrapper check fails