### PR TITLE
Refactor deployment configurations for improved secret management and health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,13 @@ not copy their values into process environment variables. Non-secret settings
 live in each environment's `container.env`. Containers do not load a
 production `.env` file.
 
+Docker Compose implements local file-backed secrets as bind mounts, so Compose
+does not apply service-level `uid`, `gid`, or `mode` attributes. The host files
+are therefore the authority: application secrets must be root-owned, grouped
+to GID `10001`, and mode `0440`; staging PostgreSQL and Redis bootstrap files
+are root-owned mode `0444`. The deployment wrapper verifies readability before
+starting containers.
+
 The complete production configuration surface is:
 
 - `APP_ENV`

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -37,39 +37,18 @@ services:
     secrets:
       - source: secret_key
         target: secret_key
-        uid: "10001"
-        gid: "10001"
-        mode: 0400
       - source: wtf_csrf_secret_key
         target: wtf_csrf_secret_key
-        uid: "10001"
-        gid: "10001"
-        mode: 0400
       - source: session_hmac_keys_json
         target: session_hmac_keys_json
-        uid: "10001"
-        gid: "10001"
-        mode: 0400
       - source: database_url
         target: database_url
-        uid: "10001"
-        gid: "10001"
-        mode: 0400
       - source: redis_url
         target: redis_url
-        uid: "10001"
-        gid: "10001"
-        mode: 0400
       - source: mfa_aes256_gcm_key_b64
         target: mfa_aes256_gcm_key_b64
-        uid: "10001"
-        gid: "10001"
-        mode: 0400
       - source: password_pepper_b64
         target: password_pepper_b64
-        uid: "10001"
-        gid: "10001"
-        mode: 0400
     volumes:
       - type: bind
         source: /etc/sitbank/common-passwords.txt

--- a/compose.staging.yml
+++ b/compose.staging.yml
@@ -116,39 +116,18 @@ services:
     secrets:
       - source: secret_key
         target: secret_key
-        uid: "10001"
-        gid: "10001"
-        mode: 0400
       - source: wtf_csrf_secret_key
         target: wtf_csrf_secret_key
-        uid: "10001"
-        gid: "10001"
-        mode: 0400
       - source: session_hmac_keys_json
         target: session_hmac_keys_json
-        uid: "10001"
-        gid: "10001"
-        mode: 0400
       - source: database_url
         target: database_url
-        uid: "10001"
-        gid: "10001"
-        mode: 0400
       - source: redis_url
         target: redis_url
-        uid: "10001"
-        gid: "10001"
-        mode: 0400
       - source: mfa_aes256_gcm_key_b64
         target: mfa_aes256_gcm_key_b64
-        uid: "10001"
-        gid: "10001"
-        mode: 0400
       - source: password_pepper_b64
         target: password_pepper_b64
-        uid: "10001"
-        gid: "10001"
-        mode: 0400
     volumes:
       - type: bind
         source: /etc/sitbank-staging/common-passwords.txt

--- a/ops/deploy/sitbank-container-deploy
+++ b/ops/deploy/sitbank-container-deploy
@@ -433,14 +433,20 @@ prepare_dependencies() {
 
 wait_until_ready() {
     curl --fail --silent --show-error \
-        --retry 15 --retry-delay 2 --retry-connrefused \
+        --retry 15 --retry-delay 2 --retry-all-errors \
         --header "Host: ${PUBLIC_HOST}" \
         --header "X-Forwarded-Proto: https" \
         "http://${APP_BIND_HOST}:${APP_BIND_PORT}/health/ready" >/dev/null
     curl --fail --silent --show-error \
-        --retry 8 --retry-delay 2 --retry-connrefused \
+        --retry 8 --retry-delay 2 --retry-all-errors \
         --resolve "${PUBLIC_HOST}:443:127.0.0.1" \
         "https://${PUBLIC_HOST}/health/ready" >/dev/null
+}
+
+show_app_diagnostics() {
+    echo "Application container diagnostics:" >&2
+    compose "${image}" ps app >&2 || true
+    compose "${image}" logs --no-color --tail 80 app >&2 || true
 }
 
 rollback() {
@@ -448,6 +454,9 @@ rollback() {
     local database_rollback_ok=1
     trap - ERR
     set +e
+    if [[ "${service_switched}" -eq 1 ]]; then
+        show_app_diagnostics
+    fi
     if [[ "${service_switched}" -eq 1 ]]; then
         compose "${image}" down --remove-orphans
     elif [[ "${target}" == "staging" \
@@ -551,6 +560,13 @@ for secret_file in "${required_secrets[@]}"; do
         echo "Missing required root-managed secret file: ${secret_file}" >&2
         exit 1
     fi
+    if [[ "${secret_file}" != "postgres_password" \
+        && "${secret_file}" != "redis.conf" ]] \
+        && ! runuser -u sitbank-container -- \
+            test -r "${SECRET_DIR}/${secret_file}"; then
+        echo "Container account cannot read secret file: ${secret_file}" >&2
+        exit 1
+    fi
 done
 validate_staging_isolation
 prepare_dependencies
@@ -572,7 +588,8 @@ elif [[ "${legacy_was_active}" -eq 1 ]]; then
 fi
 service_switched=1
 
-compose "${image}" up --detach --no-build --pull never --remove-orphans
+compose "${image}" up --detach --no-build --pull never --remove-orphans \
+    --wait --wait-timeout 120
 wait_until_ready
 
 install -d -o root -g root -m 0700 "${STATE_DIR}"

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -323,7 +323,7 @@ def test_dockerfile_and_compose_enforce_hardened_runtime():
     assert app["mem_limit"] == "768m"
     assert app["restart"] == "unless-stopped"
     assert all(volume["read_only"] for volume in app["volumes"])
-    assert all(secret["mode"] == 0o400 for secret in app["secrets"])
+    assert all(set(secret) == {"source", "target"} for secret in app["secrets"])
     assert all(
         value.startswith("/run/secrets/")
         for name, value in app["environment"].items()
@@ -382,6 +382,13 @@ def test_dockerfile_and_compose_enforce_hardened_runtime():
     assert staging_services["redis"]["container_name"] == "sitbank-staging-redis"
     assert "ports" not in staging_services["postgres"]
     assert "ports" not in staging_services["redis"]
+    assert staging_app["command"][
+        staging_app["command"].index("--bind") + 1
+    ] == "0.0.0.0:5000"
+    assert all(
+        set(secret) == {"source", "target"}
+        for secret in staging_app["secrets"]
+    )
     assert staging_compose["volumes"]["sitbank-staging-postgres-data"]["name"] == (
         "sitbank-staging-postgres-data"
     )
@@ -392,6 +399,11 @@ def test_dockerfile_and_compose_enforce_hardened_runtime():
     assert "/etc/sitbank/" not in staging_compose_text
     assert "sitbank-staging-postgres-data" not in compose_text
     assert "sitbank-staging-redis-data" not in compose_text
+    assert "--wait --wait-timeout 120" in deploy_script
+    assert deploy_script.count("--retry-all-errors") == 2
+    assert "show_app_diagnostics" in deploy_script
+    assert "logs --no-color --tail 80 app" in deploy_script
+    assert "runuser -u sitbank-container" in deploy_script
 
     app_python = "\n".join(
         path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

This PR improves deployment reliability by simplifying Docker Compose secret definitions and adding stronger health-check diagnostics.

## Changes

- Remove unsupported `uid`, `gid`, and `mode` attributes from Docker Compose secrets
- Keep secret ownership and readability enforcement in the deployment wrapper instead of Compose
- Improve container health-check reliability with adjusted retry behavior
- Wait longer for the app container to become healthy before failing deployment
- Retry curl checks to handle temporary connection resets during startup
- Add bounded app diagnostics during rollback to make startup failures easier to debug
- Add secret readability checks for the expected app runtime UID
- Update documentation for the new deployment behavior
- Update tests for Compose validation, secret handling, and health-check logic

## Security notes

- Runtime secrets remain root-managed on EC2
- Compose no longer relies on unsupported secret permission fields
- The deployment wrapper still validates secret readability before deployment proceeds
- Failed deployments now provide safer bounded diagnostics without dumping secret values
- Staging and production deployment checks remain gated by wrapper verification and release verification

## Verification

- Confirmed 25 deployment tests passed
- Confirmed compilation passed
- Confirmed both Compose models validated successfully