### PR TITLE
Enhance secret directory permissions and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,9 @@ does not apply service-level `uid`, `gid`, or `mode` attributes. The host files
 are therefore the authority: application secrets must be root-owned, grouped
 to GID `10001`, and mode `0440`; staging PostgreSQL and Redis bootstrap files
 are root-owned mode `0444`. The deployment wrapper verifies readability before
-starting containers.
+starting containers. Each environment's `secrets` directory is
+`root:sitbank-container` mode `0750`, allowing the locked container account to
+traverse the directory without granting access to the SSH deployment user.
 
 The complete production configuration surface is:
 
@@ -513,8 +515,9 @@ from pathlib import Path
 from urllib.parse import quote
 
 root = Path("/etc/sitbank-staging/secrets")
-root.mkdir(mode=0o700, parents=True, exist_ok=True)
-os.chown(root, 0, 0)
+root.mkdir(mode=0o750, parents=True, exist_ok=True)
+os.chown(root, 0, 10001)
+os.chmod(root, 0o750)
 
 def write(name, value, mode=0o440, gid=10001):
     path = root / name
@@ -711,7 +714,7 @@ sudo install -o root -g root -m 0600 \
   /etc/sitbank/container.env
 sudo cp -a /etc/sitbank/runtime-import/secrets/. /etc/sitbank/secrets/
 sudo chown -R root:10001 /etc/sitbank/secrets
-sudo chmod 0700 /etc/sitbank/secrets
+sudo chmod 0750 /etc/sitbank/secrets
 sudo chmod 0440 /etc/sitbank/secrets/*
 sudo rm -rf /etc/sitbank/runtime-import
 ```

--- a/ops/deploy/bootstrap-container-ec2
+++ b/ops/deploy/bootstrap-container-ec2
@@ -178,8 +178,9 @@ chmod 0600 "/home/${DEPLOY_USER}/.ssh/authorized_keys"
 
 install -d -o root -g root -m 0755 "${compose_dir}"
 install -d -o root -g "${CONTAINER_GID}" -m 0750 "${config_root}"
-install -d -o root -g root -m 0700 \
-    "${config_root}/secrets" "${state_dir}" "${backup_dir}"
+install -d -o root -g "${CONTAINER_GID}" -m 0750 \
+    "${config_root}/secrets"
+install -d -o root -g root -m 0700 "${state_dir}" "${backup_dir}"
 
 install -o root -g root -m 0644 \
     "${repo_root}/${compose_source}" "${compose_dir}/compose.yml"

--- a/ops/deploy/sitbank-container-deploy
+++ b/ops/deploy/sitbank-container-deploy
@@ -554,6 +554,10 @@ required_secrets=(
 if [[ "${target}" == "staging" ]]; then
     required_secrets+=(postgres_password redis.conf)
 fi
+if ! runuser -u sitbank-container -- test -x "${SECRET_DIR}"; then
+    echo "Container account cannot traverse secret directory: ${SECRET_DIR}" >&2
+    exit 1
+fi
 for secret_file in "${required_secrets[@]}"; do
     if [[ ! -r "${SECRET_DIR}/${secret_file}" \
         || -L "${SECRET_DIR}/${secret_file}" ]]; then

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -404,6 +404,9 @@ def test_dockerfile_and_compose_enforce_hardened_runtime():
     assert "show_app_diagnostics" in deploy_script
     assert "logs --no-color --tail 80 app" in deploy_script
     assert "runuser -u sitbank-container" in deploy_script
+    assert "cannot traverse secret directory" in deploy_script
+    assert '"${config_root}/secrets"' in bootstrap
+    assert '-g "${CONTAINER_GID}" -m 0750' in bootstrap
 
     app_python = "\n".join(
         path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

This PR improves staging secret directory permissions and adds deployment validation for container access.

## Changes

- Update secrets directory permissions to support proper container account access
- Ensure the container runtime UID can traverse the secrets directory when required
- Add deployment validation for secret directory traversal
- Fail deployment early if the container account cannot access required secret paths
- Improve deployment safety by detecting permission issues before app startup
- Update tests for secret directory permission validation

## Security notes

- Runtime secrets remain root-managed on EC2
- The deployment wrapper validates access without exposing secret values
- The container only receives the minimum filesystem access needed to read mounted secrets
- Permission failures now stop deployment before the app starts with unclear runtime errors

## Verification

- Added validation coverage for container secret directory traversal
- Confirmed deployment checks fail clearly when permissions are incorrect
- Confirmed secret files remain protected from unnecessary broad access