### PR TITLE
Fix release verification candidate source checkout

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -493,6 +493,13 @@ jobs:
           persist-credentials: false
           ref: ${{ github.workflow_sha }}
 
+      - name: Check out candidate source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+          ref: ${{ needs.publish.outputs.revision }}
+          path: candidate-source
+
       - name: Resolve verified image reference
         id: image
         shell: bash
@@ -540,13 +547,13 @@ jobs:
       - name: Validate production and staging Compose models for the exact digest
         env:
           SITBANK_IMAGE: ${{ steps.image.outputs.image }}
-        run: bash ops/container/validate-compose.sh "${SITBANK_IMAGE}"
+        run: bash candidate-source/ops/container/validate-compose.sh "${SITBANK_IMAGE}"
 
       - name: Smoke-test and DAST-scan the exact published digest
         env:
           IMAGE: ${{ steps.image.outputs.image }}
           RUN_ZAP_DAST: ${{ github.event_name != 'workflow_dispatch' || inputs.run_dast == true }}
-        run: bash ops/container/smoke-test.sh "${IMAGE}"
+        run: bash candidate-source/ops/container/smoke-test.sh "${IMAGE}"
 
       # zizmor: ignore[unpinned-tools] Trivy action is SHA-pinned; the action installs a pinned Trivy tool version.
       - name: Report all critical vulnerabilities in the published digest

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -666,12 +666,12 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     assert "check_dependency_locks.py" in workflow_text
     assert "IMAGE_DIGEST" in workflow_text
     assert "StrictHostKeyChecking=no" not in workflow_text
-    assert workflow_text.count("persist-credentials: false") == 9
+    assert workflow_text.count("persist-credentials: false") == 10
     assert (
         workflow_text.count(
             "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10"
         )
-        == 9
+        == 10
     )
     assert (
         "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405"


### PR DESCRIPTION
## Summary

Updates release verification so Compose validation and smoke tests run from the immutable candidate source revision instead of the trusted workflow checkout.

## Why

Previously, release verification could validate files from the trusted workflow checkout while the published image was built from the candidate source revision. This could create a mismatch between what was tested and what was actually released.

This change makes release verification match the source revision used for the published image.

## What changed

* Compose validation now runs from the immutable candidate source revision.
* Smoke tests now run from the immutable candidate source revision.
* Deployment jobs continue to run from the trusted workflow checkout.
* The trusted deployment path remains unchanged.

## Deployment impact

No staging or production deployment is included in this PR.

This change only affects release verification behavior.
