### PR TITLE
Support staging split-role deployment wrapper

### DIFF
--- a/ops/deploy/sitbank-container-deploy
+++ b/ops/deploy/sitbank-container-deploy
@@ -307,6 +307,13 @@ compose() {
         --project-name "${COMPOSE_PROJECT}" --file "${COMPOSE_FILE}" "$@"
 }
 
+staging_migration_run() {
+    compose "${image}" run --rm --no-deps \
+        --env DATABASE_MIGRATION_URL_FILE=/run/secrets/database_migration_url \
+        --volume "${SECRET_DIR}/database_migration_url:/run/secrets/database_migration_url:ro" \
+        app "$@"
+}
+
 validate_legacy_configuration() {
     if [[ "${target}" != "production" ]]; then
         return
@@ -368,6 +375,7 @@ validate_staging_isolation() {
         wtf_csrf_secret_key \
         session_hmac_keys_json \
         database_url \
+        database_migration_url \
         redis_url \
         mfa_aes256_gcm_key_b64 \
         password_pepper_b64; do
@@ -381,7 +389,9 @@ validate_staging_isolation() {
 
     python3 - \
         "${SECRET_DIR}/database_url" \
-        "${SECRET_DIR}/postgres_password" \
+        "${SECRET_DIR}/database_migration_url" \
+        "${SECRET_DIR}/postgres_app_password" \
+        "${SECRET_DIR}/postgres_owner_password" \
         "${SECRET_DIR}/redis_url" \
         "${SECRET_DIR}/redis.conf" <<'PY'
 from pathlib import Path
@@ -389,20 +399,35 @@ from urllib.parse import unquote, urlsplit
 import sys
 
 database_url = Path(sys.argv[1]).read_text(encoding="utf-8")
-postgres_password = Path(sys.argv[2]).read_text(encoding="utf-8")
-redis_url = Path(sys.argv[3]).read_text(encoding="utf-8")
-redis_config = Path(sys.argv[4]).read_text(encoding="utf-8")
+migration_url = Path(sys.argv[2]).read_text(encoding="utf-8")
+postgres_app_password = Path(sys.argv[3]).read_text(encoding="utf-8")
+postgres_owner_password = Path(sys.argv[4]).read_text(encoding="utf-8")
+redis_url = Path(sys.argv[5]).read_text(encoding="utf-8")
+redis_config = Path(sys.argv[6]).read_text(encoding="utf-8")
 
 database = urlsplit(database_url)
 if (
     database.scheme != "postgresql+psycopg2"
     or database.hostname != "postgres"
     or database.port != 5432
-    or unquote(database.username or "") != "sitbank_staging"
+    or unquote(database.username or "") != "sitbank_app"
     or database.path != "/sitbank_staging"
-    or unquote(database.password or "") != postgres_password
+    or unquote(database.password or "") != postgres_app_password
 ):
-    raise SystemExit("Staging database URL must target only the staging PostgreSQL service")
+    raise SystemExit("Staging runtime database URL must use only the staging app role")
+
+migration = urlsplit(migration_url)
+if (
+    migration.scheme != "postgresql+psycopg2"
+    or migration.hostname != "postgres"
+    or migration.port != 5432
+    or unquote(migration.username or "") != "sitbank_owner"
+    or migration.path != "/sitbank_staging"
+    or unquote(migration.password or "") != postgres_owner_password
+):
+    raise SystemExit("Staging migration database URL must use only the staging owner role")
+if database_url == migration_url:
+    raise SystemExit("Staging runtime and migration database URLs must be different")
 
 redis = urlsplit(redis_url)
 if (
@@ -552,7 +577,7 @@ required_secrets=(
     password_pepper_b64
 )
 if [[ "${target}" == "staging" ]]; then
-    required_secrets+=(postgres_password redis.conf)
+    required_secrets+=(database_migration_url postgres_owner_password postgres_app_password redis.conf)
 fi
 if ! runuser -u sitbank-container -- test -x "${SECRET_DIR}"; then
     echo "Container account cannot traverse secret directory: ${SECRET_DIR}" >&2
@@ -564,7 +589,8 @@ for secret_file in "${required_secrets[@]}"; do
         echo "Missing required root-managed secret file: ${secret_file}" >&2
         exit 1
     fi
-    if [[ "${secret_file}" != "postgres_password" \
+    if [[ "${secret_file}" != "postgres_owner_password" \
+        && "${secret_file}" != "postgres_app_password" \
         && "${secret_file}" != "redis.conf" ]] \
         && ! runuser -u sitbank-container -- \
             test -r "${SECRET_DIR}/${secret_file}"; then
@@ -577,8 +603,15 @@ prepare_dependencies
 
 compose "${image}" run --rm --no-deps app \
     python -m flask --app wsgi:app production-check
-compose "${image}" run --rm --no-deps app \
-    python -m flask --app wsgi:app db upgrade
+if [[ "${target}" == "staging" ]]; then
+    staging_migration_run \
+        python -m flask --app wsgi:app db upgrade
+    staging_migration_run \
+        python -m flask --app wsgi:app verify-runtime-db-privileges
+else
+    compose "${image}" run --rm --no-deps app \
+        python -m flask --app wsgi:app db upgrade
+fi
 
 if [[ "${target}" == "production" \
     && "${LEGACY_SERVICE:-"-"}" != "-" ]] \

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -402,6 +402,16 @@ def test_dockerfile_and_compose_enforce_hardened_runtime():
     assert "--wait --wait-timeout 120" in deploy_script
     assert deploy_script.count("--retry-all-errors") == 2
     assert "show_app_diagnostics" in deploy_script
+    assert "DATABASE_MIGRATION_URL_FILE=/run/secrets/database_migration_url" in deploy_script
+    assert "Staging runtime database URL must use only the staging app role" in deploy_script
+    assert "Staging migration database URL must use only the staging owner role" in deploy_script
+    assert "Staging runtime and migration database URLs must be different" in deploy_script
+    assert "Staging database URL must target only the staging PostgreSQL service" not in deploy_script
+    assert 'unquote(database.username or "") != "sitbank_app"' in deploy_script
+    assert 'unquote(migration.username or "") != "sitbank_owner"' in deploy_script
+    assert "postgres_app_password" in deploy_script
+    assert "postgres_owner_password" in deploy_script
+    assert "verify-runtime-db-privileges" in deploy_script
     assert "logs --no-color --tail 80 app" in deploy_script
     assert "runuser -u sitbank-container" in deploy_script
     assert "cannot traverse secret directory" in deploy_script


### PR DESCRIPTION
﻿## Summary

- Update the trusted EC2 deployment wrapper to support staging split-role database credentials.
- Validate staging runtime DB URL against `sitbank_app` and `postgres_app_password`.
- Validate staging migration DB URL against `sitbank_owner` and `postgres_owner_password`.
- Ensure staging runtime and migration URLs are different.
- Run staging migrations using `DATABASE_MIGRATION_URL_FILE`.
- Run `verify-runtime-db-privileges` from the candidate image during staging deployment.
- Leave production deployment validation unchanged.

## Root cause

PR #31 correctly changed staging to use split database roles, but the trusted deployment wrapper from `main` still validated staging against the old single-role layout:

- `sitbank_staging`
- `postgres_password`

Because the workflow verifies the EC2 wrapper against the trusted `main` version, this wrapper fix must merge into `main` first before rerunning PR #31 staging.

## Validation

- `python -m pytest tests/test_deployment.py -q`: `25 passed`
- `python -m pytest -q`: `206 passed, 1 skipped`
- `python -m compileall app config.py wsgi.py`: passed
- `python -m pip check`: passed
- `python -m bandit -q -ll -r app ops config.py wsgi.py`: passed
- `git diff --check`: passed
- `bash -n ops/deploy/sitbank-container-deploy ops/deploy/bootstrap-container-ec2 ops/deploy/sitbank-container-runtime`: passed

## Deployment note

Do not rerun PR #31 staging until this PR is merged into `main` and the EC2 root-owned trusted wrapper is updated from merged `main`.

Deploy gates remain off:

- `STAGING_DEPLOY_ENABLED=false`
- `PROD_DEPLOY_ENABLED=false`
