### PR TITLE
Enhance database migration process and role management

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,14 @@ for Alembic migrations and database privilege verification, and must use the
 `DATABASE_MIGRATION_URL_FILE`; the deployment wrapper bind-mounts it only for
 `flask db upgrade` and `flask verify-runtime-db-privileges`.
 
+Both staging and production deployments require the root-managed
+`database_migration_url` file before deployment begins. A missing file is not
+generated or copied from `database_url`: doing so would silently give the
+long-running application role schema-owner privileges. The one-shot migration
+and privilege-check containers receive the owner URL through an explicit
+read-only bind mount; the long-running application container never receives
+it.
+
 PostgreSQL ownership is split by role:
 
 - `sitbank_owner` owns `sitbank_db`/`sitbank_staging`, the `public` schema, and
@@ -800,7 +808,37 @@ database_url = postgresql+psycopg2://sitbank_app:<runtime-password>@127.0.0.1:54
 database_migration_url = postgresql+psycopg2://sitbank_owner:<owner-password>@127.0.0.1:5432/sitbank_db
 ```
 
-Prepare the cutover:
+If the production database is already named `sitbank_db` from an earlier
+container release, use the guarded in-place adoption path. First identify its
+current owner:
+
+```bash
+current_owner="$(
+  sudo -u postgres psql --no-psqlrc --tuples-only --no-align \
+    --command "SELECT pg_get_userbyid(datdba) FROM pg_database WHERE datname = 'sitbank_db';"
+)"
+printf 'Current owner: %s\n' "${current_owner}"
+```
+
+After confirming that this is the role used by the current production
+`database_url`, prepare the split:
+
+```bash
+sudo /usr/local/sbin/sitbank-database-cutover adopt-existing \
+  "${current_owner}" \
+  /root/sitbank-db-owner-password \
+  /root/sitbank-db-app-password
+```
+
+This path creates a protected backup, briefly stops the current service,
+transfers ownership to `sitbank_owner`, grants least-privilege runtime access
+to `sitbank_app`, and restarts the previous service while deployment is
+pending. The former role temporarily retains runtime DML access so production
+does not remain offline while the verified deployment runs. Successful
+deployment revokes that temporary access and removes the former role;
+deployment failure restores its ownership automatically.
+
+For a first cutover where the database still has its old name, use:
 
 ```bash
 sudo /usr/local/sbin/sitbank-database-cutover prepare \

--- a/ops/deploy/sitbank-container-deploy
+++ b/ops/deploy/sitbank-container-deploy
@@ -307,7 +307,7 @@ compose() {
         --project-name "${COMPOSE_PROJECT}" --file "${COMPOSE_FILE}" "$@"
 }
 
-staging_migration_run() {
+migration_run() {
     compose "${image}" run --rm --no-deps \
         --env DATABASE_MIGRATION_URL_FILE=/run/secrets/database_migration_url \
         --volume "${SECRET_DIR}/database_migration_url:/run/secrets/database_migration_url:ro" \
@@ -587,6 +587,12 @@ fi
 for secret_file in "${required_secrets[@]}"; do
     if [[ ! -r "${SECRET_DIR}/${secret_file}" \
         || -L "${SECRET_DIR}/${secret_file}" ]]; then
+        if [[ "${target}" == "production" \
+            && "${secret_file}" == "database_migration_url" ]]; then
+            echo "Missing required root-managed secret file: database_migration_url" >&2
+            echo "Complete the production database role split and install the owner-role migration URL before retrying deployment." >&2
+            exit 1
+        fi
         echo "Missing required root-managed secret file: ${secret_file}" >&2
         exit 1
     fi
@@ -604,15 +610,10 @@ prepare_dependencies
 
 compose "${image}" run --rm --no-deps app \
     python -m flask --app wsgi:app production-check
-if [[ "${target}" == "staging" ]]; then
-    staging_migration_run \
-        python -m flask --app wsgi:app db upgrade
-    staging_migration_run \
-        python -m flask --app wsgi:app verify-runtime-db-privileges
-else
-    compose "${image}" run --rm --no-deps app \
-        python -m flask --app wsgi:app db upgrade
-fi
+migration_run \
+    python -m flask --app wsgi:app db upgrade
+migration_run \
+    python -m flask --app wsgi:app verify-runtime-db-privileges
 
 if [[ "${target}" == "production" \
     && "${LEGACY_SERVICE:-"-"}" != "-" ]] \

--- a/ops/deploy/sitbank-database-cutover
+++ b/ops/deploy/sitbank-database-cutover
@@ -8,6 +8,7 @@ readonly BACKUP_DIR="/var/backups/sitbank"
 readonly TARGET_DATABASE="sitbank_db"
 readonly TARGET_OWNER_ROLE="sitbank_owner"
 readonly TARGET_APP_ROLE="sitbank_app"
+readonly CONTAINER_SERVICE="sitbank-container.service"
 
 if [[ "${EUID}" -ne 0 ]]; then
     echo "Database cutover helper must run as root" >&2
@@ -40,13 +41,27 @@ database_exists() {
         | grep -qx 1
 }
 
+database_owner() {
+    sudo -u postgres psql --no-psqlrc --tuples-only --no-align \
+        --command "SELECT pg_get_userbyid(datdba) FROM pg_database WHERE datname = '$1'"
+}
+
+role_has_elevated_privileges() {
+    sudo -u postgres psql --no-psqlrc --tuples-only --no-align \
+        --command "SELECT rolsuper OR rolcreaterole OR rolcreatedb OR rolreplication OR rolbypassrls FROM pg_roles WHERE rolname = '$1'" \
+        | grep -qx t
+}
+
 terminate_database_connections() {
     sudo -u postgres psql --no-psqlrc --set ON_ERROR_STOP=1 \
         --command "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '$1' AND pid <> pg_backend_pid();" \
         >/dev/null
 }
 
-restart_legacy_service() {
+restart_previous_services() {
+    if [[ "${CONTAINER_WAS_ACTIVE:-0}" == "1" ]]; then
+        systemctl start "${CONTAINER_SERVICE}"
+    fi
     if [[ "${LEGACY_WAS_ACTIVE:-0}" == "1" && "${LEGACY_SERVICE:-"-"}" != "-" ]]; then
         systemctl start "${LEGACY_SERVICE}"
     fi
@@ -95,12 +110,20 @@ rollback_cutover() {
     fi
     # shellcheck disable=SC1090
     source "${STATE_FILE}"
+    cutover_mode="${CUTOVER_MODE:-rename}"
+    if [[ "${cutover_mode}" != "rename" \
+        && "${cutover_mode}" != "adopt-existing" ]]; then
+        echo "Unsupported database cutover state" >&2
+        return 1
+    fi
     # shellcheck disable=SC2153
     validate_identifier "${SOURCE_DATABASE}"
     # shellcheck disable=SC2153
     validate_identifier "${SOURCE_ROLE}"
 
-    if database_exists "${TARGET_DATABASE}" && ! database_exists "${SOURCE_DATABASE}"; then
+    if [[ "${cutover_mode}" == "rename" ]] \
+        && database_exists "${TARGET_DATABASE}" \
+        && ! database_exists "${SOURCE_DATABASE}"; then
         terminate_database_connections "${TARGET_DATABASE}"
         if role_exists "${SOURCE_ROLE}"; then
             if role_exists "${TARGET_OWNER_ROLE}"; then
@@ -125,6 +148,31 @@ ALTER DATABASE "${TARGET_DATABASE}" OWNER TO "${SOURCE_ROLE}";
 ALTER DATABASE "${TARGET_DATABASE}" RENAME TO "${SOURCE_DATABASE}";
 SQL
         fi
+    elif [[ "${cutover_mode}" == "adopt-existing" ]] \
+        && database_exists "${TARGET_DATABASE}"; then
+        terminate_database_connections "${TARGET_DATABASE}"
+        if role_exists "${SOURCE_ROLE}"; then
+            if role_exists "${TARGET_OWNER_ROLE}"; then
+                sudo -u postgres psql --no-psqlrc --set ON_ERROR_STOP=1 \
+                    --dbname "${TARGET_DATABASE}" <<SQL
+REASSIGN OWNED BY "${TARGET_OWNER_ROLE}" TO "${SOURCE_ROLE}";
+DROP OWNED BY "${TARGET_OWNER_ROLE}";
+SQL
+            fi
+            if role_exists "${TARGET_APP_ROLE}"; then
+                sudo -u postgres psql --no-psqlrc --set ON_ERROR_STOP=1 \
+                    --dbname "${TARGET_DATABASE}" <<SQL
+DROP OWNED BY "${TARGET_APP_ROLE}";
+SQL
+            fi
+            sudo -u postgres psql --no-psqlrc --set ON_ERROR_STOP=1 \
+                --dbname "${TARGET_DATABASE}" <<SQL
+ALTER SCHEMA public OWNER TO "${SOURCE_ROLE}";
+SQL
+            sudo -u postgres psql --no-psqlrc --set ON_ERROR_STOP=1 <<SQL
+ALTER DATABASE "${TARGET_DATABASE}" OWNER TO "${SOURCE_ROLE}";
+SQL
+        fi
     fi
     if role_exists "${TARGET_APP_ROLE}"; then
         sudo -u postgres psql --no-psqlrc --set ON_ERROR_STOP=1 \
@@ -134,14 +182,29 @@ SQL
         sudo -u postgres psql --no-psqlrc --set ON_ERROR_STOP=1 \
             --command "DROP ROLE \"${TARGET_OWNER_ROLE}\";" >/dev/null
     fi
-    if ! database_exists "${SOURCE_DATABASE}" \
-        || database_exists "${TARGET_DATABASE}" \
-        || role_exists "${TARGET_APP_ROLE}" \
+    if [[ "${cutover_mode}" == "rename" ]] \
+        && ( ! database_exists "${SOURCE_DATABASE}" \
+            || database_exists "${TARGET_DATABASE}" ); then
+        echo "Database rollback is incomplete; preserving cutover state" >&2
+        return 1
+    fi
+    if [[ "${cutover_mode}" == "adopt-existing" ]] \
+        && ( ! database_exists "${TARGET_DATABASE}" \
+            || "$(database_owner "${TARGET_DATABASE}")" != "${SOURCE_ROLE}" ); then
+        echo "Database role rollback is incomplete; preserving cutover state" >&2
+        return 1
+    fi
+    if role_exists "${TARGET_APP_ROLE}" \
         || role_exists "${TARGET_OWNER_ROLE}"; then
         echo "Database rollback is incomplete; preserving cutover state" >&2
         return 1
     fi
-    restart_legacy_service
+    restart_previous_services
+    if [[ "${CONTAINER_WAS_ACTIVE:-0}" == "1" ]] \
+        && ! systemctl is-active --quiet "${CONTAINER_SERVICE}"; then
+        echo "Database was restored but the container service did not restart" >&2
+        return 1
+    fi
     if [[ "${LEGACY_WAS_ACTIVE:-0}" == "1" \
         && "${LEGACY_SERVICE:-"-"}" != "-" ]] \
         && ! systemctl is-active --quiet "${LEGACY_SERVICE}"; then
@@ -202,9 +265,11 @@ case "${1:-}" in
             legacy_was_active=1
         fi
         cat > "${STATE_FILE}" <<EOF
+CUTOVER_MODE=rename
 SOURCE_DATABASE=${source_database}
 SOURCE_ROLE=${source_role}
 LEGACY_WAS_ACTIVE=${legacy_was_active}
+CONTAINER_WAS_ACTIVE=0
 EOF
         chmod 0600 "${STATE_FILE}"
 
@@ -252,6 +317,125 @@ SQL
         rm -f -- "${temporary_backup}"
         echo "Database cutover prepared; deploy the SITBank container now"
         ;;
+    adopt-existing)
+        if [[ "$#" -ne 4 ]]; then
+            echo "Usage: sitbank-database-cutover adopt-existing SOURCE_ROLE OWNER_PASSWORD_FILE APP_PASSWORD_FILE" >&2
+            exit 2
+        fi
+        source_role="$2"
+        owner_password_file="$3"
+        app_password_file="$4"
+        validate_identifier "${source_role}"
+        if [[ "${source_role}" == "${TARGET_OWNER_ROLE}" \
+            || "${source_role}" == "${TARGET_APP_ROLE}" ]]; then
+            echo "Source role must differ from SITBank split-role targets" >&2
+            exit 2
+        fi
+        if [[ -e "${STATE_FILE}" ]]; then
+            echo "A database cutover is already pending" >&2
+            exit 1
+        fi
+        validate_password_file "${owner_password_file}" "OWNER_PASSWORD_FILE"
+        validate_password_file "${app_password_file}" "APP_PASSWORD_FILE"
+        owner_password="$(cat -- "${owner_password_file}")"
+        app_password="$(cat -- "${app_password_file}")"
+        validate_database_password "${owner_password}" "Owner database password"
+        validate_database_password "${app_password}" "Runtime app database password"
+        if [[ "${owner_password}" == "${app_password}" ]]; then
+            echo "Owner and runtime app database passwords must be different" >&2
+            exit 2
+        fi
+        if ! database_exists "${TARGET_DATABASE}" || ! role_exists "${source_role}"; then
+            echo "Existing SITBank database or source role does not exist" >&2
+            exit 1
+        fi
+        if role_has_elevated_privileges "${source_role}"; then
+            echo "Refusing to adopt a privileged PostgreSQL source role" >&2
+            exit 1
+        fi
+        if [[ "$(database_owner "${TARGET_DATABASE}")" != "${source_role}" ]]; then
+            echo "Source role must own the existing SITBank database" >&2
+            exit 1
+        fi
+        if role_exists "${TARGET_OWNER_ROLE}" || role_exists "${TARGET_APP_ROLE}"; then
+            echo "SITBank split roles already exist" >&2
+            exit 1
+        fi
+
+        install -d -o root -g root -m 0700 "${STATE_DIR}" "${BACKUP_DIR}"
+        legacy_was_active=0
+        container_was_active=0
+        if systemctl is-active --quiet "${CONTAINER_SERVICE}"; then
+            container_was_active=1
+        fi
+        if [[ "${LEGACY_SERVICE:-"-"}" != "-" ]] \
+            && systemctl is-active --quiet "${LEGACY_SERVICE}"; then
+            legacy_was_active=1
+        fi
+        if [[ "${container_was_active}" -eq 1 && "${legacy_was_active}" -eq 1 ]]; then
+            echo "Container and legacy services cannot both be active during role adoption" >&2
+            exit 1
+        fi
+        cat > "${STATE_FILE}" <<EOF
+CUTOVER_MODE=adopt-existing
+SOURCE_DATABASE=${TARGET_DATABASE}
+SOURCE_ROLE=${source_role}
+LEGACY_WAS_ACTIVE=${legacy_was_active}
+CONTAINER_WAS_ACTIVE=${container_was_active}
+EOF
+        chmod 0600 "${STATE_FILE}"
+
+        timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+        temporary_backup="$(
+            sudo -u postgres mktemp /tmp/sitbank-db.XXXXXX.dump
+        )"
+        trap prepare_failure ERR
+        trap 'rm -f -- "${temporary_backup}" "${owner_password_file}" "${app_password_file}"' EXIT
+        sudo -u postgres pg_dump --format=custom \
+            --file "${temporary_backup}" "${TARGET_DATABASE}"
+        install -o root -g root -m 0600 "${temporary_backup}" \
+            "${BACKUP_DIR}/database-${timestamp}.dump"
+
+        if [[ "${container_was_active}" -eq 1 ]]; then
+            systemctl stop "${CONTAINER_SERVICE}"
+        fi
+        if [[ "${legacy_was_active}" -eq 1 ]]; then
+            systemctl stop "${LEGACY_SERVICE}"
+        fi
+        terminate_database_connections "${TARGET_DATABASE}"
+        sudo -u postgres psql --no-psqlrc --set ON_ERROR_STOP=1 <<SQL
+CREATE ROLE "${TARGET_OWNER_ROLE}" LOGIN PASSWORD '${owner_password}';
+CREATE ROLE "${TARGET_APP_ROLE}" LOGIN PASSWORD '${app_password}';
+SQL
+        sudo -u postgres psql --no-psqlrc --set ON_ERROR_STOP=1 \
+            --dbname "${TARGET_DATABASE}" <<SQL
+REASSIGN OWNED BY "${source_role}" TO "${TARGET_OWNER_ROLE}";
+ALTER SCHEMA public OWNER TO "${TARGET_OWNER_ROLE}";
+REVOKE ALL ON SCHEMA public FROM PUBLIC;
+REVOKE ALL ON SCHEMA public FROM "${TARGET_APP_ROLE}";
+GRANT USAGE ON SCHEMA public TO "${TARGET_APP_ROLE}";
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO "${TARGET_APP_ROLE}";
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO "${TARGET_APP_ROLE}";
+GRANT USAGE ON SCHEMA public TO "${source_role}";
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO "${source_role}";
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO "${source_role}";
+ALTER DEFAULT PRIVILEGES FOR ROLE "${TARGET_OWNER_ROLE}" IN SCHEMA public
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO "${TARGET_APP_ROLE}";
+ALTER DEFAULT PRIVILEGES FOR ROLE "${TARGET_OWNER_ROLE}" IN SCHEMA public
+    GRANT USAGE, SELECT ON SEQUENCES TO "${TARGET_APP_ROLE}";
+SQL
+        sudo -u postgres psql --no-psqlrc --set ON_ERROR_STOP=1 <<SQL
+ALTER DATABASE "${TARGET_DATABASE}" OWNER TO "${TARGET_OWNER_ROLE}";
+REVOKE ALL ON DATABASE "${TARGET_DATABASE}" FROM PUBLIC;
+GRANT CONNECT ON DATABASE "${TARGET_DATABASE}" TO "${TARGET_APP_ROLE}";
+GRANT CONNECT ON DATABASE "${TARGET_DATABASE}" TO "${source_role}";
+SQL
+        rm -f -- "${owner_password_file}" "${app_password_file}"
+        rm -f -- "${temporary_backup}"
+        restart_previous_services
+        trap - ERR EXIT
+        echo "Existing SITBank database role split prepared; deploy the container now"
+        ;;
     rollback)
         rollback_cutover
         ;;
@@ -265,13 +449,16 @@ SQL
         validate_identifier "${SOURCE_ROLE}"
         if role_exists "${SOURCE_ROLE}"; then
             sudo -u postgres psql --no-psqlrc --set ON_ERROR_STOP=1 \
+                --dbname "${TARGET_DATABASE}" \
+                --command "DROP OWNED BY \"${SOURCE_ROLE}\";" >/dev/null
+            sudo -u postgres psql --no-psqlrc --set ON_ERROR_STOP=1 \
                 --command "DROP ROLE \"${SOURCE_ROLE}\";" >/dev/null
         fi
         rm -rf -- "${STATE_DIR}"
         echo "Database cutover finalized"
         ;;
     *)
-        echo "Usage: sitbank-database-cutover prepare SOURCE_DATABASE SOURCE_ROLE OWNER_PASSWORD_FILE APP_PASSWORD_FILE | rollback | finalize" >&2
+        echo "Usage: sitbank-database-cutover prepare SOURCE_DATABASE SOURCE_ROLE OWNER_PASSWORD_FILE APP_PASSWORD_FILE | adopt-existing SOURCE_ROLE OWNER_PASSWORD_FILE APP_PASSWORD_FILE | rollback | finalize" >&2
         exit 2
         ;;
 esac

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -372,6 +372,9 @@ def test_dockerfile_and_compose_enforce_hardened_runtime():
     runtime_script = Path("ops/deploy/sitbank-container-runtime").read_text(
         encoding="utf-8"
     )
+    database_cutover = Path("ops/deploy/sitbank-database-cutover").read_text(
+        encoding="utf-8"
+    )
     compose = yaml.safe_load(compose_text)
     app = compose["services"]["app"]
     staging_compose = yaml.safe_load(staging_compose_text)
@@ -537,9 +540,25 @@ def test_dockerfile_and_compose_enforce_hardened_runtime():
     assert "postgres_app_password" in deploy_script
     assert "postgres_owner_password" in deploy_script
     assert "verify-runtime-db-privileges" in deploy_script
+    assert "staging_migration_run" not in deploy_script
+    assert deploy_script.count("migration_run \\") == 2
+    assert (
+        "Complete the production database role split and install the "
+        "owner-role migration URL before retrying deployment."
+        in deploy_script
+    )
     assert "DATABASE_MIGRATION_URL must not be configured for the runtime app" in Path(
         "app/ops/commands.py"
     ).read_text(encoding="utf-8")
+    assert "adopt-existing)" in database_cutover
+    assert "CUTOVER_MODE=adopt-existing" in database_cutover
+    assert 'SOURCE_DATABASE=${TARGET_DATABASE}' in database_cutover
+    assert 'GRANT CONNECT ON DATABASE "${TARGET_DATABASE}" TO "${source_role}";' in (
+        database_cutover
+    )
+    assert 'DROP OWNED BY \\"${SOURCE_ROLE}\\";' in database_cutover
+    assert "restart_previous_services" in database_cutover
+    assert "Refusing to adopt a privileged PostgreSQL source role" in database_cutover
     assert "logs --no-color --tail 80 app" in deploy_script
     assert "runuser -u sitbank-container" in deploy_script
     assert "cannot traverse secret directory" in deploy_script
@@ -916,7 +935,6 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     assert "sitbank-deploy" in bootstrap
     assert "sitbank-container.service" in bootstrap
     assert "sitbank-staging-container.service" in bootstrap
-
     readme = Path("README.md").read_text(encoding="utf-8")
     assert "Manual pre-merge staging:" in readme
     assert "run trusted workflow from main" in readme
@@ -927,6 +945,7 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     assert "Manual production deployment is disabled." in readme
     assert "Production never skips disabled, skipped, or failed staging." in readme
     assert "Feature-branch workflow and deployment scripts" in readme
+    assert "adopt-existing" in readme
 
 
 def test_trivy_exception_is_narrow_documented_and_temporary():


### PR DESCRIPTION
## Summary

Improves the production database migration process by consolidating migration execution and enforcing a separate migration database role.

## Why

Production deployments should not run database migrations using the same low-privilege runtime database role as the application. The runtime app role should only have the permissions needed to operate the app, while schema changes should use a dedicated migration/owner role.

This reduces privilege escalation risk and supports a cleaner least-privilege database model.

## What changed

* Consolidated production migration commands into the deployment flow.
* Added enforcement for the dedicated `database_migration_url` secret file.
* Deployment now fails early if `database_migration_url` is missing.
* Keeps `database_url` and `database_migration_url` separate.
* Updates documentation with database cutover guidance.
* Clarifies that the runtime app role and migration role must not be reused interchangeably.

## Security impact

This strengthens database least privilege by ensuring:

* Runtime app deployments use the restricted app database role.
* Schema migrations use the dedicated migration/owner role.
* Missing migration credentials are caught before deployment.
* Operators are less likely to accidentally copy `database_url` into `database_migration_url`.

## Deployment impact

After this PR is merged, the updated bootstrap/deployment scripts must be installed on EC2 before rerunning deployment.

For existing production databases, follow the documented database cutover procedure to create/adopt the separate roles and generate both required database secret files.

No staging or production deployment is included in this PR.
