### PR TITLE
Add trusted EC2 bootstrap from main workflow for staging and production

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@ Dockerfile text eol=lf
 *.service text eol=lf
 
 ops/deploy/bootstrap-container-ec2 text eol=lf
+ops/deploy/sitbank-container-bootstrap text eol=lf
 ops/deploy/sitbank-container-deploy text eol=lf
 ops/deploy/sitbank-container-runtime text eol=lf
 ops/deploy/sitbank-database-cutover text eol=lf

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+## Summary
+
+Briefly describe what this PR improves or fixes.
+
+## Why
+
+Explain the problem, risk, or reason this change is needed.
+
+## What changed
+
+*
+*
+*
+
+## Security impact
+
+Explain how this affects security controls, secrets, permissions, auth, CI/CD, deployment safety, or runtime behavior.
+
+## Deployment impact
+
+Explain whether this PR requires:
+
+* EC2 bootstrap
+* staging deployment
+* production deployment
+* database migration
+* secret changes
+* no deployment action
+
+## Verification
+
+*
+*
+*
+
+## Notes
+
+Add any follow-up work, limitations, or operator instructions.

--- a/.github/workflows/bootstrap-ec2.yml
+++ b/.github/workflows/bootstrap-ec2.yml
@@ -1,0 +1,329 @@
+name: Bootstrap EC2 from trusted main
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_environment:
+        description: EC2 environment whose root-owned deployment files should be refreshed.
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+
+permissions: {}
+
+concurrency:
+  group: bootstrap-ec2-${{ inputs.target_environment }}
+  cancel-in-progress: false
+
+jobs:
+  validate-request:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Require a trusted main dispatch
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "::error::EC2 bootstrap must be dispatched with 'Use workflow from' set to main."
+            exit 1
+          fi
+          if [[ ! "${GITHUB_WORKFLOW_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::GitHub did not provide a valid trusted workflow commit."
+            exit 1
+          fi
+
+  bootstrap-staging:
+    if: inputs.target_environment == 'staging'
+    needs: validate-request
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+    environment:
+      name: staging
+      url: https://${{ vars.STAGING_PUBLIC_HOST }}
+    env:
+      TARGET: staging
+      TRUSTED_SHA: ${{ github.workflow_sha }}
+      REMOTE_HOST: ${{ vars.STAGING_EC2_HOST }}
+      REMOTE_PORT: ${{ vars.STAGING_EC2_PORT }}
+      REMOTE_USER: ${{ vars.STAGING_EC2_DEPLOY_USER }}
+    steps:
+      - name: Check out trusted main workflow commit
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.workflow_sha }}
+
+      - name: Verify staging bootstrap configuration
+        env:
+          SSH_PRIVATE_KEY_B64: ${{ secrets.STAGING_EC2_SSH_PRIVATE_KEY_B64 }}
+          SSH_KNOWN_HOSTS: ${{ secrets.STAGING_EC2_KNOWN_HOSTS }}
+        shell: bash
+        run: |
+          required=(
+            REMOTE_HOST
+            REMOTE_PORT
+            REMOTE_USER
+            SSH_PRIVATE_KEY_B64
+            SSH_KNOWN_HOSTS
+          )
+          missing=0
+          for name in "${required[@]}"; do
+            if [[ -z "${!name}" ]]; then
+              echo "::error::Missing required staging bootstrap setting: ${name}"
+              missing=1
+            fi
+          done
+          if [[ ! "${REMOTE_PORT}" =~ ^[0-9]+$ ]]; then
+            echo "::error::STAGING_EC2_PORT must be numeric."
+            missing=1
+          fi
+          exit "${missing}"
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6
+
+      - name: Create and sign trusted main bootstrap archive
+        shell: bash
+        run: |
+          umask 077
+          archive="bootstrap-${TARGET}-${TRUSTED_SHA}.tar.gz"
+          git archive \
+            --format=tar.gz \
+            --add-virtual-file=".sitbank-bootstrap-commit:${TRUSTED_SHA}" \
+            --output="${archive}" \
+            HEAD
+          cosign sign-blob --yes \
+            --bundle "${archive}.sigstore.json" \
+            "${archive}"
+
+      - name: Configure verified SSH
+        env:
+          SSH_PRIVATE_KEY_B64: ${{ secrets.STAGING_EC2_SSH_PRIVATE_KEY_B64 }}
+          SSH_KNOWN_HOSTS: ${{ secrets.STAGING_EC2_KNOWN_HOSTS }}
+        shell: bash
+        run: |
+          umask 077
+          install -d -m 0700 ~/.ssh
+          if [[ ! "${SSH_PRIVATE_KEY_B64}" =~ ^[A-Za-z0-9+/]+={0,2}$ ]]; then
+            echo "::error::STAGING_EC2_SSH_PRIVATE_KEY_B64 is not valid single-line Base64."
+            exit 1
+          fi
+          if ! printf '%s' "${SSH_PRIVATE_KEY_B64}" \
+              | base64 --decode > ~/.ssh/bootstrap_key; then
+            echo "::error::STAGING_EC2_SSH_PRIVATE_KEY_B64 could not be decoded."
+            exit 1
+          fi
+          chmod 0600 ~/.ssh/bootstrap_key
+          if ! ssh-keygen -y -P "" -f ~/.ssh/bootstrap_key >/dev/null 2>&1; then
+            echo "::error::Decoded staging SSH key could not be parsed."
+            exit 1
+          fi
+          printf '%s\n' "${SSH_KNOWN_HOSTS}" \
+            | tr -d '\r' > ~/.ssh/known_hosts
+          chmod 0600 ~/.ssh/known_hosts
+          if [[ ! -s ~/.ssh/known_hosts ]]; then
+            echo "::error::STAGING_EC2_KNOWN_HOSTS is empty."
+            exit 1
+          fi
+
+      - name: Upload signed bootstrap archive
+        shell: bash
+        run: |
+          archive="bootstrap-${TARGET}-${TRUSTED_SHA}.tar.gz"
+          scp -P "${REMOTE_PORT}" -i ~/.ssh/bootstrap_key \
+            -o BatchMode=yes -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=yes -o ConnectTimeout=15 \
+            "${archive}" "${archive}.sigstore.json" \
+            "${REMOTE_USER}@${REMOTE_HOST}:incoming/"
+
+      - name: Install trusted staging deployment files
+        shell: bash
+        run: |
+          ssh -p "${REMOTE_PORT}" -i ~/.ssh/bootstrap_key \
+            -o BatchMode=yes -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=yes -o ConnectTimeout=15 \
+            "${REMOTE_USER}@${REMOTE_HOST}" \
+            "sudo /usr/local/sbin/sitbank-container-bootstrap '${TARGET}' '${TRUSTED_SHA}'"
+
+      - name: Verify installed staging wrapper hash
+        shell: bash
+        run: |
+          expected_hash="$(
+            sha256sum ops/deploy/sitbank-container-deploy | awk '{print $1}'
+          )"
+          remote_output="$(
+            ssh -p "${REMOTE_PORT}" -i ~/.ssh/bootstrap_key \
+              -o BatchMode=yes -o IdentitiesOnly=yes \
+              -o StrictHostKeyChecking=yes -o ConnectTimeout=15 \
+              "${REMOTE_USER}@${REMOTE_HOST}" \
+              "sha256sum /usr/local/sbin/sitbank-container-deploy"
+          )"
+          remote_hash="${remote_output%% *}"
+          if [[ "${remote_hash}" != "${expected_hash}" ]]; then
+            echo "::error::Installed staging deployment wrapper hash does not match trusted main."
+            exit 1
+          fi
+          echo "EC2 staging deployment wrapper is current."
+
+      - name: Remove local bootstrap credentials and archive
+        if: always()
+        shell: bash
+        run: |
+          rm -f -- \
+            ~/.ssh/bootstrap_key \
+            "bootstrap-${TARGET}-${TRUSTED_SHA}.tar.gz" \
+            "bootstrap-${TARGET}-${TRUSTED_SHA}.tar.gz.sigstore.json"
+
+  bootstrap-production:
+    if: inputs.target_environment == 'production'
+    needs: validate-request
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+    environment:
+      name: production
+      url: https://${{ vars.PROD_PUBLIC_HOST }}
+    env:
+      TARGET: production
+      TRUSTED_SHA: ${{ github.workflow_sha }}
+      REMOTE_HOST: ${{ vars.PROD_EC2_HOST }}
+      REMOTE_PORT: ${{ vars.PROD_EC2_PORT }}
+      REMOTE_USER: ${{ vars.PROD_EC2_DEPLOY_USER }}
+    steps:
+      - name: Check out trusted main workflow commit
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.workflow_sha }}
+
+      - name: Verify production bootstrap configuration
+        env:
+          SSH_PRIVATE_KEY_B64: ${{ secrets.PROD_EC2_SSH_PRIVATE_KEY_B64 }}
+          SSH_KNOWN_HOSTS: ${{ secrets.PROD_EC2_KNOWN_HOSTS }}
+        shell: bash
+        run: |
+          required=(
+            REMOTE_HOST
+            REMOTE_PORT
+            REMOTE_USER
+            SSH_PRIVATE_KEY_B64
+            SSH_KNOWN_HOSTS
+          )
+          missing=0
+          for name in "${required[@]}"; do
+            if [[ -z "${!name}" ]]; then
+              echo "::error::Missing required production bootstrap setting: ${name}"
+              missing=1
+            fi
+          done
+          if [[ ! "${REMOTE_PORT}" =~ ^[0-9]+$ ]]; then
+            echo "::error::PROD_EC2_PORT must be numeric."
+            missing=1
+          fi
+          exit "${missing}"
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6
+
+      - name: Create and sign trusted main bootstrap archive
+        shell: bash
+        run: |
+          umask 077
+          archive="bootstrap-${TARGET}-${TRUSTED_SHA}.tar.gz"
+          git archive \
+            --format=tar.gz \
+            --add-virtual-file=".sitbank-bootstrap-commit:${TRUSTED_SHA}" \
+            --output="${archive}" \
+            HEAD
+          cosign sign-blob --yes \
+            --bundle "${archive}.sigstore.json" \
+            "${archive}"
+
+      - name: Configure verified SSH
+        env:
+          SSH_PRIVATE_KEY_B64: ${{ secrets.PROD_EC2_SSH_PRIVATE_KEY_B64 }}
+          SSH_KNOWN_HOSTS: ${{ secrets.PROD_EC2_KNOWN_HOSTS }}
+        shell: bash
+        run: |
+          umask 077
+          install -d -m 0700 ~/.ssh
+          if [[ ! "${SSH_PRIVATE_KEY_B64}" =~ ^[A-Za-z0-9+/]+={0,2}$ ]]; then
+            echo "::error::PROD_EC2_SSH_PRIVATE_KEY_B64 is not valid single-line Base64."
+            exit 1
+          fi
+          if ! printf '%s' "${SSH_PRIVATE_KEY_B64}" \
+              | base64 --decode > ~/.ssh/bootstrap_key; then
+            echo "::error::PROD_EC2_SSH_PRIVATE_KEY_B64 could not be decoded."
+            exit 1
+          fi
+          chmod 0600 ~/.ssh/bootstrap_key
+          if ! ssh-keygen -y -P "" -f ~/.ssh/bootstrap_key >/dev/null 2>&1; then
+            echo "::error::Decoded production SSH key could not be parsed."
+            exit 1
+          fi
+          printf '%s\n' "${SSH_KNOWN_HOSTS}" \
+            | tr -d '\r' > ~/.ssh/known_hosts
+          chmod 0600 ~/.ssh/known_hosts
+          if [[ ! -s ~/.ssh/known_hosts ]]; then
+            echo "::error::PROD_EC2_KNOWN_HOSTS is empty."
+            exit 1
+          fi
+
+      - name: Upload signed bootstrap archive
+        shell: bash
+        run: |
+          archive="bootstrap-${TARGET}-${TRUSTED_SHA}.tar.gz"
+          scp -P "${REMOTE_PORT}" -i ~/.ssh/bootstrap_key \
+            -o BatchMode=yes -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=yes -o ConnectTimeout=15 \
+            "${archive}" "${archive}.sigstore.json" \
+            "${REMOTE_USER}@${REMOTE_HOST}:incoming/"
+
+      - name: Install trusted production deployment files
+        shell: bash
+        run: |
+          ssh -p "${REMOTE_PORT}" -i ~/.ssh/bootstrap_key \
+            -o BatchMode=yes -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=yes -o ConnectTimeout=15 \
+            "${REMOTE_USER}@${REMOTE_HOST}" \
+            "sudo /usr/local/sbin/sitbank-container-bootstrap '${TARGET}' '${TRUSTED_SHA}'"
+
+      - name: Verify installed production wrapper hash
+        shell: bash
+        run: |
+          expected_hash="$(
+            sha256sum ops/deploy/sitbank-container-deploy | awk '{print $1}'
+          )"
+          remote_output="$(
+            ssh -p "${REMOTE_PORT}" -i ~/.ssh/bootstrap_key \
+              -o BatchMode=yes -o IdentitiesOnly=yes \
+              -o StrictHostKeyChecking=yes -o ConnectTimeout=15 \
+              "${REMOTE_USER}@${REMOTE_HOST}" \
+              "sha256sum /usr/local/sbin/sitbank-container-deploy"
+          )"
+          remote_hash="${remote_output%% *}"
+          if [[ "${remote_hash}" != "${expected_hash}" ]]; then
+            echo "::error::Installed production deployment wrapper hash does not match trusted main."
+            exit 1
+          fi
+          echo "EC2 production deployment wrapper is current."
+
+      - name: Remove local bootstrap credentials and archive
+        if: always()
+        shell: bash
+        run: |
+          rm -f -- \
+            ~/.ssh/bootstrap_key \
+            "bootstrap-${TARGET}-${TRUSTED_SHA}.tar.gz" \
+            "bootstrap-${TARGET}-${TRUSTED_SHA}.tar.gz.sigstore.json"

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -274,6 +274,7 @@ jobs:
             ops/container/validate-compose.sh \
             ops/container/dast-smoke.sh \
             ops/deploy/bootstrap-container-ec2 \
+            ops/deploy/sitbank-container-bootstrap \
             ops/deploy/sitbank-container-deploy \
             ops/deploy/sitbank-container-runtime \
             ops/deploy/sitbank-database-cutover

--- a/README.md
+++ b/README.md
@@ -294,6 +294,70 @@ closed. After any reviewed change to the wrapper, rerun the matching EC2
 bootstrap as an administrator before enabling that environment's next
 deployment.
 
+### Trusted EC2 Bootstrap Workflow
+
+The separate **Bootstrap EC2 from trusted main** workflow refreshes root-owned
+deployment files without building or deploying an application image. It is
+manual-only and accepts one target: `staging` or `production`. Always select
+`main` under **Use workflow from**. The workflow checks out
+`github.workflow_sha`, creates an archive containing that exact trusted main
+commit, signs the archive with GitHub OIDC, uploads it with strict SSH host-key
+checking, and invokes the restricted root bootstrap wrapper. The EC2 wrapper
+verifies the exact workflow identity and commit marker before running any
+archive content, then the workflow confirms that the installed deployment
+wrapper hash matches trusted main.
+
+The selected GitHub Environment still applies its reviewers and branch
+restrictions. Staging and production continue to use separate environment
+variables, SSH keys, known-hosts entries, configuration roots, and application
+secrets. The bootstrap workflow never transmits long-lived application
+secrets and never deploys an image.
+
+Use the workflows as follows:
+
+```text
+Pull request validation:
+  PR -> tests, image checks, security gates
+
+Normal application-only release:
+  PR -> checks -> merge -> deploy staging -> deploy production
+
+Reviewed EC2 deployment/runtime change:
+  PR -> checks -> merge -> Bootstrap EC2 from trusted main
+  -> deploy staging -> deploy production
+```
+
+EC2 bootstrap content is always taken from merged, protected `main`; an
+unmerged branch can never replace root-owned deployment files. The existing
+manual candidate-staging path may deploy a candidate application image to the
+isolated staging runtime, but it still uses deployment and bootstrap logic
+from trusted `main`. Ordinary pull requests remain validation-only unless a
+maintainer explicitly starts that protected staging path. Do not use the
+bootstrap workflow to work around a failed application test, image scan,
+signature check, or deployment approval.
+
+Run the bootstrap workflow after reviewed changes to root-installed deployment
+assets, including:
+
+- `ops/deploy/sitbank-container-bootstrap`
+- `ops/deploy/sitbank-container-deploy`
+- `ops/deploy/bootstrap-container-ec2`
+- `ops/deploy/sitbank-container-runtime`
+- `ops/deploy/sitbank-database-cutover`
+- `ops/deploy/render_container_bundle.py`
+- Compose, systemd, sudoers, Nginx, or other runtime files installed by the
+  bootstrap
+
+Bootstrap is normally unnecessary for Flask application code, templates,
+static assets, tests, or Docker image-only changes unless the same change also
+modifies a root-installed deployment/runtime file.
+
+The first release containing `sitbank-container-bootstrap` is the one
+exception: perform one final administrator-run bootstrap from reviewed
+`main` to install `/usr/local/sbin/sitbank-container-bootstrap` and its narrow
+sudoers entry. After that one-time installation, future trusted bootstrap
+refreshes can use the manual workflow.
+
 ### Temporary Trivy Exception
 
 `.trivyignore` contains a narrow temporary exception for only
@@ -632,12 +696,12 @@ Set `STAGING_PUBLIC_HOST=staging-sitbank.duckdns.org`,
 staging key identifier in the GitHub `staging` environment. Enable
 `STAGING_DEPLOY_ENABLED=true` only after these checks pass.
 
-The workflow intentionally cannot update its own privileged EC2 validator.
-Whenever `ops/deploy/sitbank-container-deploy`, the Compose file, sudoers
-policy, or systemd unit changes, upload a reviewed bootstrap archive and
-reinstall those root-owned assets before enabling the next automated
-deployment. This hardening change must be installed before the first workflow
-that sends `.sigstore.json` runtime bundles.
+The deployment workflow intentionally cannot update its own privileged EC2
+validator. Use **Bootstrap EC2 from trusted main** after reviewed changes to
+the deployment wrapper, Compose file, sudoers policy, systemd unit, or other
+root-installed runtime assets. For the first release containing the restricted
+bootstrap wrapper, use the administrator-run archive procedure above once;
+subsequent refreshes use the signed manual workflow.
 
 Review `/etc/sitbank/deploy.conf`. It must contain the expected GHCR repository,
 workflow identity, public host, and exact legacy service/path supplied above.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -93,6 +93,16 @@ identical. Deployment accepts only the configured GHCR repository, exact
 workflow identity, a 40-character candidate commit SHA, and an immutable
 SHA-256 digest.
 
+Root-owned EC2 deployment files are refreshed only through the manual
+`bootstrap-ec2.yml` workflow selected from protected `main`. Its archive is
+bound to `github.workflow_sha`, signed with GitHub OIDC, uploaded with strict
+SSH host-key verification, and verified by the restricted root bootstrap
+wrapper against the exact
+`bootstrap-ec2.yml@refs/heads/main` certificate identity. The deploy account
+has no general sudo or Docker access. Environment approval and separate
+staging/production SSH credentials remain mandatory. This workflow installs
+deployment files only; it cannot publish or deploy an application image.
+
 Production deployment is automatic on a protected `main` push only. It must
 not run unless staging succeeded in the same workflow; disabled, skipped, or
 failed staging blocks production.

--- a/ops/deploy/bootstrap-container-ec2
+++ b/ops/deploy/bootstrap-container-ec2
@@ -83,6 +83,7 @@ repository_lower="${github_repository,,}"
 linux_runtime_files=(
     "${repo_root}/${compose_source}"
     "${repo_root}/${systemd_source}"
+    "${repo_root}/ops/deploy/sitbank-container-bootstrap"
     "${repo_root}/ops/deploy/sitbank-container-deploy"
     "${repo_root}/ops/deploy/sitbank-container-runtime"
     "${repo_root}/ops/deploy/sitbank-database-cutover"
@@ -185,6 +186,9 @@ install -d -o root -g root -m 0700 "${state_dir}" "${backup_dir}"
 
 install -o root -g root -m 0644 \
     "${repo_root}/${compose_source}" "${compose_dir}/compose.yml"
+install -o root -g root -m 0755 \
+    "${repo_root}/ops/deploy/sitbank-container-bootstrap" \
+    /usr/local/sbin/sitbank-container-bootstrap
 install -o root -g root -m 0755 \
     "${repo_root}/ops/deploy/sitbank-container-deploy" \
     /usr/local/sbin/sitbank-container-deploy

--- a/ops/deploy/sitbank-container-bootstrap
+++ b/ops/deploy/sitbank-container-bootstrap
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+readonly DEPLOY_USER="sitbank-deploy"
+readonly INCOMING_DIR="/home/${DEPLOY_USER}/incoming"
+readonly BOOTSTRAP_ROOT="/opt/sitbank-bootstrap"
+readonly LOCK_FILE="/var/lock/sitbank-container-bootstrap.lock"
+readonly PRODUCTION_DEPLOY_LOCK="/var/lock/sitbank-container-deploy.lock"
+readonly STAGING_DEPLOY_LOCK="/var/lock/sitbank-staging-container-deploy.lock"
+
+if [[ "${EUID}" -ne 0 ]]; then
+    echo "Bootstrap wrapper must run as root" >&2
+    exit 1
+fi
+if [[ "$#" -ne 2 ]]; then
+    echo "Usage: sitbank-container-bootstrap TARGET TRUSTED_MAIN_SHA" >&2
+    exit 2
+fi
+
+target="$1"
+trusted_sha="$2"
+case "${target}" in
+    staging)
+        config_root="/etc/sitbank-staging"
+        ;;
+    production)
+        config_root="/etc/sitbank"
+        ;;
+    *)
+        echo "Bootstrap target must be staging or production" >&2
+        exit 2
+        ;;
+esac
+if [[ ! "${trusted_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "Trusted main SHA must be a full lowercase commit SHA" >&2
+    exit 2
+fi
+
+deploy_config="${config_root}/deploy.conf"
+if [[ ! -f "${deploy_config}" || -L "${deploy_config}" \
+    || "$(stat -c '%U:%G' -- "${deploy_config}")" != "root:root" ]]; then
+    echo "Missing trusted root-owned deployment configuration" >&2
+    exit 1
+fi
+
+# shellcheck disable=SC1090
+source "${deploy_config}"
+if [[ ! "${GITHUB_REPOSITORY:-}" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ \
+    || ! "${PUBLIC_HOST:-}" =~ ^[A-Za-z0-9.-]+$ ]]; then
+    echo "Trusted deployment configuration is invalid" >&2
+    exit 1
+fi
+if [[ "${target}" == "staging" \
+    && "${PUBLIC_HOST}" != "staging-sitbank.duckdns.org" ]]; then
+    echo "Trusted staging public host is invalid" >&2
+    exit 1
+fi
+if [[ "${target}" == "production" \
+    && "${PUBLIC_HOST}" != "sitbank.duckdns.org" ]]; then
+    echo "Trusted production public host is invalid" >&2
+    exit 1
+fi
+
+readonly expected_identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/bootstrap-ec2.yml@refs/heads/main"
+readonly archive_name="bootstrap-${target}-${trusted_sha}.tar.gz"
+readonly archive_path="${INCOMING_DIR}/${archive_name}"
+readonly signature_path="${archive_path}.sigstore.json"
+
+validate_input_file() {
+    local path="$1"
+    if [[ ! -f "${path}" || -L "${path}" ]]; then
+        echo "Bootstrap input must be a regular non-symlink file: ${path}" >&2
+        exit 2
+    fi
+    if [[ "$(stat -c '%U' -- "${path}")" != "${DEPLOY_USER}" ]]; then
+        echo "Bootstrap input must be owned by ${DEPLOY_USER}: ${path}" >&2
+        exit 2
+    fi
+}
+
+validate_input_file "${archive_path}"
+validate_input_file "${signature_path}"
+
+exec 9>"${LOCK_FILE}"
+if ! flock -n 9; then
+    echo "Another EC2 bootstrap is already running" >&2
+    exit 1
+fi
+exec 8>"${PRODUCTION_DEPLOY_LOCK}"
+exec 7>"${STAGING_DEPLOY_LOCK}"
+if ! flock -n 8 || ! flock -n 7; then
+    echo "An application deployment is running; retry bootstrap after it finishes" >&2
+    exit 1
+fi
+
+work_dir="$(mktemp -d /opt/sitbank-bootstrap.update.XXXXXX)"
+source_root="${work_dir}/source"
+previous_root="${work_dir}/previous"
+root_replaced=0
+
+cleanup() {
+    rm -rf -- "${work_dir}"
+    rm -f -- "${archive_path}" "${signature_path}"
+}
+
+restore_bootstrap_root() {
+    if [[ "${root_replaced}" -eq 1 && -d "${previous_root}" ]]; then
+        rm -rf -- "${BOOTSTRAP_ROOT}"
+        mv -- "${previous_root}" "${BOOTSTRAP_ROOT}"
+    fi
+}
+
+trap cleanup EXIT
+trap restore_bootstrap_root ERR
+
+cosign verify-blob \
+    --bundle "${signature_path}" \
+    --certificate-identity "${expected_identity}" \
+    --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+    "${archive_path}" >/dev/null
+
+while IFS= read -r member; do
+    case "${member}" in
+        /*|..|../*|*/../*|*/..)
+            echo "Unsafe bootstrap archive member: ${member}" >&2
+            exit 1
+            ;;
+    esac
+done < <(tar -tzf "${archive_path}")
+
+install -d -o root -g root -m 0755 "${source_root}"
+tar --extract --gzip --file "${archive_path}" \
+    --directory "${source_root}" --no-same-owner --no-same-permissions
+if find "${source_root}" \
+    \( -type l -o -type b -o -type c -o -type p -o -type s \) \
+    -print -quit | grep -q .; then
+    echo "Bootstrap archive contains an unsupported special file" >&2
+    exit 1
+fi
+if [[ ! -f "${source_root}/.sitbank-bootstrap-commit" \
+    || -L "${source_root}/.sitbank-bootstrap-commit" \
+    || "$(<"${source_root}/.sitbank-bootstrap-commit")" != "${trusted_sha}" ]]; then
+    echo "Bootstrap archive commit marker does not match the requested trusted main SHA" >&2
+    exit 1
+fi
+rm -f -- "${source_root}/.sitbank-bootstrap-commit"
+
+bootstrap_script="${source_root}/ops/deploy/bootstrap-container-ec2"
+if [[ ! -f "${bootstrap_script}" || -L "${bootstrap_script}" ]]; then
+    echo "Signed archive is missing the EC2 bootstrap script" >&2
+    exit 1
+fi
+
+legacy_service="${LEGACY_SERVICE:--}"
+legacy_app_root="${LEGACY_APP_ROOT:--}"
+if [[ "${target}" == "staging" ]]; then
+    bash "${bootstrap_script}" \
+        staging "${GITHUB_REPOSITORY}" "${PUBLIC_HOST}"
+else
+    bash "${bootstrap_script}" \
+        production "${GITHUB_REPOSITORY}" "${PUBLIC_HOST}" \
+        "${legacy_service}" "${legacy_app_root}"
+fi
+
+expected_wrapper_hash="$(
+    sha256sum "${source_root}/ops/deploy/sitbank-container-deploy" \
+        | awk '{print $1}'
+)"
+installed_wrapper_hash="$(
+    sha256sum /usr/local/sbin/sitbank-container-deploy | awk '{print $1}'
+)"
+if [[ "${installed_wrapper_hash}" != "${expected_wrapper_hash}" ]]; then
+    echo "Installed deployment wrapper does not match the signed bootstrap archive" >&2
+    exit 1
+fi
+
+if [[ -e "${BOOTSTRAP_ROOT}" ]]; then
+    if [[ -L "${BOOTSTRAP_ROOT}" || ! -d "${BOOTSTRAP_ROOT}" ]]; then
+        echo "Refusing to replace unsafe bootstrap root: ${BOOTSTRAP_ROOT}" >&2
+        exit 1
+    fi
+    mv -- "${BOOTSTRAP_ROOT}" "${previous_root}"
+    root_replaced=1
+fi
+if ! mv -- "${source_root}" "${BOOTSTRAP_ROOT}"; then
+    restore_bootstrap_root
+    exit 1
+fi
+root_replaced=0
+rm -rf -- "${previous_root}"
+trap - ERR
+
+logger --tag sitbank-bootstrap -- \
+    "environment=${target} result=success revision=${trusted_sha}"
+echo "Installed trusted ${target} EC2 deployment files from ${trusted_sha}"

--- a/ops/sudoers/sitbank-container-deploy
+++ b/ops/sudoers/sitbank-container-deploy
@@ -1,1 +1,2 @@
 sitbank-deploy ALL=(root) NOPASSWD: /usr/local/sbin/sitbank-container-deploy
+sitbank-deploy ALL=(root) NOPASSWD: /usr/local/sbin/sitbank-container-bootstrap

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -948,6 +948,124 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     assert "adopt-existing" in readme
 
 
+def test_manual_bootstrap_workflow_uses_only_signed_trusted_main_sources():
+    workflow_path = Path(".github/workflows/bootstrap-ec2.yml")
+    workflow_text = workflow_path.read_text(encoding="utf-8")
+    workflow = yaml.safe_load(workflow_text)
+    triggers = workflow[True]
+
+    assert workflow["name"] == "Bootstrap EC2 from trusted main"
+    assert set(triggers) == {"workflow_dispatch"}
+    dispatch = triggers["workflow_dispatch"]
+    target_input = dispatch["inputs"]["target_environment"]
+    assert target_input["required"] is True
+    assert target_input["type"] == "choice"
+    assert target_input["options"] == ["staging", "production"]
+    assert workflow["permissions"] == {}
+    assert set(workflow["jobs"]) == {
+        "validate-request",
+        "bootstrap-staging",
+        "bootstrap-production",
+    }
+
+    guard_step = workflow["jobs"]["validate-request"]["steps"][0]
+    assert "refs/heads/main" in guard_step["run"]
+    assert "GITHUB_WORKFLOW_SHA" in guard_step["run"]
+
+    for target, prefix in (("staging", "STAGING"), ("production", "PROD")):
+        job = workflow["jobs"][f"bootstrap-{target}"]
+        assert job["if"] == f"inputs.target_environment == '{target}'"
+        assert job["needs"] == "validate-request"
+        assert job["environment"]["name"] == target
+        assert job["permissions"] == {
+            "contents": "read",
+            "id-token": "write",
+        }
+        assert job["env"]["TARGET"] == target
+        assert job["env"]["TRUSTED_SHA"] == "${{ github.workflow_sha }}"
+        assert job["env"]["REMOTE_HOST"] == (
+            f"${{{{ vars.{prefix}_EC2_HOST }}}}"
+        )
+        checkout = next(
+            step
+            for step in job["steps"]
+            if step["name"] == "Check out trusted main workflow commit"
+        )
+        assert checkout["with"]["ref"] == "${{ github.workflow_sha }}"
+        assert checkout["with"]["persist-credentials"] is False
+        assert checkout["with"]["fetch-depth"] == 0
+        step_text = "\n".join(
+            str(step.get("run", "")) for step in job["steps"]
+        )
+        assert "git archive" in step_text
+        assert "--add-virtual-file" in step_text
+        assert "cosign sign-blob --yes" in step_text
+        assert "StrictHostKeyChecking=yes" in step_text
+        assert "StrictHostKeyChecking=no" not in step_text
+        assert "incoming/" in step_text
+        assert (
+            "sudo /usr/local/sbin/sitbank-container-bootstrap "
+            "'${TARGET}' '${TRUSTED_SHA}'"
+        ) in step_text
+        assert "sha256sum ops/deploy/sitbank-container-deploy" in step_text
+        assert (
+            "sha256sum /usr/local/sbin/sitbank-container-deploy"
+            in step_text
+        )
+
+    assert "pull_request:" not in workflow_text
+    assert "\npush:" not in workflow_text
+    assert "\nschedule:" not in workflow_text
+    assert "sitbank-container-deploy staging" not in workflow_text
+    assert "IMAGE_DIGEST" not in workflow_text
+    assert ":latest" not in workflow_text
+    assert "STAGING_EC2_SSH_PRIVATE_KEY_B64" in workflow_text
+    assert "PROD_EC2_SSH_PRIVATE_KEY_B64" in workflow_text
+    assert "STAGING_EC2_KNOWN_HOSTS" in workflow_text
+    assert "PROD_EC2_KNOWN_HOSTS" in workflow_text
+
+
+def test_root_bootstrap_wrapper_authenticates_and_limits_privileged_updates():
+    wrapper = Path("ops/deploy/sitbank-container-bootstrap").read_text(
+        encoding="utf-8"
+    )
+    bootstrap = Path("ops/deploy/bootstrap-container-ec2").read_text(
+        encoding="utf-8"
+    )
+    sudoers = Path("ops/sudoers/sitbank-container-deploy").read_text(
+        encoding="utf-8"
+    )
+
+    assert "TARGET TRUSTED_MAIN_SHA" in wrapper
+    assert "bootstrap-ec2.yml@refs/heads/main" in wrapper
+    assert "cosign verify-blob" in wrapper
+    assert 'trusted_sha}" =~ ^[0-9a-f]{40}$' in wrapper
+    assert ".sitbank-bootstrap-commit" in wrapper
+    assert "token.actions.githubusercontent.com" in wrapper
+    assert "Bootstrap input must be owned by" in wrapper
+    assert "Unsafe bootstrap archive member" in wrapper
+    assert "unsupported special file" in wrapper
+    assert "/var/lock/sitbank-container-deploy.lock" in wrapper
+    assert "/var/lock/sitbank-staging-container-deploy.lock" in wrapper
+    assert "An application deployment is running" in wrapper
+    assert "sitbank-container-deploy" in wrapper
+    assert "sha256sum /usr/local/sbin/sitbank-container-deploy" in wrapper
+    assert "sitbank-container-bootstrap" in bootstrap
+    assert "/usr/local/sbin/sitbank-container-bootstrap" in bootstrap
+    assert sudoers.splitlines() == [
+        (
+            "sitbank-deploy ALL=(root) NOPASSWD: "
+            "/usr/local/sbin/sitbank-container-deploy"
+        ),
+        (
+            "sitbank-deploy ALL=(root) NOPASSWD: "
+            "/usr/local/sbin/sitbank-container-bootstrap"
+        ),
+    ]
+    assert "NOPASSWD: ALL" not in sudoers
+    assert "/bin/bash" not in sudoers
+
+
 def test_trivy_exception_is_narrow_documented_and_temporary():
     trivyignore = Path(".trivyignore").read_text(encoding="utf-8")
     readme = Path("README.md").read_text(encoding="utf-8")
@@ -1039,6 +1157,7 @@ def test_every_github_action_is_pinned_to_a_full_commit_sha():
 
 def test_only_sitbank_container_deployment_units_are_active():
     assert not Path("ops/deploy/bootstrap-ec2").exists()
+    assert Path("ops/deploy/sitbank-container-bootstrap").exists()
     assert Path("ops/deploy/sitbank-container-deploy").exists()
     assert Path("ops/deploy/sitbank-container-runtime").exists()
     assert Path("ops/deploy/sitbank-database-cutover").exists()
@@ -1057,6 +1176,7 @@ def test_linux_deployment_artifacts_are_forced_to_lf_and_reject_crlf():
         Path("compose.prod.yml"),
         Path("compose.staging.yml"),
         Path("ops/deploy/bootstrap-container-ec2"),
+        Path("ops/deploy/sitbank-container-bootstrap"),
         Path("ops/deploy/sitbank-container-deploy"),
         Path("ops/deploy/sitbank-container-runtime"),
         Path("ops/deploy/sitbank-database-cutover"),
@@ -1072,6 +1192,7 @@ def test_linux_deployment_artifacts_are_forced_to_lf_and_reject_crlf():
     assert "*.conf text eol=lf" in attributes
     assert "*.service text eol=lf" in attributes
     assert "ops/deploy/bootstrap-container-ec2 text eol=lf" in attributes
+    assert "ops/deploy/sitbank-container-bootstrap text eol=lf" in attributes
     assert "ops/sudoers/* text eol=lf" in attributes
     for path in linux_files:
         assert b"\r\n" not in path.read_bytes(), f"{path} must use LF line endings"


### PR DESCRIPTION
## Summary

Introduces a trusted manual EC2 bootstrap workflow for staging and production environments.

This PR adds a controlled GitHub Actions workflow for updating EC2-installed deployment/bootstrap files from trusted `main` after bootstrap or deployment scripts change.

## Why

Deployments currently fail securely when the EC2-installed deployment wrapper is missing or stale. This is correct behavior because EC2 should not run outdated or untrusted deployment logic.

However, updating the EC2 bootstrap files currently requires manual archive creation, upload, extraction, and script execution. That process is easy to confuse with normal staging or production deployment.

This PR separates EC2 bootstrap from application deployment so operators can safely refresh EC2 deployment files without deploying a new app image or using pull request branch code.

## What changed

* Added a dedicated manual GitHub Actions workflow for EC2 bootstrap.
* Supports both `staging` and `production` targets.
* Uses trusted `main` as the source of bootstrap/deployment files.
* Uploads a repository archive to EC2 over SSH/SCP.
* Extracts the archive into the EC2 bootstrap directory.
* Runs the existing EC2 bootstrap script for the selected environment.
* Verifies the installed EC2 deployment wrapper hash after bootstrap.
* Fails clearly if the installed wrapper does not match the trusted `main` copy.
* Updates documentation explaining when EC2 bootstrap is required.

## Security impact

This preserves and strengthens the existing deployment security model by ensuring:

* Pull request workflows remain validation-only.
* PR branch code cannot be used to bootstrap EC2.
* Staging and production secrets remain protected by GitHub Environments.
* Existing deployment wrapper verification remains enabled.
* Existing digest-only deployment behavior remains unchanged.
* Existing Cosign signing and verification behavior remains unchanged.
* EC2 bootstrap is separate from application deployment.
* No real secrets are committed.

## Deployment impact

This PR does not deploy a staging or production application image.

After this PR is merged, use the new manual bootstrap workflow when EC2-installed deployment/bootstrap files need to be refreshed from `main`.

Deployment/bootstrap file changes should follow this flow:

```text
PR → merge → bootstrap EC2 from main → deploy staging → deploy production
```

Normal application-only changes should continue to follow the regular deployment flow:

```text
PR → checks → merge → deploy staging → deploy production
```

## When bootstrap is needed

EC2 bootstrap is usually required after changing files such as:

* `ops/deploy/sitbank-container-deploy`
* `ops/deploy/bootstrap-container-ec2`
* `ops/deploy/sitbank-container-runtime`
* `ops/deploy/sitbank-database-cutover`
* `ops/deploy/render_container_bundle.py`
* Compose/runtime files installed by bootstrap

Bootstrap is usually not required for normal Flask app code, templates, static assets, tests, or Docker image-only changes unless those changes also modify EC2-installed deployment/runtime files.

## Verification

* Confirmed the workflow is manual-only via `workflow_dispatch`.
* Confirmed the workflow does not run on pull requests.
* Confirmed the workflow checks out trusted `main`.
* Confirmed the workflow does not deploy an application image.
* Confirmed the EC2 wrapper hash is verified after bootstrap.
* Confirmed existing deployment wrapper verification remains intact.
* Confirmed staging and production environments remain separated.
* Confirmed no real secrets are committed.
