### PR TITLE
Harden Redis session binding and reduce CI brittleness

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,6 +13,7 @@ ops/deploy/sitbank-container-deploy text eol=lf
 ops/deploy/sitbank-container-runtime text eol=lf
 ops/deploy/sitbank-database-cutover text eol=lf
 ops/sudoers/* text eol=lf
+scripts/ci-local text eol=lf
 
 *.bat text eol=crlf
 *.cmd text eol=crlf

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,5 +1,5 @@
 # Temporary exception for inherited Debian Trixie perl-base CVEs.
-# Inherited from official python:3.12.13-slim-trixie / Debian Trixie.
+# Inherited from official python:3.12 slim-trixie / Debian Trixie.
 # SITBank does not install Perl directly.
 # Debian perl-base is Essential: yes and must not be removed.
 # SITBank does not invoke Perl.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ python -m venv .venv
 .\.venv\Scripts\python.exe ops/security/scan_repository_secrets.py --history
 ```
 
+To run the focused local CI entrypoint:
+
+```powershell
+.\.venv\Scripts\python.exe scripts/ci-local
+```
+
+The script runs the deployment and Redis integrity tests, the full test suite,
+compilation, package checks, Bandit, whitespace checks, and Git Bash syntax
+checks for deployment shell scripts. When Docker is running, it also validates
+the production and staging Compose models; otherwise it prints a warning and
+skips only the Docker/Compose-only check. Each phase prints a named section
+and `PASS` or `SKIP` status so the failing surface is visible without reading
+the whole log.
+
 Refresh lock files only after reviewing dependency changes:
 
 ```powershell
@@ -161,6 +175,21 @@ The direct names `SECRET_KEY`, `WTF_CSRF_SECRET_KEY`,
 `MFA_AES256_GCM_KEY_B64`, and `PASSWORD_PEPPER_B64` remain available for local
 development, tests, and the one-time protected legacy import only.
 
+When adding a runtime configuration value or secret, update
+`ops/runtime_contract.py` first, then keep `config.py`, the deployment bundle
+renderer, production and staging Compose files, container smoke fixtures,
+deployment wrapper validation, GitHub Actions, tests, and this document in
+sync. `tests/test_deployment.py` compares those surfaces against the contract
+so drift fails with a targeted message instead of a broad deployment snapshot
+failure.
+
+Drift failures in `test_runtime_secret_inventory_matches_config_and_renderer`,
+`test_compose_secret_mounts_match_runtime_contract`, or
+`test_smoke_fixture_and_deployment_wrapper_match_runtime_contract` list the
+missing or unexpected names. Treat those failures as a contract mismatch, not
+as a reason to bypass the runtime split between app secrets and migration-only
+secrets.
+
 `DATABASE_URL` is always the Flask runtime URL and must use the non-owner
 `sitbank_app` role in staging and production. `DATABASE_MIGRATION_URL` is only
 for Alembic migrations and database privilege verification, and must use the
@@ -189,10 +218,12 @@ PostgreSQL ownership is split by role:
   alter, drop, or create extensions.
 
 Redis session data is stored as a versioned HMAC envelope around the
-Flask-Session serialized payload. `SESSION_HMAC_ACTIVE_KEY_ID` chooses the key
-used for new writes, while every key in `SESSION_HMAC_KEYS_JSON` can verify
-existing sessions during rotation. Missing signatures, invalid signatures,
-unknown key IDs, malformed payloads, and unsupported legacy payload formats are
+Flask-Session serialized payload. The signature is bound to the Redis session
+store key, so a valid signed payload copied under a different session key is
+rejected. `SESSION_HMAC_ACTIVE_KEY_ID` chooses the key used for new writes,
+while every key in `SESSION_HMAC_KEYS_JSON` can verify existing sessions during
+rotation. Missing signatures, invalid signatures, unknown key IDs, malformed
+payloads, missing binding context, and unsupported legacy payload formats are
 deleted, logged as `session_integrity` security events, and treated as a fresh
 unauthenticated session without exposing raw session contents.
 
@@ -381,7 +412,7 @@ the protected workflow can perform later staging or production refreshes.
 
 `.trivyignore` contains a narrow temporary exception for only
 `CVE-2026-42496` and `CVE-2026-8376`. Both findings are inherited from the
-official `python:3.12.13-slim-trixie` Debian Trixie base image through
+official `python:3.12` slim-trixie Debian Trixie base image through
 `perl-base`; the Dockerfile does not install Perl directly. Debian marks
 `perl-base` as an essential package. Removing `perl-base` or mixing Debian sid packages into Trixie is riskier
 than a narrow, documented exception while no safe Trixie fix exists.

--- a/app/security/session_hmac.py
+++ b/app/security/session_hmac.py
@@ -9,7 +9,7 @@ from collections.abc import Iterator
 from flask import current_app
 
 
-SESSION_PAYLOAD_FORMAT_VERSION = 1
+SESSION_PAYLOAD_FORMAT_VERSION = 2
 
 
 class SessionPayloadIntegrityError(ValueError):
@@ -47,10 +47,11 @@ def validate_session_hmac_config() -> int:
     return len(keyring)
 
 
-def sign_session_payload(payload: bytes) -> bytes:
+def sign_session_payload(payload: bytes, *, binding_context: str) -> bytes:
+    context = _binding_context(binding_context)
     active_key_id = str(current_app.config["SESSION_HMAC_ACTIVE_KEY_ID"])
     encoded_payload = base64.b64encode(payload).decode("ascii")
-    signature = _payload_signature(active_key_id, encoded_payload)
+    signature = _payload_signature(active_key_id, encoded_payload, context)
     envelope = {
         "v": SESSION_PAYLOAD_FORMAT_VERSION,
         "kid": active_key_id,
@@ -60,7 +61,8 @@ def sign_session_payload(payload: bytes) -> bytes:
     return json.dumps(envelope, separators=(",", ":"), sort_keys=True).encode("utf-8")
 
 
-def verify_session_payload(envelope_bytes: bytes) -> bytes:
+def verify_session_payload(envelope_bytes: bytes, *, binding_context: str) -> bytes:
+    context = _binding_context(binding_context)
     try:
         envelope = json.loads(envelope_bytes.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
@@ -83,7 +85,7 @@ def verify_session_payload(envelope_bytes: bytes) -> bytes:
     if key_id not in keyring:
         raise SessionPayloadIntegrityError("unknown_key_id")
 
-    expected_signature = _payload_signature(key_id, encoded_payload)
+    expected_signature = _payload_signature(key_id, encoded_payload, context)
     if not hmac.compare_digest(signature, expected_signature):
         raise SessionPayloadIntegrityError("invalid_signature")
 
@@ -112,7 +114,26 @@ def _digest(key: bytes, message: str, length: int) -> str:
     return hmac.new(key, message.encode("utf-8"), hashlib.sha256).hexdigest()[:length]
 
 
-def _payload_signature(key_id: str, encoded_payload: str) -> str:
+def _binding_context(binding_context: str) -> str:
+    if not isinstance(binding_context, str) or not binding_context:
+        raise SessionPayloadIntegrityError("missing_binding_context")
+    return binding_context
+
+
+def _payload_signature(key_id: str, encoded_payload: str, binding_context: str) -> str:
     keyring = current_app.config["SESSION_HMAC_KEYS"]
-    signing_input = f"sitbank-session-v{SESSION_PAYLOAD_FORMAT_VERSION}.{key_id}.{encoded_payload}"
-    return hmac.new(bytes(keyring[key_id]), signing_input.encode("ascii"), hashlib.sha256).hexdigest()
+    signing_input = json.dumps(
+        {
+            "ctx": binding_context,
+            "kid": key_id,
+            "payload": encoded_payload,
+            "v": SESSION_PAYLOAD_FORMAT_VERSION,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hmac.new(
+        bytes(keyring[key_id]),
+        signing_input.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()

--- a/app/security/sessions.py
+++ b/app/security/sessions.py
@@ -54,7 +54,10 @@ class UuidRedisSessionInterface(RedisSessionInterface):
             return None
 
         try:
-            payload = verify_session_payload(serialized_session_data)
+            payload = verify_session_payload(
+                serialized_session_data,
+                binding_context=store_id,
+            )
             session_data = self.serializer.decode(payload)
         except SessionPayloadIntegrityError as exc:
             self._handle_session_integrity_failure(store_id, exc.reason)
@@ -70,7 +73,10 @@ class UuidRedisSessionInterface(RedisSessionInterface):
 
     def _upsert_session(self, session_lifetime, session, store_id: str) -> None:
         serialized_session_data = self.serializer.encode(session)
-        signed_session_data = sign_session_payload(serialized_session_data)
+        signed_session_data = sign_session_payload(
+            serialized_session_data,
+            binding_context=store_id,
+        )
         self.client.set(
             name=store_id,
             value=signed_session_data,

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -83,6 +83,8 @@ secrets:
     file: /etc/sitbank/secrets/session_hmac_keys_json
   database_url:
     file: /etc/sitbank/secrets/database_url
+  database_migration_url:
+    file: /etc/sitbank/secrets/database_migration_url
   redis_url:
     file: /etc/sitbank/secrets/redis_url
   mfa_aes256_gcm_key_b64:

--- a/ops/deploy/render_container_bundle.py
+++ b/ops/deploy/render_container_bundle.py
@@ -9,25 +9,13 @@ import re
 import stat
 from pathlib import Path
 
+from ops.runtime_contract import (
+    DEPLOYMENT_SECRET_INPUTS,
+    NON_SECRET_DEFAULTS as RUNTIME_NON_SECRET_DEFAULTS,
+)
 
-SECRET_INPUTS = {
-    "DATABASE_MIGRATION_URL": "database_migration_url",
-    "DATABASE_URL": "database_url",
-    "MFA_AES256_GCM_KEY_B64": "mfa_aes256_gcm_key_b64",
-    "PASSWORD_PEPPER_B64": "password_pepper_b64",
-    "REDIS_URL": "redis_url",
-    "SECRET_KEY": "secret_key",
-    "WTF_CSRF_SECRET_KEY": "wtf_csrf_secret_key",
-}
-
-NON_SECRET_DEFAULTS = {
-    "COMMON_PASSWORDS_MIN_ENTRIES": "100000",
-    "HIBP_CIRCUIT_FAILURE_THRESHOLD": "3",
-    "HIBP_CIRCUIT_OPEN_SECONDS": "300",
-    "HIBP_PASSWORD_CHECK_TIMEOUT_SECONDS": "2.0",
-    "PASSWORD_PBKDF2_ITERATIONS": "600000",
-    "TRUSTED_PROXY_COUNT": "1",
-}
+SECRET_INPUTS = dict(DEPLOYMENT_SECRET_INPUTS)
+NON_SECRET_DEFAULTS = dict(RUNTIME_NON_SECRET_DEFAULTS)
 
 DEPLOYMENT_PREFIXES = {"PROD", "STAGING"}
 

--- a/ops/runtime_contract.py
+++ b/ops/runtime_contract.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+APP_SECRET_INPUTS = {
+    "SECRET_KEY": "secret_key",
+    "WTF_CSRF_SECRET_KEY": "wtf_csrf_secret_key",
+    "SESSION_HMAC_KEYS_JSON": "session_hmac_keys_json",
+    "DATABASE_URL": "database_url",
+    "REDIS_URL": "redis_url",
+    "MFA_AES256_GCM_KEY_B64": "mfa_aes256_gcm_key_b64",
+    "PASSWORD_PEPPER_B64": "password_pepper_b64",
+}
+
+MIGRATION_SECRET_INPUTS = {
+    "DATABASE_MIGRATION_URL": "database_migration_url",
+}
+
+CONFIG_SECRET_INPUTS = {
+    **MIGRATION_SECRET_INPUTS,
+    **APP_SECRET_INPUTS,
+}
+
+DEPLOYMENT_SECRET_INPUTS = {
+    name: secret_file
+    for name, secret_file in CONFIG_SECRET_INPUTS.items()
+    if name != "SESSION_HMAC_KEYS_JSON"
+}
+
+APP_SECRET_FILE_ENVIRONMENT = {
+    f"{name}_FILE": f"/run/secrets/{secret_file}"
+    for name, secret_file in APP_SECRET_INPUTS.items()
+}
+
+APP_SECRET_FILES = tuple(APP_SECRET_INPUTS.values())
+DEPLOYMENT_SECRET_FILES = tuple(CONFIG_SECRET_INPUTS.values())
+STAGING_DATA_SERVICE_SECRETS = {
+    "postgres_owner_password": "postgres_owner_password",
+    "postgres_app_password": "postgres_app_password",
+    "redis_conf": "redis.conf",
+}
+STAGING_DATA_SERVICE_SECRET_FILES = tuple(STAGING_DATA_SERVICE_SECRETS.values())
+
+NON_SECRET_DEFAULTS = {
+    "COMMON_PASSWORDS_MIN_ENTRIES": "100000",
+    "HIBP_CIRCUIT_FAILURE_THRESHOLD": "3",
+    "HIBP_CIRCUIT_OPEN_SECONDS": "300",
+    "HIBP_PASSWORD_CHECK_TIMEOUT_SECONDS": "2.0",
+    "PASSWORD_PBKDF2_ITERATIONS": "600000",
+    "TRUSTED_PROXY_COUNT": "1",
+}
+
+POLICY_CONFIG_PATHS = {
+    "COMMON_PASSWORDS_PATH": "/run/config/common-passwords.txt",
+    "WEBAUTHN_APPROVED_AAGUIDS_PATH": "/run/config/fido-approved-aaguids.json",
+    "WEBAUTHN_MDS_CACHE_PATH": "/run/config/fido-mds-cache.json",
+}
+
+NON_SECRET_RUNTIME_ENVIRONMENT = tuple(
+    sorted(
+        {
+            "APP_ENV",
+            "MFA_ISSUER_NAME",
+            "SESSION_HMAC_ACTIVE_KEY_ID",
+            "WEBAUTHN_RP_ID",
+            "WEBAUTHN_RP_ORIGIN",
+            *NON_SECRET_DEFAULTS,
+            *POLICY_CONFIG_PATHS,
+        }
+    )
+)

--- a/scripts/ci-local
+++ b/scripts/ci-local
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+BASH_SCRIPTS = (
+    "ops/container/smoke-test.sh",
+    "ops/container/validate-compose.sh",
+    "ops/container/dast-smoke.sh",
+    "ops/deploy/bootstrap-container-ec2",
+    "ops/deploy/sitbank-container-bootstrap",
+    "ops/deploy/sitbank-container-deploy",
+    "ops/deploy/sitbank-container-runtime",
+    "ops/deploy/sitbank-database-cutover",
+)
+
+PYTHON_CHECKS = (
+    (
+        "Deployment contract tests",
+        (sys.executable, "-m", "pytest", "tests/test_deployment.py", "-q"),
+    ),
+    (
+        "Redis session integrity tests",
+        (sys.executable, "-m", "pytest", "tests/test_redis_session_integrity.py", "-q"),
+    ),
+    ("Full test suite", (sys.executable, "-m", "pytest", "-q")),
+    ("Compile Python sources", (sys.executable, "-m", "compileall", "app", "config.py", "wsgi.py")),
+    ("Package consistency", (sys.executable, "-m", "pip", "check")),
+    (
+        "Bandit high-confidence scan",
+        (sys.executable, "-m", "bandit", "-q", "-ll", "-r", "app", "ops", "config.py", "wsgi.py"),
+    ),
+    ("Whitespace check", ("git", "diff", "--check")),
+)
+
+
+def section(name: str) -> None:
+    print(f"\n== {name} ==", flush=True)
+
+
+def run(name: str, command: tuple[str, ...] | list[str]) -> None:
+    print(f"\n-- {name}", flush=True)
+    print("+ " + " ".join(command), flush=True)
+    subprocess.run(command, cwd=REPO_ROOT, check=True)
+    print(f"PASS: {name}", flush=True)
+
+
+def find_git_bash() -> str:
+    candidates: list[Path] = []
+    if os.name == "nt":
+        program_files = Path(os.environ.get("ProgramFiles", r"C:\Program Files"))
+        program_files_x86 = Path(os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)"))
+        candidates.extend(
+            (
+                program_files / "Git" / "bin" / "bash.exe",
+                program_files_x86 / "Git" / "bin" / "bash.exe",
+            )
+        )
+    path_bash = shutil.which("bash")
+    if path_bash:
+        candidates.append(Path(path_bash))
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return str(candidate)
+    raise SystemExit("Git Bash bash.exe was not found; install Git for Windows and retry.")
+
+
+def docker_available() -> bool:
+    docker = shutil.which("docker")
+    if not docker:
+        return False
+    result = subprocess.run(
+        [docker, "info"],
+        cwd=REPO_ROOT,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def main() -> None:
+    section("Python/test checks")
+    for name, command in PYTHON_CHECKS:
+        run(name, list(command))
+
+    section("Git Bash syntax checks")
+    bash = find_git_bash()
+    for script in BASH_SCRIPTS:
+        run(f"Syntax check {script}", [bash, "-n", script])
+
+    section("Docker/Compose checks")
+    if docker_available():
+        run("Compose model validation", [bash, "ops/container/validate-compose.sh", "sitbank:local-ci"])
+    else:
+        print(
+            "SKIP: Docker is unavailable; skipped Docker/Compose-only local checks. "
+            "No Docker result was recorded.",
+            file=sys.stderr,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import re
 import subprocess
 import sys
@@ -12,12 +13,29 @@ from flask import request
 
 from ops.deploy.import_legacy_env import import_legacy_environment
 from ops.deploy.render_container_bundle import (
+    NON_SECRET_DEFAULTS,
+    SECRET_INPUTS,
     build_container_bundle,
     build_container_environment,
     build_deployment_environment,
     write_container_bundle,
 )
+from ops.runtime_contract import (
+    APP_SECRET_FILE_ENVIRONMENT,
+    APP_SECRET_FILES,
+    CONFIG_SECRET_INPUTS,
+    DEPLOYMENT_SECRET_INPUTS,
+    DEPLOYMENT_SECRET_FILES,
+    NON_SECRET_DEFAULTS as CONTRACT_NON_SECRET_DEFAULTS,
+    NON_SECRET_RUNTIME_ENVIRONMENT,
+    STAGING_DATA_SERVICE_SECRETS,
+)
 
+
+ACTION_USES_PIN_RE = re.compile(r"[^@]+@[0-9a-f]{40}")
+PYTHON_SLIM_TRIXIE_DIGEST_RE = re.compile(
+    r"python:3\.12(?:\.\d+)?-slim-trixie@sha256:[0-9a-f]{64}"
+)
 
 DEPLOYMENT_VALUES = {
     "PROD_DATABASE_MIGRATION_URL": "postgresql+psycopg2://bank_owner:secret@127.0.0.1/bank",
@@ -82,6 +100,72 @@ def _nginx_location_bodies(config: str, selector: str) -> list[str]:
     )
 
 
+def _config_secret_inputs() -> set[str]:
+    tree = ast.parse(Path("config.py").read_text(encoding="utf-8"))
+    secret_readers = {
+        "_optional_url",
+        "_required_b64_32_bytes",
+        "_required_secret",
+        "_required_session_hmac_keys",
+        "_required_url",
+    }
+    names = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Name) or node.func.id not in secret_readers:
+            continue
+        if node.args and isinstance(node.args[0], ast.Constant) and isinstance(node.args[0].value, str):
+            names.add(node.args[0].value)
+    return names
+
+
+def _service_secret_targets(service: dict) -> dict[str, str]:
+    targets = {}
+    for secret in service.get("secrets", []):
+        if isinstance(secret, str):
+            targets[secret] = secret
+        else:
+            targets[secret["source"]] = secret["target"]
+    return targets
+
+
+def _extract_bash_array(script: str, name: str) -> list[str]:
+    match = re.search(rf"(?:local\s+)?{re.escape(name)}=\((.*?)\)", script, flags=re.DOTALL)
+    assert match, f"Missing bash array: {name}"
+    return re.findall(r"[A-Za-z0-9_.-]+", match.group(1))
+
+
+def _workflow_uses(workflow_text: str) -> list[str]:
+    return re.findall(r"^\s*uses:\s*([^\s#]+)", workflow_text, flags=re.MULTILINE)
+
+
+def _assert_pinned_actions(actions: list[str], *, context: str) -> None:
+    assert actions, f"{context} must use at least one pinned action"
+    for action in actions:
+        assert ACTION_USES_PIN_RE.fullmatch(action), f"{context} is not pinned: {action}"
+
+
+def _assert_sets_equal(actual: set[str], expected: set[str], *, context: str) -> None:
+    missing = sorted(expected - actual)
+    unexpected = sorted(actual - expected)
+    assert not missing and not unexpected, (
+        f"{context} drifted; missing={missing or 'none'}; "
+        f"unexpected={unexpected or 'none'}"
+    )
+
+
+def _dockerfile_stage_images(dockerfile: str) -> dict[str, str]:
+    return {
+        stage: image
+        for image, stage in re.findall(
+            r"^FROM\s+(\S+)\s+AS\s+([A-Za-z0-9_-]+)$",
+            dockerfile,
+            flags=re.MULTILINE,
+        )
+    }
+
+
 def test_runtime_privilege_verifier_quotes_create_probe_table_name():
     db_privileges = _load_db_privileges_module()
     probe_table = "sitbank_privilege_probe_deadbeef"
@@ -133,12 +217,15 @@ def test_container_bundle_separates_secrets_from_non_secret_environment(monkeypa
 
     environment, secrets = build_container_bundle()
 
+    assert set(environment) == set(NON_SECRET_RUNTIME_ENVIRONMENT)
     assert environment["APP_ENV"] == "production"
     assert environment["WEBAUTHN_RP_ID"] == "sitbank.duckdns.org"
     assert environment["WEBAUTHN_RP_ORIGIN"] == "https://sitbank.duckdns.org"
     assert environment["SESSION_HMAC_ACTIVE_KEY_ID"] == "2026-06"
     assert environment["COMMON_PASSWORDS_PATH"] == "/run/config/common-passwords.txt"
     assert "SECRET_KEY" not in environment
+    assert "DATABASE_MIGRATION_URL" not in environment
+    assert "DATABASE_MIGRATION_URL_FILE" not in environment
     assert secrets["secret_key"] == DEPLOYMENT_VALUES["PROD_SECRET_KEY"]
     assert secrets["database_url"] == DEPLOYMENT_VALUES["PROD_DATABASE_URL"]
     assert secrets["database_migration_url"] == DEPLOYMENT_VALUES["PROD_DATABASE_MIGRATION_URL"]
@@ -247,6 +334,120 @@ def test_container_bundle_builds_two_key_rotation_ring(monkeypatch):
 
     assert '"2026-03":"MzMz' in secrets["session_hmac_keys_json"]
     assert '"2026-06":"MjIy' in secrets["session_hmac_keys_json"]
+
+
+def test_runtime_secret_inventory_matches_config_and_renderer():
+    assert SECRET_INPUTS == DEPLOYMENT_SECRET_INPUTS
+    assert NON_SECRET_DEFAULTS == CONTRACT_NON_SECRET_DEFAULTS
+    _assert_sets_equal(
+        _config_secret_inputs(),
+        set(CONFIG_SECRET_INPUTS),
+        context="Runtime secret readers in config.py vs ops/runtime_contract.py",
+    )
+
+
+def test_compose_secret_mounts_match_runtime_contract():
+    expected_app_secrets = {name: name for name in APP_SECRET_FILES}
+    for path, secret_root, extra_secrets in (
+        (
+            Path("compose.prod.yml"),
+            "/etc/sitbank/secrets",
+            {},
+        ),
+        (
+            Path("compose.staging.yml"),
+            "/etc/sitbank-staging/secrets",
+            STAGING_DATA_SERVICE_SECRETS,
+        ),
+    ):
+        compose = yaml.safe_load(path.read_text(encoding="utf-8"))
+        app = compose["services"]["app"]
+
+        assert app["environment"] == APP_SECRET_FILE_ENVIRONMENT, (
+            f"{path} app secret _FILE environment must match runtime contract"
+        )
+        assert "DATABASE_MIGRATION_URL_FILE" not in app["environment"]
+        assert _service_secret_targets(app) == expected_app_secrets, (
+            f"{path} app service secrets must match runtime contract"
+        )
+
+        expected_top_level = set(DEPLOYMENT_SECRET_FILES) | set(extra_secrets)
+        _assert_sets_equal(
+            set(compose["secrets"]),
+            expected_top_level,
+            context=f"{path} top-level Compose secrets vs runtime contract",
+        )
+        expected_secret_files = {
+            **{secret_name: secret_name for secret_name in DEPLOYMENT_SECRET_FILES},
+            **extra_secrets,
+        }
+        for secret_name in expected_top_level:
+            assert (
+                compose["secrets"][secret_name]["file"]
+                == f"{secret_root}/{expected_secret_files[secret_name]}"
+            ), f"{path} secret {secret_name} must map to its contract file"
+
+
+def test_smoke_fixture_and_deployment_wrapper_match_runtime_contract():
+    smoke_test = Path("ops/container/smoke-test.sh").read_text(encoding="utf-8")
+    deploy_script = Path("ops/deploy/sitbank-container-deploy").read_text(encoding="utf-8")
+
+    for env_name, secret_path in APP_SECRET_FILE_ENVIRONMENT.items():
+        assert f"--env {env_name}={secret_path}" in smoke_test, (
+            f"ops/container/smoke-test.sh is missing {env_name}={secret_path}"
+        )
+    for secret_name in DEPLOYMENT_SECRET_FILES:
+        assert f"${{work_dir}}/secrets/{secret_name}" in smoke_test, (
+            f"ops/container/smoke-test.sh is missing secret fixture {secret_name}"
+        )
+
+    assert "--env DATABASE_MIGRATION_URL_FILE=/run/secrets/database_migration_url" in smoke_test
+    assert ':/run/secrets/database_migration_url:ro' not in smoke_test
+    assert '"${secrets_mount_source}:/run/secrets:ro"' in smoke_test
+
+    _assert_sets_equal(
+        set(_extract_bash_array(deploy_script, "allowed_environment")),
+        set(NON_SECRET_RUNTIME_ENVIRONMENT),
+        context="sitbank-container-deploy allowed_environment vs runtime contract",
+    )
+    _assert_sets_equal(
+        set(_extract_bash_array(deploy_script, "required_secrets")),
+        set(DEPLOYMENT_SECRET_FILES),
+        context="sitbank-container-deploy required_secrets vs runtime contract",
+    )
+    assert "DATABASE_MIGRATION_URL_FILE=/run/secrets/database_migration_url" in deploy_script
+    assert (
+        '--volume "${SECRET_DIR}/database_migration_url:/run/secrets/database_migration_url:ro"'
+        in deploy_script
+    )
+
+
+def test_local_ci_command_documents_required_local_checks():
+    ci_local = Path("scripts/ci-local").read_text(encoding="utf-8")
+    readme = Path("README.md").read_text(encoding="utf-8")
+
+    for expected in (
+        "tests/test_deployment.py",
+        "tests/test_redis_session_integrity.py",
+        '"pytest"',
+        '"compileall"',
+        '"pip", "check"',
+        '"bandit"',
+        '"git", "diff", "--check"',
+        "ops/deploy/sitbank-container-deploy",
+        "ops/container/validate-compose.sh",
+        "== {name} ==",
+        "Python/test checks",
+        "Git Bash syntax checks",
+        "Docker/Compose checks",
+        "PASS:",
+        "SKIP:",
+        "No Docker result was recorded",
+    ):
+        assert expected in ci_local
+    assert "Docker is unavailable; skipped Docker/Compose-only local checks" in ci_local
+    assert "scripts/ci-local" in readme
+    assert "ops/runtime_contract.py" in readme
 
 
 def test_environment_only_bundle_does_not_export_long_lived_secrets(
@@ -390,12 +591,13 @@ def test_dockerfile_and_compose_enforce_hardened_runtime():
     staging_app = staging_services["app"]
 
     assert compose["name"] == "sitbank"
-    assert (
-        "python:3.12.13-slim-trixie@"
-        "sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203"
-        in dockerfile
+    stage_images = _dockerfile_stage_images(dockerfile)
+    assert set(stage_images) == {"builder", "runtime"}
+    assert stage_images["builder"] == stage_images["runtime"]
+    assert PYTHON_SLIM_TRIXIE_DIGEST_RE.fullmatch(stage_images["runtime"]), (
+        "Dockerfile must use a Python 3.12 slim-trixie base image pinned by "
+        f"sha256 digest, got {stage_images['runtime']}"
     )
-    assert dockerfile.count("python:3.12.13-slim-trixie@sha256:") == 2
     assert 'org.opencontainers.image.title="SITBank banking application"' in dockerfile
     assert "USER 10001:10001" in dockerfile
     assert "--require-hashes" in dockerfile
@@ -858,16 +1060,20 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     assert "check_dependency_locks.py" in workflow_text
     assert "IMAGE_DIGEST" in workflow_text
     assert "StrictHostKeyChecking=no" not in workflow_text
-    assert workflow_text.count("persist-credentials: false") == 10
-    assert (
-        workflow_text.count(
-            "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10"
-        )
-        == 10
-    )
-    assert (
-        "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405"
-        in workflow_text
+    checkout_uses = [
+        action for action in _workflow_uses(workflow_text)
+        if action.startswith("actions/checkout@")
+    ]
+    setup_python_uses = [
+        action for action in _workflow_uses(workflow_text)
+        if action.startswith("actions/setup-python@")
+    ]
+    assert len(checkout_uses) == 10
+    assert workflow_text.count("persist-credentials: false") == len(checkout_uses)
+    _assert_pinned_actions(checkout_uses, context="actions/checkout")
+    _assert_pinned_actions(
+        setup_python_uses,
+        context="actions/setup-python",
     )
     assert "sitbank:pr" in workflow_text
     assert "SITBANK_IMAGE" in workflow_text
@@ -1091,7 +1297,7 @@ def test_trivy_exception_is_narrow_documented_and_temporary():
 
     assert active_ignores == ["CVE-2026-42496", "CVE-2026-8376"]
     for required in (
-        "official python:3.12.13-slim-trixie / Debian Trixie",
+        "official python:3.12 slim-trixie / Debian Trixie",
         "does not install Perl directly",
         "Essential: yes",
         "must not be removed",
@@ -1150,8 +1356,17 @@ def test_codeowners_and_codeql_cover_security_sensitive_changes():
         "/ops/security/",
     ):
         assert protected_path in codeowners
-    assert "github/codeql-action/init@411bbbe57033eedfc1a82d68c01345aa96c737d7" in codeql
-    assert "github/codeql-action/analyze@411bbbe57033eedfc1a82d68c01345aa96c737d7" in codeql
+    codeql_uses = _workflow_uses(codeql)
+    init_actions = [
+        action for action in codeql_uses
+        if action.startswith("github/codeql-action/init@")
+    ]
+    analyze_actions = [
+        action for action in codeql_uses
+        if action.startswith("github/codeql-action/analyze@")
+    ]
+    _assert_pinned_actions(init_actions, context="github/codeql-action/init")
+    _assert_pinned_actions(analyze_actions, context="github/codeql-action/analyze")
     assert "languages: python" in codeql
 
 
@@ -1160,11 +1375,9 @@ def test_every_github_action_is_pinned_to_a_full_commit_sha():
         path.read_text(encoding="utf-8")
         for path in Path(".github/workflows").glob("*.yml")
     )
-    uses = re.findall(r"^\s*uses:\s*([^\s#]+)", workflow_text, flags=re.MULTILINE)
+    uses = _workflow_uses(workflow_text)
 
-    assert uses
-    for action in uses:
-        assert re.fullmatch(r"[^@]+@[0-9a-f]{40}", action), action
+    _assert_pinned_actions(uses, context="GitHub Actions workflow")
     assert "pull_request_target:" not in workflow_text
 
 

--- a/tests/test_redis_session_integrity.py
+++ b/tests/test_redis_session_integrity.py
@@ -7,9 +7,16 @@ import json
 import time
 from datetime import datetime, timezone
 
+import pytest
+
 from app.extensions import db
 from app.models import SecurityAuditEvent, User
-from app.security.session_hmac import SESSION_PAYLOAD_FORMAT_VERSION
+from app.security.session_hmac import (
+    SESSION_PAYLOAD_FORMAT_VERSION,
+    SessionPayloadIntegrityError,
+    sign_session_payload,
+    verify_session_payload,
+)
 
 
 def _create_user(username: str = "alice01") -> int:
@@ -68,13 +75,20 @@ def _replace_unsigned_payload(app, session_id: str, mutator) -> None:
     _store_envelope(app, session_id, envelope)
 
 
-def _signature(app, key_id: str, encoded_payload: str) -> str:
-    signing_input = (
-        f"sitbank-session-v{SESSION_PAYLOAD_FORMAT_VERSION}.{key_id}.{encoded_payload}"
+def _signature(app, key_id: str, encoded_payload: str, binding_context: str) -> str:
+    signing_input = json.dumps(
+        {
+            "ctx": binding_context,
+            "kid": key_id,
+            "payload": encoded_payload,
+            "v": SESSION_PAYLOAD_FORMAT_VERSION,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
     )
     return hmac.new(
         app.config["SESSION_HMAC_KEYS"][key_id],
-        signing_input.encode("ascii"),
+        signing_input.encode("utf-8"),
         hashlib.sha256,
     ).hexdigest()
 
@@ -164,7 +178,12 @@ def test_malformed_redis_session_payload_is_rejected(app, client):
     session_id = _authenticate_session(client, user_id)
     envelope = _load_envelope(app, session_id)
     envelope["payload"] = "not-valid-base64"
-    envelope["sig"] = _signature(app, envelope["kid"], envelope["payload"])
+    envelope["sig"] = _signature(
+        app,
+        envelope["kid"],
+        envelope["payload"],
+        _session_key(app, session_id),
+    )
     _store_envelope(app, session_id, envelope)
 
     _assert_session_rejected(app, client)
@@ -178,6 +197,20 @@ def test_unsupported_redis_session_payload_format_is_rejected(app, client):
     _assert_session_rejected(app, client)
 
 
+def test_signed_redis_session_payload_copied_to_another_key_is_rejected(app, client):
+    alice_id = _create_user("alice01")
+    alice_session_id = _authenticate_session(client, alice_id)
+    signed_payload = app.extensions["redis_session"].get(_session_key(app, alice_session_id))
+    assert signed_payload is not None
+
+    second_client = app.test_client()
+    bob_id = _create_user("bob02")
+    bob_session_id = _authenticate_session(second_client, bob_id)
+    app.extensions["redis_session"].set(_session_key(app, bob_session_id), signed_payload)
+
+    _assert_session_rejected(app, second_client)
+
+
 def test_redis_session_payload_survives_active_hmac_key_rotation(app, client):
     user_id = _create_user()
     session_id = _authenticate_session(client, user_id)
@@ -189,3 +222,18 @@ def test_redis_session_payload_survives_active_hmac_key_rotation(app, client):
 
     assert response.status_code == 200
     assert rotated_envelope["kid"] == "test-previous"
+
+
+def test_session_payload_binding_context_is_required_and_checked(app):
+    payload = app.session_interface.serializer.encode({"user_id": 1})
+    signed_payload = sign_session_payload(payload, binding_context="session:alpha")
+
+    assert verify_session_payload(signed_payload, binding_context="session:alpha") == payload
+
+    with pytest.raises(SessionPayloadIntegrityError) as missing_context:
+        verify_session_payload(signed_payload, binding_context="")
+    assert missing_context.value.reason == "missing_binding_context"
+
+    with pytest.raises(SessionPayloadIntegrityError) as wrong_context:
+        verify_session_payload(signed_payload, binding_context="session:bravo")
+    assert wrong_context.value.reason == "invalid_signature"


### PR DESCRIPTION
## Summary

This PR hardens Redis-backed session integrity and reduces CI/CD brittleness while preserving the existing security and supply-chain guarantees.

Branch for #34: `harden-session-binding-ci-brittleness`

It fixes the Redis session HMAC replay/copy weakness by binding the signed session payload to the Redis store context, adds a runtime contract for config/secret drift checks, improves local CI diagnosis, and keeps deployment-sensitive invariants under explicit tests.

Closes #34.

## Why

The previous Redis session HMAC protected against payload mutation, but it was not bound to the Redis session key/session identity. If Redis were readable/writable by an attacker, a valid signed payload could potentially be copied under another Redis session key.

The CI/CD pipeline is intentionally strict, but required runtime config and secret mappings were spread across config, Compose, renderer, deployment, smoke-test, and test code. This made normal config/deployment changes easier to break and harder to diagnose.

## What changed

- Updated Redis session HMAC format to v2.
- Bound Redis session HMAC signing input to `store_id`.
- Added fail-closed handling for missing binding context.
- Added copied-payload replay test coverage.
- Preserved HMAC key rotation behavior.
- Added `scripts/ci-local` for local developer validation with named phases and pass/skip output.
- Added `ops/runtime_contract.py` for runtime config/secret contract checks.
- Added deployment/config drift tests with missing/unexpected-name diagnostics.
- Added production runtime contract checks to ensure the long-running app does not receive migration DB credentials.
- Reduced brittle exact dependency/version assertions while preserving full SHA action pins, digest-pinned base images, lock/hash enforcement, deployment gating, wrapper verification, Cosign, and container hardening checks.

## Security impact

Security is strengthened.

No real secrets were added. No secrets, session IDs, Redis payloads, or HMAC keys are logged.

This PR does not weaken PR validation-only behavior, staging/production secret separation, Cosign verification, digest-only deployment, deployment wrapper verification, dependency locking, security scanning, or container hardening.

## Deployment / Bootstrap Impact

This PR changes EC2 bootstrap/deployment/runtime-installed files.

Changed bootstrap-sensitive files:

* `compose.prod.yml`
* `ops/deploy/render_container_bundle.py`

After merge, do not deploy staging or production immediately.

Required post-merge flow:

1. Merge to `main`.
2. Run `Bootstrap EC2 from trusted main` for `staging`.
3. Run `Bootstrap EC2 from trusted main` for `production`, because production-installed files changed.
4. Rerun the main `CI, publish, and deploy` release workflow from `main`.
5. Deploy staging.
6. Verify staging.
7. Deploy production.

Do not bootstrap from this PR branch. Bootstrap only from trusted `origin/main` after merge.

Deployment requirements:

* EC2 bootstrap: required after merge
* Staging deployment: required after EC2 staging bootstrap and release verification
* Production deployment: only after staging is verified and production EC2 bootstrap is run
* Database migration: no direct manual migration required by this PR
* Secret changes: no real secret value changes
* PR deployment: not allowed; keep deploy OFF during PR verification

## Verification

Local validation passed before the latest rebase:

* `python -m pytest tests/test_deployment.py -q`: passed
* `python -m pytest tests/test_redis_session_integrity.py -q`: passed
* `python -m pytest -q`: passed
* `python -m compileall app config.py wsgi.py`: passed
* `python -m pip check`: passed
* `python -m bandit -q -ll -r app ops config.py wsgi.py`: passed
* `git diff --check`: passed
* Git Bash `bash.exe -n` for deployment scripts: passed
* `python -m py_compile scripts/ci-local ops/runtime_contract.py`: passed

After rebasing onto latest `origin/main`, the following quick validation passed:

* `python -m pytest tests/test_deployment.py -q`: 34 passed
* `python -m pytest tests/test_redis_session_integrity.py -q`: 11 passed
* `git diff --check`: passed

Final branch HEAD after latest rebase/push:

* `8d913c9dddd14286c091bcfb801477d4f99fc488`

## Operator instructions after merge

1. Run `Bootstrap EC2 from trusted main` with `staging`.
2. Verify wrapper hash succeeds.
3. Run `Bootstrap EC2 from trusted main` with `production`.
4. Rerun the main `CI, publish, and deploy` release workflow from `main`.
5. Deploy staging.
6. Test staging.
7. Deploy production.

Do not tick “Deploy the verified digest after release verification” during PR verification before merge.