### PR TITLE
Harden staging Nginx endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,9 +575,89 @@ configuration. It does not add `sitbank-deploy` to the Docker group.
 
 ### 4. Bootstrap Isolated Staging on the Existing EC2 Host
 
-Run this from the same reviewed bootstrap checkout. It installs only staging
-Compose/config/state assets plus the shared restricted wrapper; it does not
-restart or migrate production:
+Prepare the staging Nginx edge files on EC2 before running the reviewed
+bootstrap. These files are local machine state, not repository content, and
+must never be committed, copied into GitHub secrets, or included in a runtime
+bundle.
+
+Install the operator tools and create the Basic Auth file. `htpasswd` prompts
+for the password without echoing it:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y nginx certbot python3-certbot-nginx apache2-utils
+
+read -r -p "Staging Basic Auth username: " STAGING_BASIC_AUTH_USER
+sudo htpasswd -c /etc/nginx/.htpasswd-sitbank-staging \
+  "$STAGING_BASIC_AUTH_USER"
+sudo chown root:www-data /etc/nginx/.htpasswd-sitbank-staging
+sudo chmod 0640 /etc/nginx/.htpasswd-sitbank-staging
+sudo test -s /etc/nginx/.htpasswd-sitbank-staging
+unset STAGING_BASIC_AUTH_USER
+```
+
+Do not store the Basic Auth password or generated htpasswd hash in the repo.
+To rotate the staging gate later, rerun `htpasswd` on EC2 and keep the same
+`root:www-data` ownership and `0640` mode.
+
+Issue the staging certificate before installing the final HTTPS server block.
+If an HTTP-only staging Nginx site is already serving
+`staging-sitbank.duckdns.org`, the Nginx plugin is acceptable:
+
+```bash
+sudo certbot --nginx -d staging-sitbank.duckdns.org
+```
+
+For a first-time host with no staging site yet, use an ACME-only webroot site
+so production Nginx keeps running:
+
+```bash
+sudo install -d -m 0755 /var/www/certbot
+sudo tee /etc/nginx/sites-available/sitbank-staging-acme >/dev/null <<'NGINX'
+server {
+    listen 80;
+    listen [::]:80;
+    server_name staging-sitbank.duckdns.org;
+
+    location ^~ /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+        default_type "text/plain";
+        try_files $uri =404;
+    }
+
+    location / {
+        return 404;
+    }
+}
+NGINX
+sudo ln -sfn /etc/nginx/sites-available/sitbank-staging-acme \
+  /etc/nginx/sites-enabled/sitbank-staging-acme
+sudo nginx -t
+# If validation succeeds:
+sudo systemctl reload nginx
+sudo certbot certonly --webroot \
+  -w /var/www/certbot \
+  -d staging-sitbank.duckdns.org
+sudo rm -f /etc/nginx/sites-enabled/sitbank-staging-acme
+sudo rm -f /etc/nginx/sites-available/sitbank-staging-acme
+sudo nginx -t
+# If validation succeeds:
+sudo systemctl reload nginx
+```
+
+Check renewal without changing production or deploying the app:
+
+```bash
+sudo certbot renew --dry-run
+```
+
+Run this from the same reviewed bootstrap checkout after the htpasswd file and
+certificate exist. It installs only staging Compose/config/state assets, the
+Nginx proxy header snippet, the staging HTTPS server block, and the staging
+rate-limit include. It backs up an existing staging site config, replaces it
+from the reviewed repo files, runs `nginx -t`, and reloads Nginx only after
+validation succeeds. It does not restart, migrate, publish, pull, or deploy a
+SITBank application image:
 
 ```bash
 cd /opt/sitbank-bootstrap
@@ -667,16 +747,58 @@ write(
 PY
 ```
 
-Install the staging TLS certificate before the first deployment, because the
-deployment wrapper verifies public HTTPS readiness:
+If `nginx -t` fails after a reviewed Nginx change, do not reload. The bootstrap
+keeps backups under `/var/backups/sitbank-staging`; restore the previous site
+config, validate, and reload only after validation succeeds:
+
+```bash
+sudo install -o root -g root -m 0644 \
+  /var/backups/sitbank-staging/nginx-sitbank-staging.<timestamp>.conf \
+  /etc/nginx/sites-available/sitbank-staging
+sudo nginx -t
+# If validation succeeds:
+sudo systemctl reload nginx
+```
+
+After the staging app has been deployed intentionally through the protected
+staging deployment path, verify the edge behavior:
 
 ```bash
 sudo nginx -t
-sudo systemctl reload nginx
-sudo certbot --nginx -d staging-sitbank.duckdns.org
-sudo nginx -t
-sudo systemctl reload nginx
+curl -k -I https://staging-sitbank.duckdns.org/
+
+read -r -p "Staging Basic Auth username: " STAGING_BASIC_AUTH_USER
+read -r -s -p "Staging Basic Auth password: " STAGING_BASIC_AUTH_PASSWORD
+printf '\n'
+curl -k -I -u "$STAGING_BASIC_AUTH_USER:$STAGING_BASIC_AUTH_PASSWORD" \
+  https://staging-sitbank.duckdns.org/
+unset STAGING_BASIC_AUTH_USER
+unset STAGING_BASIC_AUTH_PASSWORD
+
+# Run this external check from a workstation or another non-loopback host.
+curl -k -I https://staging-sitbank.duckdns.org/health/ready
+curl -fsS http://127.0.0.1:5001/health/ready
 ```
+
+Expected results: unauthenticated `/` returns `401`, authenticated `/` returns
+`200`, external `/health/ready` returns `403`, and the local app readiness
+endpoint returns the app's ready JSON body. From EC2, the deployment wrapper's
+HTTPS readiness check still works through loopback because Nginx allows local
+`/health/ready` requests:
+
+```bash
+curl -k -fsS \
+  --resolve staging-sitbank.duckdns.org:443:127.0.0.1 \
+  https://staging-sitbank.duckdns.org/health/ready
+```
+
+Staging is behind Basic Auth to keep preview traffic, scanners, and credential
+stuffing away from the public banking app while testers still use normal app
+authentication inside the gate. External `/health/ready` is blocked because it
+reveals dependency readiness; local EC2 and deployment checks use loopback
+instead. This edge setup is separate from application deployment: Certbot,
+htpasswd, Nginx config replacement, rate-limit includes, `nginx -t`, and Nginx
+reload do not publish or roll a container image.
 
 Verify that staging assets are separate and production remains healthy:
 
@@ -685,6 +807,9 @@ sudo systemctl is-active sitbank-container.service
 sudo test -r /etc/sitbank-staging/deploy.conf
 sudo test -r /opt/sitbank-staging/compose.yml
 sudo test -r /etc/sitbank-staging/postgres/init-sitbank-staging-roles.sh
+sudo test -r /etc/nginx/.htpasswd-sitbank-staging
+sudo test -r /etc/nginx/conf.d/sitbank-staging-rate-limits.conf
+sudo test -r /etc/nginx/sites-available/sitbank-staging
 sudo -u sitbank-container test -r /etc/sitbank-staging/secrets/database_url
 sudo -u sitbank-container test -r /etc/sitbank-staging/secrets/database_migration_url
 sudo -u sitbank-container test -r /etc/sitbank-staging/common-passwords.txt
@@ -694,7 +819,10 @@ curl --fail https://sitbank.duckdns.org/health/ready
 Set `STAGING_PUBLIC_HOST=staging-sitbank.duckdns.org`,
 `STAGING_EC2_HOST=sitbank.duckdns.org` or the EC2 address, and the matching
 staging key identifier in the GitHub `staging` environment. Enable
-`STAGING_DEPLOY_ENABLED=true` only after these checks pass.
+`STAGING_DEPLOY_ENABLED=true` only after bootstrap, Nginx validation, Certbot,
+and local asset checks pass. Run the `401`, `200`, `403`, and local ready
+checks after the first intentional staging deployment before handing the URL
+to testers.
 
 The deployment workflow intentionally cannot update its own privileged EC2
 validator. Use **Bootstrap EC2 from trusted main** after reviewed changes to

--- a/ops/deploy/bootstrap-container-ec2
+++ b/ops/deploy/bootstrap-container-ec2
@@ -6,6 +6,9 @@ readonly CONTAINER_GID="10001"
 readonly CONTAINER_ACCOUNT="sitbank-container"
 readonly COSIGN_VERSION="3.0.5"
 readonly COSIGN_SHA256="db15cc99e6e4837daabab023742aaddc3841ce57f193d11b7c3e06c8003642b2"
+readonly STAGING_PUBLIC_HOST="staging-sitbank.duckdns.org"
+readonly STAGING_BASIC_AUTH_FILE="/etc/nginx/.htpasswd-sitbank-staging"
+readonly STAGING_RATE_LIMITS_FILE="/etc/nginx/conf.d/sitbank-staging-rate-limits.conf"
 
 if [[ "${EUID}" -ne 0 ]]; then
     echo "Run this bootstrap script as root" >&2
@@ -35,6 +38,10 @@ if [[ -z "${public_host}" ]]; then
 fi
 if [[ ! "${public_host}" =~ ^[A-Za-z0-9.-]+$ ]]; then
     echo "PUBLIC_HOST must be a bare hostname" >&2
+    exit 2
+fi
+if [[ "${target}" == "staging" && "${public_host}" != "${STAGING_PUBLIC_HOST}" ]]; then
+    echo "Staging PUBLIC_HOST must be ${STAGING_PUBLIC_HOST}" >&2
     exit 2
 fi
 if [[ "${target}" == "staging" \
@@ -93,6 +100,7 @@ if [[ "${target}" == "staging" ]]; then
     linux_runtime_files+=(
         "${repo_root}/ops/nginx-proxy-headers.conf"
         "${repo_root}/ops/nginx/sitbank-staging.conf"
+        "${repo_root}/ops/nginx/sitbank-staging-rate-limits.conf"
         "${repo_root}/ops/postgres/init-sitbank-staging-roles.sh"
     )
 fi
@@ -127,6 +135,9 @@ if ! command -v docker >/dev/null 2>&1 \
         docker-buildx-plugin docker-compose-plugin
 fi
 systemctl enable --now docker.service
+if [[ "${target}" == "staging" ]]; then
+    apt-get install -y nginx certbot python3-certbot-nginx apache2-utils
+fi
 
 cosign_tmp="$(mktemp)"
 trap 'rm -f -- "${cosign_tmp}"' EXIT
@@ -237,6 +248,28 @@ for policy_file in \
 done
 
 if [[ "${target}" == "staging" ]]; then
+    staging_cert_dir="/etc/letsencrypt/live/${public_host}"
+    if [[ ! -f "${STAGING_BASIC_AUTH_FILE}" || -L "${STAGING_BASIC_AUTH_FILE}" \
+        || ! -r "${STAGING_BASIC_AUTH_FILE}" ]]; then
+        echo "Missing required staging Basic Auth file: ${STAGING_BASIC_AUTH_FILE}" >&2
+        echo "Create it with htpasswd, owned by root:www-data and mode 0640, before rerunning bootstrap." >&2
+        exit 1
+    fi
+    for required_staging_file in \
+        "${staging_cert_dir}/fullchain.pem" \
+        "${staging_cert_dir}/privkey.pem"; do
+        if [[ ! -r "${required_staging_file}" ]]; then
+            echo "Missing required staging TLS file: ${required_staging_file}" >&2
+            echo "Issue the staging Certbot certificate before rerunning bootstrap." >&2
+            exit 1
+        fi
+    done
+    if [[ "$(stat -c '%U:%G' -- "${STAGING_BASIC_AUTH_FILE}")" != "root:www-data" \
+        || "$(stat -c '%a' -- "${STAGING_BASIC_AUTH_FILE}")" != "640" ]]; then
+        echo "${STAGING_BASIC_AUTH_FILE} must be owned by root:www-data with mode 0640" >&2
+        exit 1
+    fi
+
     nginx_conflict=0
     while IFS= read -r enabled_site; do
         if [[ "$(readlink -f "${enabled_site}")" \
@@ -256,15 +289,42 @@ if [[ "${target}" == "staging" ]]; then
     fi
 
     install -d -o root -g root -m 0755 /etc/nginx/snippets
+    install -d -o root -g root -m 0755 /etc/nginx/conf.d
+    install -d -o root -g root -m 0755 /var/www/certbot
     install -o root -g root -m 0644 \
         "${repo_root}/ops/nginx-proxy-headers.conf" \
         /etc/nginx/snippets/sitbank-proxy-headers.conf
-    if [[ ! -e /etc/nginx/sites-available/sitbank-staging ]]; then
-        install -o root -g root -m 0644 \
-            "${repo_root}/ops/nginx/sitbank-staging.conf" \
-            /etc/nginx/sites-available/sitbank-staging
+    if [[ -e "${STAGING_RATE_LIMITS_FILE}" \
+        && ( -L "${STAGING_RATE_LIMITS_FILE}" || ! -f "${STAGING_RATE_LIMITS_FILE}" ) ]]; then
+        echo "Refusing to replace unsafe staging Nginx rate-limit file: ${STAGING_RATE_LIMITS_FILE}" >&2
+        exit 1
     fi
-    ln -sfn /etc/nginx/sites-available/sitbank-staging \
+    if [[ -f "${STAGING_RATE_LIMITS_FILE}" \
+        && ! cmp -s "${repo_root}/ops/nginx/sitbank-staging-rate-limits.conf" "${STAGING_RATE_LIMITS_FILE}" ]]; then
+        install -o root -g root -m 0644 \
+            "${STAGING_RATE_LIMITS_FILE}" \
+            "${backup_dir}/nginx-sitbank-staging-rate-limits.$(date -u +%Y%m%dT%H%M%SZ).conf"
+    fi
+    install -o root -g root -m 0644 \
+        "${repo_root}/ops/nginx/sitbank-staging-rate-limits.conf" \
+        "${STAGING_RATE_LIMITS_FILE}"
+
+    staging_site="/etc/nginx/sites-available/sitbank-staging"
+    if [[ -e "${staging_site}" \
+        && ( -L "${staging_site}" || ! -f "${staging_site}" ) ]]; then
+        echo "Refusing to replace unsafe staging Nginx config: ${staging_site}" >&2
+        exit 1
+    fi
+    if [[ -f "${staging_site}" \
+        && ! cmp -s "${repo_root}/ops/nginx/sitbank-staging.conf" "${staging_site}" ]]; then
+        install -o root -g root -m 0644 \
+            "${staging_site}" \
+            "${backup_dir}/nginx-sitbank-staging.$(date -u +%Y%m%dT%H%M%SZ).conf"
+    fi
+    install -o root -g root -m 0644 \
+        "${repo_root}/ops/nginx/sitbank-staging.conf" \
+        "${staging_site}"
+    ln -sfn "${staging_site}" \
         /etc/nginx/sites-enabled/sitbank-staging
     nginx -t
     systemctl reload nginx

--- a/ops/deploy/bootstrap-container-ec2
+++ b/ops/deploy/bootstrap-container-ec2
@@ -299,8 +299,10 @@ if [[ "${target}" == "staging" ]]; then
         echo "Refusing to replace unsafe staging Nginx rate-limit file: ${STAGING_RATE_LIMITS_FILE}" >&2
         exit 1
     fi
-    if [[ -f "${STAGING_RATE_LIMITS_FILE}" \
-        && ! cmp -s "${repo_root}/ops/nginx/sitbank-staging-rate-limits.conf" "${STAGING_RATE_LIMITS_FILE}" ]]; then
+    if [[ -f "${STAGING_RATE_LIMITS_FILE}" ]] \
+        && ! cmp -s \
+            "${repo_root}/ops/nginx/sitbank-staging-rate-limits.conf" \
+            "${STAGING_RATE_LIMITS_FILE}"; then
         install -o root -g root -m 0644 \
             "${STAGING_RATE_LIMITS_FILE}" \
             "${backup_dir}/nginx-sitbank-staging-rate-limits.$(date -u +%Y%m%dT%H%M%SZ).conf"
@@ -315,8 +317,10 @@ if [[ "${target}" == "staging" ]]; then
         echo "Refusing to replace unsafe staging Nginx config: ${staging_site}" >&2
         exit 1
     fi
-    if [[ -f "${staging_site}" \
-        && ! cmp -s "${repo_root}/ops/nginx/sitbank-staging.conf" "${staging_site}" ]]; then
+    if [[ -f "${staging_site}" ]] \
+        && ! cmp -s \
+            "${repo_root}/ops/nginx/sitbank-staging.conf" \
+            "${staging_site}"; then
         install -o root -g root -m 0644 \
             "${staging_site}" \
             "${backup_dir}/nginx-sitbank-staging.$(date -u +%Y%m%dT%H%M%SZ).conf"

--- a/ops/nginx/sitbank-staging-rate-limits.conf
+++ b/ops/nginx/sitbank-staging-rate-limits.conf
@@ -1,0 +1,3 @@
+# Included from Nginx's http context by /etc/nginx/conf.d/*.conf.
+limit_req_zone $binary_remote_addr zone=sitbank_staging_login:10m rate=5r/m;
+limit_req_zone $binary_remote_addr zone=sitbank_staging_app:10m rate=10r/s;

--- a/ops/nginx/sitbank-staging.conf
+++ b/ops/nginx/sitbank-staging.conf
@@ -3,7 +3,117 @@ server {
     listen [::]:80;
     server_name staging-sitbank.duckdns.org;
 
+    server_tokens off;
+
+    location ^~ /.well-known/acme-challenge/ {
+        auth_basic off;
+        root /var/www/certbot;
+        default_type "text/plain";
+        try_files $uri =404;
+    }
+
+    location ~ /\.(?!well-known/acme-challenge/) {
+        return 404;
+    }
+
+    location ~* \.(?:bak|old|orig|save|swp|tmp)$ {
+        return 404;
+    }
+
     location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name staging-sitbank.duckdns.org;
+
+    server_tokens off;
+    access_log /var/log/nginx/sitbank-staging.access.log;
+    error_log /var/log/nginx/sitbank-staging.error.log warn;
+
+    ssl_certificate /etc/letsencrypt/live/staging-sitbank.duckdns.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/staging-sitbank.duckdns.org/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache shared:sitbank_staging_ssl:10m;
+    ssl_session_timeout 1d;
+    ssl_session_tickets off;
+
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "no-referrer" always;
+    add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()" always;
+    add_header Strict-Transport-Security "max-age=300" always;
+
+    auth_basic "SITBank staging";
+    auth_basic_user_file /etc/nginx/.htpasswd-sitbank-staging;
+
+    limit_req_status 429;
+    limit_req_log_level warn;
+
+    client_max_body_size 4m;
+    client_body_timeout 15s;
+    client_header_timeout 15s;
+    keepalive_timeout 30s;
+    send_timeout 30s;
+    proxy_connect_timeout 5s;
+    proxy_send_timeout 30s;
+    proxy_read_timeout 30s;
+
+    location ^~ /.well-known/acme-challenge/ {
+        auth_basic off;
+        root /var/www/certbot;
+        default_type "text/plain";
+        try_files $uri =404;
+    }
+
+    location = /health/ready {
+        auth_basic off;
+        allow 127.0.0.1;
+        allow ::1;
+        deny all;
+
+        proxy_pass http://127.0.0.1:5001;
+        include /etc/nginx/snippets/sitbank-proxy-headers.conf;
+    }
+
+    location ~ /\.(?!well-known/acme-challenge/) {
+        return 404;
+    }
+
+    location ~* \.(?:bak|old|orig|save|swp|tmp)$ {
+        return 404;
+    }
+
+    location = /login {
+        limit_req zone=sitbank_staging_login burst=5 nodelay;
+        proxy_pass http://127.0.0.1:5001;
+        include /etc/nginx/snippets/sitbank-proxy-headers.conf;
+    }
+
+    location = /register {
+        limit_req zone=sitbank_staging_login burst=5 nodelay;
+        proxy_pass http://127.0.0.1:5001;
+        include /etc/nginx/snippets/sitbank-proxy-headers.conf;
+    }
+
+    location = /mfa/verify {
+        limit_req zone=sitbank_staging_login burst=5 nodelay;
+        proxy_pass http://127.0.0.1:5001;
+        include /etc/nginx/snippets/sitbank-proxy-headers.conf;
+    }
+
+    location ^~ /auth/ {
+        limit_req zone=sitbank_staging_login burst=5 nodelay;
+        proxy_pass http://127.0.0.1:5001;
+        include /etc/nginx/snippets/sitbank-proxy-headers.conf;
+    }
+
+    location / {
+        limit_req zone=sitbank_staging_app burst=40 nodelay;
         proxy_pass http://127.0.0.1:5001;
         include /etc/nginx/snippets/sitbank-proxy-headers.conf;
     }

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1291,7 +1291,9 @@ def test_staging_nginx_enforces_https_auth_health_and_rate_limits():
     assert "ops/nginx/sitbank-staging-rate-limits.conf" in bootstrap
     assert "sitbank-staging-rate-limits.$(date -u +%Y%m%dT%H%M%SZ).conf" in bootstrap
     assert "nginx-sitbank-staging.$(date -u +%Y%m%dT%H%M%SZ).conf" in bootstrap
-    assert "cmp -s \"${repo_root}/ops/nginx/sitbank-staging.conf\" \"${staging_site}\"" in bootstrap
+    assert "&& ! cmp -s \\" in bootstrap
+    assert '"${repo_root}/ops/nginx/sitbank-staging.conf" \\' in bootstrap
+    assert '"${staging_site}"; then' in bootstrap
     assert "if [[ ! -e /etc/nginx/sites-available/sitbank-staging" not in bootstrap
     assert bootstrap.index("nginx -t") < bootstrap.index("systemctl reload nginx")
     assert "docker compose up" not in bootstrap

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -74,6 +74,14 @@ def _load_create_dast_session_module():
     return module
 
 
+def _nginx_location_bodies(config: str, selector: str) -> list[str]:
+    return re.findall(
+        rf"location\s+{re.escape(selector)}\s*\{{(.*?)\n\s*\}}",
+        config,
+        flags=re.DOTALL,
+    )
+
+
 def test_runtime_privilege_verifier_quotes_create_probe_table_name():
     db_privileges = _load_db_privileges_module()
     probe_table = "sitbank_privilege_probe_deadbeef"
@@ -1182,6 +1190,7 @@ def test_linux_deployment_artifacts_are_forced_to_lf_and_reject_crlf():
         Path("ops/deploy/sitbank-database-cutover"),
         Path("ops/nginx-proxy-headers.conf"),
         Path("ops/nginx/sitbank-staging.conf"),
+        Path("ops/nginx/sitbank-staging-rate-limits.conf"),
         Path("ops/sudoers/sitbank-container-deploy"),
         Path("ops/systemd/sitbank-container.service"),
         Path("ops/systemd/sitbank-staging-container.service"),
@@ -1201,18 +1210,123 @@ def test_linux_deployment_artifacts_are_forced_to_lf_and_reject_crlf():
     assert "grep -q $'\\r$'" in bootstrap
 
 
-def test_staging_nginx_routes_only_to_the_staging_loopback_port():
+def test_staging_nginx_enforces_https_auth_health_and_rate_limits():
     nginx = Path("ops/nginx/sitbank-staging.conf").read_text(encoding="utf-8")
+    rate_limits = Path("ops/nginx/sitbank-staging-rate-limits.conf").read_text(
+        encoding="utf-8"
+    )
+    staging_compose = yaml.safe_load(Path("compose.staging.yml").read_text(encoding="utf-8"))
     bootstrap = Path("ops/deploy/bootstrap-container-ec2").read_text(
         encoding="utf-8"
     )
 
+    assert Path("ops/nginx/sitbank-staging-rate-limits.conf").exists()
+    assert "listen 80;" in nginx
+    assert "return 301 https://$host$request_uri;" in nginx
+    assert "listen 443 ssl http2;" in nginx
     assert "server_name staging-sitbank.duckdns.org;" in nginx
-    assert "proxy_pass http://127.0.0.1:5001;" in nginx
+    assert "ssl_certificate /etc/letsencrypt/live/staging-sitbank.duckdns.org/fullchain.pem;" in nginx
+    assert "ssl_certificate_key /etc/letsencrypt/live/staging-sitbank.duckdns.org/privkey.pem;" in nginx
+    assert 'add_header X-Content-Type-Options "nosniff" always;' in nginx
+    assert 'add_header X-Frame-Options "DENY" always;' in nginx
+    assert 'add_header Referrer-Policy "no-referrer" always;' in nginx
+    assert "Permissions-Policy" in nginx
+    assert "preload" not in nginx
+    assert 'auth_basic "SITBank staging";' in nginx
+    assert "auth_basic_user_file /etc/nginx/.htpasswd-sitbank-staging;" in nginx
+    assert not Path("ops/nginx/.htpasswd-sitbank-staging").exists()
+    assert not re.search(
+        r"^\S+:\$(?:apr1|2[aby]|5|6)\$",
+        nginx,
+        flags=re.MULTILINE,
+    )
+
+    acme_bodies = _nginx_location_bodies(nginx, "^~ /.well-known/acme-challenge/")
+    assert len(acme_bodies) == 2
+    for acme_body in acme_bodies:
+        assert "auth_basic off;" in acme_body
+        assert "root /var/www/certbot;" in acme_body
+        assert "limit_req" not in acme_body
+
+    health_bodies = _nginx_location_bodies(nginx, "= /health/ready")
+    assert len(health_bodies) == 1
+    health_body = health_bodies[0]
+    assert "auth_basic off;" in health_body
+    assert "allow 127.0.0.1;" in health_body
+    assert "allow ::1;" in health_body
+    assert "deny all;" in health_body
+    assert "proxy_pass http://127.0.0.1:5001;" in health_body
+    assert "limit_req" not in health_body
+
+    proxy_targets = set(re.findall(r"proxy_pass\s+([^;]+);", nginx))
+    assert proxy_targets == {"http://127.0.0.1:5001"}
     assert "127.0.0.1:5000" not in nginx
     assert "server_name sitbank.duckdns.org;" not in nginx
+    assert staging_compose["services"]["app"]["ports"] == ["127.0.0.1:5001:5000"]
+    assert "ports" not in staging_compose["services"]["postgres"]
+    assert "ports" not in staging_compose["services"]["redis"]
+
+    assert "limit_req_zone $binary_remote_addr zone=sitbank_staging_login:10m rate=5r/m;" in rate_limits
+    assert "limit_req_zone $binary_remote_addr zone=sitbank_staging_app:10m rate=10r/s;" in rate_limits
+    assert "limit_req_status 429;" in nginx
+    assert "limit_req_log_level warn;" in nginx
+    assert "limit_req_status" not in rate_limits
+    assert "limit_req_log_level" not in rate_limits
+    for selector in ("= /login", "= /register", "= /mfa/verify", "^~ /auth/"):
+        bodies = _nginx_location_bodies(nginx, selector)
+        assert len(bodies) == 1
+        assert "limit_req zone=sitbank_staging_login" in bodies[0]
+    assert any(
+        "limit_req zone=sitbank_staging_app" in body
+        for body in _nginx_location_bodies(nginx, "/")
+    )
+
     assert "Conflicting Nginx staging site is already enabled" in bootstrap
     assert "Disable the duplicate staging server block" in bootstrap
+    assert "Missing required staging Basic Auth file" in bootstrap
+    assert "Missing required staging TLS file" in bootstrap
+    assert "apache2-utils" in bootstrap
+    assert "certbot" in bootstrap
+    assert "STAGING_RATE_LIMITS_FILE=\"/etc/nginx/conf.d/sitbank-staging-rate-limits.conf\"" in bootstrap
+    assert "ops/nginx/sitbank-staging-rate-limits.conf" in bootstrap
+    assert "sitbank-staging-rate-limits.$(date -u +%Y%m%dT%H%M%SZ).conf" in bootstrap
+    assert "nginx-sitbank-staging.$(date -u +%Y%m%dT%H%M%SZ).conf" in bootstrap
+    assert "cmp -s \"${repo_root}/ops/nginx/sitbank-staging.conf\" \"${staging_site}\"" in bootstrap
+    assert "if [[ ! -e /etc/nginx/sites-available/sitbank-staging" not in bootstrap
+    assert bootstrap.index("nginx -t") < bootstrap.index("systemctl reload nginx")
+    assert "docker compose up" not in bootstrap
+    assert "docker pull" not in bootstrap
+    assert "SITBANK_IMAGE" not in bootstrap
+
+
+def test_staging_edge_runbook_documents_operator_verification_steps():
+    readme = Path("README.md").read_text(encoding="utf-8")
+
+    for required in (
+        "sudo htpasswd -c /etc/nginx/.htpasswd-sitbank-staging",
+        "sudo chown root:www-data /etc/nginx/.htpasswd-sitbank-staging",
+        "sudo chmod 0640 /etc/nginx/.htpasswd-sitbank-staging",
+        "Do not store the Basic Auth password or generated htpasswd hash in the repo.",
+        "sudo certbot --nginx -d staging-sitbank.duckdns.org",
+        "sudo certbot certonly --webroot",
+        "sudo certbot renew --dry-run",
+        "ops/deploy/bootstrap-container-ec2",
+        "staging-sitbank.duckdns.org",
+        "Nginx proxy header snippet",
+        "rate-limit include",
+        "sudo nginx -t",
+        "sudo systemctl reload nginx",
+        "curl -k -I https://staging-sitbank.duckdns.org/",
+        'curl -k -I -u "$STAGING_BASIC_AUTH_USER:$STAGING_BASIC_AUTH_PASSWORD"',
+        "curl -k -I https://staging-sitbank.duckdns.org/health/ready",
+        "curl -fsS http://127.0.0.1:5001/health/ready",
+        "unauthenticated `/` returns `401`",
+        "external `/health/ready` returns `403`",
+        "local app readiness",
+        "separate from application deployment",
+    ):
+        assert required in readme
+    assert re.search(r"authenticated `/` returns\s+`200`", readme)
 
 
 def test_dependency_manifests_have_one_hashed_lockfile_source_of_truth():


### PR DESCRIPTION
## Summary

This PR hardens the public staging endpoint for `staging-sitbank.duckdns.org` by placing it behind HTTPS, Basic Auth, Nginx rate limiting, and restricted readiness access.

No application deployment is triggered by this change, and no real secrets, htpasswd contents, private keys, certificates, tokens, or passwords are committed.

## Changes

- Replaced the staging Nginx config with:
  - HTTP-to-HTTPS redirect
  - ACME HTTP-01 challenge support
  - HTTPS server block for `staging-sitbank.duckdns.org`
  - Basic Auth for normal staging routes
  - restricted `/health/ready` access
  - staging security headers
  - dotfile and backup-file denial
  - conservative proxy/body timeout settings

- Added a staging Nginx rate-limit include:
  - `ops/nginx/sitbank-staging-rate-limits.conf`
  - installs to `/etc/nginx/conf.d/sitbank-staging-rate-limits.conf`
  - defines rate-limit zones in Nginx `http` context

- Updated EC2 bootstrap staging flow to:
  - keep duplicate server-block detection
  - keep CRLF checks for Linux-installed files
  - install the proxy header snippet
  - install/replace the staging Nginx config
  - install/replace the rate-limit zone file
  - back up changed Nginx files before replacement
  - fail clearly if htpasswd or Certbot cert/key files are missing
  - run `nginx -t`
  - reload Nginx only after validation succeeds
  - avoid app image deployment behavior

- Updated README runbook with operator steps for:
  - creating `/etc/nginx/.htpasswd-sitbank-staging`
  - issuing the staging HTTPS certificate with Certbot
  - refreshing staging Nginx config safely
  - validating and reloading Nginx
  - verifying `401`, `200`, `403`, and local readiness behavior
  - distinguishing Nginx/bootstrap work from application deployment

- Added tests for the staging Nginx security posture and runbook coverage.

## Security Notes

- Basic Auth password/hash is not committed.
- Certbot certificates and ACME account files are not committed.
- Staging app remains bound to `127.0.0.1:5001:5000`.
- PostgreSQL and Redis remain unexposed.
- Existing CI/CD, Cosign, digest-only deployment, container hardening, and PR validation controls remain intact.
- `/health/ready` is blocked externally but remains available from EC2 loopback.

## Verification

Ran:

```bash
git diff --check
python -m pytest tests/test_deployment.py
python -m pytest tests/test_secret_scanner.py