### PR TITLE
Fix runtime contract import in bundle renderer

### DIFF
--- a/ops/deploy/render_container_bundle.py
+++ b/ops/deploy/render_container_bundle.py
@@ -7,7 +7,12 @@ import json
 import os
 import re
 import stat
+import sys
 from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from ops.runtime_contract import (
     DEPLOYMENT_SECRET_INPUTS,

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import os
 import re
 import subprocess
 import sys
@@ -344,6 +345,22 @@ def test_runtime_secret_inventory_matches_config_and_renderer():
         set(CONFIG_SECRET_INPUTS),
         context="Runtime secret readers in config.py vs ops/runtime_contract.py",
     )
+
+
+def test_bundle_renderer_runs_directly_without_pythonpath():
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+
+    result = subprocess.run(
+        [sys.executable, "ops/deploy/render_container_bundle.py", "--help"],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "usage:" in result.stdout.lower()
 
 
 def test_compose_secret_mounts_match_runtime_contract():


### PR DESCRIPTION
## Summary

Fixes the main deployment workflow failure in `deploy-staging` where `ops/deploy/render_container_bundle.py` could not import `ops.runtime_contract` when executed directly by file path.

## Why

The workflow runs:

```bash
python ops/deploy/render_container_bundle.py
```

When Python executes a script by path, the script directory is placed on `sys.path`, not the repository root. The new `from ops.runtime_contract import ...` import therefore failed with:

```text
ModuleNotFoundError: No module named 'ops'
```

## What changed

* Added repo-root path setup in `ops/deploy/render_container_bundle.py` before importing `ops.runtime_contract`.
* Kept `ops.runtime_contract` as the single runtime contract source.
* Did not duplicate runtime contract definitions.
* Added a regression test that runs `python ops/deploy/render_container_bundle.py --help` without `PYTHONPATH`.

## Deployment impact

This PR changes a bootstrap-sensitive file:

* `ops/deploy/render_container_bundle.py`

After merge, rerun `Bootstrap EC2 from trusted main` for staging and production before rerunning deployment.

Do not bootstrap from this PR branch.

## Verification

- `python -m pytest tests/test_deployment.py -q`: 35 passed
- `python -m pytest tests/test_redis_session_integrity.py -q`: 11 passed
- `python -m pytest -q`: 227 passed, 1 skipped
- `python -m compileall app config.py wsgi.py`: passed
- `python -m pip check`: passed
- `python -m bandit -q -ll -r app ops config.py wsgi.py`: passed
- `git diff --check`: passed
- Git Bash `bash.exe -n` for deployment scripts: passed
- `python -m py_compile scripts/ci-local ops/runtime_contract.py ops/deploy/render_container_bundle.py`: passed
- `python ops/deploy/render_container_bundle.py --help`: passed

## Security

No security guarantees were weakened. No secrets were added. No deployment was triggered.