### PR TITLE
Add route security inventory and production edge hardening proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,75 @@ or container deployment scripts. GitHub Actions remains the authoritative
 - The SSH deployment user is not a member of the `docker` group and can run
   only the validated root deployment wrapper.
 
+### Production Edge and Network Hardening
+
+Production edge proof lives in:
+
+- `ops/nginx/sitbank-production.conf`
+- `ops/nginx/sitbank-production-rate-limits.conf`
+- `ops/nginx-proxy-headers.conf`
+- `compose.prod.yml`
+- `Dockerfile`
+
+The intended production network posture is:
+
+- Public ingress is TCP `80` and `443` only.
+- SSH is restricted to an administrator IP allowlist, AWS Systems Manager,
+  a bastion, or VPN. Do not expose TCP `22` to `0.0.0.0/0` or `::/0`.
+- Nginx terminates TLS, redirects HTTP to HTTPS, and proxies only to
+  `127.0.0.1:5000`.
+- Gunicorn binds only to `127.0.0.1:5000`; `compose.prod.yml` publishes no
+  application port.
+- PostgreSQL and Redis remain localhost-only host services and are not exposed
+  through Docker or the public security group.
+- `/health/live` may be public because it only reports process liveness.
+- `/health/ready` is for local deployment and load-balancer checks and must be
+  restricted to loopback at Nginx.
+- The production edge applies request body limits, proxy timeouts, security
+  headers, TRACE denial, and rate limits for login, registration, MFA,
+  WebAuthn challenge, password, account, profile, and session endpoints.
+- Cloudflare or AWS WAF should sit in front of Nginx with managed common,
+  SQL injection, XSS, bot, and rate-based rules enabled for the same
+  auth-sensitive paths.
+
+The current bootstrap workflow does not install the production Nginx sample.
+Install or manage the production edge files through reviewed infrastructure
+provisioning, or add a reviewed bootstrap installer before relying on them:
+
+```bash
+sudo install -o root -g root -m 0644 \
+  ops/nginx/sitbank-production-rate-limits.conf \
+  /etc/nginx/conf.d/sitbank-production-rate-limits.conf
+sudo install -o root -g root -m 0644 \
+  ops/nginx/sitbank-production.conf \
+  /etc/nginx/sites-available/sitbank
+sudo install -o root -g root -m 0644 \
+  ops/nginx-proxy-headers.conf \
+  /etc/nginx/snippets/sitbank-proxy-headers.conf
+sudo ln -sfn /etc/nginx/sites-available/sitbank \
+  /etc/nginx/sites-enabled/sitbank
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+Verify the edge posture after any production infrastructure change:
+
+```bash
+sudo nginx -t
+sudo ss -ltnp | grep -E ':(80|443|5000)\b'
+sudo docker inspect --format '{{json .NetworkSettings.Ports}}' sitbank-app
+sudo docker inspect --format '{{json .HostConfig.PortBindings}}' sitbank-app
+curl --fail https://sitbank.duckdns.org/health/live
+curl -I https://sitbank.duckdns.org/health/ready
+curl --fail -H 'X-Forwarded-Proto: https' \
+  http://127.0.0.1:5000/health/ready
+```
+
+Expected results: Nginx listens publicly on `80` and `443`, Gunicorn listens
+on loopback `127.0.0.1:5000`, Docker reports no published app ports,
+external `/health/live` returns `200`, external `/health/ready` returns `403`,
+and local direct readiness returns `200`.
+
 Staging runs beside production without sharing its Compose project, paths,
 containers, secrets, or data:
 
@@ -1238,6 +1307,8 @@ Treat changes to these paths as production-security changes:
 - `compose.prod.yml`
 - `ops/container/`
 - `ops/deploy/`
+- `ops/nginx/`
+- `ops/nginx-proxy-headers.conf`
 - `ops/systemd/`
 - `ops/sudoers/`
 - `config.py`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -112,6 +112,50 @@ readiness fails, the wrapper restores the previous digest and non-secret
 configuration. Database rollback follows the documented cutover procedure and
 must not be improvised during an incident.
 
+## Production Edge and WAF Checklist
+
+Before exposing production, the administrator must verify the edge/network
+controls below. Some controls are represented by repository files; Cloudflare
+or AWS WAF and security-group settings remain infrastructure state and must be
+checked manually.
+
+- Install or equivalently manage `ops/nginx/sitbank-production.conf`,
+  `ops/nginx/sitbank-production-rate-limits.conf`, and
+  `ops/nginx-proxy-headers.conf`.
+- Allow public inbound TCP `80` and `443` only.
+- Restrict SSH to an administrator IP allowlist, AWS Systems Manager, a
+  bastion, or VPN; never allow TCP `22` from `0.0.0.0/0` or `::/0`.
+- Do not expose Gunicorn, PostgreSQL, or Redis directly to the internet.
+- Keep Gunicorn bound to `127.0.0.1:5000` and keep `compose.prod.yml` free of
+  published app ports.
+- Restrict `/health/ready` to loopback and allow public `/health/live` only.
+- Enable WAF managed common, SQL injection, XSS, bot, and protocol anomaly
+  rules.
+- Add WAF rate-based rules for `/login`, `/register`, `/mfa/verify`,
+  `/auth/`, `/auth/webauthn/`, `/password/`, `/sessions/`, `/security-keys/`,
+  `/profile`, and `/account/`.
+- Block TRACE at the edge and preserve only the expected proxy headers:
+  `Host`, `X-Real-IP`, `X-Forwarded-For`, and `X-Forwarded-Proto`.
+- If a CDN or WAF forwards traffic to Nginx, configure the trusted real-client
+  IP source ranges deliberately before basing rate limits on client IPs.
+
+Verification commands:
+
+```bash
+sudo nginx -t
+sudo ss -ltnp | grep -E ':(80|443|5000)\b'
+sudo docker inspect --format '{{json .NetworkSettings.Ports}}' sitbank-app
+sudo docker inspect --format '{{json .HostConfig.PortBindings}}' sitbank-app
+curl --fail https://sitbank.duckdns.org/health/live
+curl -I https://sitbank.duckdns.org/health/ready
+curl --fail -H 'X-Forwarded-Proto: https' \
+  http://127.0.0.1:5000/health/ready
+```
+
+Expected results: only `80` and `443` are publicly reachable, Gunicorn is
+loopback-only, Docker publishes no app ports, external readiness is denied,
+and local readiness succeeds.
+
 ## Monitoring
 
 Forward these sources to a protected centralized log destination:

--- a/ops/nginx/sitbank-production-rate-limits.conf
+++ b/ops/nginx/sitbank-production-rate-limits.conf
@@ -1,0 +1,8 @@
+# Included from Nginx's http context by /etc/nginx/conf.d/*.conf.
+# Keep these zones separate from server blocks so nginx -t catches duplicate
+# zone definitions before a reload.
+limit_req_zone $binary_remote_addr zone=sitbank_prod_app:10m rate=20r/s;
+limit_req_zone $binary_remote_addr zone=sitbank_prod_auth:10m rate=5r/m;
+limit_req_zone $binary_remote_addr zone=sitbank_prod_register:10m rate=2r/m;
+limit_req_zone $binary_remote_addr zone=sitbank_prod_challenge:10m rate=3r/m;
+limit_req_zone $binary_remote_addr zone=sitbank_prod_security:10m rate=10r/m;

--- a/ops/nginx/sitbank-production.conf
+++ b/ops/nginx/sitbank-production.conf
@@ -20,7 +20,7 @@ server {
     }
 
     location / {
-        return 301 https://$host$request_uri;
+        return 301 https://sitbank.duckdns.org$request_uri;
     }
 }
 

--- a/ops/nginx/sitbank-production.conf
+++ b/ops/nginx/sitbank-production.conf
@@ -1,0 +1,159 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name sitbank.duckdns.org;
+
+    server_tokens off;
+
+    location ^~ /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+        default_type "text/plain";
+        try_files $uri =404;
+    }
+
+    location ~ /\.(?!well-known/acme-challenge/) {
+        return 404;
+    }
+
+    location ~* \.(?:bak|old|orig|save|swp|tmp)$ {
+        return 404;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name sitbank.duckdns.org;
+
+    server_tokens off;
+    access_log /var/log/nginx/sitbank.access.log;
+    error_log /var/log/nginx/sitbank.error.log warn;
+
+    ssl_certificate /etc/letsencrypt/live/sitbank.duckdns.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/sitbank.duckdns.org/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache shared:sitbank_prod_ssl:10m;
+    ssl_session_timeout 1d;
+    ssl_session_tickets off;
+
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "no-referrer" always;
+    add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+    limit_req_status 429;
+    limit_req_log_level warn;
+
+    client_max_body_size 4m;
+    client_body_timeout 15s;
+    client_header_timeout 15s;
+    keepalive_timeout 30s;
+    send_timeout 30s;
+    proxy_connect_timeout 5s;
+    proxy_send_timeout 30s;
+    proxy_read_timeout 30s;
+
+    if ($request_method = TRACE) {
+        return 405;
+    }
+
+    location ^~ /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+        default_type "text/plain";
+        try_files $uri =404;
+    }
+
+    location = /health/ready {
+        allow 127.0.0.1;
+        allow ::1;
+        deny all;
+
+        proxy_pass http://127.0.0.1:5000;
+        include /etc/nginx/snippets/sitbank-proxy-headers.conf;
+    }
+
+    location = /health/live {
+        proxy_pass http://127.0.0.1:5000;
+        include /etc/nginx/snippets/sitbank-proxy-headers.conf;
+    }
+
+    location ~ /\.(?!well-known/acme-challenge/) {
+        return 404;
+    }
+
+    location ~* \.(?:bak|old|orig|save|swp|tmp)$ {
+        return 404;
+    }
+
+    location = /register {
+        limit_req zone=sitbank_prod_register burst=3 nodelay;
+        proxy_pass http://127.0.0.1:5000;
+        include /etc/nginx/snippets/sitbank-proxy-headers.conf;
+    }
+
+    location = /auth/register {
+        limit_req zone=sitbank_prod_register burst=3 nodelay;
+        proxy_pass http://127.0.0.1:5000;
+        include /etc/nginx/snippets/sitbank-proxy-headers.conf;
+    }
+
+    location = /login {
+        limit_req zone=sitbank_prod_auth burst=5 nodelay;
+        proxy_pass http://127.0.0.1:5000;
+        include /etc/nginx/snippets/sitbank-proxy-headers.conf;
+    }
+
+    location = /auth/login {
+        limit_req zone=sitbank_prod_auth burst=5 nodelay;
+        proxy_pass http://127.0.0.1:5000;
+        include /etc/nginx/snippets/sitbank-proxy-headers.conf;
+    }
+
+    location = /mfa/verify {
+        limit_req zone=sitbank_prod_auth burst=5 nodelay;
+        proxy_pass http://127.0.0.1:5000;
+        include /etc/nginx/snippets/sitbank-proxy-headers.conf;
+    }
+
+    location = /auth/mfa/verify {
+        limit_req zone=sitbank_prod_auth burst=5 nodelay;
+        proxy_pass http://127.0.0.1:5000;
+        include /etc/nginx/snippets/sitbank-proxy-headers.conf;
+    }
+
+    location ~ ^/auth/webauthn/(?:register|authenticate|step-up)/(?:options|verify)$ {
+        limit_req zone=sitbank_prod_challenge burst=3 nodelay;
+        proxy_pass http://127.0.0.1:5000;
+        include /etc/nginx/snippets/sitbank-proxy-headers.conf;
+    }
+
+    location ~ ^/(?:account|password|profile|security-keys|sessions)(?:/|$) {
+        limit_req zone=sitbank_prod_security burst=10 nodelay;
+        proxy_pass http://127.0.0.1:5000;
+        include /etc/nginx/snippets/sitbank-proxy-headers.conf;
+    }
+
+    location ~ ^/auth/(?:account|mfa|password|sessions|webauthn/credentials)(?:/|$) {
+        limit_req zone=sitbank_prod_security burst=10 nodelay;
+        proxy_pass http://127.0.0.1:5000;
+        include /etc/nginx/snippets/sitbank-proxy-headers.conf;
+    }
+
+    location /auth/ {
+        limit_req zone=sitbank_prod_auth burst=5 nodelay;
+        proxy_pass http://127.0.0.1:5000;
+        include /etc/nginx/snippets/sitbank-proxy-headers.conf;
+    }
+
+    location / {
+        limit_req zone=sitbank_prod_app burst=60 nodelay;
+        proxy_pass http://127.0.0.1:5000;
+        include /etc/nginx/snippets/sitbank-proxy-headers.conf;
+    }
+}

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1551,7 +1551,7 @@ def test_production_nginx_edge_config_enforces_network_boundary_and_limits():
     assert Path("ops/nginx/sitbank-production.conf").exists()
     assert Path("ops/nginx/sitbank-production-rate-limits.conf").exists()
     assert "listen 80;" in nginx
-    assert "return 301 https://$host$request_uri;" in nginx
+    assert "return 301 https://sitbank.duckdns.org$request_uri;" in nginx
     assert "listen 443 ssl http2;" in nginx
     assert "server_name sitbank.duckdns.org;" in nginx
     assert "ssl_certificate /etc/letsencrypt/live/sitbank.duckdns.org/fullchain.pem;" in nginx

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1424,6 +1424,8 @@ def test_linux_deployment_artifacts_are_forced_to_lf_and_reject_crlf():
         Path("ops/deploy/sitbank-container-runtime"),
         Path("ops/deploy/sitbank-database-cutover"),
         Path("ops/nginx-proxy-headers.conf"),
+        Path("ops/nginx/sitbank-production.conf"),
+        Path("ops/nginx/sitbank-production-rate-limits.conf"),
         Path("ops/nginx/sitbank-staging.conf"),
         Path("ops/nginx/sitbank-staging-rate-limits.conf"),
         Path("ops/sudoers/sitbank-container-deploy"),
@@ -1534,6 +1536,144 @@ def test_staging_nginx_enforces_https_auth_health_and_rate_limits():
     assert "docker compose up" not in bootstrap
     assert "docker pull" not in bootstrap
     assert "SITBANK_IMAGE" not in bootstrap
+
+
+def test_production_nginx_edge_config_enforces_network_boundary_and_limits():
+    nginx = Path("ops/nginx/sitbank-production.conf").read_text(encoding="utf-8")
+    rate_limits = Path("ops/nginx/sitbank-production-rate-limits.conf").read_text(
+        encoding="utf-8"
+    )
+    proxy_headers = Path("ops/nginx-proxy-headers.conf").read_text(encoding="utf-8")
+    dockerfile = Path("Dockerfile").read_text(encoding="utf-8")
+    production_compose = yaml.safe_load(Path("compose.prod.yml").read_text(encoding="utf-8"))
+    app = production_compose["services"]["app"]
+
+    assert Path("ops/nginx/sitbank-production.conf").exists()
+    assert Path("ops/nginx/sitbank-production-rate-limits.conf").exists()
+    assert "listen 80;" in nginx
+    assert "return 301 https://$host$request_uri;" in nginx
+    assert "listen 443 ssl http2;" in nginx
+    assert "server_name sitbank.duckdns.org;" in nginx
+    assert "ssl_certificate /etc/letsencrypt/live/sitbank.duckdns.org/fullchain.pem;" in nginx
+    assert "ssl_certificate_key /etc/letsencrypt/live/sitbank.duckdns.org/privkey.pem;" in nginx
+    assert 'add_header X-Content-Type-Options "nosniff" always;' in nginx
+    assert 'add_header X-Frame-Options "DENY" always;' in nginx
+    assert 'add_header Referrer-Policy "no-referrer" always;' in nginx
+    assert "Permissions-Policy" in nginx
+    assert 'add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;' in nginx
+    assert "client_max_body_size 4m;" in nginx
+    for timeout in (
+        "client_body_timeout 15s;",
+        "client_header_timeout 15s;",
+        "keepalive_timeout 30s;",
+        "send_timeout 30s;",
+        "proxy_connect_timeout 5s;",
+        "proxy_send_timeout 30s;",
+        "proxy_read_timeout 30s;",
+    ):
+        assert timeout in nginx
+    assert "if ($request_method = TRACE)" in nginx
+    assert "return 405;" in nginx
+
+    health_ready_bodies = _nginx_location_bodies(nginx, "= /health/ready")
+    assert len(health_ready_bodies) == 1
+    health_ready = health_ready_bodies[0]
+    assert "allow 127.0.0.1;" in health_ready
+    assert "allow ::1;" in health_ready
+    assert "deny all;" in health_ready
+    assert "proxy_pass http://127.0.0.1:5000;" in health_ready
+    assert "limit_req" not in health_ready
+
+    health_live_bodies = _nginx_location_bodies(nginx, "= /health/live")
+    assert len(health_live_bodies) == 1
+    assert "proxy_pass http://127.0.0.1:5000;" in health_live_bodies[0]
+
+    proxy_targets = set(re.findall(r"proxy_pass\s+([^;]+);", nginx))
+    assert proxy_targets == {"http://127.0.0.1:5000"}
+    assert "0.0.0.0:5000" not in nginx
+    assert "--bind\", \"127.0.0.1:5000" in dockerfile
+    assert app["network_mode"] == "host"
+    assert "ports" not in app
+
+    for zone in (
+        "limit_req_zone $binary_remote_addr zone=sitbank_prod_app:10m rate=20r/s;",
+        "limit_req_zone $binary_remote_addr zone=sitbank_prod_auth:10m rate=5r/m;",
+        "limit_req_zone $binary_remote_addr zone=sitbank_prod_register:10m rate=2r/m;",
+        "limit_req_zone $binary_remote_addr zone=sitbank_prod_challenge:10m rate=3r/m;",
+        "limit_req_zone $binary_remote_addr zone=sitbank_prod_security:10m rate=10r/m;",
+    ):
+        assert zone in rate_limits
+    assert "limit_req_status 429;" in nginx
+    assert "limit_req_log_level warn;" in nginx
+    assert "limit_req_status" not in rate_limits
+    assert "limit_req_log_level" not in rate_limits
+
+    expected_location_limits = {
+        "= /login": "sitbank_prod_auth",
+        "= /auth/login": "sitbank_prod_auth",
+        "= /mfa/verify": "sitbank_prod_auth",
+        "= /auth/mfa/verify": "sitbank_prod_auth",
+        "= /register": "sitbank_prod_register",
+        "= /auth/register": "sitbank_prod_register",
+        "~ ^/auth/webauthn/(?:register|authenticate|step-up)/(?:options|verify)$": "sitbank_prod_challenge",
+        "~ ^/(?:account|password|profile|security-keys|sessions)(?:/|$)": "sitbank_prod_security",
+        "~ ^/auth/(?:account|mfa|password|sessions|webauthn/credentials)(?:/|$)": "sitbank_prod_security",
+        "/auth/": "sitbank_prod_auth",
+    }
+    for selector, zone in expected_location_limits.items():
+        bodies = _nginx_location_bodies(nginx, selector)
+        assert len(bodies) == 1
+        assert f"limit_req zone={zone}" in bodies[0]
+        assert "include /etc/nginx/snippets/sitbank-proxy-headers.conf;" in bodies[0]
+    assert any(
+        "limit_req zone=sitbank_prod_app" in body
+        for body in _nginx_location_bodies(nginx, "/")
+    )
+
+    assert "proxy_set_header X-Forwarded-For $remote_addr;" in proxy_headers
+    assert "$proxy_add_x_forwarded_for" not in proxy_headers
+
+
+def test_production_edge_runbook_documents_network_waf_and_verification_steps():
+    readme = Path("README.md").read_text(encoding="utf-8")
+    security = Path("SECURITY.md").read_text(encoding="utf-8")
+
+    for required in (
+        "Production Edge and Network Hardening",
+        "ops/nginx/sitbank-production.conf",
+        "ops/nginx/sitbank-production-rate-limits.conf",
+        "Public ingress is TCP `80` and `443` only.",
+        "SSH is restricted to an administrator IP allowlist",
+        "Nginx terminates TLS, redirects HTTP to HTTPS",
+        "Gunicorn binds only to `127.0.0.1:5000`",
+        "compose.prod.yml` publishes no",
+        "`/health/ready` is for local deployment and load-balancer checks",
+        "Cloudflare or AWS WAF should sit in front of Nginx",
+        "sudo nginx -t",
+        "sudo ss -ltnp | grep -E ':(80|443|5000)\\b'",
+        "sudo docker inspect --format '{{json .NetworkSettings.Ports}}' sitbank-app",
+        "curl --fail https://sitbank.duckdns.org/health/live",
+        "curl -I https://sitbank.duckdns.org/health/ready",
+        "external `/health/ready` returns `403`",
+    ):
+        assert required in readme
+
+    for required in (
+        "Production Edge and WAF Checklist",
+        "Allow public inbound TCP `80` and `443` only.",
+        "never allow TCP `22` from `0.0.0.0/0` or `::/0`",
+        "Do not expose Gunicorn, PostgreSQL, or Redis directly to the internet.",
+        "Keep Gunicorn bound to `127.0.0.1:5000`",
+        "Restrict `/health/ready` to loopback",
+        "Enable WAF managed common, SQL injection, XSS, bot, and protocol anomaly",
+        "rules.",
+        "Add WAF rate-based rules for `/login`, `/register`, `/mfa/verify`,",
+        "Block TRACE at the edge",
+        "Host`, `X-Real-IP`, `X-Forwarded-For`, and `X-Forwarded-Proto`",
+        "sudo nginx -t",
+        "external readiness is denied",
+    ):
+        assert required in security
 
 
 def test_staging_edge_runbook_documents_operator_verification_steps():

--- a/tests/test_route_inventory_security.py
+++ b/tests/test_route_inventory_security.py
@@ -566,13 +566,22 @@ ROUTE_SECURITY_INVENTORY = {
 
 def _actual_routes(app):
     routes = {}
+    duplicate_routes = {}
     for rule in app.url_map.iter_rules():
         if rule.endpoint == "static":
             continue
-        routes[rule.endpoint] = {
+        route = {
             "rule": rule.rule,
             "methods": set(rule.methods) - {"HEAD", "OPTIONS"},
         }
+        if rule.endpoint in routes:
+            duplicate_routes.setdefault(rule.endpoint, [routes[rule.endpoint]]).append(route)
+            continue
+        routes[rule.endpoint] = route
+    assert not duplicate_routes, (
+        "Route inventory keys by endpoint; model multiple rules explicitly "
+        f"before reusing endpoint names: {duplicate_routes}"
+    )
     return routes
 
 

--- a/tests/test_route_inventory_security.py
+++ b/tests/test_route_inventory_security.py
@@ -1,0 +1,681 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+UNSAFE_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
+AUTH_DECORATORS = {"login_required", "web_login_required"}
+RATE_LIMIT_DECISIONS = {
+    "per_route",
+    "edge_auth",
+    "edge_app",
+    "edge_health_ready",
+    "not_needed_liveness",
+}
+STEP_UP_DECISIONS = {
+    "not_required",
+    "required",
+    "conditional",
+    "ceremony_endpoint",
+    "fresh_mfa",
+    "already_authorized_continuation",
+}
+SENSITIVE_CLASSIFICATIONS = {
+    "account_freeze",
+    "csrf",
+    "dashboard",
+    "login",
+    "logout",
+    "mfa",
+    "password",
+    "profile",
+    "registration",
+    "session",
+    "webauthn",
+}
+
+
+ROUTE_MODULES = {
+    "auth": Path("app/auth/routes.py"),
+    "main": Path("app/main/routes.py"),
+    "web": Path("app/web/routes.py"),
+}
+
+
+ROUTE_SECURITY_INVENTORY = {
+    "main.index": {
+        "endpoint": "main.index",
+        "rule": "/",
+        "methods": {"GET"},
+        "access": "public",
+        "classification": "homepage",
+        "csrf": "not_applicable",
+        "rate_limit": "edge_app",
+        "step_up": "not_required",
+        "public_justification": "Public landing page; authenticated users are redirected to the dashboard.",
+    },
+    "main.health_live": {
+        "endpoint": "main.health_live",
+        "rule": "/health/live",
+        "methods": {"GET"},
+        "access": "public",
+        "classification": "health",
+        "csrf": "not_applicable",
+        "rate_limit": "not_needed_liveness",
+        "step_up": "not_required",
+        "public_justification": "Liveness endpoint intentionally returns only process status for external monitors.",
+    },
+    "main.health_ready": {
+        "endpoint": "main.health_ready",
+        "rule": "/health/ready",
+        "methods": {"GET"},
+        "access": "public",
+        "classification": "health",
+        "csrf": "not_applicable",
+        "rate_limit": "edge_health_ready",
+        "step_up": "not_required",
+        "public_justification": "Readiness is public only inside Flask; production and staging Nginx restrict it to loopback.",
+    },
+    "auth.csrf_token": {
+        "endpoint": "auth.csrf_token",
+        "rule": "/auth/csrf-token",
+        "methods": {"GET"},
+        "access": "public",
+        "classification": "csrf",
+        "csrf": "not_applicable",
+        "rate_limit": "edge_auth",
+        "step_up": "not_required",
+        "public_justification": "JSON clients need a token before submitting CSRF-protected auth requests.",
+    },
+    "auth.register": {
+        "endpoint": "auth.register",
+        "rule": "/auth/register",
+        "methods": {"POST"},
+        "access": "public",
+        "classification": "registration",
+        "csrf": "required",
+        "rate_limit": "per_route",
+        "step_up": "not_required",
+        "public_justification": "Account creation remains intentionally open but CSRF-protected and rate-limited.",
+    },
+    "auth.login": {
+        "endpoint": "auth.login",
+        "rule": "/auth/login",
+        "methods": {"POST"},
+        "access": "public",
+        "classification": "login",
+        "csrf": "required",
+        "rate_limit": "per_route",
+        "step_up": "not_required",
+        "public_justification": "Primary authentication must be reachable before a user has a session.",
+    },
+    "auth.webauthn_register_options": {
+        "endpoint": "auth.webauthn_register_options",
+        "rule": "/auth/webauthn/register/options",
+        "methods": {"POST"},
+        "access": "authenticated",
+        "classification": "webauthn",
+        "csrf": "required",
+        "rate_limit": "per_route",
+        "step_up": "not_required",
+        "public_justification": "",
+    },
+    "auth.webauthn_register_verify": {
+        "endpoint": "auth.webauthn_register_verify",
+        "rule": "/auth/webauthn/register/verify",
+        "methods": {"POST"},
+        "access": "authenticated",
+        "classification": "webauthn",
+        "csrf": "required",
+        "rate_limit": "per_route",
+        "step_up": "not_required",
+        "public_justification": "",
+    },
+    "auth.webauthn_authenticate_options": {
+        "endpoint": "auth.webauthn_authenticate_options",
+        "rule": "/auth/webauthn/authenticate/options",
+        "methods": {"POST"},
+        "access": "public",
+        "classification": "webauthn",
+        "csrf": "required",
+        "rate_limit": "per_route",
+        "step_up": "not_required",
+        "public_justification": "WebAuthn login challenge endpoint is part of authentication before a user session exists.",
+    },
+    "auth.webauthn_authenticate_verify": {
+        "endpoint": "auth.webauthn_authenticate_verify",
+        "rule": "/auth/webauthn/authenticate/verify",
+        "methods": {"POST"},
+        "access": "public",
+        "classification": "webauthn",
+        "csrf": "required",
+        "rate_limit": "per_route",
+        "step_up": "not_required",
+        "public_justification": "WebAuthn login assertion endpoint completes authentication before a user session exists.",
+    },
+    "auth.webauthn_step_up_options": {
+        "endpoint": "auth.webauthn_step_up_options",
+        "rule": "/auth/webauthn/step-up/options",
+        "methods": {"POST"},
+        "access": "authenticated",
+        "classification": "webauthn",
+        "csrf": "required",
+        "rate_limit": "per_route",
+        "step_up": "ceremony_endpoint",
+        "public_justification": "",
+    },
+    "auth.webauthn_step_up_verify": {
+        "endpoint": "auth.webauthn_step_up_verify",
+        "rule": "/auth/webauthn/step-up/verify",
+        "methods": {"POST"},
+        "access": "authenticated",
+        "classification": "webauthn",
+        "csrf": "required",
+        "rate_limit": "per_route",
+        "step_up": "ceremony_endpoint",
+        "public_justification": "",
+    },
+    "auth.webauthn_credentials": {
+        "endpoint": "auth.webauthn_credentials",
+        "rule": "/auth/webauthn/credentials",
+        "methods": {"GET"},
+        "access": "authenticated",
+        "classification": "webauthn",
+        "csrf": "not_applicable",
+        "rate_limit": "edge_auth",
+        "step_up": "not_required",
+        "public_justification": "",
+    },
+    "auth.webauthn_revoke_credential": {
+        "endpoint": "auth.webauthn_revoke_credential",
+        "rule": "/auth/webauthn/credentials/<credential_id>",
+        "methods": {"DELETE"},
+        "access": "authenticated",
+        "classification": "webauthn",
+        "csrf": "required",
+        "rate_limit": "edge_auth",
+        "step_up": "required",
+        "public_justification": "",
+    },
+    "auth.logout": {
+        "endpoint": "auth.logout",
+        "rule": "/auth/logout",
+        "methods": {"POST"},
+        "access": "public",
+        "classification": "logout",
+        "csrf": "required",
+        "rate_limit": "edge_auth",
+        "step_up": "not_required",
+        "public_justification": "Logout is idempotent and clears only the caller's current session state.",
+    },
+    "auth.mfa_setup": {
+        "endpoint": "auth.mfa_setup",
+        "rule": "/auth/mfa/setup",
+        "methods": {"POST"},
+        "access": "authenticated",
+        "classification": "mfa",
+        "csrf": "required",
+        "rate_limit": "per_route",
+        "step_up": "not_required",
+        "public_justification": "",
+    },
+    "auth.mfa_setup_verify": {
+        "endpoint": "auth.mfa_setup_verify",
+        "rule": "/auth/mfa/setup/verify",
+        "methods": {"POST"},
+        "access": "authenticated",
+        "classification": "mfa",
+        "csrf": "required",
+        "rate_limit": "per_route",
+        "step_up": "not_required",
+        "public_justification": "",
+    },
+    "auth.mfa_replace_start": {
+        "endpoint": "auth.mfa_replace_start",
+        "rule": "/auth/mfa/replace/start",
+        "methods": {"POST"},
+        "access": "authenticated",
+        "classification": "mfa",
+        "csrf": "required",
+        "rate_limit": "per_route",
+        "step_up": "required",
+        "public_justification": "",
+    },
+    "auth.mfa_replace_verify": {
+        "endpoint": "auth.mfa_replace_verify",
+        "rule": "/auth/mfa/replace/verify",
+        "methods": {"POST"},
+        "access": "authenticated",
+        "classification": "mfa",
+        "csrf": "required",
+        "rate_limit": "per_route",
+        "step_up": "already_authorized_continuation",
+        "public_justification": "",
+    },
+    "auth.mfa_verify": {
+        "endpoint": "auth.mfa_verify",
+        "rule": "/auth/mfa/verify",
+        "methods": {"POST"},
+        "access": "public",
+        "classification": "mfa",
+        "csrf": "required",
+        "rate_limit": "per_route",
+        "step_up": "not_required",
+        "public_justification": "TOTP verification completes a pending login before a full user session exists.",
+    },
+    "auth.sessions_dashboard": {
+        "endpoint": "auth.sessions_dashboard",
+        "rule": "/auth/sessions",
+        "methods": {"GET"},
+        "access": "authenticated",
+        "classification": "session",
+        "csrf": "not_applicable",
+        "rate_limit": "edge_auth",
+        "step_up": "not_required",
+        "public_justification": "",
+    },
+    "auth.terminate_session": {
+        "endpoint": "auth.terminate_session",
+        "rule": "/auth/sessions/<session_id>",
+        "methods": {"DELETE"},
+        "access": "authenticated",
+        "classification": "session",
+        "csrf": "required",
+        "rate_limit": "edge_auth",
+        "step_up": "not_required",
+        "public_justification": "",
+    },
+    "auth.revoke_other_sessions": {
+        "endpoint": "auth.revoke_other_sessions",
+        "rule": "/auth/sessions/revoke-others",
+        "methods": {"POST"},
+        "access": "authenticated",
+        "classification": "session",
+        "csrf": "required",
+        "rate_limit": "edge_auth",
+        "step_up": "required",
+        "public_justification": "",
+    },
+    "auth.freeze_account": {
+        "endpoint": "auth.freeze_account",
+        "rule": "/auth/account/freeze",
+        "methods": {"POST"},
+        "access": "authenticated",
+        "classification": "account_freeze",
+        "csrf": "required",
+        "rate_limit": "per_route",
+        "step_up": "required",
+        "public_justification": "",
+    },
+    "auth.password_change": {
+        "endpoint": "auth.password_change",
+        "rule": "/auth/password/change",
+        "methods": {"POST"},
+        "access": "authenticated",
+        "classification": "password",
+        "csrf": "required",
+        "rate_limit": "per_route",
+        "step_up": "required",
+        "public_justification": "",
+    },
+    "web.register_form": {
+        "endpoint": "web.register_form",
+        "rule": "/register",
+        "methods": {"GET"},
+        "access": "public",
+        "classification": "registration",
+        "csrf": "not_applicable",
+        "rate_limit": "edge_app",
+        "step_up": "not_required",
+        "public_justification": "Registration form must be reachable before account creation.",
+    },
+    "web.register_submit": {
+        "endpoint": "web.register_submit",
+        "rule": "/register",
+        "methods": {"POST"},
+        "access": "public",
+        "classification": "registration",
+        "csrf": "required",
+        "rate_limit": "per_route",
+        "step_up": "not_required",
+        "public_justification": "Account creation remains intentionally open but CSRF-protected and rate-limited.",
+    },
+    "web.login": {
+        "endpoint": "web.login",
+        "rule": "/login",
+        "methods": {"GET"},
+        "access": "public",
+        "classification": "login",
+        "csrf": "not_applicable",
+        "rate_limit": "edge_app",
+        "step_up": "not_required",
+        "public_justification": "Login form must be reachable before a user has a session.",
+    },
+    "web.login_submit": {
+        "endpoint": "web.login_submit",
+        "rule": "/login",
+        "methods": {"POST"},
+        "access": "public",
+        "classification": "login",
+        "csrf": "required",
+        "rate_limit": "per_route",
+        "step_up": "not_required",
+        "public_justification": "Primary authentication must be reachable before a user has a session.",
+    },
+    "web.mfa_verify": {
+        "endpoint": "web.mfa_verify",
+        "rule": "/mfa/verify",
+        "methods": {"GET"},
+        "access": "public",
+        "classification": "mfa",
+        "csrf": "not_applicable",
+        "rate_limit": "edge_app",
+        "step_up": "not_required",
+        "public_justification": "MFA form is reachable with a pending MFA session before full authentication.",
+    },
+    "web.mfa_verify_submit": {
+        "endpoint": "web.mfa_verify_submit",
+        "rule": "/mfa/verify",
+        "methods": {"POST"},
+        "access": "public",
+        "classification": "mfa",
+        "csrf": "required",
+        "rate_limit": "per_route",
+        "step_up": "not_required",
+        "public_justification": "TOTP verification completes a pending login before a full user session exists.",
+    },
+    "web.dashboard": {
+        "endpoint": "web.dashboard",
+        "rule": "/dashboard",
+        "methods": {"GET"},
+        "access": "authenticated",
+        "classification": "dashboard",
+        "csrf": "not_applicable",
+        "rate_limit": "edge_app",
+        "step_up": "not_required",
+        "public_justification": "",
+    },
+    "web.security_keys": {
+        "endpoint": "web.security_keys",
+        "rule": "/security-keys",
+        "methods": {"GET"},
+        "access": "authenticated",
+        "classification": "webauthn",
+        "csrf": "not_applicable",
+        "rate_limit": "edge_app",
+        "step_up": "not_required",
+        "public_justification": "",
+    },
+    "web.security_keys_mfa_refresh": {
+        "endpoint": "web.security_keys_mfa_refresh",
+        "rule": "/security-keys/mfa/refresh",
+        "methods": {"POST"},
+        "access": "authenticated",
+        "classification": "mfa",
+        "csrf": "required",
+        "rate_limit": "per_route",
+        "step_up": "fresh_mfa",
+        "public_justification": "",
+    },
+    "web.security_key_revoke": {
+        "endpoint": "web.security_key_revoke",
+        "rule": "/security-keys/<credential_id>/revoke",
+        "methods": {"POST"},
+        "access": "authenticated",
+        "classification": "webauthn",
+        "csrf": "required",
+        "rate_limit": "edge_app",
+        "step_up": "required",
+        "public_justification": "",
+    },
+    "web.profile": {
+        "endpoint": "web.profile",
+        "rule": "/profile",
+        "methods": {"GET"},
+        "access": "authenticated",
+        "classification": "profile",
+        "csrf": "not_applicable",
+        "rate_limit": "edge_app",
+        "step_up": "not_required",
+        "public_justification": "",
+    },
+    "web.profile_submit": {
+        "endpoint": "web.profile_submit",
+        "rule": "/profile",
+        "methods": {"POST"},
+        "access": "authenticated",
+        "classification": "profile",
+        "csrf": "required",
+        "rate_limit": "edge_app",
+        "step_up": "required",
+        "public_justification": "",
+    },
+    "web.mfa_setup": {
+        "endpoint": "web.mfa_setup",
+        "rule": "/mfa/setup",
+        "methods": {"GET"},
+        "access": "authenticated",
+        "classification": "mfa",
+        "csrf": "not_applicable",
+        "rate_limit": "edge_app",
+        "step_up": "not_required",
+        "public_justification": "",
+    },
+    "web.mfa_setup_submit": {
+        "endpoint": "web.mfa_setup_submit",
+        "rule": "/mfa/setup",
+        "methods": {"POST"},
+        "access": "authenticated",
+        "classification": "mfa",
+        "csrf": "required",
+        "rate_limit": "per_route",
+        "step_up": "conditional",
+        "public_justification": "",
+    },
+    "web.password_change": {
+        "endpoint": "web.password_change",
+        "rule": "/password/change",
+        "methods": {"GET"},
+        "access": "authenticated",
+        "classification": "password",
+        "csrf": "not_applicable",
+        "rate_limit": "edge_app",
+        "step_up": "not_required",
+        "public_justification": "",
+    },
+    "web.password_change_submit": {
+        "endpoint": "web.password_change_submit",
+        "rule": "/password/change",
+        "methods": {"POST"},
+        "access": "authenticated",
+        "classification": "password",
+        "csrf": "required",
+        "rate_limit": "per_route",
+        "step_up": "required",
+        "public_justification": "",
+    },
+    "web.sessions_dashboard": {
+        "endpoint": "web.sessions_dashboard",
+        "rule": "/sessions",
+        "methods": {"GET"},
+        "access": "authenticated",
+        "classification": "session",
+        "csrf": "not_applicable",
+        "rate_limit": "edge_app",
+        "step_up": "not_required",
+        "public_justification": "",
+    },
+    "web.terminate_session": {
+        "endpoint": "web.terminate_session",
+        "rule": "/sessions/<session_id>/terminate",
+        "methods": {"POST"},
+        "access": "authenticated",
+        "classification": "session",
+        "csrf": "required",
+        "rate_limit": "edge_app",
+        "step_up": "not_required",
+        "public_justification": "",
+    },
+    "web.revoke_other_sessions": {
+        "endpoint": "web.revoke_other_sessions",
+        "rule": "/sessions/revoke-others",
+        "methods": {"POST"},
+        "access": "authenticated",
+        "classification": "session",
+        "csrf": "required",
+        "rate_limit": "edge_app",
+        "step_up": "required",
+        "public_justification": "",
+    },
+    "web.freeze_account": {
+        "endpoint": "web.freeze_account",
+        "rule": "/account/freeze",
+        "methods": {"GET"},
+        "access": "authenticated",
+        "classification": "account_freeze",
+        "csrf": "not_applicable",
+        "rate_limit": "edge_app",
+        "step_up": "not_required",
+        "public_justification": "",
+    },
+    "web.freeze_account_submit": {
+        "endpoint": "web.freeze_account_submit",
+        "rule": "/account/freeze",
+        "methods": {"POST"},
+        "access": "authenticated",
+        "classification": "account_freeze",
+        "csrf": "required",
+        "rate_limit": "per_route",
+        "step_up": "required",
+        "public_justification": "",
+    },
+    "web.logout": {
+        "endpoint": "web.logout",
+        "rule": "/logout",
+        "methods": {"POST"},
+        "access": "public",
+        "classification": "logout",
+        "csrf": "required",
+        "rate_limit": "edge_app",
+        "step_up": "not_required",
+        "public_justification": "Logout is idempotent and clears only the caller's current session state.",
+    },
+}
+
+
+def _actual_routes(app):
+    routes = {}
+    for rule in app.url_map.iter_rules():
+        if rule.endpoint == "static":
+            continue
+        routes[rule.endpoint] = {
+            "rule": rule.rule,
+            "methods": set(rule.methods) - {"HEAD", "OPTIONS"},
+        }
+    return routes
+
+
+def _decorator_name(decorator: ast.expr) -> str:
+    target = decorator.func if isinstance(decorator, ast.Call) else decorator
+    if isinstance(target, ast.Attribute):
+        return target.attr
+    if isinstance(target, ast.Name):
+        return target.id
+    return ast.dump(target)
+
+
+def _route_source_inventory():
+    decorators = {}
+    sources = {}
+    for blueprint, path in ROUTE_MODULES.items():
+        text = path.read_text(encoding="utf-8")
+        lines = text.splitlines()
+        tree = ast.parse(text)
+        for node in tree.body:
+            if not isinstance(node, ast.FunctionDef):
+                continue
+            names = {_decorator_name(decorator) for decorator in node.decorator_list}
+            if names.intersection({"route", "get", "post", "put", "patch", "delete"}):
+                endpoint = f"{blueprint}.{node.name}"
+                decorators[endpoint] = names
+                sources[endpoint] = "\n".join(lines[node.lineno - 1 : node.end_lineno])
+    return decorators, sources
+
+
+def test_route_inventory_matches_registered_flask_routes(app):
+    actual = _actual_routes(app)
+    expected = {
+        endpoint: {
+            "rule": entry["rule"],
+            "methods": entry["methods"],
+        }
+        for endpoint, entry in ROUTE_SECURITY_INVENTORY.items()
+    }
+
+    assert actual == expected
+
+
+def test_route_inventory_has_complete_security_decisions(app):
+    actual = _actual_routes(app)
+    decorators, sources = _route_source_inventory()
+
+    for endpoint, entry in ROUTE_SECURITY_INVENTORY.items():
+        assert entry["endpoint"] == endpoint
+        assert entry["rule"] == actual[endpoint]["rule"]
+        assert entry["methods"] == actual[endpoint]["methods"]
+        assert entry["access"] in {"public", "authenticated"}
+        assert entry["classification"]
+        assert entry["rate_limit"] in RATE_LIMIT_DECISIONS
+        assert entry["step_up"] in STEP_UP_DECISIONS
+
+        route_decorators = decorators[endpoint]
+        if entry["access"] == "authenticated":
+            assert route_decorators.intersection(AUTH_DECORATORS), (
+                f"{endpoint} is inventoried as authenticated but has no login decorator"
+            )
+            assert not entry["public_justification"]
+        else:
+            assert entry["public_justification"], f"{endpoint} needs a public route justification"
+            assert not route_decorators.intersection(AUTH_DECORATORS), (
+                f"{endpoint} is inventoried as public but has an auth decorator"
+            )
+
+        if entry["methods"].intersection(UNSAFE_METHODS):
+            assert entry["csrf"] == "required", f"{endpoint} must have an unsafe-method CSRF decision"
+            assert "exempt" not in route_decorators, f"{endpoint} must not be CSRF-exempt"
+        else:
+            assert entry["csrf"] == "not_applicable"
+
+        if entry["classification"] in SENSITIVE_CLASSIFICATIONS:
+            assert entry["rate_limit"] in RATE_LIMIT_DECISIONS, (
+                f"{endpoint} is sensitive and needs an explicit rate-limit decision"
+            )
+        if entry["rate_limit"] == "per_route":
+            assert "limit" in route_decorators, f"{endpoint} is expected to have Flask-Limiter decorators"
+
+        source = sources[endpoint]
+        if entry["step_up"] == "required":
+            assert "stepup_token" in source or "verify_high_risk_authorization" in source, (
+                f"{endpoint} is expected to require WebAuthn step-up"
+            )
+        if entry["step_up"] == "conditional":
+            assert "stepup_token" in source, f"{endpoint} must document its conditional step-up branch"
+        if entry["step_up"] == "ceremony_endpoint":
+            assert endpoint.startswith("auth.webauthn_step_up_")
+
+
+def test_login_and_registration_have_method_level_security_decisions(app):
+    actual = _actual_routes(app)
+
+    assert actual["web.login"] == {"rule": "/login", "methods": {"GET"}}
+    assert actual["web.login_submit"] == {"rule": "/login", "methods": {"POST"}}
+    assert ROUTE_SECURITY_INVENTORY["web.login"]["csrf"] == "not_applicable"
+    assert ROUTE_SECURITY_INVENTORY["web.login_submit"]["csrf"] == "required"
+    assert ROUTE_SECURITY_INVENTORY["web.login_submit"]["rate_limit"] == "per_route"
+
+    assert actual["web.register_form"] == {"rule": "/register", "methods": {"GET"}}
+    assert actual["web.register_submit"] == {"rule": "/register", "methods": {"POST"}}
+    assert ROUTE_SECURITY_INVENTORY["web.register_form"]["csrf"] == "not_applicable"
+    assert ROUTE_SECURITY_INVENTORY["web.register_submit"]["csrf"] == "required"
+    assert ROUTE_SECURITY_INVENTORY["web.register_submit"]["rate_limit"] == "per_route"


### PR DESCRIPTION
## Summary

- Added a generic Flask route security inventory test using `app.url_map.iter_rules()`.
- Documented every non-static route with auth/public status, CSRF decision, rate-limit decision, WebAuthn step-up expectation, and public-route justification.
- Added production Nginx edge hardening proof/configuration for HTTPS redirect, loopback proxying, body/time limits, TRACE denial, restricted `/health/ready`, and auth-sensitive rate limits.
- Added README and SECURITY.md guidance for production ports, SSH restrictions, WAF/security-group requirements, and verification commands.

## Tests

- `python -m pytest tests/test_route_inventory_security.py -q`
- `python -m pytest tests/test_deployment.py -q`
- `python -m pytest -q`
- `git diff --check`

## Bootstrap

No EC2 bootstrap required for this PR. The changed files do not modify the current bootstrap-installed deployment files. Production Nginx files are documented/manual infrastructure inputs unless a future bootstrap installer is added.