### PR TITLE
Fix duplicate edge security headers

### DIFF
--- a/ops/nginx/sitbank-production.conf
+++ b/ops/nginx/sitbank-production.conf
@@ -41,6 +41,12 @@ server {
     ssl_session_timeout 1d;
     ssl_session_tickets off;
 
+    proxy_hide_header X-Content-Type-Options;
+    proxy_hide_header X-Frame-Options;
+    proxy_hide_header Referrer-Policy;
+    proxy_hide_header Permissions-Policy;
+    proxy_hide_header Strict-Transport-Security;
+
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "DENY" always;
     add_header Referrer-Policy "no-referrer" always;

--- a/ops/nginx/sitbank-staging.conf
+++ b/ops/nginx/sitbank-staging.conf
@@ -42,6 +42,12 @@ server {
     ssl_session_timeout 1d;
     ssl_session_tickets off;
 
+    proxy_hide_header X-Content-Type-Options;
+    proxy_hide_header X-Frame-Options;
+    proxy_hide_header Referrer-Policy;
+    proxy_hide_header Permissions-Policy;
+    proxy_hide_header Strict-Transport-Security;
+
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "DENY" always;
     add_header Referrer-Policy "no-referrer" always;

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -102,6 +102,43 @@ def _nginx_location_bodies(config: str, selector: str) -> list[str]:
     )
 
 
+def _nginx_https_server_prelocation(config: str) -> str:
+    https_start = config.index("listen 443 ssl http2;")
+    first_location = config.index("\n    location ", https_start)
+    return config[https_start:first_location]
+
+
+def _assert_nginx_owns_duplicate_edge_security_headers(
+    nginx: str,
+    *,
+    hsts_add_header: str,
+) -> None:
+    https_server = _nginx_https_server_prelocation(nginx)
+    hide_directives = (
+        "proxy_hide_header X-Content-Type-Options;",
+        "proxy_hide_header X-Frame-Options;",
+        "proxy_hide_header Referrer-Policy;",
+        "proxy_hide_header Permissions-Policy;",
+        "proxy_hide_header Strict-Transport-Security;",
+    )
+    add_header_directives = (
+        'add_header X-Content-Type-Options "nosniff" always;',
+        'add_header X-Frame-Options "DENY" always;',
+        'add_header Referrer-Policy "no-referrer" always;',
+        'add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()" always;',
+        hsts_add_header,
+    )
+
+    first_add_header = min(https_server.index(directive) for directive in add_header_directives)
+    for directive in hide_directives:
+        assert directive in https_server
+        assert nginx.count(directive) == 1
+        assert https_server.index(directive) < first_add_header
+    for directive in add_header_directives:
+        assert directive in https_server
+        assert nginx.count(directive) == 1
+
+
 def _config_secret_inputs() -> set[str]:
     tree = ast.parse(Path("config.py").read_text(encoding="utf-8"))
     secret_readers = {
@@ -1526,10 +1563,10 @@ def test_staging_nginx_enforces_https_auth_health_and_rate_limits():
     assert "server_name staging-sitbank.duckdns.org;" in nginx
     assert "ssl_certificate /etc/letsencrypt/live/staging-sitbank.duckdns.org/fullchain.pem;" in nginx
     assert "ssl_certificate_key /etc/letsencrypt/live/staging-sitbank.duckdns.org/privkey.pem;" in nginx
-    assert 'add_header X-Content-Type-Options "nosniff" always;' in nginx
-    assert 'add_header X-Frame-Options "DENY" always;' in nginx
-    assert 'add_header Referrer-Policy "no-referrer" always;' in nginx
-    assert "Permissions-Policy" in nginx
+    _assert_nginx_owns_duplicate_edge_security_headers(
+        nginx,
+        hsts_add_header='add_header Strict-Transport-Security "max-age=300" always;',
+    )
     assert "preload" not in nginx
     assert 'auth_basic "SITBank staging";' in nginx
     assert "auth_basic_user_file /etc/nginx/.htpasswd-sitbank-staging;" in nginx
@@ -1632,11 +1669,13 @@ def test_production_nginx_edge_config_enforces_network_boundary_and_limits():
     assert "server_name sitbank.duckdns.org;" in nginx
     assert "ssl_certificate /etc/letsencrypt/live/sitbank.duckdns.org/fullchain.pem;" in nginx
     assert "ssl_certificate_key /etc/letsencrypt/live/sitbank.duckdns.org/privkey.pem;" in nginx
-    assert 'add_header X-Content-Type-Options "nosniff" always;' in nginx
-    assert 'add_header X-Frame-Options "DENY" always;' in nginx
-    assert 'add_header Referrer-Policy "no-referrer" always;' in nginx
-    assert "Permissions-Policy" in nginx
-    assert 'add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;' in nginx
+    _assert_nginx_owns_duplicate_edge_security_headers(
+        nginx,
+        hsts_add_header=(
+            'add_header Strict-Transport-Security "max-age=31536000; '
+            'includeSubDomains" always;'
+        ),
+    )
     assert "client_max_body_size 4m;" in nginx
     for timeout in (
         "client_body_timeout 15s;",

--- a/tests/test_owasp_regressions.py
+++ b/tests/test_owasp_regressions.py
@@ -12,6 +12,7 @@ def test_security_headers_are_present(client):
     assert response.headers["X-Content-Type-Options"] == "nosniff"
     assert response.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
     assert "default-src 'self'" in response.headers["Content-Security-Policy"]
+    assert response.headers["Cross-Origin-Resource-Policy"] == "same-origin"
 
 
 def test_public_homepage_exposes_verification_and_student_disclaimer(client):


### PR DESCRIPTION
## Summary

Fixes duplicate and conflicting production/staging security response headers by making Nginx the final owner for duplicated edge security headers.

## Why

Production responses currently include overlapping Flask/Talisman and Nginx security headers, including `X-Frame-Options`, `Referrer-Policy`, `Strict-Transport-Security`, `X-Content-Type-Options`, and `Permissions-Policy`.

The headers are mostly protective, but duplicate/conflicting values make the effective browser policy harder to audit and can confuse security scanners.

## What changed

* Added `proxy_hide_header` directives in production Nginx to hide duplicated upstream Flask/Talisman headers.
* Added the same duplicate-header handling in staging Nginx while keeping staging HSTS at `max-age=300`.
* Updated deployment/security tests to assert Nginx owns the final edge header values and Flask still emits `Cross-Origin-Resource-Policy`.

## Security impact

This preserves the existing protective headers while making the final browser-visible policy deterministic. It does not disable Flask/Talisman, remove CSP, change auth, expose new ports, weaken rate limits, change secrets, or modify permissions.

## Deployment impact

This PR requires:

* EC2 bootstrap: yes, to copy the updated Nginx config and reload Nginx
* staging deployment: no app/container deployment required
* production deployment: no app/container deployment required
* database migration: no
* secret changes: no
* no deployment action: not applicable, Nginx bootstrap/reload is needed for the live header fix

## Verification

* `python -m pytest tests/test_deployment.py -q` passed
* `python -m pytest tests/test_route_inventory_security.py -q` passed
* `python -m pytest tests/test_owasp_regressions.py -q` passed

## Notes

After merge, run the appropriate EC2 bootstrap from reviewed `main` so the updated Nginx config is installed and reloaded. Live responses will continue to show duplicate headers until bootstrap applies the config on the server.