### PR TITLE
Fix and improve Discord alert formatting and delivery

### DIFF
--- a/app/security/alerts.py
+++ b/app/security/alerts.py
@@ -36,7 +36,10 @@ TRANSACTION_EVENT_TYPES = {
 ALERT_SEVERITY_RANK = {"low": 10, "medium": 20, "high": 30, "critical": 40}
 DEFAULT_ALERT_TIMEOUT_SECONDS = 5.0
 DEFAULT_ALERT_DEDUPE_TTL_SECONDS = 300
-DISCORD_MESSAGE_LIMIT = 1900
+DISCORD_EMBED_FIELD_LIMIT = 10
+ALERT_USER_AGENT = "SITBank-SecurityAlerts/1.0"
+DISCORD_DISPLAY_TIMEZONE = timezone(timedelta(hours=8))
+DISCORD_DISPLAY_TIMEZONE_LABEL = "UTC+8"
 
 
 class AlertConfigurationError(RuntimeError):
@@ -154,7 +157,11 @@ def deliver_security_alerts(
     request = urllib.request.Request(
         url,
         data=body,
-        headers={"Content-Type": "application/json"},
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "User-Agent": ALERT_USER_AGENT,
+        },
         method="POST",
     )
     if timeout_seconds is None:
@@ -313,10 +320,7 @@ def _webhook_provider(url: str) -> str:
 def _alert_webhook_body(alerts: list[dict[str, Any]], *, provider: str) -> bytes:
     generated_at = _utc_iso(datetime.now(timezone.utc))
     if provider == "discord":
-        payload = {
-            "content": _discord_alert_content(alerts, generated_at=generated_at),
-            "allowed_mentions": {"parse": []},
-        }
+        payload = _discord_alert_payload(alerts, generated_at=generated_at)
     else:
         payload = {
             "message": "security_alerts",
@@ -326,27 +330,89 @@ def _alert_webhook_body(alerts: list[dict[str, Any]], *, provider: str) -> bytes
     return json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
 
 
-def _discord_alert_content(alerts: list[dict[str, Any]], *, generated_at: str) -> str:
-    lines = [
-        "SITBank security alerts",
-        f"Generated: {generated_at}",
-        "",
-    ]
-    for alert in alerts[:15]:
-        lines.append(
-            "- "
-            f"[{_safe_text(alert.get('severity'), 24).upper()}] "
-            f"{_safe_text(alert.get('alert_type'), 80)} "
-            f"source={_safe_text(alert.get('source'), 160)} "
-            f"count={_safe_text(alert.get('count'), 12)}"
-        )
-    omitted = len(alerts) - 15
+def _discord_alert_payload(alerts: list[dict[str, Any]], *, generated_at: str) -> dict[str, Any]:
+    displayed_alerts = alerts[:DISCORD_EMBED_FIELD_LIMIT]
+    omitted = len(alerts) - len(displayed_alerts)
+    embed = {
+        "title": "SITBank Security Alerts",
+        "description": _discord_alert_summary(alerts, generated_at=generated_at),
+        "color": _discord_embed_color(alerts),
+        "timestamp": generated_at,
+        "fields": [_discord_alert_field(alert) for alert in displayed_alerts],
+        "footer": {"text": "Audit monitoring"},
+    }
     if omitted > 0:
-        lines.append(f"- {omitted} additional alerts omitted from Discord summary")
-    content = "\n".join(lines)
-    if len(content) <= DISCORD_MESSAGE_LIMIT:
-        return content
-    return content[: DISCORD_MESSAGE_LIMIT - 3] + "..."
+        embed["fields"].append(
+            {
+                "name": "Additional alerts",
+                "value": f"{omitted} more alert(s) omitted from this Discord summary.",
+                "inline": False,
+            }
+        )
+    return {
+        "content": f"SITBank security alerts: {len(alerts)} active",
+        "embeds": [embed],
+        "allowed_mentions": {"parse": []},
+    }
+
+
+def _discord_alert_summary(alerts: list[dict[str, Any]], *, generated_at: str) -> str:
+    timestamp = _parse_utc_iso(generated_at).astimezone(DISCORD_DISPLAY_TIMEZONE)
+    date_text = timestamp.strftime("%Y-%m-%d")
+    time_text = timestamp.strftime("%H:%M:%S.%f")
+    return (
+        f"{len(alerts)} active alert(s).\n"
+        f"Date: {date_text}\n"
+        f"Time: {time_text}\n"
+        f"Timezone: {DISCORD_DISPLAY_TIMEZONE_LABEL}"
+    )
+
+
+def _discord_embed_color(alerts: list[dict[str, Any]]) -> int:
+    highest = max(
+        (
+            ALERT_SEVERITY_RANK.get(str(alert.get("severity", "low")).casefold(), 0)
+            for alert in alerts
+        ),
+        default=0,
+    )
+    if highest >= ALERT_SEVERITY_RANK["critical"]:
+        return 0xD92D20
+    if highest >= ALERT_SEVERITY_RANK["high"]:
+        return 0xDC6803
+    if highest >= ALERT_SEVERITY_RANK["medium"]:
+        return 0xF79009
+    return 0x1570EF
+
+
+def _discord_alert_field(alert: Mapping[str, Any]) -> dict[str, Any]:
+    severity = _safe_text(alert.get("severity"), 24).upper() or "UNKNOWN"
+    alert_type = _safe_text(alert.get("alert_type"), 80) or "security_alert"
+    source = _safe_text(alert.get("source"), 160) or "unknown"
+    count = _safe_text(alert.get("count"), 12) or "1"
+    window = _format_window_seconds(alert.get("window_seconds"))
+    return {
+        "name": f"{severity} | {alert_type}"[:256],
+        "value": (
+            f"Source: {source}\n"
+            f"Count: {count}\n"
+            f"Window: {window}"
+        )[:1024],
+        "inline": False,
+    }
+
+
+def _format_window_seconds(value: Any) -> str:
+    try:
+        seconds = int(value or 0)
+    except (TypeError, ValueError):
+        seconds = 0
+    if seconds <= 0:
+        return "immediate"
+    if seconds % 60 == 0:
+        minutes = seconds // 60
+        return f"{minutes} minute(s)"
+    return f"{seconds} second(s)"
 
 
 def _filter_alerts_by_min_severity(alerts: list[dict[str, Any]], min_severity: str) -> list[dict[str, Any]]:
@@ -645,3 +711,7 @@ def _as_utc(value: datetime) -> datetime:
 
 def _utc_iso(value: datetime) -> str:
     return _as_utc(value).isoformat().replace("+00:00", "Z")
+
+
+def _parse_utc_iso(value: str) -> datetime:
+    return _as_utc(datetime.fromisoformat(value.replace("Z", "+00:00")))

--- a/tests/test_group_a_security.py
+++ b/tests/test_group_a_security.py
@@ -2440,6 +2440,7 @@ def test_security_alert_webhook_delivery_is_sanitized(monkeypatch):
     def fake_urlopen(request, timeout):
         captured["url"] = request.full_url
         captured["body"] = request.data.decode("utf-8")
+        captured["user_agent"] = request.headers["User-agent"]
         captured["timeout"] = timeout
         return FakeResponse()
 
@@ -2463,6 +2464,7 @@ def test_security_alert_webhook_delivery_is_sanitized(monkeypatch):
     assert result["attempted"] is True
     assert result["delivered"] is True
     assert captured["url"].endswith("/secret-token")
+    assert captured["user_agent"] == "SITBank-SecurityAlerts/1.0"
     assert "secret-token" not in captured["body"]
     assert "secret-token" not in serialized_result
 
@@ -2507,6 +2509,7 @@ def test_security_alert_delivery_formats_discord_webhooks(monkeypatch):
         del timeout
         captured["body"] = request.data.decode("utf-8")
         captured["content_type"] = request.headers["Content-type"]
+        captured["user_agent"] = request.headers["User-agent"]
         return FakeResponse()
 
     monkeypatch.setattr("app.security.alerts.urllib.request.urlopen", fake_urlopen)
@@ -2532,11 +2535,18 @@ def test_security_alert_delivery_formats_discord_webhooks(monkeypatch):
     assert result["delivered"] is True
     assert result["provider"] == "discord"
     assert captured["content_type"] == "application/json"
+    assert captured["user_agent"] == "SITBank-SecurityAlerts/1.0"
     assert payload["allowed_mentions"] == {"parse": []}
-    assert "content" in payload
-    assert "SITBank security alerts" in payload["content"]
-    assert "login_failure_burst" in payload["content"]
-    assert "principal_ref:abc123" in payload["content"]
+    assert payload["content"] == "SITBank security alerts: 1 active"
+    assert payload["embeds"][0]["title"] == "SITBank Security Alerts"
+    assert payload["embeds"][0]["color"] == 0xD92D20
+    assert "Date: " in payload["embeds"][0]["description"]
+    assert "Time: " in payload["embeds"][0]["description"]
+    assert "Timezone: UTC+8" in payload["embeds"][0]["description"]
+    assert payload["embeds"][0]["fields"][0]["name"] == "CRITICAL | login_failure_burst"
+    assert "Source: principal_ref:abc123" in payload["embeds"][0]["fields"][0]["value"]
+    assert "Count: 10" in payload["embeds"][0]["fields"][0]["value"]
+    assert "Window: 5 minute(s)" in payload["embeds"][0]["fields"][0]["value"]
     assert "example-secret-token" not in serialized_payload
     assert "example-secret-token" not in serialized_result
 


### PR DESCRIPTION
## Summary

Improves Discord security alert delivery and readability.

## Why

Discord was rejecting webhook delivery with an HTTP error from its edge layer, and the alert message format was plain text that was harder for operators to scan. This change makes webhook delivery more reliable and formats Discord alerts as structured embeds with readable UTC+8 timestamps.

## What changed

* Added stable `User-Agent`, `Accept`, and JSON content headers for security alert webhook delivery.
* Changed Discord webhook payloads from plain text summaries to Discord embeds.
* Added UTC+8 human-readable date, time, and timezone text while keeping the machine-readable embed timestamp in UTC.
* Updated tests to verify webhook headers, Discord embed structure, mention parsing protection, and secret redaction.

## Security impact

Improves alert delivery reliability without adding secrets or changing authentication behavior. Discord alerts still disable mention parsing with `allowed_mentions: {"parse": []}`, and tests continue to verify webhook tokens are not included in payloads or delivery results.

## Deployment impact

This PR requires:

* EC2 bootstrap: no
* staging deployment: yes, to apply the alert delivery code change.
* production deployment: yes, to apply the alert delivery code change.
* database migration: no
* secret changes: no
* no deployment action: no

## Verification

* `.venv\Scripts\python -m pytest -q tests/test_group_a_security.py::test_security_alert_webhook_delivery_is_sanitized tests/test_group_a_security.py::test_security_alert_delivery_formats_discord_webhooks`
* `.venv\Scripts\python -m compileall app/security/alerts.py`
* `git diff --check`
* Manual local Discord webhook smoke test returned `delivered: True` with Discord status `204`.

## Notes

The Discord embed keeps the standard machine-readable timestamp in UTC, while the visible description displays UTC+8 for operator readability. No webhook URL or real secret was committed.