### PR TITLE
Schedule security alerts and sanitize webhooks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@ Dockerfile text eol=lf
 *.yaml text eol=lf
 *.conf text eol=lf
 *.service text eol=lf
+*.timer text eol=lf
 
 ops/deploy/bootstrap-container-ec2 text eol=lf
 ops/deploy/sitbank-container-bootstrap text eol=lf

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -263,12 +263,16 @@ is a secret and must be regenerated if exposed.
 of the same alert while preserving the alert in reports. Delivery failures are
 reported by type only and must not include webhook URLs, tokens, headers,
 request bodies, raw identifiers, passwords, session IDs, or full account
-numbers. Set `SECURITY_AUDIT_ANCHOR_PATH` to the latest exported anchor path to
-make `check-security-alerts` alert on anchor mismatch, chain rewind, or tail
-deletion detectable from the anchor. On mismatch, treat the database and host
-as incident evidence, stop routine anchor rotation, preserve the mismatched
-anchor, run `verify-audit-log-chain --anchor`, and investigate before resuming
-normal deployments.
+numbers. Immediately before webhook delivery, both generic JSON payloads and
+Discord-formatted payloads pass through a final sanitizer that redacts
+sensitive keys, bearer/basic credentials, session or cookie values, database or
+Redis URLs with credentials, webhook URLs, API keys, private-key-like values,
+and long token-like strings. Set `SECURITY_AUDIT_ANCHOR_PATH` to the latest
+exported anchor path to make `check-security-alerts` alert on anchor mismatch,
+chain rewind, or tail deletion detectable from the anchor. On mismatch, treat
+the database and host as incident evidence, stop routine anchor rotation,
+preserve the mismatched anchor, run `verify-audit-log-chain --anchor`, and
+investigate before resuming normal deployments.
 
 Alert immediately on any `security_audit_write_failed`, `account_lock`,
 `webauthn_clone_detected`, `session_integrity` failure,
@@ -283,10 +287,18 @@ deployments, signature or revision mismatches, unexpected image digests,
 security-key counter anomalies, and changes to root-managed secret or FIDO
 policy files.
 
-Run a systemd timer or equivalent scheduler for
-`verify-audit-log-chain --anchor /var/lib/sitbank/audit-anchor.json --alert-on-failure`
-and `check-security-alerts` so anchor mismatch and alert delivery failures are
-visible without waiting for a manual audit.
+Production installs `sitbank-security-alerts.service` and
+`sitbank-security-alerts.timer` through the EC2 bootstrap path. The timer runs
+`check-security-alerts` through the container runtime wrapper every 5 minutes,
+so anchor mismatch and alert delivery failures are visible without waiting for
+a manual audit.
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now sitbank-security-alerts.timer
+sudo systemctl status sitbank-security-alerts.timer
+journalctl -u sitbank-security-alerts.service
+```
 
 ## AWS OIDC and Systems Manager
 

--- a/app/security/alerts.py
+++ b/app/security/alerts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import urllib.request
 from collections import Counter
 from collections.abc import Mapping
@@ -41,6 +42,75 @@ DISCORD_EMBED_FIELD_LIMIT = 10
 ALERT_USER_AGENT = "SITBank-SecurityAlerts/1.0"
 DISCORD_DISPLAY_TIMEZONE = timezone(timedelta(hours=8))
 DISCORD_DISPLAY_TIMEZONE_LABEL = "UTC+8"
+DELIVERY_SAFE_KEYS = {
+    "alert_type",
+    "anchor_error_count",
+    "correlation_id",
+    "count",
+    "display_timestamp",
+    "event_count",
+    "event_id",
+    "event_type",
+    "generated_at",
+    "latest_event_id",
+    "message",
+    "outcome",
+    "public_session_ref",
+    "safe_user_id",
+    "safe_user_identifier",
+    "session_ref",
+    "severity",
+    "source",
+    "summary",
+    "timestamp",
+    "user_id",
+    "user_ref",
+    "window_seconds",
+}
+DELIVERY_SENSITIVE_KEY_PARTS = (
+    "access_token",
+    "api_key",
+    "apikey",
+    "authorization",
+    "bearer",
+    "cookie",
+    "csrf",
+    "database_url",
+    "mfa_secret",
+    "passwd",
+    "password",
+    "postgres_url",
+    "postgresql_url",
+    "private_key",
+    "redis_url",
+    "refresh_token",
+    "secret",
+    "session",
+    "session_id",
+    "sid",
+    "set_cookie",
+    "set-cookie",
+    "token",
+    "totp",
+    "webhook",
+)
+DELIVERY_CREDENTIAL_URL_RE = re.compile(
+    r"\b(?:postgres(?:ql)?|redis)://[^\s/@]*:[^\s/@]*@",
+    re.IGNORECASE,
+)
+DELIVERY_WEBHOOK_URL_RE = re.compile(
+    r"https://(?:[^/\s]*hooks[^/\s]*|(?:discord(?:app)?\.com))/(?:api/)?(?:webhooks|services)/\S+",
+    re.IGNORECASE,
+)
+DELIVERY_PRIVATE_KEY_RE = re.compile(
+    r"BEGIN (?:RSA |EC |OPENSSH |)PRIVATE KEY",
+    re.IGNORECASE,
+)
+DELIVERY_LONG_TOKEN_RE = re.compile(r"(?=.*[A-Za-z])(?=.*\d)[A-Za-z0-9_+/=-]{40,}")
+UUID_TEXT_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
 
 
 class AlertConfigurationError(RuntimeError):
@@ -444,15 +514,80 @@ def _audit_chain_status(
 
 def _alert_webhook_body(alerts: list[dict[str, Any]], *, provider: str) -> bytes:
     generated_at = _utc_iso(datetime.now(timezone.utc))
+    safe_alerts = [_sanitize_alert_for_delivery(alert) for alert in alerts]
     if provider == "discord":
-        payload = _discord_alert_payload(alerts, generated_at=generated_at)
+        payload = _discord_alert_payload(safe_alerts, generated_at=generated_at)
     else:
         payload = {
             "message": "security_alerts",
             "generated_at": generated_at,
-            "alerts": alerts,
+            "alerts": safe_alerts,
         }
     return json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def _sanitize_alert_for_delivery(alert: Mapping[str, Any]) -> dict[str, Any]:
+    clean: dict[str, Any] = {}
+    for key, value in alert.items():
+        key_text = _safe_text(key, 80) or "field"
+        key_lower = key_text.casefold()
+        if _is_sensitive_delivery_key(key_lower):
+            clean[key_text] = "[redacted]"
+            continue
+        clean[key_text] = _sanitize_delivery_value(value, key_lower, depth=0)
+    return clean
+
+
+def _sanitize_delivery_value(value: Any, key_lower: str, *, depth: int) -> Any:
+    if isinstance(value, bool | int | float) or value is None:
+        return value
+    if depth < 4 and isinstance(value, Mapping):
+        nested: dict[str, Any] = {}
+        for nested_key, nested_value in list(value.items())[:25]:
+            nested_key_text = _safe_text(nested_key, 80) or "field"
+            nested_key_lower = nested_key_text.casefold()
+            nested[nested_key_text] = (
+                "[redacted]"
+                if _is_sensitive_delivery_key(nested_key_lower)
+                else _sanitize_delivery_value(nested_value, nested_key_lower, depth=depth + 1)
+            )
+        return nested
+    if depth < 4 and isinstance(value, list | tuple):
+        return [
+            _sanitize_delivery_value(item, key_lower, depth=depth + 1)
+            for item in list(value)[:25]
+        ]
+
+    text = _safe_text(value, 512)
+    if _looks_like_sensitive_delivery_value(text):
+        return "[redacted]"
+    return text
+
+
+def _is_sensitive_delivery_key(key_lower: str) -> bool:
+    normalized = key_lower.replace("-", "_")
+    if normalized in DELIVERY_SAFE_KEYS:
+        return False
+    return any(part in normalized for part in DELIVERY_SENSITIVE_KEY_PARTS)
+
+
+def _looks_like_sensitive_delivery_value(text: str) -> bool:
+    if not text:
+        return False
+    lowered = text.casefold()
+    if lowered == "[redacted]":
+        return True
+    if lowered.startswith(("bearer ", "basic ", "token ")):
+        return True
+    if DELIVERY_CREDENTIAL_URL_RE.search(text):
+        return True
+    if DELIVERY_WEBHOOK_URL_RE.search(text):
+        return True
+    if DELIVERY_PRIVATE_KEY_RE.search(text):
+        return True
+    if UUID_TEXT_RE.fullmatch(text.strip()):
+        return False
+    return bool(DELIVERY_LONG_TOKEN_RE.fullmatch(text.strip()))
 
 
 def _discord_alert_payload(alerts: list[dict[str, Any]], *, generated_at: str) -> dict[str, Any]:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -11,6 +11,7 @@ Only Flask/Gunicorn runs in the SITBank container. Nginx, TLS, PostgreSQL, Redis
 - Production config root: `/etc/sitbank`
 - Production compose dir: `/opt/sitbank`
 - Production service: `sitbank-container.service`
+- Production alert timer: `sitbank-security-alerts.timer`
 - Production database: `sitbank_db`
 - Production owner role: `sitbank_owner`
 - Production app role: `sitbank_app`
@@ -46,6 +47,19 @@ hash chain and compares the anchor during automated alert runs. Audit trigger
 changes require `db upgrade`, then `apply-runtime-db-privileges` and
 `verify-runtime-db-privileges`; they do not require an EC2 edge bootstrap
 unless host-managed deployment, Nginx, or systemd files also changed.
+
+Security alert scheduling is host-managed systemd state. Changes to
+`ops/systemd/sitbank-security-alerts.service`,
+`ops/systemd/sitbank-security-alerts.timer`, or
+`ops/deploy/sitbank-container-runtime` require the trusted EC2 bootstrap after
+merge so production receives the unit files and runs `systemctl daemon-reload`.
+Then enable or verify the timer:
+
+```bash
+sudo systemctl enable --now sitbank-security-alerts.timer
+sudo systemctl status sitbank-security-alerts.timer
+journalctl -u sitbank-security-alerts.service
+```
 
 ## Production Edge and Network Hardening
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -101,22 +101,38 @@ incoming webhook URL is supported directly; the application formats Discord
 payloads with mention parsing disabled. Optional direct
 `SECURITY_ALERT_WEBHOOK_URL` is supported for non-production tests only; these
 are placeholder secret names, not checked-in values. Delivery failures are
-sanitized by exception type and must not print webhook URLs or tokens. Redis
-dedupe suppresses repeated delivery of the same alert for
+sanitized by exception type and must not print webhook URLs or tokens. A final
+sanitization pass runs immediately before outbound webhook JSON serialization
+for both generic and Discord payloads; it redacts sensitive keys, bearer/basic
+credentials, cookies, session values, MFA/TOTP secrets, API keys,
+private-key-like text, database or Redis URLs with credentials, webhook URLs,
+and long token-like strings while preserving harmless severity, event type, summary,
+timestamp, correlation ID, public session reference, and safe user references.
+Redis dedupe suppresses repeated delivery of the same alert for
 `SECURITY_ALERT_DEDUPE_TTL_SECONDS` while keeping the active alert in the JSON
 report. Set `SECURITY_AUDIT_ANCHOR_PATH` when a trusted exported anchor is
 available so `check-security-alerts` emits critical
 `audit_chain_verification_failed` or `audit_anchor_mismatch` alerts for chain
 tampering, rewind, or tail deletion detectable from the anchor.
 
-Example systemd timer cadence: run
-`python -m flask --app wsgi:app verify-audit-log-chain --anchor /var/lib/sitbank/audit-anchor.json --alert-on-failure`
-every 15 minutes and
-`python -m flask --app wsgi:app check-security-alerts` every 5 minutes from a
-root-managed service account with the same container/runtime environment. A
-change to audit trigger migrations requires `db upgrade` and runtime privilege
-reapply/verify; it does not require an EC2 edge bootstrap unless deployment
-unit or host-managed configuration files also changed.
+Production uses the committed systemd timer `sitbank-security-alerts.timer` to run
+`check-security-alerts` through the container runtime wrapper every 5 minutes.
+The service fails visibly when alert evaluation fails, when active alerts are
+present, or when required delivery fails.
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now sitbank-security-alerts.timer
+sudo systemctl status sitbank-security-alerts.timer
+journalctl -u sitbank-security-alerts.service
+```
+
+Changes to `ops/systemd/sitbank-security-alerts.service`,
+`ops/systemd/sitbank-security-alerts.timer`, or the container runtime wrapper
+require the reviewed production bootstrap so the host-managed unit files are
+installed, followed by `systemctl daemon-reload`. Application-only alert code
+changes require the normal staging/production deploy path. A change to audit
+trigger migrations requires `db upgrade` and runtime privilege reapply/verify.
 
 Alert on any `security_audit_write_failed`, `account_lock`,
 `webauthn_clone_detected`, or `session_integrity` failure; 10 or more login

--- a/ops/deploy/bootstrap-container-ec2
+++ b/ops/deploy/bootstrap-container-ec2
@@ -62,6 +62,8 @@ case "${target}" in
         compose_source="compose.prod.yml"
         systemd_source="ops/systemd/sitbank-container.service"
         systemd_service="sitbank-container.service"
+        alert_systemd_service="sitbank-security-alerts.service"
+        alert_systemd_timer="sitbank-security-alerts.timer"
         ;;
     staging)
         config_root="/etc/sitbank-staging"
@@ -71,6 +73,8 @@ case "${target}" in
         compose_source="compose.staging.yml"
         systemd_source="ops/systemd/sitbank-staging-container.service"
         systemd_service="sitbank-staging-container.service"
+        alert_systemd_service=""
+        alert_systemd_timer=""
         ;;
 esac
 
@@ -98,6 +102,8 @@ else
         "${repo_root}/ops/nginx-proxy-headers.conf"
         "${repo_root}/ops/nginx/sitbank-production.conf"
         "${repo_root}/ops/nginx/sitbank-production-rate-limits.conf"
+        "${repo_root}/ops/systemd/${alert_systemd_service}"
+        "${repo_root}/ops/systemd/${alert_systemd_timer}"
     )
 fi
 for runtime_file in "${linux_runtime_files[@]}"; do
@@ -216,6 +222,14 @@ fi
 install -o root -g root -m 0644 \
     "${repo_root}/${systemd_source}" \
     "/etc/systemd/system/${systemd_service}"
+if [[ "${target}" == "production" ]]; then
+    install -o root -g root -m 0644 \
+        "${repo_root}/ops/systemd/${alert_systemd_service}" \
+        "/etc/systemd/system/${alert_systemd_service}"
+    install -o root -g root -m 0644 \
+        "${repo_root}/ops/systemd/${alert_systemd_timer}" \
+        "/etc/systemd/system/${alert_systemd_timer}"
+fi
 install -o root -g root -m 0440 \
     "${repo_root}/ops/sudoers/sitbank-container-deploy" \
     /etc/sudoers.d/sitbank-container-deploy
@@ -413,6 +427,9 @@ fi
 visudo -cf /etc/sudoers.d/sitbank-container-deploy
 systemctl daemon-reload
 systemctl enable "${systemd_service}"
+if [[ "${target}" == "production" ]]; then
+    systemctl enable "${alert_systemd_timer}"
+fi
 
 echo "${target^} container bootstrap complete; existing production containers were not restarted."
 echo "Seed ${config_root} with unique runtime secrets and policy files before deployment."

--- a/ops/deploy/sitbank-container-runtime
+++ b/ops/deploy/sitbank-container-runtime
@@ -59,8 +59,13 @@ case "${1:-}" in
         exec docker compose --project-name "${COMPOSE_PROJECT}" \
             --file "${COMPOSE_FILE}" down --remove-orphans
         ;;
+    check-security-alerts)
+        exec docker compose --project-name "${COMPOSE_PROJECT}" \
+            --file "${COMPOSE_FILE}" \
+            exec -T app python -m flask --app wsgi:app check-security-alerts
+        ;;
     *)
-        echo "Usage: sitbank-container-runtime [staging|production] up|down" >&2
+        echo "Usage: sitbank-container-runtime [staging|production] up|down|check-security-alerts" >&2
         exit 2
         ;;
 esac

--- a/ops/systemd/sitbank-security-alerts.service
+++ b/ops/systemd/sitbank-security-alerts.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=SITBank security alert check
+Requires=docker.service sitbank-container.service
+After=docker.service network-online.target sitbank-container.service
+Wants=network-online.target
+ConditionPathExists=/var/lib/sitbank-container/current
+
+[Service]
+Type=oneshot
+Environment=HOME=/tmp
+ExecStart=/usr/local/sbin/sitbank-container-runtime check-security-alerts
+TimeoutStartSec=90
+
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ReadWritePaths=/run/docker.sock

--- a/ops/systemd/sitbank-security-alerts.timer
+++ b/ops/systemd/sitbank-security-alerts.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run SITBank security alert checks every 5 minutes
+
+[Timer]
+OnActiveSec=5min
+OnUnitActiveSec=5min
+AccuracySec=30s
+Unit=sitbank-security-alerts.service
+
+[Install]
+WantedBy=timers.target

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1248,6 +1248,8 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     assert "sitbank-deploy" in bootstrap
     assert "sitbank-container.service" in bootstrap
     assert "sitbank-staging-container.service" in bootstrap
+    assert "sitbank-security-alerts.service" in bootstrap
+    assert "sitbank-security-alerts.timer" in bootstrap
     docs = _project_docs_text()
     assert "Manual pre-merge staging:" in docs
     assert "run trusted workflow from main" in docs
@@ -1506,6 +1508,8 @@ def test_only_sitbank_container_deployment_units_are_active():
     assert Path("ops/deploy/sitbank-database-cutover").exists()
     assert Path("ops/systemd/sitbank-container.service").exists()
     assert Path("ops/systemd/sitbank-staging-container.service").exists()
+    assert Path("ops/systemd/sitbank-security-alerts.service").exists()
+    assert Path("ops/systemd/sitbank-security-alerts.timer").exists()
     assert Path("ops/sudoers/sitbank-container-deploy").exists()
 
 
@@ -1531,12 +1535,15 @@ def test_linux_deployment_artifacts_are_forced_to_lf_and_reject_crlf():
         Path("ops/sudoers/sitbank-container-deploy"),
         Path("ops/systemd/sitbank-container.service"),
         Path("ops/systemd/sitbank-staging-container.service"),
+        Path("ops/systemd/sitbank-security-alerts.service"),
+        Path("ops/systemd/sitbank-security-alerts.timer"),
     )
 
     assert "*.sh text eol=lf" in attributes
     assert "*.yml text eol=lf" in attributes
     assert "*.conf text eol=lf" in attributes
     assert "*.service text eol=lf" in attributes
+    assert "*.timer text eol=lf" in attributes
     assert "ops/deploy/bootstrap-container-ec2 text eol=lf" in attributes
     assert "ops/deploy/sitbank-container-bootstrap text eol=lf" in attributes
     assert "ops/sudoers/* text eol=lf" in attributes
@@ -1545,6 +1552,54 @@ def test_linux_deployment_artifacts_are_forced_to_lf_and_reject_crlf():
 
     assert "Refusing to install CRLF-formatted Linux file" in bootstrap
     assert "grep -q $'\\r$'" in bootstrap
+
+
+def test_security_alert_scheduler_units_are_committed_and_safe():
+    service_path = Path("ops/systemd/sitbank-security-alerts.service")
+    timer_path = Path("ops/systemd/sitbank-security-alerts.timer")
+    service = service_path.read_text(encoding="utf-8")
+    timer = timer_path.read_text(encoding="utf-8")
+    runtime = Path("ops/deploy/sitbank-container-runtime").read_text(encoding="utf-8")
+    bootstrap = Path("ops/deploy/bootstrap-container-ec2").read_text(encoding="utf-8")
+    docs = _project_docs_text()
+    exec_start = next(
+        line for line in service.splitlines() if line.startswith("ExecStart=")
+    )
+
+    assert "Description=SITBank security alert check" in service
+    assert "ConditionPathExists=/var/lib/sitbank-container/current" in service
+    assert "ExecStart=/usr/local/sbin/sitbank-container-runtime check-security-alerts" in service
+    assert "NoNewPrivileges=true" in service
+    assert "ProtectSystem=strict" in service
+    assert "ReadWritePaths=/run/docker.sock" in service
+    assert "OnActiveSec=5min" in timer
+    assert "OnUnitActiveSec=5min" in timer
+    assert "Unit=sitbank-security-alerts.service" in timer
+    for forbidden in (
+        "webhook",
+        "password",
+        "token",
+        "api_key",
+        "apikey",
+        "secret",
+        "https://",
+    ):
+        assert forbidden not in exec_start.casefold()
+
+    assert "check-security-alerts)" in runtime
+    assert "exec -T app python -m flask --app wsgi:app check-security-alerts" in runtime
+    assert "ops/systemd/${alert_systemd_service}" in bootstrap
+    assert "ops/systemd/${alert_systemd_timer}" in bootstrap
+    assert "systemctl enable \"${alert_systemd_timer}\"" in bootstrap
+    for required in (
+        "sudo systemctl daemon-reload",
+        "sudo systemctl enable --now sitbank-security-alerts.timer",
+        "sudo systemctl status sitbank-security-alerts.timer",
+        "journalctl -u sitbank-security-alerts.service",
+        "every 5 minutes",
+        "production bootstrap",
+    ):
+        assert required in docs
 
 
 def test_staging_nginx_enforces_https_auth_health_and_rate_limits():

--- a/tests/test_group_a_security.py
+++ b/tests/test_group_a_security.py
@@ -2520,6 +2520,120 @@ def test_security_alert_webhook_delivery_is_sanitized(monkeypatch):
     assert "secret-token" not in json.dumps(invalid_scheme, sort_keys=True)
 
 
+def test_security_alert_webhook_delivery_redacts_final_payload_fields(monkeypatch):
+    from app.security.alerts import deliver_security_alerts
+
+    captured_bodies = []
+
+    class FakeResponse:
+        status = 202
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def getcode(self):
+            return self.status
+
+    def fake_urlopen(request, timeout):
+        del timeout
+        captured_bodies.append(json.loads(request.data.decode("utf-8")))
+        return FakeResponse()
+
+    monkeypatch.setattr("app.security.alerts.urllib.request.urlopen", fake_urlopen)
+    long_token = "alerttoken" + ("A1" * 24)
+    private_key_marker = "BEGIN " + "PRIVATE KEY fake material"
+    alert = {
+        "alert_type": "manual_security_alert",
+        "severity": "critical",
+        "summary": "safe summary",
+        "generated_at": "2026-06-19T08:00:00Z",
+        "display_timestamp": "2026-06-19 16:00:00 UTC+8",
+        "correlation_id": "corr-123",
+        "public_session_ref": "public-session-ref-123",
+        "safe_user_identifier": "user:7",
+        "password": "plain-password",
+        "Authorization": "Bearer authorization-secret",
+        "cookie": "session=cookie-secret",
+        "mfa_secret": "mfa-secret",
+        "totp_secret": "totp-secret",
+        "api_key": "api-secret",
+        "private_key": private_key_marker,
+        "database_url": "postgresql://user:postgres-password@db/sitbank",
+        "redis_url": "redis://:redis-password@redis:6379/0",
+        "webhook_url": "https://hooks.example.test/services/webhook-secret",
+        "nested": {
+            "refresh_token": long_token,
+            "note": "safe nested note",
+        },
+        "list_values": [
+            {"csrf_token": "csrf-secret"},
+            "safe list note",
+        ],
+    }
+    original_alert = json.loads(json.dumps(alert, sort_keys=True))
+
+    generic = deliver_security_alerts(
+        [alert],
+        webhook_url="https://hooks.example.test/services/delivery-secret",
+    )
+    discord = deliver_security_alerts(
+        [alert],
+        webhook_url="https://discord.com/api/webhooks/123456789012345678/delivery-secret",
+    )
+
+    generic_payload = captured_bodies[0]
+    discord_payload = captured_bodies[1]
+    serialized_generic = json.dumps(generic_payload, sort_keys=True)
+    serialized_discord = json.dumps(discord_payload, sort_keys=True)
+
+    assert generic["delivered"] is True
+    assert discord["delivered"] is True
+    assert alert == original_alert
+    delivered_alert = generic_payload["alerts"][0]
+    assert delivered_alert["severity"] == "critical"
+    assert delivered_alert["summary"] == "safe summary"
+    assert delivered_alert["generated_at"] == "2026-06-19T08:00:00Z"
+    assert delivered_alert["display_timestamp"] == "2026-06-19 16:00:00 UTC+8"
+    assert delivered_alert["correlation_id"] == "corr-123"
+    assert delivered_alert["public_session_ref"] == "public-session-ref-123"
+    assert delivered_alert["safe_user_identifier"] == "user:7"
+    assert delivered_alert["password"] == "[redacted]"
+    assert delivered_alert["Authorization"] == "[redacted]"
+    assert delivered_alert["cookie"] == "[redacted]"
+    assert delivered_alert["mfa_secret"] == "[redacted]"
+    assert delivered_alert["totp_secret"] == "[redacted]"
+    assert delivered_alert["api_key"] == "[redacted]"
+    assert delivered_alert["private_key"] == "[redacted]"
+    assert delivered_alert["database_url"] == "[redacted]"
+    assert delivered_alert["redis_url"] == "[redacted]"
+    assert delivered_alert["webhook_url"] == "[redacted]"
+    assert delivered_alert["nested"]["refresh_token"] == "[redacted]"
+    assert delivered_alert["nested"]["note"] == "safe nested note"
+    assert delivered_alert["list_values"][0]["csrf_token"] == "[redacted]"
+    assert delivered_alert["list_values"][1] == "safe list note"
+    assert discord_payload["allowed_mentions"] == {"parse": []}
+    assert discord_payload["embeds"][0]["fields"][0]["name"] == "CRITICAL | manual_security_alert"
+    for forbidden in (
+        "plain-password",
+        "authorization-secret",
+        "cookie-secret",
+        "mfa-secret",
+        "totp-secret",
+        "api-secret",
+        "PRIVATE KEY fake material",
+        "postgres-password",
+        "redis-password",
+        "webhook-secret",
+        "delivery-secret",
+        long_token,
+    ):
+        assert forbidden not in serialized_generic
+        assert forbidden not in serialized_discord
+
+
 def test_security_alert_delivery_formats_discord_webhooks(monkeypatch):
     from app.security.alerts import deliver_security_alerts
 


### PR DESCRIPTION
## Summary

Add production scheduling for `check-security-alerts` and harden outbound webhook payload sanitization.

## Why

Security alert evaluation existed, but it only ran when manually invoked. Generic webhook delivery also serialized caller-provided alert dictionaries too directly, creating a risk that sensitive fields could be sent outside the system if future callers passed unsafe alert data.

## What changed

* Added `sitbank-security-alerts.service` and `sitbank-security-alerts.timer`.
* Updated the container runtime wrapper to run `check-security-alerts` inside the deployed app container.
* Updated production bootstrap to install and enable the alert timer units.
* Added final outbound alert payload sanitization for generic and Discord webhooks.
* Added tests for scheduler units, timer cadence, safe `ExecStart`, bootstrap installation, and final payload redaction.
* Updated security, operations, and deployment docs.

## Security impact

Improves monitoring reliability by running security alert checks every 5 minutes in production. Reduces secret-leak risk by sanitizing outbound webhook payloads immediately before JSON serialization. No secrets are added, and webhook URLs remain stored as root-managed secret files.

## Deployment impact

This PR requires:

* EC2 bootstrap: Yes, because new systemd units and the runtime wrapper are host-managed files
* staging deployment: Yes, for app/runtime changes
* production deployment: Yes, for app/runtime changes
* database migration: No
* secret changes: No
* no deployment action: No

After bootstrap, verify or enable the timer:

```bash
sudo systemctl daemon-reload
sudo systemctl enable --now sitbank-security-alerts.timer
sudo systemctl status sitbank-security-alerts.timer
journalctl -u sitbank-security-alerts.service