### PR TITLE
Harden audit metadata sanitization

### DIFF
--- a/app/security/audit.py
+++ b/app/security/audit.py
@@ -23,6 +23,8 @@ except ImportError:  # pragma: no cover - dependency is required in production.
 
 
 SENSITIVE_KEY_PARTS = (
+    "api_key",
+    "apikey",
     "authorization",
     "bearer",
     "challenge",
@@ -33,6 +35,7 @@ SENSITIVE_KEY_PARTS = (
     "iban",
     "mfa_secret",
     "nonce",
+    "passwd",
     "password",
     "private_key",
     "public_key",
@@ -48,12 +51,31 @@ SENSITIVE_KEY_PARTS = (
     "url",
 )
 
+SENSITIVE_EXACT_KEYS = (
+    "credential",
+    "sid",
+)
+
 ACCOUNT_KEY_PARTS = (
     "account_number",
     "account_no",
     "payee_account",
     "pan",
 )
+
+SENSITIVE_CREDENTIAL_URL_RE = re.compile(
+    r"\b(?:postgres(?:ql)?|redis)://[^\s/@]*:[^\s/@]*@",
+    re.IGNORECASE,
+)
+SENSITIVE_WEBHOOK_URL_RE = re.compile(
+    r"https://(?:[^/\s]*hooks[^/\s]*|(?:discord(?:app)?\.com))/(?:api/)?(?:webhooks|services)/\S+",
+    re.IGNORECASE,
+)
+SENSITIVE_PRIVATE_KEY_RE = re.compile(
+    r"BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY",
+    re.IGNORECASE,
+)
+SENSITIVE_LONG_TOKEN_RE = re.compile(r"(?=.*[A-Za-z])(?=.*\d)[A-Za-z0-9_+/=-]{48,}")
 
 AUDIT_HASH_ALGORITHM = "sha256-v1"
 AUDIT_CHAIN_START_HASH = "0" * 64
@@ -329,7 +351,7 @@ def _sanitize_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
 def _sanitize_metadata_value(value: Any, key_lower: str, *, depth: int) -> Any:
     if isinstance(value, bool | int | float) or value is None:
         return value
-    if depth < 2 and isinstance(value, Mapping):
+    if depth < 4 and isinstance(value, Mapping):
         nested: dict[str, Any] = {}
         for nested_key, nested_value in list(value.items())[:20]:
             nested_key_text = _clean_audit_text(nested_key, 64)
@@ -340,7 +362,7 @@ def _sanitize_metadata_value(value: Any, key_lower: str, *, depth: int) -> Any:
                 else _sanitize_metadata_value(nested_value, nested_key_lower, depth=depth + 1)
             )
         return nested
-    if depth < 2 and isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+    if depth < 4 and isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
         return [_sanitize_metadata_value(item, key_lower, depth=depth + 1) for item in list(value)[:20]]
 
     text = _clean_audit_text(value, 256)
@@ -358,12 +380,23 @@ def _clean_audit_text(value: Any, limit: int) -> str:
 def _is_sensitive_key(key_lower: str) -> bool:
     if key_lower.endswith("_ref") or key_lower in {"principal_ref", "session_ref"}:
         return False
-    return any(part in key_lower for part in SENSITIVE_KEY_PARTS)
+    normalized_key = key_lower.replace("-", "_")
+    if normalized_key in SENSITIVE_EXACT_KEYS:
+        return True
+    return any(part in normalized_key for part in SENSITIVE_KEY_PARTS)
 
 
 def _looks_like_sensitive_value(text: str) -> bool:
     lowered = text.casefold()
-    return lowered.startswith(("bearer ", "basic ", "token "))
+    if lowered.startswith(("bearer ", "basic ", "token ")):
+        return True
+    if SENSITIVE_CREDENTIAL_URL_RE.search(text):
+        return True
+    if SENSITIVE_WEBHOOK_URL_RE.search(text):
+        return True
+    if SENSITIVE_PRIVATE_KEY_RE.search(text):
+        return True
+    return bool(SENSITIVE_LONG_TOKEN_RE.fullmatch(text.strip()))
 
 
 def _looks_like_account_value(key_lower: str, text: str) -> bool:

--- a/tests/test_audit_metadata_sanitization.py
+++ b/tests/test_audit_metadata_sanitization.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import copy
+import json
+
+from app.models import SecurityAuditEvent
+from app.security.audit import _sanitize_metadata
+
+
+SENSITIVE_KEY_NAMES = (
+    "password",
+    "passwd",
+    "new_password",
+    "old_password",
+    "token",
+    "access_token",
+    "refresh_token",
+    "csrf",
+    "csrf_token",
+    "secret",
+    "mfa_secret",
+    "totp_secret",
+    "totp",
+    "challenge",
+    "credential",
+    "ciphertext",
+    "cookie",
+    "set_cookie",
+    "set-cookie",
+    "authorization",
+    "bearer",
+    "api_key",
+    "apikey",
+    "private_key",
+    "webhook_url",
+    "discord_webhook_url",
+    "slack_webhook_url",
+    "database_url",
+    "postgres_url",
+    "postgresql_url",
+    "redis_url",
+    "session_id",
+    "sid",
+    "redis_payload",
+)
+
+
+def test_audit_metadata_sensitive_top_level_keys_are_redacted():
+    metadata = {
+        key: f"raw-{key}-secret"
+        for key in SENSITIVE_KEY_NAMES
+    }
+
+    sanitized = _sanitize_metadata(metadata)
+
+    assert set(sanitized) == set(SENSITIVE_KEY_NAMES)
+    assert all(value == "[redacted]" for value in sanitized.values())
+    assert "raw-" not in json.dumps(sanitized, sort_keys=True)
+
+
+def test_audit_metadata_sanitizes_nested_dicts_and_lists_without_mutating_input():
+    private_key_marker = "BEGIN " + "PRIVATE KEY fake material"
+    metadata = {
+        "safe": "visible",
+        "nested": {
+            "password": "nested-password",
+            "reason": "safe nested reason",
+            "items": [
+                {"token": "nested-token"},
+                {"reason": "Bearer nested-bearer-token"},
+                "safe list value",
+            ],
+        },
+        "events": [
+            {"cookie": "session=cookie-secret"},
+            {"reason": private_key_marker},
+            {"public_session_ref": "public-session-ref-123"},
+        ],
+    }
+    original = copy.deepcopy(metadata)
+
+    first = _sanitize_metadata(metadata)
+    second = _sanitize_metadata(metadata)
+    serialized = json.dumps(first, sort_keys=True)
+
+    assert metadata == original
+    assert first == second
+    assert first["safe"] == "visible"
+    assert first["nested"]["password"] == "[redacted]"
+    assert first["nested"]["reason"] == "safe nested reason"
+    assert first["nested"]["items"][0]["token"] == "[redacted]"
+    assert first["nested"]["items"][1]["reason"] == "[redacted]"
+    assert first["nested"]["items"][2] == "safe list value"
+    assert first["events"][0]["cookie"] == "[redacted]"
+    assert first["events"][1]["reason"] == "[redacted]"
+    assert first["events"][2]["public_session_ref"] == "public-session-ref-123"
+    for forbidden in (
+        "nested-password",
+        "nested-token",
+        "nested-bearer-token",
+        "cookie-secret",
+        "PRIVATE KEY fake material",
+    ):
+        assert forbidden not in serialized
+
+
+def test_audit_metadata_value_based_redaction_patterns():
+    private_key_marker = "BEGIN " + "PRIVATE KEY fake material"
+    rsa_private_key_marker = "BEGIN " + "RSA PRIVATE KEY fake material"
+    long_token = "auditToken" + ("A1" * 24)
+    metadata = {
+        "bearer_value": "Bearer bearer-secret",
+        "basic_value": "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==",
+        "postgres_value": "postgresql://user:postgres-password@db/sitbank",
+        "redis_value": "redis://:redis-password@redis:6379/0",
+        "private_key_value": private_key_marker,
+        "rsa_private_key_value": rsa_private_key_marker,
+        "webhook_value": "https://hooks.example.test/services/webhook-secret",
+        "discord_webhook_value": "https://discord.com/api/webhooks/1234567890/webhook-secret",
+        "long_token_value": long_token,
+        "control_text": "line-one\nline-two\r\x00line-three",
+    }
+
+    sanitized = _sanitize_metadata(metadata)
+    serialized = json.dumps(sanitized, sort_keys=True)
+
+    for key in (
+        "bearer_value",
+        "basic_value",
+        "postgres_value",
+        "redis_value",
+        "private_key_value",
+        "rsa_private_key_value",
+        "webhook_value",
+        "discord_webhook_value",
+        "long_token_value",
+    ):
+        assert sanitized[key] == "[redacted]"
+    assert sanitized["control_text"] == "line-one line-two line-three"
+    for forbidden in (
+        "bearer-secret",
+        "QWxhZGRpbjpvcGVuIHNlc2FtZQ==",
+        "postgres-password",
+        "redis-password",
+        "PRIVATE KEY fake material",
+        "webhook-secret",
+        long_token,
+        "\n",
+        "\r",
+        "\x00",
+    ):
+        assert forbidden not in serialized
+
+
+def test_audit_metadata_safe_fields_remain_useful_when_harmless():
+    metadata = {
+        "event_type": "login",
+        "outcome": "success",
+        "correlation_id": "corr-123",
+        "session_ref": "session-ref-123",
+        "public_session_ref": "public-session-ref-123",
+        "user_id": 42,
+        "ip_address": "203.0.113.10",
+        "user_agent": "Mozilla/5.0 Test",
+        "reason": "normal login",
+        "credential_device_type": "single_device",
+    }
+
+    assert _sanitize_metadata(metadata) == metadata
+
+
+def test_audit_metadata_safe_field_names_redact_sensitive_values_only():
+    metadata = {
+        "reason": "redis://:redis-password@redis:6379/0",
+        "user_agent": "Bearer user-agent-token",
+        "correlation_id": "corr-123",
+        "session_ref": "session-ref-123",
+        "public_session_ref": "public-session-ref-123",
+    }
+
+    sanitized = _sanitize_metadata(metadata)
+
+    assert sanitized["reason"] == "[redacted]"
+    assert sanitized["user_agent"] == "[redacted]"
+    assert sanitized["correlation_id"] == "corr-123"
+    assert sanitized["session_ref"] == "session-ref-123"
+    assert sanitized["public_session_ref"] == "public-session-ref-123"
+
+
+def test_audit_event_storage_and_logs_do_not_leak_sensitive_metadata(app, caplog):
+    from app.security.audit import audit_event
+
+    raw_values = (
+        "plain-password",
+        "postgres-password",
+        "redis-password",
+        "webhook-secret",
+        "Bearer bearer-secret",
+    )
+    caplog.set_level("INFO", logger=app.logger.name)
+
+    with app.test_request_context("/audit/sanitize", method="POST"):
+        audit_event(
+            "audit_metadata_sanitization",
+            "success",
+            metadata={
+                "reason": "postgresql://user:postgres-password@db/sitbank",
+                "nested": {
+                    "password": "plain-password",
+                    "redis": "redis://:redis-password@redis:6379/0",
+                },
+                "events": [
+                    "https://hooks.example.test/services/webhook-secret",
+                    "Bearer bearer-secret",
+                ],
+            },
+        )
+
+    event = (
+        app.extensions["sqlalchemy"]
+        .session.query(SecurityAuditEvent)
+        .filter_by(event_type="audit_metadata_sanitization")
+        .one()
+    )
+    serialized_event = json.dumps(event.event_metadata, sort_keys=True)
+    serialized_logs = "\n".join(record.getMessage() for record in caplog.records)
+
+    assert event.event_metadata["reason"] == "[redacted]"
+    assert event.event_metadata["nested"]["password"] == "[redacted]"
+    assert event.event_metadata["nested"]["redis"] == "[redacted]"
+    assert event.event_metadata["events"] == ["[redacted]", "[redacted]"]
+    for forbidden in raw_values:
+        assert forbidden not in serialized_event
+        assert forbidden not in serialized_logs


### PR DESCRIPTION
## Summary

Strengthens audit metadata sanitization so sensitive keys and secret-like values are redacted before being stored or emitted in structured audit logs.

## Why

Audit metadata could miss some sensitive aliases and value patterns, including `passwd`, exact `credential`/`sid` fields, credential-bearing Postgres/Redis URLs, webhook URLs, private-key markers, long token-like strings, and deeper nested list/dict structures.

## What changed

* Expanded audit metadata sensitive-key detection.
* Added value-pattern redaction for credential URLs, webhook URLs, private-key markers, and long token-like values.
* Preserved safe metadata such as `session_ref`, `public_session_ref`, `correlation_id`, and `credential_device_type`.
* Added regression tests for top-level keys, nested metadata, value-based redaction, safe-field preservation, and end-to-end audit storage/log output.

## Security impact

Improves defense against accidental secret leakage in durable `SecurityAuditEvent.event_metadata` records and structured application logs. This does not change authentication, authorization, permissions, secrets, or CI/CD credentials.

## Deployment impact

This PR requires:

* EC2 bootstrap: no
* staging deployment: yes, to apply runtime sanitizer behavior
* production deployment: yes, after staging verification
* database migration: no
* secret changes: no
* no deployment action: no

## Verification

* `python -m compileall app tests`
* `python -m pytest -q tests/test_audit_metadata_sanitization.py`
* `python -m pytest -q tests/test_group_a_security.py::test_audit_metadata_strips_control_characters_and_redacts_secrets tests/test_group_a_security.py::test_structured_audit_log_output_is_sanitized tests/test_group_a_security.py::test_audit_write_failure_warning_is_sanitized tests/test_group_a_security.py::test_security_alert_evaluator_cli_and_output_are_sanitized tests/test_webauthn_lifecycle.py::test_registration_rejects_unknown_mds_aaguid`
* `.venv\Scripts\python.exe -m pytest -q -n auto --durations=30 --durations-min=0.5`
* `.venv\Scripts\python.exe scripts\ci-local`

## Notes

Local CI passed. Docker/Compose-only checks were skipped because Docker is unavailable on the local machine.