### PR TITLE
Wire SMTP secrets into admin containers

### DIFF
--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -139,6 +139,8 @@ services:
       ADMIN_REDIS_URL_FILE: /run/secrets/admin_redis_url
       ADMIN_PASSWORD_PEPPER_B64_FILE: /run/secrets/admin_password_pepper_b64
       SECURITY_ALERT_WEBHOOK_URL_FILE: /run/secrets/security_alert_webhook_url
+      SMTP_USERNAME_FILE: /run/secrets/smtp_username
+      SMTP_PASSWORD_FILE: /run/secrets/smtp_password
     secrets:
       - source: admin_secret_key
         target: admin_secret_key
@@ -154,6 +156,10 @@ services:
         target: admin_password_pepper_b64
       - source: security_alert_webhook_url
         target: security_alert_webhook_url
+      - source: smtp_username
+        target: smtp_username
+      - source: smtp_password
+        target: smtp_password
     volumes:
       - type: bind
         source: /etc/sitbank/common-passwords.txt

--- a/compose.staging.yml
+++ b/compose.staging.yml
@@ -231,6 +231,8 @@ services:
       ADMIN_REDIS_URL_FILE: /run/secrets/admin_redis_url
       ADMIN_PASSWORD_PEPPER_B64_FILE: /run/secrets/admin_password_pepper_b64
       SECURITY_ALERT_WEBHOOK_URL_FILE: /run/secrets/security_alert_webhook_url
+      SMTP_USERNAME_FILE: /run/secrets/smtp_username
+      SMTP_PASSWORD_FILE: /run/secrets/smtp_password
     secrets:
       - source: admin_secret_key
         target: admin_secret_key
@@ -246,6 +248,10 @@ services:
         target: admin_password_pepper_b64
       - source: security_alert_webhook_url
         target: security_alert_webhook_url
+      - source: smtp_username
+        target: smtp_username
+      - source: smtp_password
+        target: smtp_password
     volumes:
       - type: bind
         source: /etc/sitbank-staging/common-passwords.txt

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -509,10 +509,14 @@ def test_compose_secret_mounts_match_runtime_contract():
     expected_admin_environment = {
         **ADMIN_SECRET_FILE_ENVIRONMENT,
         "SECURITY_ALERT_WEBHOOK_URL_FILE": "/run/secrets/security_alert_webhook_url",
+        "SMTP_USERNAME_FILE": "/run/secrets/smtp_username",
+        "SMTP_PASSWORD_FILE": "/run/secrets/smtp_password",
     }
     expected_admin_secrets = {
         **{name: name for name in ADMIN_SECRET_FILES},
         "security_alert_webhook_url": "security_alert_webhook_url",
+        "smtp_username": "smtp_username",
+        "smtp_password": "smtp_password",
     }
     for path, secret_root, base_extra_secrets in (
         (
@@ -837,6 +841,11 @@ def test_dockerfile_and_compose_enforce_hardened_runtime():
     assert "DATABASE_MIGRATION_URL_FILE" not in admin["environment"]
     assert "ADMIN_DATABASE_URL_FILE" in admin["environment"]
     assert "ADMIN_REDIS_URL_FILE" in admin["environment"]
+    for smtp_env in ("SMTP_USERNAME_FILE", "SMTP_PASSWORD_FILE"):
+        assert admin["environment"][smtp_env] == app["environment"][smtp_env]
+    admin_secret_targets = _service_secret_targets(admin)
+    assert admin_secret_targets["smtp_username"] == "smtp_username"
+    assert admin_secret_targets["smtp_password"] == "smtp_password"
     assert "/app/redis_compatibility_check.py:ro" in smoke_test
     assert "python /app/redis_compatibility_check.py" in smoke_test
     assert "ci_owner" in smoke_test
@@ -946,12 +955,17 @@ def test_dockerfile_and_compose_enforce_hardened_runtime():
     assert "no-new-privileges:true" in staging_admin["security_opt"]
     assert staging_admin["env_file"] == ["/etc/sitbank-staging/container.env"]
     assert "DATABASE_MIGRATION_URL_FILE" not in staging_admin["environment"]
+    for smtp_env in ("SMTP_USERNAME_FILE", "SMTP_PASSWORD_FILE"):
+        assert staging_admin["environment"][smtp_env] == staging_app["environment"][smtp_env]
     assert (
         staging_admin["command"][staging_admin["command"].index("--bind") + 1]
         == "0.0.0.0:5000"
     )
     assert staging_admin["command"][-1] == "admin_wsgi:app"
     assert all(set(secret) == {"source", "target"} for secret in staging_admin["secrets"])
+    staging_admin_secret_targets = _service_secret_targets(staging_admin)
+    assert staging_admin_secret_targets["smtp_username"] == "smtp_username"
+    assert staging_admin_secret_targets["smtp_password"] == "smtp_password"
     assert staging_volume_by_target["/run/state"]["source"] == (
         "/var/lib/sitbank-staging-container/security-alert-state"
     )


### PR DESCRIPTION
## Summary

Fixes staging admin container startup by wiring SMTP secret-file configuration into the staging admin service, matching the customer app service configuration.

## Why

The staging admin container requires the same SMTP secret-file configuration pattern as the customer app service. Without these secret-file environment settings, the admin container can fail startup or readiness checks when mail-related configuration is loaded.

This change keeps the staging admin service aligned with the existing staging customer app runtime configuration.

## What changed

* Added SMTP secret-file configuration to the staging admin service.
* Aligned the admin service SMTP runtime configuration with the customer app service.
* Fixed the staging admin startup issue caused by missing SMTP secret-file wiring.

## Security impact

This preserves the secret-file based configuration model instead of placing SMTP secrets directly in environment variables.

The change improves staging runtime parity while avoiding new plaintext secret exposure. It does not weaken authentication, authorization, database permissions, session security, or production deployment gating.

## Deployment impact

This PR requires:

* EC2 bootstrap: Yes, if the staging service configuration is bootstrap-managed.
* Staging deployment: Yes.
* Production deployment: No.
* Database migration: No.
* Secret changes: No, assuming the required SMTP secret files already exist.
* No deployment action: No.

## Verification

* Confirmed the staging admin service now includes SMTP secret-file configuration.
* Confirmed the admin service matches the customer app service SMTP configuration pattern.
* Confirmed this addresses the staging admin container startup issue caused by missing SMTP secret-file wiring.

## Notes

After merging, rerun the trusted staging bootstrap if the changed staging service configuration is managed by EC2 bootstrap. Then redeploy staging and confirm the admin container starts successfully.
