### PR TITLE
Fix staging admin readiness database provisioning

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -43,6 +43,7 @@ def health_ready():
         db.session.execute(text("SELECT 1"))
         current_app.extensions["redis"].ping()
     except Exception:
+        current_app.logger.warning("Admin readiness dependency check failed", exc_info=True)
         db.session.rollback()
         return jsonify({"status": "unavailable", "app_mode": "admin"}), 503
     return jsonify({"status": "ready", "app_mode": "admin"})

--- a/app/ops/commands.py
+++ b/app/ops/commands.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import urlparse
@@ -27,7 +28,11 @@ from app.security.crypto import (
 from app.security.fido_mds import validate_fido_metadata_config
 from app.security.passwords import validate_common_password_dictionary, validate_password_hash_config
 from app.security.session_hmac import validate_session_hmac_config
-from app.ops.db_privileges import apply_runtime_audit_table_privileges, verify_runtime_database_privileges
+from app.ops.db_privileges import (
+    apply_admin_runtime_database_privileges,
+    apply_runtime_audit_table_privileges,
+    verify_runtime_database_privileges,
+)
 
 
 def register_ops_commands(app: Flask) -> None:
@@ -232,6 +237,31 @@ def register_ops_commands(app: Flask) -> None:
             "audit_update_delete_truncate=revoked"
         )
 
+    @app.cli.command("apply-admin-runtime-db-privileges")
+    def apply_admin_runtime_db_privileges() -> None:
+        """Create/update the admin runtime role and grant fail-closed DB access."""
+        migration_url = str(app.config.get("SQLALCHEMY_MIGRATION_DATABASE_URI") or "")
+        try:
+            result = apply_admin_runtime_database_privileges(
+                admin_url=_env_or_file("ADMIN_DATABASE_URL"),
+                migration_url=migration_url,
+            )
+        except Exception as exc:
+            _deliver_ops_failure_alert(
+                "admin_runtime_db_privilege_application_failed",
+                "apply-admin-runtime-db-privileges",
+                exc,
+            )
+            raise click.ClickException(str(exc)) from exc
+
+        click.echo(
+            "Admin runtime database privilege application passed: "
+            f"admin_role={result.admin_role} "
+            f"migration_role={result.migration_role} "
+            f"database={result.database} "
+            f"schema={result.schema}"
+        )
+
     @app.cli.command("verify-audit-log-chain")
     @click.option(
         "--anchor",
@@ -406,6 +436,18 @@ def _load_audit_anchor(anchor_path: Path) -> dict:
     if not isinstance(anchor, dict):
         raise click.ClickException("Audit anchor must be a JSON object")
     return anchor
+
+
+def _env_or_file(name: str) -> str:
+    value = os.getenv(name)
+    file_path = os.getenv(f"{name}_FILE")
+    if value and file_path:
+        raise click.ClickException(f"{name} and {name}_FILE must not both be configured")
+    if file_path:
+        return Path(file_path).read_text(encoding="utf-8").strip()
+    if value:
+        return value
+    raise click.ClickException(f"{name} or {name}_FILE is required")
 
 
 def _audit_chain_failure_alert(result: dict) -> dict:

--- a/app/ops/db_privileges.py
+++ b/app/ops/db_privileges.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from collections.abc import Mapping, Sequence
 
 from sqlalchemy import Column, DateTime, Integer, JSON, MetaData, String, Table, bindparam, create_engine, select, text
-from sqlalchemy.engine import Engine
+from sqlalchemy.engine import Engine, make_url
 from sqlalchemy.exc import DBAPIError
 
 
@@ -33,6 +33,120 @@ class AuditPrivilegeApplication:
     runtime_role: str
     migration_role: str
     audit_table: str
+
+
+@dataclass(frozen=True)
+class AdminRuntimePrivilegeApplication:
+    admin_role: str
+    migration_role: str
+    database: str
+    schema: str
+
+
+def apply_admin_runtime_database_privileges(
+    *,
+    admin_url: str,
+    migration_url: str,
+    schema: str = "public",
+) -> AdminRuntimePrivilegeApplication:
+    if not admin_url:
+        raise RuntimeError("ADMIN_DATABASE_URL is required for admin privilege application")
+    if not migration_url:
+        raise RuntimeError("DATABASE_MIGRATION_URL is required for admin privilege application")
+    if admin_url == migration_url:
+        raise RuntimeError("ADMIN_DATABASE_URL and DATABASE_MIGRATION_URL must use different roles")
+    if not _is_identifier(schema):
+        raise RuntimeError("Schema name is not a safe PostgreSQL identifier")
+
+    admin_config = make_url(admin_url)
+    migration_config = make_url(migration_url)
+    admin_role = str(admin_config.username or "")
+    admin_password = str(admin_config.password or "")
+    migration_config_role = str(migration_config.username or "")
+    database = str(admin_config.database or "")
+    if not _is_identifier(admin_role):
+        raise RuntimeError("ADMIN_DATABASE_URL username must be a safe PostgreSQL role")
+    if not admin_password:
+        raise RuntimeError("ADMIN_DATABASE_URL must include a password")
+    if admin_role == migration_config_role:
+        raise RuntimeError("Admin runtime and migration connections must use different roles")
+    if not _is_identifier(database):
+        raise RuntimeError("ADMIN_DATABASE_URL database name is not a safe PostgreSQL identifier")
+    if database != str(migration_config.database or ""):
+        raise RuntimeError("ADMIN_DATABASE_URL must target the migration database")
+
+    migration_engine = create_engine(migration_url)
+    try:
+        with migration_engine.begin() as connection:
+            migration_role = str(connection.execute(text("SELECT current_user")).scalar_one())
+            if admin_role == migration_role:
+                raise RuntimeError("Admin runtime and migration connections are using the same role")
+            current_database = str(connection.execute(text("SELECT current_database()")).scalar_one())
+            if current_database != database:
+                raise RuntimeError("Migration connection is not using the admin runtime database")
+
+            quoted_admin_role = _quote_identifier(admin_role)
+            quoted_migration_role = _quote_identifier(migration_role)
+            quoted_database = _quote_identifier(database)
+            qualified_schema = _quote_identifier(schema)
+            role_exists = bool(
+                connection.execute(
+                    text("SELECT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = :role)"),
+                    {"role": admin_role},
+                ).scalar_one()
+            )
+            if role_exists:
+                connection.execute(
+                    text(f"ALTER ROLE {quoted_admin_role} LOGIN PASSWORD :password"),
+                    {"password": admin_password},
+                )
+            else:
+                connection.execute(
+                    text(f"CREATE ROLE {quoted_admin_role} LOGIN PASSWORD :password"),
+                    {"password": admin_password},
+                )
+
+            connection.execute(
+                text(f"GRANT CONNECT ON DATABASE {quoted_database} TO {quoted_admin_role}")
+            )
+            connection.execute(
+                text(f"GRANT USAGE ON SCHEMA {qualified_schema} TO {quoted_admin_role}")
+            )
+            connection.execute(
+                text(
+                    f"GRANT SELECT, INSERT ON ALL TABLES IN SCHEMA {qualified_schema} "
+                    f"TO {quoted_admin_role}"
+                )
+            )
+            connection.execute(
+                text(
+                    f"GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA {qualified_schema} "
+                    f"TO {quoted_admin_role}"
+                )
+            )
+            connection.execute(
+                text(
+                    f"ALTER DEFAULT PRIVILEGES FOR ROLE {quoted_migration_role} "
+                    f"IN SCHEMA {qualified_schema} GRANT SELECT, INSERT ON TABLES "
+                    f"TO {quoted_admin_role}"
+                )
+            )
+            connection.execute(
+                text(
+                    f"ALTER DEFAULT PRIVILEGES FOR ROLE {quoted_migration_role} "
+                    f"IN SCHEMA {qualified_schema} GRANT USAGE, SELECT ON SEQUENCES "
+                    f"TO {quoted_admin_role}"
+                )
+            )
+    finally:
+        migration_engine.dispose()
+
+    return AdminRuntimePrivilegeApplication(
+        admin_role=admin_role,
+        migration_role=migration_role,
+        database=database,
+        schema=schema,
+    )
 
 
 def apply_runtime_audit_table_privileges(

--- a/ops/deploy/sitbank-container-deploy
+++ b/ops/deploy/sitbank-container-deploy
@@ -364,6 +364,18 @@ migration_run() {
         app "$@"
 }
 
+apply_staging_admin_runtime_db_privileges() {
+    if [[ "${target}" != "staging" ]]; then
+        return
+    fi
+    compose "${image}" run --rm --no-deps \
+        --env DATABASE_MIGRATION_URL_FILE=/run/secrets/database_migration_url \
+        --env ADMIN_DATABASE_URL_FILE=/run/secrets/admin_database_url \
+        --volume "${SECRET_DIR}/database_migration_url:/run/secrets/database_migration_url:ro" \
+        --volume "${SECRET_DIR}/admin_database_url:/run/secrets/admin_database_url:ro" \
+        app python -m flask --app wsgi:app apply-admin-runtime-db-privileges
+}
+
 validate_staging_isolation() {
     local secret_file
     local production_secret
@@ -379,6 +391,12 @@ validate_staging_isolation() {
         redis_url \
         mfa_kek_keys_json \
         password_pepper_b64 \
+        admin_secret_key \
+        admin_wtf_csrf_secret_key \
+        admin_session_hmac_keys_json \
+        admin_database_url \
+        admin_redis_url \
+        admin_password_pepper_b64 \
         smtp_username \
         smtp_password; do
         production_secret="/etc/sitbank/secrets/${secret_file}"
@@ -395,7 +413,9 @@ validate_staging_isolation() {
         "${SECRET_DIR}/postgres_app_password" \
         "${SECRET_DIR}/postgres_owner_password" \
         "${SECRET_DIR}/redis_url" \
-        "${SECRET_DIR}/redis.conf" <<'PY'
+        "${SECRET_DIR}/redis.conf" \
+        "${SECRET_DIR}/admin_database_url" \
+        "${SECRET_DIR}/admin_redis_url" <<'PY'
 from pathlib import Path
 from urllib.parse import unquote, urlsplit
 import sys
@@ -406,6 +426,8 @@ postgres_app_password = Path(sys.argv[3]).read_text(encoding="utf-8")
 postgres_owner_password = Path(sys.argv[4]).read_text(encoding="utf-8")
 redis_url = Path(sys.argv[5]).read_text(encoding="utf-8")
 redis_config = Path(sys.argv[6]).read_text(encoding="utf-8")
+admin_database_url = Path(sys.argv[7]).read_text(encoding="utf-8")
+admin_redis_url = Path(sys.argv[8]).read_text(encoding="utf-8")
 
 database = urlsplit(database_url)
 if (
@@ -431,6 +453,19 @@ if (
 if database_url == migration_url:
     raise SystemExit("Staging runtime and migration database URLs must be different")
 
+admin_database = urlsplit(admin_database_url)
+if (
+    admin_database.scheme != "postgresql+psycopg2"
+    or admin_database.hostname != "postgres"
+    or admin_database.port != 5432
+    or unquote(admin_database.username or "") != "sitbank_admin"
+    or admin_database.path != "/sitbank_staging"
+    or not unquote(admin_database.password or "")
+):
+    raise SystemExit("Staging admin runtime database URL must use only the staging admin role")
+if admin_database_url in {database_url, migration_url}:
+    raise SystemExit("Staging admin runtime database URL must be distinct from app and migration URLs")
+
 redis = urlsplit(redis_url)
 if (
     redis.scheme != "redis"
@@ -440,6 +475,15 @@ if (
 ):
     raise SystemExit("Staging Redis URL must target only the staging Redis service")
 
+admin_redis = urlsplit(admin_redis_url)
+if (
+    admin_redis.scheme != "redis"
+    or admin_redis.hostname != "redis"
+    or admin_redis.port != 6379
+    or admin_redis.path != "/14"
+):
+    raise SystemExit("Staging admin Redis URL must target only isolated staging admin Redis DB 14")
+
 password_lines = [
     line.split(None, 1)[1]
     for line in redis_config.splitlines()
@@ -448,6 +492,10 @@ password_lines = [
 ]
 if len(password_lines) != 1 or unquote(redis.password or "") != password_lines[0]:
     raise SystemExit("Staging Redis URL and protected Redis configuration do not match")
+if unquote(admin_redis.password or "") != password_lines[0]:
+    raise SystemExit("Staging admin Redis URL and protected Redis configuration do not match")
+if admin_redis.path == redis.path:
+    raise SystemExit("Staging admin Redis URL must use an isolated Redis logical database")
 PY
 }
 
@@ -636,7 +684,17 @@ required_secrets=(
     smtp_password
 )
 if [[ "${target}" == "staging" ]]; then
-    required_secrets+=(postgres_owner_password postgres_app_password redis.conf)
+    required_secrets+=(
+        postgres_owner_password
+        postgres_app_password
+        redis.conf
+        admin_secret_key
+        admin_wtf_csrf_secret_key
+        admin_session_hmac_keys_json
+        admin_database_url
+        admin_redis_url
+        admin_password_pepper_b64
+    )
 elif [[ "${target}" == "production" ]]; then
     required_secrets+=(
         admin_secret_key
@@ -686,8 +744,13 @@ migration_run \
     python -m flask --app wsgi:app db upgrade
 migration_run \
     python -m flask --app wsgi:app apply-runtime-db-privileges
+apply_staging_admin_runtime_db_privileges
 migration_run \
     python -m flask --app wsgi:app verify-runtime-db-privileges
+if [[ "${target}" == "staging" ]]; then
+    compose "${image}" run --rm --no-deps admin \
+        python -m flask --app admin_wsgi:app production-check
+fi
 
 if [[ -n "${previous_image}" ]]; then
     compose "${image}" down --remove-orphans

--- a/tests/test_admin_isolation.py
+++ b/tests/test_admin_isolation.py
@@ -84,6 +84,32 @@ def test_app_factory_reenables_shared_application_logger(monkeypatch):
         logger.disabled = False
 
 
+def test_admin_health_reports_liveness_and_dependency_readiness(monkeypatch):
+    _install_fake_redis(monkeypatch)
+    from app import create_app
+
+    admin_app = create_app(TestConfig, app_mode="admin")
+    client = admin_app.test_client()
+
+    live = client.get("/health/live")
+    ready = client.get("/health/ready")
+
+    assert live.status_code == 200
+    assert live.get_json() == {"status": "ok", "app_mode": "admin"}
+    assert ready.status_code == 200
+    assert ready.get_json() == {"status": "ready", "app_mode": "admin"}
+
+    monkeypatch.setattr(
+        admin_app.extensions["redis"],
+        "ping",
+        lambda: (_ for _ in ()).throw(ConnectionError("offline")),
+    )
+    unavailable = client.get("/health/ready")
+
+    assert unavailable.status_code == 503
+    assert unavailable.get_json() == {"status": "unavailable", "app_mode": "admin"}
+
+
 def test_admin_runtime_config_is_separate_and_stricter(monkeypatch):
     _install_fake_redis(monkeypatch)
     from app import create_app

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -287,6 +287,12 @@ def test_runtime_privilege_verifier_quotes_create_probe_table_name():
     ):
         assert privilege_probe in source
     assert "apply_runtime_audit_table_privileges" in source
+    assert "apply_admin_runtime_database_privileges" in source
+    assert "ADMIN_DATABASE_URL is required for admin privilege application" in source
+    assert "CREATE ROLE" in source
+    assert "ALTER ROLE" in source
+    assert "GRANT SELECT, INSERT ON ALL TABLES" in source
+    assert "ALTER DEFAULT PRIVILEGES FOR ROLE" in source
     assert "REVOKE UPDATE, DELETE, TRUNCATE ON TABLE" in source
     assert "GRANT SELECT, INSERT ON TABLE" in source
     assert "previous_event_hash" in source
@@ -1025,11 +1031,19 @@ def test_dockerfile_and_compose_enforce_hardened_runtime():
     assert "Staging migration database URL must use only the staging owner role" in deploy_script
     assert "Staging runtime and migration database URLs must be different" in deploy_script
     assert "Staging database URL must target only the staging PostgreSQL service" not in deploy_script
+    assert "Staging admin runtime database URL must use only the staging admin role" in deploy_script
+    assert "Staging admin runtime database URL must be distinct from app and migration URLs" in deploy_script
+    assert "Staging admin Redis URL must target only isolated staging admin Redis DB 14" in deploy_script
     assert 'unquote(database.username or "") != "sitbank_app"' in deploy_script
     assert 'unquote(migration.username or "") != "sitbank_owner"' in deploy_script
+    assert 'unquote(admin_database.username or "") != "sitbank_admin"' in deploy_script
     assert "postgres_app_password" in deploy_script
     assert "postgres_owner_password" in deploy_script
+    assert "admin_database_url" in deploy_script
+    assert "admin_redis_url" in deploy_script
     assert "apply-runtime-db-privileges" in deploy_script
+    assert "apply-admin-runtime-db-privileges" in deploy_script
+    assert "apply_staging_admin_runtime_db_privileges" in deploy_script
     assert "verify-runtime-db-privileges" in deploy_script
     assert "validate_production_admin_isolation" in deploy_script
     assert "ADMIN_APP_BIND_PORT='5002'" in deploy_script
@@ -1039,8 +1053,17 @@ def test_dockerfile_and_compose_enforce_hardened_runtime():
     assert "Admin runtime database role must not be the migration/schema-owner role" in deploy_script
     assert "python -m flask --app admin_wsgi:app production-check" in deploy_script
     assert '"http://${APP_BIND_HOST}:5002/health/ready"' in deploy_script
-    assert deploy_script.index("db upgrade") < deploy_script.index("apply-runtime-db-privileges")
-    assert deploy_script.index("apply-runtime-db-privileges") < deploy_script.index("verify-runtime-db-privileges")
+    deploy_db_sequence = re.search(
+        r"migration_run \\\n    python -m flask --app wsgi:app db upgrade"
+        r".*?if \[\[ -n \"\$\{previous_image\}\" \]\]; then",
+        deploy_script,
+        flags=re.DOTALL,
+    )
+    assert deploy_db_sequence is not None
+    deploy_db_sequence_text = deploy_db_sequence.group(0)
+    assert deploy_db_sequence_text.index("db upgrade") < deploy_db_sequence_text.index("apply-runtime-db-privileges")
+    assert deploy_db_sequence_text.index("apply-runtime-db-privileges") < deploy_db_sequence_text.index("apply_staging_admin_runtime_db_privileges")
+    assert deploy_db_sequence_text.index("apply_staging_admin_runtime_db_privileges") < deploy_db_sequence_text.index("verify-runtime-db-privileges")
     assert "staging_migration_run" not in deploy_script
     assert deploy_script.count("migration_run \\") == 3
     assert (


### PR DESCRIPTION
## Summary

Fixes staging admin readiness by provisioning the admin runtime database role and required privileges before starting the admin container. Also improves diagnostics for admin readiness failures.

## Why

The staging admin container can fail readiness checks if its runtime database role or privileges are missing when the container starts. This creates staging deployment failures and makes the admin environment unreliable as a production-like test target.

Improved diagnostics are needed so operators can quickly identify whether failures are caused by database role setup, privilege issues, container startup problems, or readiness check failures.

## What changed

* Provisioned the staging admin runtime database role before starting the admin container.
* Granted the required database privileges needed by the admin service.
* Improved admin readiness diagnostics to surface more useful failure information during staging deployment.

## Security impact

This improves staging deployment safety by ensuring the admin service runs with its intended dedicated database runtime role instead of relying on missing, incorrect, or overly broad database access.

The change supports least-privilege separation for the admin deployment boundary. It does not weaken authentication, authorization, session security, secret handling, or production deployment gating.

## Deployment impact

This PR requires:

* EC2 bootstrap: Yes, if the database provisioning or deployment wrapper changes are bootstrap-managed.
* Staging deployment: Yes.
* Production deployment: No, unless the same provisioning change is intentionally applied to production.
* Database migration: No, assuming this only provisions roles/privileges and does not change schema.
* Secret changes: No.
* No deployment action: No.

## Verification

* Confirmed the staging admin runtime database role is provisioned before admin container startup.
* Confirmed the required admin database privileges are granted.
* Confirmed admin readiness diagnostics now provide better failure information.

## Notes

After merging, rerun the trusted staging bootstrap if the changed provisioning or deployment files are managed by EC2 bootstrap. Then redeploy staging and confirm the admin container reaches readiness successfully.
