### PR TITLE
Fix Nginx default_server conflict when production and staging share one EC2

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -90,7 +90,7 @@ journalctl -u sitbank-security-alerts.service
 
 ## Production Edge and Network Hardening
 
-The reviewed production bootstrap installs and enables the production edge from `ops/nginx/sitbank-production.conf`, `ops/nginx/sitbank-production-rate-limits.conf`, and `ops/nginx-proxy-headers.conf`. Any change to those files requires a production bootstrap after merge.
+The reviewed production bootstrap installs and enables the production edge from `ops/nginx/sitbank-default.conf`, `ops/nginx/sitbank-production.conf`, `ops/nginx/sitbank-production-rate-limits.conf`, and `ops/nginx-proxy-headers.conf`. The shared default config owns unknown-host rejection so production and staging can run on the same EC2 without duplicate Nginx `default_server` listeners. Any change to those files requires a production bootstrap after merge.
 
 - Public ingress is TCP `80` and `443` only.
 - SSH is restricted to an administrator IP allowlist, AWS Systems Manager, a bastion, or VPN.

--- a/ops/deploy/bootstrap-container-ec2
+++ b/ops/deploy/bootstrap-container-ec2
@@ -8,6 +8,7 @@ readonly COSIGN_VERSION="3.0.5"
 readonly COSIGN_SHA256="db15cc99e6e4837daabab023742aaddc3841ce57f193d11b7c3e06c8003642b2"
 readonly PRODUCTION_PUBLIC_HOST="sitbank.duckdns.org"
 readonly PRODUCTION_ADMIN_PUBLIC_HOST="admin-sitbank.duckdns.org"
+readonly EDGE_DEFAULTS_FILE="/etc/nginx/conf.d/sitbank-default.conf"
 readonly PRODUCTION_RATE_LIMITS_FILE="/etc/nginx/conf.d/sitbank-production-rate-limits.conf"
 readonly STAGING_PUBLIC_HOST="staging-sitbank.duckdns.org"
 readonly STAGING_BASIC_AUTH_FILE="/etc/nginx/.htpasswd-sitbank-staging"
@@ -90,6 +91,7 @@ linux_runtime_files=(
     "${repo_root}/ops/deploy/sitbank-container-deploy"
     "${repo_root}/ops/deploy/sitbank-container-runtime"
     "${repo_root}/ops/deploy/sitbank-database-cutover"
+    "${repo_root}/ops/nginx/sitbank-default.conf"
     "${repo_root}/ops/sudoers/sitbank-container-deploy"
 )
 if [[ "${target}" == "staging" ]]; then
@@ -257,6 +259,52 @@ for policy_file in \
     fi
 done
 
+install_nginx_config() {
+    local source_file="$1"
+    local target_file="$2"
+    local label="$3"
+    local backup_prefix="$4"
+
+    if [[ -e "${target_file}" \
+        && ( -L "${target_file}" || ! -f "${target_file}" ) ]]; then
+        echo "Refusing to replace unsafe ${label}: ${target_file}" >&2
+        exit 1
+    fi
+    if [[ -f "${target_file}" ]] \
+        && ! cmp -s "${source_file}" "${target_file}"; then
+        install -o root -g root -m 0644 \
+            "${target_file}" \
+            "${backup_dir}/${backup_prefix}.$(date -u +%Y%m%dT%H%M%SZ).conf"
+    fi
+    install -o root -g root -m 0644 "${source_file}" "${target_file}"
+}
+
+install_edge_default_site() {
+    install_nginx_config \
+        "${repo_root}/ops/nginx/sitbank-default.conf" \
+        "${EDGE_DEFAULTS_FILE}" \
+        "shared Nginx default config" \
+        "nginx-sitbank-default"
+}
+
+refresh_enabled_sibling_site() {
+    if [[ "${target}" == "production" \
+        && -e /etc/nginx/sites-enabled/sitbank-staging ]]; then
+        install_nginx_config \
+            "${repo_root}/ops/nginx/sitbank-staging.conf" \
+            /etc/nginx/sites-available/sitbank-staging \
+            "staging Nginx config" \
+            "nginx-sitbank-staging"
+    elif [[ "${target}" == "staging" \
+        && -e /etc/nginx/sites-enabled/sitbank ]]; then
+        install_nginx_config \
+            "${repo_root}/ops/nginx/sitbank-production.conf" \
+            /etc/nginx/sites-available/sitbank \
+            "production Nginx config" \
+            "nginx-sitbank-production"
+    fi
+}
+
 if [[ "${target}" == "production" ]]; then
     production_cert_dir="/etc/letsencrypt/live/${public_host}"
     production_admin_cert_dir="/etc/letsencrypt/live/${PRODUCTION_ADMIN_PUBLIC_HOST}"
@@ -293,6 +341,7 @@ if [[ "${target}" == "production" ]]; then
     install -d -o root -g root -m 0755 /etc/nginx/snippets
     install -d -o root -g root -m 0755 /etc/nginx/conf.d
     install -d -o root -g root -m 0755 /var/www/certbot
+    install_edge_default_site
     install -o root -g root -m 0644 \
         "${repo_root}/ops/nginx-proxy-headers.conf" \
         /etc/nginx/snippets/sitbank-proxy-headers.conf
@@ -330,6 +379,7 @@ if [[ "${target}" == "production" ]]; then
     install -o root -g root -m 0644 \
         "${repo_root}/ops/nginx/sitbank-production.conf" \
         "${production_site}"
+    refresh_enabled_sibling_site
     ln -sfn "${production_site}" \
         /etc/nginx/sites-enabled/sitbank
     nginx -t
@@ -380,6 +430,7 @@ if [[ "${target}" == "staging" ]]; then
     install -d -o root -g root -m 0755 /etc/nginx/snippets
     install -d -o root -g root -m 0755 /etc/nginx/conf.d
     install -d -o root -g root -m 0755 /var/www/certbot
+    install_edge_default_site
     install -o root -g root -m 0644 \
         "${repo_root}/ops/nginx-proxy-headers.conf" \
         /etc/nginx/snippets/sitbank-proxy-headers.conf
@@ -417,6 +468,7 @@ if [[ "${target}" == "staging" ]]; then
     install -o root -g root -m 0644 \
         "${repo_root}/ops/nginx/sitbank-staging.conf" \
         "${staging_site}"
+    refresh_enabled_sibling_site
     ln -sfn "${staging_site}" \
         /etc/nginx/sites-enabled/sitbank-staging
     nginx -t

--- a/ops/nginx/sitbank-default.conf
+++ b/ops/nginx/sitbank-default.conf
@@ -1,0 +1,14 @@
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name _;
+    return 444;
+}
+
+server {
+    listen 443 ssl http2 default_server;
+    listen [::]:443 ssl http2 default_server;
+    server_name _;
+    ssl_reject_handshake on;
+    return 444;
+}

--- a/ops/nginx/sitbank-production.conf
+++ b/ops/nginx/sitbank-production.conf
@@ -1,19 +1,4 @@
 server {
-    listen 80 default_server;
-    listen [::]:80 default_server;
-    server_name _;
-    return 444;
-}
-
-server {
-    listen 443 ssl http2 default_server;
-    listen [::]:443 ssl http2 default_server;
-    server_name _;
-    ssl_reject_handshake on;
-    return 444;
-}
-
-server {
     listen 80;
     listen [::]:80;
     server_name sitbank.duckdns.org;

--- a/ops/nginx/sitbank-staging.conf
+++ b/ops/nginx/sitbank-staging.conf
@@ -1,19 +1,4 @@
 server {
-    listen 80 default_server;
-    listen [::]:80 default_server;
-    server_name _;
-    return 444;
-}
-
-server {
-    listen 443 ssl http2 default_server;
-    listen [::]:443 ssl http2 default_server;
-    server_name _;
-    ssl_reject_handshake on;
-    return 444;
-}
-
-server {
     listen 80;
     listen [::]:80;
     server_name staging-sitbank.duckdns.org;

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1853,6 +1853,7 @@ def test_linux_deployment_artifacts_are_forced_to_lf_and_reject_crlf():
         Path("ops/deploy/sitbank-container-runtime"),
         Path("ops/deploy/sitbank-database-cutover"),
         Path("ops/nginx-proxy-headers.conf"),
+        Path("ops/nginx/sitbank-default.conf"),
         Path("ops/nginx/sitbank-production.conf"),
         Path("ops/nginx/sitbank-production-rate-limits.conf"),
         Path("ops/nginx/sitbank-staging.conf"),
@@ -1927,7 +1928,25 @@ def test_security_alert_scheduler_units_are_committed_and_safe():
         assert required in docs
 
 
+def test_nginx_default_server_is_shared_for_same_host_production_and_staging():
+    default_nginx = Path("ops/nginx/sitbank-default.conf").read_text(encoding="utf-8")
+    production_nginx = Path("ops/nginx/sitbank-production.conf").read_text(encoding="utf-8")
+    staging_nginx = Path("ops/nginx/sitbank-staging.conf").read_text(encoding="utf-8")
+    combined = "\n".join([default_nginx, production_nginx, staging_nginx])
+
+    assert combined.count("listen 80 default_server;") == 1
+    assert combined.count("listen [::]:80 default_server;") == 1
+    assert combined.count("listen 443 ssl http2 default_server;") == 1
+    assert combined.count("listen [::]:443 ssl http2 default_server;") == 1
+    assert "listen 80 default_server;" not in production_nginx
+    assert "listen 80 default_server;" not in staging_nginx
+    assert "server_name sitbank.duckdns.org;" in combined
+    assert "server_name admin-sitbank.duckdns.org;" in combined
+    assert "server_name staging-sitbank.duckdns.org;" in combined
+
+
 def test_staging_nginx_enforces_https_auth_health_and_rate_limits():
+    default_nginx = Path("ops/nginx/sitbank-default.conf").read_text(encoding="utf-8")
     nginx = Path("ops/nginx/sitbank-staging.conf").read_text(encoding="utf-8")
     rate_limits = Path("ops/nginx/sitbank-staging-rate-limits.conf").read_text(
         encoding="utf-8"
@@ -1937,13 +1956,19 @@ def test_staging_nginx_enforces_https_auth_health_and_rate_limits():
         encoding="utf-8"
     )
 
+    assert Path("ops/nginx/sitbank-default.conf").exists()
     assert Path("ops/nginx/sitbank-staging-rate-limits.conf").exists()
+    assert "listen 80 default_server;" in default_nginx
+    assert "listen [::]:80 default_server;" in default_nginx
+    assert "listen 443 ssl http2 default_server;" in default_nginx
+    assert "listen [::]:443 ssl http2 default_server;" in default_nginx
+    assert "server_name _;" in default_nginx
+    assert "ssl_reject_handshake on;" in default_nginx
+    assert "return 444;" in default_nginx
     assert "listen 80;" in nginx
-    assert "listen 80 default_server;" in nginx
-    assert "listen 443 ssl http2 default_server;" in nginx
-    assert "server_name _;" in nginx
-    assert "ssl_reject_handshake on;" in nginx
-    assert "return 444;" in nginx
+    assert "listen 80 default_server;" not in nginx
+    assert "listen 443 ssl http2 default_server;" not in nginx
+    assert "server_name _;" not in nginx
     assert "return 301 https://$host$request_uri;" in nginx
     assert "listen 443 ssl http2;" in nginx
     assert "server_name staging-sitbank.duckdns.org;" in nginx
@@ -2021,11 +2046,17 @@ def test_staging_nginx_enforces_https_auth_health_and_rate_limits():
     assert "apache2-utils" in bootstrap
     assert "certbot" in bootstrap
     assert "STAGING_RATE_LIMITS_FILE=\"/etc/nginx/conf.d/sitbank-staging-rate-limits.conf\"" in bootstrap
+    assert "EDGE_DEFAULTS_FILE=\"/etc/nginx/conf.d/sitbank-default.conf\"" in bootstrap
+    assert "ops/nginx/sitbank-default.conf" in bootstrap
     assert "ops/nginx/sitbank-staging-rate-limits.conf" in bootstrap
     assert "sitbank-staging-rate-limits.$(date -u +%Y%m%dT%H%M%SZ).conf" in bootstrap
+    assert '"nginx-sitbank-default"' in bootstrap
+    assert '${backup_prefix}.$(date -u +%Y%m%dT%H%M%SZ).conf' in bootstrap
     assert "nginx-sitbank-staging.$(date -u +%Y%m%dT%H%M%SZ).conf" in bootstrap
     assert "&& ! cmp -s \\" in bootstrap
     assert '"${repo_root}/ops/nginx/sitbank-staging.conf" \\' in bootstrap
+    assert "refresh_enabled_sibling_site" in bootstrap
+    assert "&& -e /etc/nginx/sites-enabled/sitbank" in bootstrap
     assert '"${staging_site}"; then' in bootstrap
     assert "if [[ ! -e /etc/nginx/sites-available/sitbank-staging" not in bootstrap
     staging_site_install = bootstrap.index('"${repo_root}/ops/nginx/sitbank-staging.conf"')
@@ -2040,6 +2071,7 @@ def test_staging_nginx_enforces_https_auth_health_and_rate_limits():
 
 
 def test_production_nginx_edge_config_enforces_network_boundary_and_limits():
+    default_nginx = Path("ops/nginx/sitbank-default.conf").read_text(encoding="utf-8")
     nginx = Path("ops/nginx/sitbank-production.conf").read_text(encoding="utf-8")
     rate_limits = Path("ops/nginx/sitbank-production-rate-limits.conf").read_text(
         encoding="utf-8"
@@ -2055,16 +2087,22 @@ def test_production_nginx_edge_config_enforces_network_boundary_and_limits():
     customer_nginx = _nginx_server_block(nginx, "sitbank.duckdns.org")
     admin_nginx = _nginx_server_block(nginx, "admin-sitbank.duckdns.org")
 
+    assert Path("ops/nginx/sitbank-default.conf").exists()
     assert Path("ops/nginx/sitbank-production.conf").exists()
     assert Path("ops/nginx/sitbank-production-rate-limits.conf").exists()
+    assert "listen 80 default_server;" in default_nginx
+    assert "listen [::]:80 default_server;" in default_nginx
+    assert "listen 443 ssl http2 default_server;" in default_nginx
+    assert "listen [::]:443 ssl http2 default_server;" in default_nginx
+    assert "server_name _;" in default_nginx
+    assert "ssl_reject_handshake on;" in default_nginx
+    assert "return 444;" in default_nginx
     assert "listen 80;" in nginx
     assert "return 301 https://sitbank.duckdns.org$request_uri;" in nginx
     assert "return 301 https://admin-sitbank.duckdns.org$request_uri;" in nginx
-    assert "listen 80 default_server;" in nginx
-    assert "listen 443 ssl http2 default_server;" in nginx
-    assert "server_name _;" in nginx
-    assert "ssl_reject_handshake on;" in nginx
-    assert "return 444;" in nginx
+    assert "listen 80 default_server;" not in nginx
+    assert "listen 443 ssl http2 default_server;" not in nginx
+    assert "server_name _;" not in nginx
     assert "listen 443 ssl http2;" in nginx
     assert "server_name sitbank.duckdns.org;" in nginx
     assert "server_name admin-sitbank.duckdns.org;" in nginx
@@ -2195,6 +2233,8 @@ def test_production_nginx_edge_config_enforces_network_boundary_and_limits():
     assert "/etc/letsencrypt/live/${PRODUCTION_ADMIN_PUBLIC_HOST}" in bootstrap
     assert "Issue the production Certbot certificate before rerunning bootstrap." in bootstrap
     assert "PRODUCTION_RATE_LIMITS_FILE=\"/etc/nginx/conf.d/sitbank-production-rate-limits.conf\"" in bootstrap
+    assert "EDGE_DEFAULTS_FILE=\"/etc/nginx/conf.d/sitbank-default.conf\"" in bootstrap
+    assert "ops/nginx/sitbank-default.conf" in bootstrap
     assert "ops/nginx/sitbank-production-rate-limits.conf" in bootstrap
     assert "ops/nginx/sitbank-production.conf" in bootstrap
     assert "Refusing to replace unsafe production Nginx rate-limit file" in bootstrap
@@ -2202,8 +2242,11 @@ def test_production_nginx_edge_config_enforces_network_boundary_and_limits():
     assert "Conflicting Nginx production site is already enabled" in bootstrap
     assert "Disable the duplicate production server block" in bootstrap
     assert "nginx-sitbank-production-rate-limits.$(date -u +%Y%m%dT%H%M%SZ).conf" in bootstrap
+    assert '"nginx-sitbank-default"' in bootstrap
+    assert '${backup_prefix}.$(date -u +%Y%m%dT%H%M%SZ).conf' in bootstrap
     assert "nginx-sitbank-production.$(date -u +%Y%m%dT%H%M%SZ).conf" in bootstrap
     assert "/etc/nginx/sites-enabled/sitbank" in bootstrap
+    assert "&& -e /etc/nginx/sites-enabled/sitbank-staging" in bootstrap
 
     production_rate_install = bootstrap.index(
         '"${repo_root}/ops/nginx/sitbank-production-rate-limits.conf"'


### PR DESCRIPTION
## Summary

Fixes the Nginx bootstrap failure when production and staging are enabled on the same EC2 host by moving the shared `default_server` listener into one common Nginx config.

## Why

Production and staging each declared their own `default_server` blocks for ports 80 and 443. When both sites are enabled on the same EC2 instance, Nginx rejects the config with:

`a duplicate default server for 0.0.0.0:80`

This prevents bootstrap from completing and blocks Nginx reloads.

## What changed

* Added `ops/nginx/sitbank-default.conf` as the single shared catch-all/default Nginx site.
* Removed `default_server` listeners from the production and staging site configs.
* Updated EC2 bootstrap to install the shared default config and refresh an already-enabled sibling site before running `nginx -t`.
* Added deployment regression tests covering co-hosted production and staging Nginx configs.
* Updated deployment docs to mention the shared default Nginx config.

## Security impact

This preserves the existing edge behavior for unknown hosts by keeping a catch-all default server that rejects unmatched HTTP traffic and rejects unmatched TLS handshakes. It does not add secrets, change app authentication, change permissions, or expose new services.

The change improves deployment safety because Nginx validation can now pass when production and staging share one EC2 host.

## Deployment impact

Requires:

* EC2 bootstrap

Does not require:

* staging deployment
* production deployment
* database migration
* secret changes

## Verification

* `git diff --check HEAD~1..HEAD`
* `bash -n ops/deploy/bootstrap-container-ec2`
* `python -m pytest -q tests/test_deployment.py` -> `41 passed`

## Notes

After this is merged, rerun the EC2 bootstrap so `/etc/nginx/conf.d/sitbank-default.conf` is installed and both enabled site configs are refreshed.