### PR TITLE
Add admin verification page and improve MFA recovery-code UX

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1058,6 +1058,12 @@ input:focus {
   align-items: stretch;
 }
 
+.mfa-support-grid {
+  display: grid;
+  grid-template-columns: minmax(280px, 0.34fr);
+  gap: var(--space-4);
+}
+
 .freeze-grid {
   grid-template-columns: minmax(0, 1.05fr) minmax(320px, 0.95fr);
   align-items: start;
@@ -1209,6 +1215,16 @@ input:focus {
 .mfa-step.is-complete .step-number {
   background: var(--primary);
   color: var(--primary-contrast);
+}
+
+.recovery-code-panel .step-number {
+  background: var(--primary-soft);
+  color: var(--primary);
+}
+
+.recovery-code-panel .step-number .icon {
+  width: 17px;
+  height: 17px;
 }
 
 .mfa-step-header {
@@ -1438,6 +1454,10 @@ input:focus {
   list-style: none;
 }
 
+.recovery-code-actions {
+  justify-content: flex-start;
+}
+
 code {
   overflow-wrap: anywhere;
   border-radius: var(--radius-sm);
@@ -1584,6 +1604,7 @@ th {
   .status-grid,
   .quick-grid,
   .profile-grid,
+  .mfa-support-grid,
   .mfa-steps,
   .freeze-grid {
     grid-template-columns: 1fr;

--- a/app/static/js/account.js
+++ b/app/static/js/account.js
@@ -63,5 +63,92 @@
         meter.textContent = strengthLabel(input.value || "");
       });
     });
+
+    document.querySelectorAll("[data-recovery-code-list]").forEach(function (list) {
+      var status = document.querySelector("[data-recovery-code-status]");
+      var copyButton = document.querySelector("[data-copy-recovery-codes]");
+      var downloadButton = document.querySelector("[data-download-recovery-codes]");
+
+      function recoveryCodesText() {
+        return Array.prototype.slice.call(list.querySelectorAll("[data-recovery-code]"))
+          .map(function (item) {
+            return item.textContent.trim();
+          })
+          .filter(Boolean)
+          .join("\n");
+      }
+
+      function setStatus(message) {
+        if (status) {
+          status.textContent = message;
+        }
+      }
+
+      function fallbackCopy(text) {
+        var textarea = document.createElement("textarea");
+        textarea.value = text;
+        textarea.setAttribute("readonly", "readonly");
+        textarea.style.position = "fixed";
+        textarea.style.left = "-9999px";
+        document.body.appendChild(textarea);
+        textarea.select();
+        try {
+          if (document.execCommand("copy")) {
+            setStatus("Recovery codes copied.");
+          } else {
+            setStatus("Copy was not available. Download the codes instead.");
+          }
+        } catch (error) {
+          setStatus("Copy was not available. Download the codes instead.");
+        } finally {
+          document.body.removeChild(textarea);
+        }
+      }
+
+      if (copyButton) {
+        copyButton.addEventListener("click", function () {
+          var text = recoveryCodesText();
+          if (!text) {
+            return;
+          }
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(function () {
+              setStatus("Recovery codes copied.");
+            }).catch(function () {
+              fallbackCopy(text);
+            });
+            return;
+          }
+          fallbackCopy(text);
+        });
+      }
+
+      if (downloadButton) {
+        downloadButton.addEventListener("click", function () {
+          var text = recoveryCodesText();
+          var blob;
+          var url;
+          var link;
+          if (!text) {
+            return;
+          }
+          blob = new Blob([
+            "SITBank recovery codes\n",
+            "Store these codes somewhere private. Each code can be used once.\n\n",
+            text,
+            "\n"
+          ], { type: "text/plain" });
+          url = URL.createObjectURL(blob);
+          link = document.createElement("a");
+          link.href = url;
+          link.download = "sitbank-recovery-codes.txt";
+          document.body.appendChild(link);
+          link.click();
+          document.body.removeChild(link);
+          URL.revokeObjectURL(url);
+          setStatus("Recovery codes download started.");
+        });
+      }
+    });
   });
 })();

--- a/app/templates/mfa_setup.html
+++ b/app/templates/mfa_setup.html
@@ -34,32 +34,26 @@
         <div>
           <h2>Save your recovery codes</h2>
           <p class="muted">These codes are shown only once. Store them somewhere private before leaving this page.</p>
-          <ul class="recovery-code-list">
+          <ul class="recovery-code-list" data-recovery-code-list>
             {% for code in recovery_codes %}
-              <li><code>{{ code }}</code></li>
+              <li><code data-recovery-code>{{ code }}</code></li>
             {% endfor %}
           </ul>
+          <div class="button-row recovery-code-actions" data-recovery-code-actions>
+            <button class="button secondary" type="button" data-copy-recovery-codes>Copy all codes</button>
+            <button class="button secondary" type="button" data-download-recovery-codes>Download codes</button>
+          </div>
+          <p class="hint" data-recovery-code-status aria-live="polite"></p>
         </div>
       </div>
     {% endif %}
 
-    <div class="mfa-steps">
-      <article class="mfa-step is-complete">
+    <div class="mfa-support-grid">
+      <article class="mfa-step recovery-code-panel">
         <div class="mfa-step-header">
-          <span class="step-number">1</span>
-          <div>
-            <p class="eyebrow">Status</p>
-            <h2>Current authenticator active</h2>
-          </div>
-        </div>
-        <div class="mfa-step-body">
-          <p class="muted">Do not remove this authenticator from your app until replacement has been verified.</p>
-        </div>
-      </article>
-
-      <article class="mfa-step">
-        <div class="mfa-step-header">
-          <span class="step-number">2</span>
+          <span class="step-number" aria-hidden="true">
+            <svg class="icon" focusable="false"><use href="#icon-lock"></use></svg>
+          </span>
           <div>
             <p class="eyebrow">Recovery</p>
             <h2>Recovery codes</h2>
@@ -77,10 +71,25 @@
           </form>
         </div>
       </article>
+    </div>
+
+    <div class="mfa-steps">
+      <article class="mfa-step is-complete">
+        <div class="mfa-step-header">
+          <span class="step-number">1</span>
+          <div>
+            <p class="eyebrow">Status</p>
+            <h2>Current authenticator active</h2>
+          </div>
+        </div>
+        <div class="mfa-step-body">
+          <p class="muted">Do not remove this authenticator from your app until replacement has been verified.</p>
+        </div>
+      </article>
 
       <article class="mfa-step{% if replacement %} is-complete{% endif %}">
         <div class="mfa-step-header">
-          <span class="step-number">3</span>
+          <span class="step-number">2</span>
           <div>
             <p class="eyebrow">Replacement</p>
             <h2>Replace authenticator</h2>
@@ -99,7 +108,7 @@
 
       <article class="mfa-step{% if not replacement %} is-muted{% endif %}">
         <div class="mfa-step-header">
-          <span class="step-number">4</span>
+          <span class="step-number">3</span>
           <div>
             <p class="eyebrow">New authenticator</p>
             <h2>Scan QR or enter key</h2>
@@ -124,7 +133,7 @@
 
       <article class="mfa-step{% if not replacement %} is-muted{% endif %}">
         <div class="mfa-step-header">
-          <span class="step-number">5</span>
+          <span class="step-number">4</span>
           <div>
             <p class="eyebrow">Confirm</p>
             <h2>Verify replacement</h2>

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -100,9 +100,10 @@ The reviewed production bootstrap installs and enables the production edge from 
   `admin-sitbank.duckdns.org` Nginx server block.
 - `compose.prod.yml` publishes no app ports.
 - `/health/ready` is for local deployment and load-balancer checks and should deny public traffic.
-- Admin `/health/ready` is not public through Nginx. Admin routes use
-  `deny all` by default until a future VPN, explicit IP allowlist, or
-  equivalent network control is configured.
+- Admin `/` serves only a static Google verification and restricted-access
+  notice. Admin `/health/ready`, `/login`, and all other admin routes remain
+  denied by default until a future VPN, explicit IP allowlist, or equivalent
+  network control is configured.
 - Cloudflare or AWS WAF should sit in front of Nginx for managed common, SQL injection, XSS, bot, and protocol anomaly rules.
 - Cloudflare or AWS WAF rules and security-group allowlists are still infrastructure state and must be checked manually.
 - Admin WebAuthn/passkey authentication and admin step-up are Phase 2 and are
@@ -119,13 +120,17 @@ sudo docker inspect --format '{{json .NetworkSettings.Ports}}' sitbank-app
 sudo docker inspect --format '{{json .NetworkSettings.Ports}}' sitbank-admin
 curl --fail https://sitbank.duckdns.org/health/live
 curl -I https://sitbank.duckdns.org/health/ready
+curl https://admin-sitbank.duckdns.org/ | grep google-site-verification
 curl -I https://admin-sitbank.duckdns.org/health/ready
 curl -I https://admin-sitbank.duckdns.org/login
 ```
 
 Expected: local customer and admin readiness succeeds, external `/health/ready`
-returns `403`, and admin public routes return `403` or are otherwise denied by
-Nginx.
+returns `403`, admin `/` returns only the static verification page, and admin
+application routes return `403` or are otherwise denied by Nginx. The Google
+verification tag proves Search Console ownership only; dangerous-site removal
+still requires reviewing Security Issues in Search Console and requesting a
+Google review after the reported cause is resolved.
 
 Staging admin must follow the same boundary pattern as production. Do not expose
 admin routes publicly. The staging admin service must bind only to localhost

--- a/ops/deploy/bootstrap-container-ec2
+++ b/ops/deploy/bootstrap-container-ec2
@@ -287,6 +287,13 @@ install_edge_default_site() {
         "nginx-sitbank-default"
 }
 
+install_admin_verification_page() {
+    install -d -o root -g root -m 0755 /var/www/sitbank-admin-verification
+    install -o root -g root -m 0644 \
+        "${repo_root}/ops/nginx/admin-verification.html" \
+        /var/www/sitbank-admin-verification/index.html
+}
+
 refresh_enabled_sibling_site() {
     if [[ "${target}" == "production" \
         && -e /etc/nginx/sites-enabled/sitbank-staging ]]; then
@@ -342,6 +349,7 @@ if [[ "${target}" == "production" ]]; then
     install -d -o root -g root -m 0755 /etc/nginx/conf.d
     install -d -o root -g root -m 0755 /var/www/certbot
     install_edge_default_site
+    install_admin_verification_page
     install -o root -g root -m 0644 \
         "${repo_root}/ops/nginx-proxy-headers.conf" \
         /etc/nginx/snippets/sitbank-proxy-headers.conf
@@ -431,6 +439,7 @@ if [[ "${target}" == "staging" ]]; then
     install -d -o root -g root -m 0755 /etc/nginx/conf.d
     install -d -o root -g root -m 0755 /var/www/certbot
     install_edge_default_site
+    install_admin_verification_page
     install -o root -g root -m 0644 \
         "${repo_root}/ops/nginx-proxy-headers.conf" \
         /etc/nginx/snippets/sitbank-proxy-headers.conf

--- a/ops/nginx/admin-verification.html
+++ b/ops/nginx/admin-verification.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="google-site-verification" content="TdWqsa4Ln9t_GIYl4Devi4rrU48Z7XNSue_PiImREJs">
+    <title>SITBank Admin</title>
+  </head>
+  <body>
+    <main>
+      <h1>SITBank Admin</h1>
+      <p>SITBank is a student cybersecurity project and demonstration site. Do not enter real banking credentials, card numbers, phone numbers, or personal financial information.</p>
+      <p>Administrative access is restricted.</p>
+    </main>
+  </body>
+</html>

--- a/ops/nginx/sitbank-production.conf
+++ b/ops/nginx/sitbank-production.conf
@@ -232,6 +232,13 @@ server {
         return 405;
     }
 
+    location = / {
+        limit_req zone=sitbank_prod_admin burst=10 nodelay;
+        root /var/www/sitbank-admin-verification;
+        default_type text/html;
+        try_files /index.html =404;
+    }
+
     location = /health/ready {
         deny all;
         return 403;

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -2076,6 +2076,9 @@ def test_staging_nginx_enforces_https_auth_health_and_rate_limits():
 def test_production_nginx_edge_config_enforces_network_boundary_and_limits():
     default_nginx = Path("ops/nginx/sitbank-default.conf").read_text(encoding="utf-8")
     nginx = Path("ops/nginx/sitbank-production.conf").read_text(encoding="utf-8")
+    admin_verification = Path("ops/nginx/admin-verification.html").read_text(
+        encoding="utf-8"
+    )
     rate_limits = Path("ops/nginx/sitbank-production-rate-limits.conf").read_text(
         encoding="utf-8"
     )
@@ -2092,7 +2095,14 @@ def test_production_nginx_edge_config_enforces_network_boundary_and_limits():
 
     assert Path("ops/nginx/sitbank-default.conf").exists()
     assert Path("ops/nginx/sitbank-production.conf").exists()
+    assert Path("ops/nginx/admin-verification.html").exists()
     assert Path("ops/nginx/sitbank-production-rate-limits.conf").exists()
+    assert (
+        '<meta name="google-site-verification" '
+        'content="TdWqsa4Ln9t_GIYl4Devi4rrU48Z7XNSue_PiImREJs">'
+        in admin_verification
+    )
+    assert admin_verification.index("google-site-verification") < admin_verification.index("</head>")
     assert "listen 80 default_server;" in default_nginx
     assert "listen [::]:80 default_server;" in default_nginx
     assert "listen 443 ssl http2 default_server;" in default_nginx
@@ -2172,6 +2182,16 @@ def test_production_nginx_edge_config_enforces_network_boundary_and_limits():
     assert "limit_req zone=sitbank_prod_admin_auth" in admin_login_bodies[0]
     assert "proxy_pass http://127.0.0.1:5002;" in admin_login_bodies[0]
 
+    admin_exact_root_bodies = _nginx_location_bodies(admin_nginx, "= /")
+    assert len(admin_exact_root_bodies) == 1
+    admin_exact_root = admin_exact_root_bodies[0]
+    assert "root /var/www/sitbank-admin-verification;" in admin_exact_root
+    assert "try_files /index.html =404;" in admin_exact_root
+    assert "default_type text/html;" in admin_exact_root
+    assert "limit_req zone=sitbank_prod_admin" in admin_exact_root
+    assert "proxy_pass" not in admin_exact_root
+    assert "deny all;" not in admin_exact_root
+
     admin_root_bodies = _nginx_location_bodies(admin_nginx, "/")
     assert any("deny all;" in body and "limit_req zone=sitbank_prod_admin" in body for body in admin_root_bodies)
 
@@ -2240,6 +2260,8 @@ def test_production_nginx_edge_config_enforces_network_boundary_and_limits():
     assert "ops/nginx/sitbank-default.conf" in bootstrap
     assert "ops/nginx/sitbank-production-rate-limits.conf" in bootstrap
     assert "ops/nginx/sitbank-production.conf" in bootstrap
+    assert "ops/nginx/admin-verification.html" in bootstrap
+    assert "/var/www/sitbank-admin-verification/index.html" in bootstrap
     assert "Refusing to replace unsafe production Nginx rate-limit file" in bootstrap
     assert "Refusing to replace unsafe production Nginx config" in bootstrap
     assert "Conflicting Nginx production site is already enabled" in bootstrap

--- a/tests/test_group_a_security.py
+++ b/tests/test_group_a_security.py
@@ -830,7 +830,7 @@ def test_mfa_setup_generates_ten_hashed_recovery_codes_and_shows_once(client):
 
     response = client.post("/mfa/setup", data={"action": "verify", "totp_code": code})
     markup = response.data.decode("utf-8")
-    recovery_codes = re.findall(r"<code>([0-9a-f]{8}(?:-[0-9a-f]{8}){3})</code>", markup)
+    recovery_codes = re.findall(r"<code[^>]*>([0-9a-f]{8}(?:-[0-9a-f]{8}){3})</code>", markup)
     stored_codes = list(
         db.session.execute(
             db.select(RecoveryCode).where(
@@ -844,11 +844,47 @@ def test_mfa_setup_generates_ten_hashed_recovery_codes_and_shows_once(client):
     followup_markup = followup.data.decode("utf-8")
 
     assert response.status_code == 200
+    assert "data-recovery-code-list" in markup
+    assert "data-copy-recovery-codes" in markup
+    assert "data-download-recovery-codes" in markup
+    assert "Copy all codes" in markup
+    assert "Download codes" in markup
     assert len(recovery_codes) == 10
     assert len(stored_codes) == 10
     assert all(len(code.replace("-", "")) == 32 for code in recovery_codes)
     assert all(item.code_hmac not in recovery_codes for item in stored_codes)
     assert recovery_codes[0] not in followup_markup
+    assert "data-copy-recovery-codes" not in followup_markup
+    assert "data-download-recovery-codes" not in followup_markup
+
+
+def test_mfa_recovery_codes_are_separate_from_replacement_steps(client):
+    register(client)
+    login(client)
+    enable_mfa_for_user()
+
+    response = client.get("/mfa/setup")
+    markup = response.data.decode("utf-8")
+    script = Path("app/static/js/account.js").read_text(encoding="utf-8")
+    recovery_heading = markup.index("<h2>Recovery codes</h2>")
+    replacement_heading = markup.index("<h2>Replace authenticator</h2>")
+    recovery_article_start = markup.rfind("<article", 0, recovery_heading)
+    recovery_article_end = markup.index("</article>", recovery_heading)
+    recovery_article = markup[recovery_article_start:recovery_article_end]
+
+    assert response.status_code == 200
+    assert recovery_heading < replacement_heading
+    assert 'class="mfa-step recovery-code-panel"' in recovery_article
+    assert '<span class="step-number">2</span>' not in recovery_article
+    assert '<span class="step-number">2</span>' in markup[
+        markup.rfind("<article", 0, replacement_heading):markup.index("</article>", replacement_heading)
+    ]
+    assert '<span class="step-number">3</span>' in markup
+    assert '<span class="step-number">4</span>' in markup
+    assert '<span class="step-number">5</span>' not in markup
+    assert "navigator.clipboard" in script
+    assert "sitbank-recovery-codes.txt" in script
+    assert "console." not in script
 
 
 def test_recovery_code_satisfies_pending_totp_login_once_and_notifies(app, client):


### PR DESCRIPTION
## Summary

This PR adds a static admin verification page for `admin-sitbank.duckdns.org` and updates production Nginx so the admin root path serves only that verification page, while `/login`, `/health/ready`, and other admin routes remain denied or protected.

It also improves the MFA recovery-code UX by separating recovery codes into their own unnumbered MFA card, renumbering authenticator replacement steps, and adding copy/download actions for the one-time recovery-code display.

## What changed

* Added `ops/nginx/admin-verification.html`.
* Updated production Nginx routing so `admin-sitbank.duckdns.org/` serves only the static verification page.
* Kept `/login`, `/health/ready`, and other admin routes denied or protected.
* Added bootstrap installation for the static admin verification page.
* Moved recovery codes into a separate unnumbered MFA card.
* Renumbered authenticator replacement steps to 1-4.
* Added **Copy all codes** and **Download codes** buttons for one-time recovery-code display.
* Added JS/CSS and regression tests for the new recovery-code behavior.
