### PR TITLE
Polish recovery-code UI layout and styling

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1060,7 +1060,7 @@ input:focus {
 
 .mfa-support-grid {
   display: grid;
-  grid-template-columns: minmax(280px, 0.34fr);
+  grid-template-columns: minmax(0, 1fr);
   gap: var(--space-4);
 }
 
@@ -1225,6 +1225,10 @@ input:focus {
 .recovery-code-panel .step-number .icon {
   width: 17px;
   height: 17px;
+}
+
+.recovery-code-panel form {
+  max-width: 100%;
 }
 
 .mfa-step-header {
@@ -1454,8 +1458,28 @@ input:focus {
   list-style: none;
 }
 
+.recovery-code-list-display {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+}
+
+.recovery-code-list code {
+  display: block;
+  border: 1px solid color-mix(in srgb, var(--primary) 22%, var(--line));
+  padding: 8px 10px;
+  background: var(--surface-raised);
+  color: var(--text);
+  font-family: Consolas, "Liberation Mono", monospace;
+  font-size: 0.9rem;
+  line-height: 1.35;
+  letter-spacing: 0;
+}
+
 .recovery-code-actions {
   justify-content: flex-start;
+  margin-top: var(--space-5);
+  gap: var(--space-3);
 }
 
 code {

--- a/app/templates/mfa_setup.html
+++ b/app/templates/mfa_setup.html
@@ -27,14 +27,14 @@
     </div>
 
     {% if recovery_codes %}
-      <div class="notice">
+      <div class="notice recovery-code-notice">
         <span class="notice-icon" aria-hidden="true">
           <svg class="icon" focusable="false"><use href="#icon-lock"></use></svg>
         </span>
         <div>
           <h2>Save your recovery codes</h2>
           <p class="muted">These codes are shown only once. Store them somewhere private before leaving this page.</p>
-          <ul class="recovery-code-list" data-recovery-code-list>
+          <ul class="recovery-code-list recovery-code-list-display" data-recovery-code-list>
             {% for code in recovery_codes %}
               <li><code data-recovery-code>{{ code }}</code></li>
             {% endfor %}

--- a/tests/test_group_a_security.py
+++ b/tests/test_group_a_security.py
@@ -887,6 +887,28 @@ def test_mfa_recovery_codes_are_separate_from_replacement_steps(client):
     assert "console." not in script
 
 
+def test_recovery_code_ui_uses_full_width_card_and_readable_code_chips(client):
+    from app.auth.recovery_codes import generate_recovery_codes_for_user
+
+    register(client)
+    login(client)
+    user, _secret = enable_mfa_for_user()
+    recovery_codes = generate_recovery_codes_for_user(user)
+    stylesheet = Path("app/static/css/app.css").read_text(encoding="utf-8")
+
+    response = client.post("/mfa/setup", data={"action": "recovery_codes_regenerate"})
+    markup = response.data.decode("utf-8")
+
+    assert response.status_code == 200
+    assert recovery_codes[0] not in markup
+    assert 'class="notice recovery-code-notice"' in markup
+    assert "recovery-code-list-display" in markup
+    assert "grid-template-columns: minmax(0, 1fr);" in stylesheet
+    assert ".recovery-code-list code" in stylesheet
+    assert "background: var(--surface-raised);" in stylesheet
+    assert "margin-top: var(--space-5);" in stylesheet
+
+
 def test_recovery_code_satisfies_pending_totp_login_once_and_notifies(app, client):
     from app.auth.recovery_codes import generate_recovery_codes_for_user
     from app.security.email import password_reset_outbox


### PR DESCRIPTION
## Summary

Polishes the recovery-code UI so the one-time code display and recovery-code management sections have a more consistent layout and visual style.

The one-time recovery-code panel now uses lighter app-surface code chips instead of the previous dark code styling, with improved spacing before the copy/download actions. The recovery-code management card now spans the full row width, matching the one-time code display panel instead of appearing as a narrow card.

## Verification

* `.\.venv\Scripts\python.exe -m pytest -q -n auto`

  * `312 passed, 1 skipped`
* `.\.venv\Scripts\python.exe -m compileall app config.py wsgi.py admin_wsgi.py`
* `git diff --check`

  * Passed earlier after the same changes
