### PR TITLE
Update repository owner references to hetp88

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,21 +1,21 @@
 # Default owner for application and documentation changes.
-* @WenJiangggg
+* @hetp88
 
 # Production supply-chain and deployment controls require explicit ownership.
-/.github/workflows/ @WenJiangggg
-/.github/dependabot.yml @WenJiangggg
-/Dockerfile @WenJiangggg
-/compose.prod.yml @WenJiangggg
-/compose.staging.yml @WenJiangggg
-/requirements.in @WenJiangggg
-/requirements-dev.in @WenJiangggg
-/requirements.lock @WenJiangggg
-/requirements-dev.lock @WenJiangggg
-/ops/container/ @WenJiangggg
-/ops/deploy/ @WenJiangggg
-/ops/nginx/ @WenJiangggg
-/ops/nginx-proxy-headers.conf @WenJiangggg
-/ops/security/ @WenJiangggg
-/ops/sudoers/ @WenJiangggg
-/ops/systemd/ @WenJiangggg
-/migrations/ @WenJiangggg
+/.github/workflows/ @hetp88
+/.github/dependabot.yml @hetp88
+/Dockerfile @hetp88
+/compose.prod.yml @hetp88
+/compose.staging.yml @hetp88
+/requirements.in @hetp88
+/requirements-dev.in @hetp88
+/requirements.lock @hetp88
+/requirements-dev.lock @hetp88
+/ops/container/ @hetp88
+/ops/deploy/ @hetp88
+/ops/nginx/ @hetp88
+/ops/nginx-proxy-headers.conf @hetp88
+/ops/security/ @hetp88
+/ops/sudoers/ @hetp88
+/ops/systemd/ @hetp88
+/migrations/ @hetp88

--- a/README.md
+++ b/README.md
@@ -124,6 +124,6 @@ reset is not implemented in the customer domain.
 
 ## Deployment Snapshot
 
-Images are published as immutable signed digests under `ghcr.io/wenjiangggg/sitbank@sha256:<digest>` from the renamed `WenJiangggg/SITBank` repository. Production uses `/etc/sitbank`, `/opt/sitbank`, `sitbank-container.service`, `sitbank_db`, `sitbank_owner`, `sitbank_app`, and a distinct admin runtime DB role such as `sitbank_admin`. Staging uses separate `/etc/sitbank-staging`, `/opt/sitbank-staging`, isolated Compose services, and isolated Docker volumes.
+Images are published as immutable signed digests under `ghcr.io/hetp88/sitbank@sha256:<digest>` from the `hetp88/SITBank` repository. The workflow derives the package path from `GITHUB_REPOSITORY` so future owner changes need only docs, CODEOWNERS, EC2 deploy config, and bootstrap inputs updated. Production uses `/etc/sitbank`, `/opt/sitbank`, `sitbank-container.service`, `sitbank_db`, `sitbank_owner`, `sitbank_app`, and a distinct admin runtime DB role such as `sitbank_admin`. Staging uses separate `/etc/sitbank-staging`, `/opt/sitbank-staging`, isolated Compose services, and isolated Docker volumes.
 
 Database migrations use Alembic. Existing databases that predate Alembic must first pass `verify-migration-baseline`, then be stamped with `db stamp 20260610_0001`. Do not run `db.create_all()` in deployment.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -371,7 +371,7 @@ The current restricted SSH deployment remains supported. The preferred next
 step is GitHub OIDC federation to a narrowly scoped AWS IAM role and Systems
 Manager Run Command:
 
-- trust only `repo:WenJiangggg/SITBank:environment:production`;
+- trust only `repo:hetp88/SITBank:environment:production`;
 - require the GitHub OIDC audience `sts.amazonaws.com`;
 - allow commands only on the tagged SITBank instance and approved SSM
   document;

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -7,8 +7,8 @@ Only Flask/Gunicorn runs in the SITBank container. Nginx, TLS, PostgreSQL, Redis
 - Production public host: `sitbank.duckdns.org`
 - Production admin host: `admin-sitbank.duckdns.org`
 - Staging public host: `staging-sitbank.duckdns.org`
-- Production image form: `ghcr.io/wenjiangggg/sitbank@sha256:<digest>`
-- Repository identity: `WenJiangggg/SITBank`
+- Production image form: `ghcr.io/hetp88/sitbank@sha256:<digest>`
+- Repository identity: `hetp88/SITBank`
 - Production config root: `/etc/sitbank`
 - Production compose dir: `/opt/sitbank`
 - Production service: `sitbank-container.service`
@@ -165,7 +165,7 @@ sudo certbot certonly --webroot -w /var/www/certbot -d staging-sitbank.duckdns.o
 sudo certbot renew --dry-run
 ```
 
-Then run `ops/deploy/bootstrap-container-ec2 staging WenJiangggg/SITBank staging-sitbank.duckdns.org`. The bootstrap installs the Nginx proxy header snippet and rate-limit include, then runs `sudo nginx -t` before `sudo systemctl reload nginx`. This edge setup is separate from application deployment.
+Then run `ops/deploy/bootstrap-container-ec2 staging hetp88/SITBank staging-sitbank.duckdns.org`. The bootstrap installs the Nginx proxy header snippet and rate-limit include, then runs `sudo nginx -t` before `sudo systemctl reload nginx`. This edge setup is separate from application deployment.
 
 Staging verification:
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -2487,8 +2487,8 @@ def test_migration_baseline_and_existing_database_runbook_are_present():
     assert "verify-migration-baseline" in docs
     assert "db stamp 20260610_0001" in docs
     assert "Do not run `db.create_all()`" in docs
-    assert "WenJiangggg/SITBank" in docs
-    assert "ghcr.io/wenjiangggg/sitbank@sha256:<digest>" in docs
+    assert "hetp88/SITBank" in docs
+    assert "ghcr.io/hetp88/sitbank@sha256:<digest>" in docs
     assert "sitbank_db" in docs
     assert "sitbank_owner" in docs
     assert "sitbank_app" in docs


### PR DESCRIPTION
## Summary

Updates the repository references to reflect the new owner, `hetp88/SITBank`.

This changes repository ownership references across CODEOWNERS, documentation, deployment examples, container image references, and deployment tests. The workflow logic already remains dynamic where needed, with GHCR image paths, Cosign verification, and Docker labels deriving from the current GitHub repository context.

## What changed

* Updated `.github/CODEOWNERS` to use `@hetp88`.
* Updated `README.md`, `SECURITY.md`, and `docs/DEPLOYMENT.md` to reference `hetp88/SITBank`.
* Updated GHCR image references to `ghcr.io/hetp88/sitbank@sha256:<digest>`.
* Updated `tests/test_deployment.py` to assert the new repository owner and image identity.
* Updated the local `origin` remote to `https://github.com/hetp88/SITBank.git`.
* Confirmed existing workflow behavior remains dynamic:

  * GHCR image path derives from `${GITHUB_REPOSITORY,,}`.
  * Cosign verification uses `${GITHUB_REPOSITORY}`.
  * Docker labels use `${{ github.repository }}`.

## Verification

* `python -m pytest -q tests/test_deployment.py`

  * `41 passed`
* `rg` found no remaining old owner references.
* `git diff --check` passed, with only the expected LF normalization warning for `CODEOWNERS`.
