### PR TITLE
Use browser-native passkey registration chooser

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -253,7 +253,7 @@ def manual_recovery_request():
 @limiter.limit("5 per 5 minutes", key_func=mfa_principal)
 def webauthn_register_options():
     data = WebAuthnRegistrationOptionsSchema().load(request.get_json(silent=False) or {})
-    return jsonify(begin_registration_options(g.current_user, data["label"], data["credential_kind"]))
+    return jsonify(begin_registration_options(g.current_user, data["label"]))
 
 
 @auth_bp.post("/webauthn/register/verify")

--- a/app/auth/schemas.py
+++ b/app/auth/schemas.py
@@ -10,7 +10,6 @@ TOTP_RE = r"^[0-9]{6}$"
 SESSION_REFERENCE_RE = r"^[A-Fa-f0-9]{32}$"
 WEBAUTHN_CREDENTIAL_REFERENCE_RE = r"^[A-Za-z0-9_-]{16,4096}$"
 WEBAUTHN_LABEL_RE = r"^[A-Za-z0-9][A-Za-z0-9 ._()#:/+\-]{0,79}$"
-WEBAUTHN_CREDENTIAL_KIND_RE = r"^(platform|password_manager|security_key)$"
 STEP_UP_ACTION_RE = r"^[a-z_]{3,64}$"
 STEP_UP_TOKEN_RE = r"^[A-Za-z0-9_-]{32,256}$"
 RESET_TOKEN_RE = r"^[A-Za-z0-9_-]{16,96}\.[A-Za-z0-9_-]{32,128}$"
@@ -144,17 +143,15 @@ class PasswordResetSchema(Schema):
 
 
 class WebAuthnRegistrationOptionsSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
     label = fields.Str(
         required=True,
         validate=[
             validate.Length(min=1, max=80),
             validate.Regexp(WEBAUTHN_LABEL_RE, error="Invalid security key label"),
         ],
-    )
-    credential_kind = fields.Str(
-        required=False,
-        load_default="security_key",
-        validate=validate.Regexp(WEBAUTHN_CREDENTIAL_KIND_RE, error="Invalid passkey type"),
     )
 
 

--- a/app/auth/webauthn_services.py
+++ b/app/auth/webauthn_services.py
@@ -20,11 +20,9 @@ from webauthn.helpers import base64url_to_bytes, bytes_to_base64url, options_to_
 from webauthn.helpers.exceptions import InvalidAuthenticationResponse, InvalidRegistrationResponse
 from webauthn.helpers.structs import (
     AttestationConveyancePreference,
-    AuthenticatorAttachment,
     AuthenticatorSelectionCriteria,
     CredentialDeviceType,
     PublicKeyCredentialDescriptor,
-    PublicKeyCredentialHint,
     ResidentKeyRequirement,
     UserVerificationRequirement,
 )
@@ -49,7 +47,6 @@ LABEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9 ._()#:/+\-]{0,79}$")
 GENERIC_WEBAUTHN_ERROR = "Security key verification failed"
 REGISTRATION_CHALLENGE_KEY = "webauthn_registration_challenge"
 REGISTRATION_LABEL_KEY = "webauthn_registration_label"
-REGISTRATION_KIND_KEY = "webauthn_registration_credential_kind"
 REGISTRATION_USER_KEY = "webauthn_registration_user_id"
 AUTH_CHALLENGE_KEY = "webauthn_authentication_challenge"
 AUTH_USER_KEY = "webauthn_authentication_user_id"
@@ -67,11 +64,13 @@ PASSWORD_RESET_CHALLENGE_PREFIX = "ospbank:password_reset_webauthn:"
 PASSKEY_KIND_PLATFORM = "platform"
 PASSKEY_KIND_PASSWORD_MANAGER = "password_manager"
 PASSKEY_KIND_SECURITY_KEY = "security_key"
+PASSKEY_KIND_GENERIC = "passkey"
 PASSKEY_KINDS = frozenset(
     {
         PASSKEY_KIND_PLATFORM,
         PASSKEY_KIND_PASSWORD_MANAGER,
         PASSKEY_KIND_SECURITY_KEY,
+        PASSKEY_KIND_GENERIC,
     }
 )
 STEP_UP_ACTIONS = frozenset(
@@ -125,11 +124,10 @@ def current_webauthn_credential_reference() -> str | None:
     return str(value) if value else None
 
 
-def begin_registration_options(user: User, label: str, credential_kind: str = PASSKEY_KIND_SECURITY_KEY) -> dict[str, Any]:
+def begin_registration_options(user: User, label: str) -> dict[str, Any]:
     enforce_request_origin()
     ensure_account_not_frozen(user, "security key registration")
     label = _validate_label(label)
-    credential_kind = _validate_credential_kind(credential_kind)
     _ensure_registration_session_allowed(user)
     _ensure_label_available(user, label)
 
@@ -142,17 +140,18 @@ def begin_registration_options(user: User, label: str, credential_kind: str = PA
         user_display_name=user.username,
         timeout=current_app.config["WEBAUTHN_TIMEOUT_MS"],
         attestation=AttestationConveyancePreference.NONE,
-        authenticator_selection=_registration_authenticator_selection(credential_kind),
+        authenticator_selection=AuthenticatorSelectionCriteria(
+            resident_key=ResidentKeyRequirement.PREFERRED,
+            user_verification=UserVerificationRequirement.REQUIRED,
+        ),
         exclude_credentials=[PublicKeyCredentialDescriptor(id=item.credential_id) for item in credentials],
-        hints=_registration_hints(credential_kind),
     )
 
     session[REGISTRATION_CHALLENGE_KEY] = bytes_to_base64url(options.challenge)
     session[REGISTRATION_LABEL_KEY] = label
-    session[REGISTRATION_KIND_KEY] = credential_kind
     session[REGISTRATION_USER_KEY] = user.id
     session.modified = True
-    audit_webauthn_event("register_options", "success", user=user, label=label, metadata={"credential_kind": credential_kind})
+    audit_webauthn_event("register_options", "success", user=user, label=label)
     return options_to_json_dict(options)
 
 
@@ -166,7 +165,6 @@ def verify_registration(user: User, credential: dict[str, Any]) -> dict[str, Any
     label = str(session.get(REGISTRATION_LABEL_KEY) or "")
     _ensure_registration_session_allowed(user)
     _ensure_label_available(user, label)
-    credential_kind = _validate_credential_kind(str(session.get(REGISTRATION_KIND_KEY) or PASSKEY_KIND_SECURITY_KEY))
 
     verification = None
     failure_stage = "attestation_verification"
@@ -191,6 +189,7 @@ def verify_registration(user: User, credential: dict[str, Any]) -> dict[str, Any
         raise AuthError(GENERIC_WEBAUTHN_ERROR, 401) from exc
 
     transports = _registration_transports(credential)
+    credential_kind = _credential_kind_from_browser_response(credential, transports)
     item = WebAuthnCredential(
         user_id=user.id,
         credential_id=verification.credential_id,
@@ -222,7 +221,6 @@ def verify_registration(user: User, credential: dict[str, Any]) -> dict[str, Any
 
     session.pop(REGISTRATION_CHALLENGE_KEY, None)
     session.pop(REGISTRATION_LABEL_KEY, None)
-    session.pop(REGISTRATION_KIND_KEY, None)
     session.pop(REGISTRATION_USER_KEY, None)
     session.modified = True
     audit_webauthn_event(
@@ -969,31 +967,20 @@ def _aaguid_value(value: Any) -> str:
 
 
 def _validate_credential_kind(value: str) -> str:
-    normalized = str(value or PASSKEY_KIND_SECURITY_KEY).strip().casefold()
+    normalized = str(value or PASSKEY_KIND_GENERIC).strip().casefold()
     if normalized not in PASSKEY_KINDS:
         raise AuthError("Invalid passkey type", 400)
     return normalized
 
 
-def _registration_authenticator_selection(credential_kind: str) -> AuthenticatorSelectionCriteria:
-    attachment = None
-    if credential_kind == PASSKEY_KIND_PLATFORM:
-        attachment = AuthenticatorAttachment.PLATFORM
-    elif credential_kind == PASSKEY_KIND_SECURITY_KEY:
-        attachment = AuthenticatorAttachment.CROSS_PLATFORM
-    return AuthenticatorSelectionCriteria(
-        authenticator_attachment=attachment,
-        resident_key=ResidentKeyRequirement.PREFERRED,
-        user_verification=UserVerificationRequirement.REQUIRED,
-    )
-
-
-def _registration_hints(credential_kind: str):
-    if credential_kind == PASSKEY_KIND_SECURITY_KEY:
-        return [PublicKeyCredentialHint.SECURITY_KEY]
-    hint_name = "CLIENT_DEVICE" if credential_kind == PASSKEY_KIND_PLATFORM else "HYBRID"
-    hint = getattr(PublicKeyCredentialHint, hint_name, None)
-    return [hint] if hint is not None else None
+def _credential_kind_from_browser_response(credential: dict[str, Any], transports: list[str]) -> str:
+    attachment = str(credential.get("authenticatorAttachment") or "").strip().casefold()
+    normalized_transports = {str(value).strip().casefold() for value in transports}
+    if attachment == "platform" or "internal" in normalized_transports:
+        return PASSKEY_KIND_PLATFORM
+    if attachment == "cross-platform" or normalized_transports.intersection({"usb", "nfc", "ble"}):
+        return PASSKEY_KIND_SECURITY_KEY
+    return PASSKEY_KIND_GENERIC
 
 
 def _should_lock_for_counter_anomaly(stored_count: int | None, new_count: int | None) -> bool:
@@ -1397,6 +1384,7 @@ def _credential_kind_display(value: str | None) -> str:
         PASSKEY_KIND_PLATFORM: "This device",
         PASSKEY_KIND_PASSWORD_MANAGER: "Browser or password manager",
         PASSKEY_KIND_SECURITY_KEY: "External security key",
+        PASSKEY_KIND_GENERIC: "Passkey",
     }.get(str(value or "").strip().casefold(), "Passkey")
 
 

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -909,7 +909,8 @@ label {
   font-weight: 650;
 }
 
-input {
+input,
+select {
   width: 100%;
   min-height: 46px;
   border: 1px solid var(--line);
@@ -924,18 +925,39 @@ input {
     background-color 150ms ease;
 }
 
+select {
+  appearance: none;
+  padding-right: 42px;
+  background-color: var(--input-bg);
+  background-image:
+    linear-gradient(45deg, transparent 50%, var(--muted-strong) 50%),
+    linear-gradient(135deg, var(--muted-strong) 50%, transparent 50%);
+  background-position:
+    calc(100% - 19px) 50%,
+    calc(100% - 13px) 50%;
+  background-repeat: no-repeat;
+  background-size: 6px 6px, 6px 6px;
+}
+
+select option {
+  background: var(--surface);
+  color: var(--text);
+}
+
 input::placeholder {
   color: color-mix(in srgb, var(--muted) 72%, transparent);
 }
 
 input:focus,
+select:focus,
 a:focus-visible,
 button:focus-visible {
   outline: 3px solid var(--focus);
   outline-offset: 2px;
 }
 
-input:focus {
+input:focus,
+select:focus {
   border-color: var(--primary);
   box-shadow: 0 0 0 4px var(--focus);
   outline: 0;

--- a/app/static/js/webauthn.js
+++ b/app/static/js/webauthn.js
@@ -168,12 +168,10 @@
         event.preventDefault();
         var errorNode = document.querySelector("[data-webauthn-register-error]");
         var label = registerForm.querySelector('input[name="label"]').value;
-        var kindInput = registerForm.querySelector('select[name="credential_kind"], input[name="credential_kind"]:checked');
-        var credentialKind = kindInput ? kindInput.value : "security_key";
         clearError(errorNode);
         postJson(
           "/auth/webauthn/register/options",
-          { label: label, credential_kind: credentialKind },
+          { label: label },
           csrfToken(registerForm)
         )
           .then(function (options) {

--- a/app/templates/security_keys.html
+++ b/app/templates/security_keys.html
@@ -66,22 +66,14 @@
         <p class="eyebrow">Register passkey</p>
         <h2>Add a passkey or security key</h2>
       </div>
-      <p class="muted">Use Windows Hello, a browser or password-manager passkey such as Bitwarden, or an external FIDO2 security key.</p>
+      <p class="muted">Your browser may offer Bitwarden or another password manager, Windows Hello, or an external FIDO2 security key. SITBank verifies the result after your browser completes registration.</p>
       <form method="post" action="{{ url_for('web.security_keys') }}" data-webauthn-register-form novalidate>
         {{ add_form.hidden_tag() }}
         <div class="form-group">
           <label for="security-key-label">Passkey label</label>
           <input id="security-key-label" name="label" maxlength="80" autocomplete="off" placeholder="Windows Hello" required>
         </div>
-        <div class="form-group">
-          <label for="credential-kind">Passkey type</label>
-          <select id="credential-kind" name="credential_kind">
-            <option value="platform">This device or Windows Hello</option>
-            <option value="password_manager">Browser or password manager</option>
-            <option value="security_key">External security key</option>
-          </select>
-        </div>
-        <p class="hint">Origin, RP ID, challenge, and user verification are checked server-side before the passkey is accepted.</p>
+        <p class="hint">The browser and installed passkey provider decide which prompt appears. Origin, RP ID, challenge, and user verification are checked server-side before the passkey is accepted.</p>
         <button class="button full" type="submit"{% if not user.mfa_enabled or not recent_mfa %} disabled{% endif %}>Register passkey</button>
         <p class="field-error" data-webauthn-register-error hidden></p>
       </form>

--- a/tests/test_group_a_security.py
+++ b/tests/test_group_a_security.py
@@ -1183,6 +1183,9 @@ def test_security_management_pages_use_polished_stepup_ui(client):
     assert "AAGUID" not in keys_markup
     assert "11111111-1111-1111-1111-111111111111" not in keys_markup
     assert "Last used: 05 Jun 2026 15:11 UTC" in keys_markup
+    assert 'name="credential_kind"' not in keys_markup
+    assert "Passkey type" not in keys_markup
+    assert "browser and installed passkey provider decide which prompt appears" in keys_markup
     assert "Verify and revoke" in keys_markup
     assert 'class="button danger-button button-small key-revoke-button"' in keys_markup
     assert "Revoke is disabled because at least two approved security keys must stay registered" not in keys_markup
@@ -1192,6 +1195,10 @@ def test_security_management_pages_use_polished_stepup_ui(client):
     assert "Verify and freeze account" in freeze_markup
     assert "color: var(--button-primary-text);" in css
     assert "text-align: left;" in css
+    assert "select {" in css
+    assert "appearance: none;" in css
+    assert "background-color: var(--input-bg);" in css
+    assert "background-image:" in css
 
 
 def test_mfa_replacement_start_requires_fresh_mfa_stepup(client):
@@ -3229,6 +3236,8 @@ def test_webauthn_browser_errors_are_sanitized_before_display():
     assert "Security key verification was not completed. Try again." in source
     assert "showError(errorNode, error.message)" not in source
     assert "webAuthnErrorMessage(error)" in source
+    assert "credential_kind" not in source
+    assert 'querySelector(\'select[name="credential_kind"]' not in source
 
 
 def test_production_env_docs_require_pbkdf2_pepper_not_bcrypt():

--- a/tests/test_webauthn_lifecycle.py
+++ b/tests/test_webauthn_lifecycle.py
@@ -146,22 +146,14 @@ def test_webauthn_options_fail_closed_without_exact_origin(client):
     assert old_origin.get_json()["error"] == "Invalid request origin"
 
 
-@pytest.mark.parametrize(
-    ("credential_kind", "expected_attachment"),
-    [
-        ("platform", "platform"),
-        ("password_manager", None),
-        ("security_key", "cross-platform"),
-    ],
-)
-def test_registration_options_support_optional_passkey_modes(client, credential_kind, expected_attachment):
+def test_registration_options_are_generic_so_browser_can_choose_passkey_provider(client):
     register(client)
     login(client)
     mark_recent_mfa_session(client, user_by_name())
 
     response = client.post(
         "/auth/webauthn/register/options",
-        json={"label": f"{credential_kind} credential", "credential_kind": credential_kind},
+        json={"label": "Primary passkey"},
         headers=ORIGIN,
     )
     payload = response.get_json()
@@ -169,10 +161,8 @@ def test_registration_options_support_optional_passkey_modes(client, credential_
     assert response.status_code == 200
     assert payload["rp"]["id"] == "sitbank.duckdns.org"
     assert payload["attestation"] == "none"
-    if expected_attachment is None:
-        assert "authenticatorAttachment" not in payload["authenticatorSelection"]
-    else:
-        assert payload["authenticatorSelection"]["authenticatorAttachment"] == expected_attachment
+    assert "authenticatorAttachment" not in payload["authenticatorSelection"]
+    assert "hints" not in payload
     assert payload["authenticatorSelection"]["userVerification"] == "required"
     assert payload["authenticatorSelection"]["residentKey"] == "preferred"
 
@@ -224,19 +214,19 @@ def test_registration_allows_optional_passkey_without_mds_aaguid(client, monkeyp
     assert response.get_json()["requires_backup_key"] is False
 
 
-def test_registration_records_password_manager_kind_for_synced_passkey(client, monkeypatch):
+def test_registration_records_platform_kind_for_internal_passkey(client, monkeypatch):
     register(client)
     login(client)
     mark_recent_mfa_session(client, user_by_name())
     client.post(
         "/auth/webauthn/register/options",
-        json={"label": "Bitwarden", "credential_kind": "password_manager"},
+        json={"label": "Windows Hello"},
         headers=ORIGIN,
     )
 
     def fake_verify_registration_response(**_kwargs):
         return SimpleNamespace(
-            credential_id=b"bitwarden-passkey",
+            credential_id=b"windows-passkey",
             credential_public_key=b"public-key",
             sign_count=0,
             aaguid="",
@@ -254,8 +244,8 @@ def test_registration_records_password_manager_kind_for_synced_passkey(client, m
         "/auth/webauthn/register/verify",
         json={
             "credential": {
-                "id": bytes_to_base64url(b"bitwarden-passkey"),
-                "rawId": bytes_to_base64url(b"bitwarden-passkey"),
+                "id": bytes_to_base64url(b"windows-passkey"),
+                "rawId": bytes_to_base64url(b"windows-passkey"),
                 "type": "public-key",
                 "authenticatorAttachment": "platform",
                 "response": {
@@ -273,9 +263,54 @@ def test_registration_records_password_manager_kind_for_synced_passkey(client, m
     assert item.attestation_format == "none"
     assert item.credential_device_type == "multi_device"
     assert item.credential_backed_up is True
-    assert item.credential_kind == "password_manager"
-    assert response.get_json()["credential"]["credential_kind"] == "password_manager"
+    assert item.credential_kind == "platform"
+    assert response.get_json()["credential"]["credential_kind"] == "platform"
     assert response.get_json()["credential"]["aaguid"] == "00000000-0000-0000-0000-000000000000"
+
+
+def test_registration_records_generic_passkey_when_browser_metadata_is_opaque(client, monkeypatch):
+    register(client)
+    login(client)
+    mark_recent_mfa_session(client, user_by_name())
+    client.post("/auth/webauthn/register/options", json={"label": "Browser passkey"}, headers=ORIGIN)
+
+    def fake_verify_registration_response(**_kwargs):
+        return SimpleNamespace(
+            credential_id=b"browser-passkey",
+            credential_public_key=b"public-key",
+            sign_count=0,
+            aaguid="",
+            fmt="none",
+            credential_device_type="multi_device",
+            credential_backed_up=True,
+        )
+
+    monkeypatch.setattr(
+        "app.auth.webauthn_services.verify_registration_response",
+        fake_verify_registration_response,
+    )
+
+    response = client.post(
+        "/auth/webauthn/register/verify",
+        json={
+            "credential": {
+                "id": bytes_to_base64url(b"browser-passkey"),
+                "rawId": bytes_to_base64url(b"browser-passkey"),
+                "type": "public-key",
+                "response": {
+                    "attestationObject": "AA",
+                    "clientDataJSON": "AA",
+                    "transports": [],
+                },
+            }
+        },
+        headers=ORIGIN,
+    )
+
+    assert response.status_code == 200
+    item = db.session.query(WebAuthnCredential).one()
+    assert item.credential_kind == "passkey"
+    assert response.get_json()["credential"]["credential_kind_display"] == "Passkey"
 
 
 def test_registration_verify_unexpected_error_returns_json(app, client, monkeypatch):


### PR DESCRIPTION
## Summary

Updates passkey registration so users no longer need to choose a passkey type manually.

The browser now receives generic WebAuthn registration options without `authenticatorAttachment` or hints, allowing Chrome, Windows, Bitwarden, and other authenticators to present their normal chooser flow. SITBank then classifies the credential after registration from browser-returned metadata when possible as a platform authenticator, external security key, or generic passkey.

This also updates global dropdown styling so the remaining **Preferred verification** select matches the SITBank dark input theme instead of rendering with the native beige browser styling.

## What changed

* Removed user-facing passkey type selection during registration.
* Generated generic WebAuthn registration options.
* Removed `authenticatorAttachment` and registration hints from browser options.
* Let the browser and authenticator ecosystem present the normal chooser flow.
* Added post-registration credential classification where metadata is available:

  * Platform authenticator
  * External security key
  * Generic passkey
* Updated global select/dropdown theme styling.
* Ensured the remaining **Preferred verification** select matches the SITBank dark input style.
