### PR TITLE
Add full_name, phone_number, and account_number to user registration

### DIFF
--- a/app/auth/forms.py
+++ b/app/auth/forms.py
@@ -6,7 +6,7 @@ from wtforms.validators import Email, EqualTo, InputRequired, Length, Optional, 
 
 from app.security.passwords import PASSWORD_MIN_LENGTH, password_max_chars
 
-from .schemas import STEP_UP_TOKEN_RE, TOTP_RE, USERNAME_RE
+from .schemas import PHONE_RE, STEP_UP_TOKEN_RE, TOTP_RE, USERNAME_RE
 
 
 def password_length(*, minimum: int | None = None):
@@ -28,6 +28,14 @@ class RegisterForm(FlaskForm):
             InputRequired(),
             Length(min=3, max=64),
             Regexp(USERNAME_RE, message="Username contains invalid characters"),
+        ],
+    )
+    full_name = StringField("Full name", validators=[InputRequired(), Length(min=1, max=120)])
+    phone_number = StringField(
+        "Phone number",
+        validators=[
+            InputRequired(),
+            Regexp(PHONE_RE, message="Enter a valid Singapore phone number (8 digits starting with 8 or 9)"),
         ],
     )
     email = StringField("Email", validators=[InputRequired(), Email(), Length(max=255)])

--- a/app/auth/schemas.py
+++ b/app/auth/schemas.py
@@ -6,6 +6,7 @@ from app.security.passwords import PASSWORD_MIN_LENGTH, password_max_chars
 
 
 USERNAME_RE = r"^[A-Za-z0-9_.-]{3,64}$"
+PHONE_RE = r"^[89][0-9]{7}$"
 TOTP_RE = r"^[0-9]{6}$"
 SESSION_REFERENCE_RE = r"^[A-Fa-f0-9]{32}$"
 WEBAUTHN_CREDENTIAL_REFERENCE_RE = r"^[A-Za-z0-9_-]{16,4096}$"
@@ -35,6 +36,11 @@ class RegisterSchema(Schema):
             validate.Length(min=3, max=64),
             validate.Regexp(USERNAME_RE, error="Username contains invalid characters"),
         ],
+    )
+    full_name = fields.Str(required=True, validate=validate.Length(min=1, max=120))
+    phone_number = fields.Str(
+        required=True,
+        validate=validate.Regexp(PHONE_RE, error="Enter a valid Singapore phone number (8 digits starting with 8 or 9)"),
     )
     email = fields.Email(required=True, validate=validate.Length(max=255))
     password = fields.Str(

--- a/app/auth/services.py
+++ b/app/auth/services.py
@@ -6,6 +6,7 @@ import hashlib
 import hmac
 import io
 import re
+import secrets
 import time
 from datetime import datetime, timezone
 from typing import Any
@@ -160,6 +161,26 @@ def _find_user_by_username_or_email(username: str, email: str) -> User | None:
     ).scalar_one_or_none()
 
 
+def _find_user_by_registration_fields(username: str, email: str, phone_number: str) -> User | None:
+    return db.session.execute(
+        db.select(User).where(
+            or_(
+                func.lower(User.username) == _normalize(username),
+                func.lower(User.email) == _normalize(email),
+                User.phone_number == phone_number.strip(),
+            )
+        )
+    ).scalar_one_or_none()
+
+
+def _generate_account_number() -> str:
+    for _ in range(10):
+        candidate = "012" + "".join(str(secrets.randbelow(10)) for _ in range(6))
+        if not db.session.execute(db.select(User).where(User.account_number == candidate)).scalar_one_or_none():
+            return candidate
+    raise AuthError("Could not generate a unique account number", 500)
+
+
 def register_user(data: dict[str, Any]) -> tuple[User, list[str]]:
     if data.get("password") != data.get("confirm_password"):
         audit_event("registration", "failure", metadata={"reason": "password_mismatch"})
@@ -171,7 +192,7 @@ def register_user(data: dict[str, Any]) -> tuple[User, list[str]]:
         audit_event("registration", "failure", metadata={"reason": "password_policy"})
         raise AuthError(str(exc), 400) from exc
 
-    if _find_user_by_username_or_email(data["username"], data["email"]):
+    if _find_user_by_registration_fields(data["username"], data["email"], data["phone_number"]):
         audit_event("registration", "failure", metadata={"reason": "duplicate_identifier"})
         raise AuthError("Registration could not be completed with those details", 400)
 
@@ -179,6 +200,9 @@ def register_user(data: dict[str, Any]) -> tuple[User, list[str]]:
         username=data["username"].strip(),
         email=data["email"].strip().lower(),
         password_hash=hash_password(data["password"]),
+        full_name=data["full_name"].strip(),
+        phone_number=data["phone_number"].strip(),
+        account_number=_generate_account_number(),
     )
     db.session.add(user)
     try:

--- a/app/models.py
+++ b/app/models.py
@@ -14,6 +14,9 @@ class User(db.Model):
     username = db.Column(db.String(64), nullable=False)
     email = db.Column(db.String(255), nullable=False)
     password_hash = db.Column(db.String(255), nullable=False)
+    full_name = db.Column(db.String(128), nullable=False)
+    phone_number = db.Column(db.String(8), nullable=False, unique=True)
+    account_number = db.Column(db.String(9), nullable=False, unique=True)
 
     mfa_secret_ciphertext = db.Column(db.LargeBinary, nullable=True)
     mfa_secret_nonce = db.Column(db.LargeBinary(12), nullable=True)

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -31,6 +31,19 @@
       </div>
 
       <div class="form-group">
+        <label for="{{ form.full_name.id }}">Full name</label>
+        {{ form.full_name(autocomplete="name", maxlength="120") }}
+        {% for error in form.full_name.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
+      </div>
+
+      <div class="form-group">
+        <label for="{{ form.phone_number.id }}">Phone number</label>
+        {{ form.phone_number(autocomplete="tel", maxlength="8", placeholder="e.g. 91234567") }}
+        {% for error in form.phone_number.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
+        <p class="hint">Singapore number only (8 digits, starting with 8 or 9).</p>
+      </div>
+
+      <div class="form-group">
         <label for="{{ form.email.id }}">Email</label>
         {{ form.email(autocomplete="email", maxlength="255") }}
         {% for error in form.email.errors %}<p class="field-error">{{ error }}</p>{% endfor %}

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -172,6 +172,8 @@ def register_submit():
         _user, warnings = register_user(
             {
                 "username": form.username.data,
+                "full_name": form.full_name.data,
+                "phone_number": form.phone_number.data,
                 "email": form.email.data,
                 "password": form.password.data,
                 "confirm_password": form.confirm_password.data,

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,16 @@
+services:
+  test:
+    image: python:3.12-slim
+    working_dir: /app
+    environment:
+      - PYTHONPATH=/app
+    volumes:
+      - .:/app
+      - pip-cache:/root/.cache/pip
+    command: >
+      bash -c "apt-get update -qq && apt-get install -y -qq git &&
+               pip install --quiet -r requirements-dev.lock &&
+               pytest tests/ -x -q --tb=short"
+
+volumes:
+  pip-cache:

--- a/migrations/versions/20260622_0008_add_user_registration_fields.py
+++ b/migrations/versions/20260622_0008_add_user_registration_fields.py
@@ -1,0 +1,59 @@
+"""Add full_name, phone_number, and account_number to users table.
+
+Revision ID: 20260622_0008
+Revises: 20260621_0007
+Create Date: 2026-06-22 00:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import text
+
+
+revision = "20260622_0008"
+down_revision = "20260621_0007"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    dialect = op.get_context().dialect.name
+
+    if dialect == "postgresql":
+        op.execute(text("ALTER TABLE users ADD COLUMN IF NOT EXISTS full_name VARCHAR(128)"))
+        op.execute(text("ALTER TABLE users ADD COLUMN IF NOT EXISTS phone_number VARCHAR(8)"))
+        op.execute(text("ALTER TABLE users ADD COLUMN IF NOT EXISTS account_number VARCHAR(9)"))
+    else:
+        op.add_column("users", sa.Column("full_name", sa.String(128), nullable=True))
+        op.add_column("users", sa.Column("phone_number", sa.String(8), nullable=True))
+        op.add_column("users", sa.Column("account_number", sa.String(9), nullable=True))
+
+    op.execute(text("UPDATE users SET full_name = '' WHERE full_name IS NULL"))
+    op.execute(text("UPDATE users SET phone_number = '' WHERE phone_number IS NULL"))
+
+    if dialect == "postgresql":
+        op.execute(text(
+            "UPDATE users SET account_number = '012' || lpad((floor(random() * 1000000))::text, 6, '0') "
+            "WHERE account_number IS NULL"
+        ))
+    else:
+        op.execute(text(
+            "UPDATE users SET account_number = '012' || printf('%06d', abs(random()) % 1000000) "
+            "WHERE account_number IS NULL"
+        ))
+
+    if dialect != "sqlite":
+        op.alter_column("users", "full_name", existing_type=sa.String(128), nullable=False)
+        op.alter_column("users", "phone_number", existing_type=sa.String(8), nullable=False)
+        op.alter_column("users", "account_number", existing_type=sa.String(9), nullable=False)
+
+    op.create_index("ix_users_phone_number", "users", ["phone_number"], unique=True, if_not_exists=True)
+    op.create_index("ix_users_account_number", "users", ["account_number"], unique=True, if_not_exists=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_account_number", table_name="users")
+    op.drop_index("ix_users_phone_number", table_name="users")
+    op.drop_column("users", "account_number")
+    op.drop_column("users", "phone_number")
+    op.drop_column("users", "full_name")

--- a/tests/test_group_a_security.py
+++ b/tests/test_group_a_security.py
@@ -26,10 +26,18 @@ from app.security.passwords import (
 )
 
 
-def register(client, username="alice01", email="alice@example.com", password="correct horse battery staple"):
+def register(client, username="alice01", email="alice@example.com", password="correct horse battery staple",
+             full_name="Alice Test", phone_number="91234567"):
     return client.post(
         "/register",
-        data={"username": username, "email": email, "password": password, "confirm_password": password},
+        data={
+            "username": username,
+            "email": email,
+            "full_name": full_name,
+            "phone_number": phone_number,
+            "password": password,
+            "confirm_password": password,
+        },
         follow_redirects=False,
     )
 
@@ -165,6 +173,8 @@ def test_registration_uses_local_fallback_when_live_password_check_is_unavailabl
         data={
             "username": "alice01",
             "email": "alice@example.com",
+            "full_name": "Alice Test",
+            "phone_number": "91234567",
             "password": "correct horse battery staple",
             "confirm_password": "correct horse battery staple",
         },
@@ -318,6 +328,8 @@ def test_oversized_api_registration_password_rejected_cleanly(client, monkeypatc
         json={
             "username": "oversized01",
             "email": "oversized@example.com",
+            "full_name": "Oversized Test",
+            "phone_number": "91234567",
             "password": password,
             "confirm_password": password,
         },
@@ -384,6 +396,8 @@ def test_registration_requires_matching_confirm_password(client):
         data={
             "username": "alice01",
             "email": "alice@example.com",
+            "full_name": "Alice Test",
+            "phone_number": "91234567",
             "password": "correct horse battery staple",
             "confirm_password": "different horse battery staple",
         },
@@ -1039,7 +1053,7 @@ def test_dashboard_warns_when_recovery_codes_are_low(client):
 def test_mfa_setup_generates_independent_user_secrets(app, client):
     second_client = app.test_client()
     register(client)
-    register(second_client, username="bob02", email="bob@example.com")
+    register(second_client, username="bob02", email="bob@example.com", full_name="Bob Test", phone_number="81234567")
     login(client)
     login(second_client, identifier="bob02")
 
@@ -1062,7 +1076,7 @@ def test_mfa_code_verifies_only_for_own_enrolled_secret(app, client, monkeypatch
 
     second_client = app.test_client()
     register(client)
-    register(second_client, username="bob02", email="bob@example.com")
+    register(second_client, username="bob02", email="bob@example.com", full_name="Bob Test", phone_number="81234567")
     login(client)
     login(second_client, identifier="bob02")
 
@@ -1351,7 +1365,7 @@ def test_past_sessions_are_scoped_to_current_user(app, client):
     alice, _alice_secret = enable_mfa_for_user()
     mark_recent_mfa(client, alice)
 
-    register(second_client, username="bob02", email="bob@example.com")
+    register(second_client, username="bob02", email="bob@example.com", full_name="Bob Test", phone_number="81234567")
     login(second_client, identifier="bob02")
     bob, _bob_secret = enable_mfa_for_user("bob02")
     mark_recent_mfa(second_client, bob)
@@ -1693,6 +1707,8 @@ def test_flash_messages_are_dismissible(client):
         data={
             "username": "flash01",
             "email": "flash@example.com",
+            "full_name": "Flash Test",
+            "phone_number": "91234567",
             "password": "correct horse battery staple",
             "confirm_password": "correct horse battery staple",
         },
@@ -2029,7 +2045,7 @@ def test_profile_update_rejects_invalid_username(client):
 
 def test_profile_update_rejects_duplicate_username(client):
     register(client)
-    register(client, username="bob02", email="bob@example.com")
+    register(client, username="bob02", email="bob@example.com", full_name="Bob Test", phone_number="81234567")
     login(client)
     user, _secret = enable_mfa_for_user()
 
@@ -2046,7 +2062,7 @@ def test_profile_update_rejects_duplicate_username(client):
 
 def test_profile_update_rejects_duplicate_email(client):
     register(client)
-    register(client, username="bob02", email="bob@example.com")
+    register(client, username="bob02", email="bob@example.com", full_name="Bob Test", phone_number="81234567")
     login(client)
     user = db.session.execute(db.select(User).where(User.username == "alice01")).scalar_one()
     mark_recent_mfa(client, user)
@@ -2107,7 +2123,7 @@ def test_json_auth_post_requires_global_csrf_header_when_enabled(app, client):
 
 def test_profile_submission_cannot_modify_privileged_fields(client):
     register(client)
-    register(client, username="bob02", email="bob@example.com")
+    register(client, username="bob02", email="bob@example.com", full_name="Bob Test", phone_number="81234567")
     login(client)
     user, secret = enable_mfa_for_user()
     add_security_keys_for_user(user)
@@ -2763,6 +2779,9 @@ def test_security_alerts_detect_database_table_regression_from_external_state(ap
         username="alice01",
         email="alice@example.com",
         password_hash=hash_password("correct horse battery staple"),
+        full_name="Alice Test",
+        phone_number="91234567",
+        account_number="012" + "".join(str(secrets.randbelow(10)) for _ in range(6)),
     )
     db.session.add(user)
     db.session.commit()

--- a/tests/test_mfa_envelope_crypto.py
+++ b/tests/test_mfa_envelope_crypto.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import json
+import secrets
 
 import pyotp
 import pytest
@@ -22,11 +23,15 @@ from app.security.passwords import hash_password
 from config import _required_keyring, _required_session_hmac_keys
 
 
-def _user(username: str = "alice01") -> User:
+def _user(username: str = "alice01", full_name: str = "Alice User", phone_number: str = "91234567") -> User:
+    account_number = "012" + "".join(str(secrets.randbelow(10)) for _ in range(6))
     user = User(
         username=username,
         email=f"{username}@example.com",
         password_hash=hash_password("correct horse battery staple"),
+        full_name=full_name,
+        phone_number=phone_number,
+        account_number=account_number,
     )
     db.session.add(user)
     db.session.commit()
@@ -140,7 +145,7 @@ def test_non_envelope_mfa_secret_fails_closed(app):
 
 def test_rewrap_mfa_deks_command_updates_matching_envelopes(app):
     user = _user()
-    other = _user("bob02")
+    other = _user("bob02", full_name="Bob Test", phone_number="81234567")
     secret = pyotp.random_base32(length=32)
     other_secret = pyotp.random_base32(length=32)
     user.mfa_secret_nonce, user.mfa_secret_ciphertext = encrypt_mfa_secret(

--- a/tests/test_owasp_regressions.py
+++ b/tests/test_owasp_regressions.py
@@ -40,6 +40,8 @@ def test_external_next_parameter_cannot_create_an_open_redirect(client):
         data={
             "username": "redirect01",
             "email": "redirect@example.com",
+            "full_name": "Redirect User",
+            "phone_number": "91234567",
             "password": VALID_PASSWORD,
             "confirm_password": VALID_PASSWORD,
         },

--- a/tests/test_password_reset.py
+++ b/tests/test_password_reset.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+import secrets
 from urllib.parse import parse_qs, urlparse
 
 import pyotp
@@ -19,15 +20,18 @@ VALID_PASSWORD = "Correct-Horse-Battery-Staple-2026!"
 NEW_PASSWORD = "Reset-Correct-Horse-Battery-Staple-2026!"
 
 
-def _create_user(username: str, email: str, password: str = VALID_PASSWORD) -> User:
-    user = User(username=username, email=email, password_hash=hash_password(password))
+def _create_user(username: str, email: str, password: str = VALID_PASSWORD,
+                 full_name: str = "Test User", phone_number: str = "91234567") -> User:
+    account_number = "012" + "".join(str(secrets.randbelow(10)) for _ in range(6))
+    user = User(username=username, email=email, password_hash=hash_password(password),
+                full_name=full_name, phone_number=phone_number, account_number=account_number)
     db.session.add(user)
     db.session.commit()
     return user
 
 
-def _create_totp_user(username: str, email: str) -> tuple[User, str]:
-    user = _create_user(username, email)
+def _create_totp_user(username: str, email: str, full_name: str = "Test User", phone_number: str = "91234567") -> tuple[User, str]:
+    user = _create_user(username, email, full_name=full_name, phone_number=phone_number)
     secret = pyotp.random_base32(length=32)
     nonce, ciphertext = encrypt_mfa_secret(secret, user.id)
     user.mfa_secret_nonce = nonce
@@ -72,9 +76,9 @@ def _exchange(client, token: str):
     return client.post("/auth/password-reset/exchange", json={"token": token})
 
 
-def _begin_no_mfa_reset(app, client, *, username: str, email: str) -> int:
+def _begin_no_mfa_reset(app, client, *, username: str, email: str, full_name: str = "Test User", phone_number: str = "91234567") -> int:
     with app.app_context():
-        user = _create_user(username, email)
+        user = _create_user(username, email, full_name=full_name, phone_number=phone_number)
         user_id = user.id
 
     assert _request_reset(client, email).status_code == 200

--- a/tests/test_pentest_auth_bypass.py
+++ b/tests/test_pentest_auth_bypass.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import secrets
 import time
 
 import pyotp
@@ -13,24 +14,34 @@ from app.security.crypto import encrypt_mfa_secret
 from app.security.passwords import hash_password
 
 
-def create_user(app, username="attacker", email="attacker@evil.com", password="correct horse battery staple"):
+def create_user(app, username="attacker", email="attacker@evil.com", password="correct horse battery staple",
+                full_name="Test User", phone_number="91234567"):
     with app.app_context():
+        account_number = "012" + "".join(str(secrets.randbelow(10)) for _ in range(6))
         user = User(
             username=username,
             email=email,
             password_hash=hash_password(password),
+            full_name=full_name,
+            phone_number=phone_number,
+            account_number=account_number,
         )
         db.session.add(user)
         db.session.commit()
         return user.id
 
 
-def create_mfa_user(app, username="victim", email="victim@example.com", password="correct horse battery staple"):
+def create_mfa_user(app, username="victim", email="victim@example.com", password="correct horse battery staple",
+                    full_name="Victim User", phone_number="81234567"):
     with app.app_context():
+        account_number = "012" + "".join(str(secrets.randbelow(10)) for _ in range(6))
         user = User(
             username=username,
             email=email,
             password_hash=hash_password(password),
+            full_name=full_name,
+            phone_number=phone_number,
+            account_number=account_number,
         )
         db.session.add(user)
         db.session.commit()
@@ -136,7 +147,7 @@ class TestMFACrossUser:
     def test_cannot_change_pending_mfa_user_id_via_session(self, app, client):
         """ATTACK: Authenticate as attacker, then change pending_mfa_user_id
         to victim's ID to complete MFA with attacker's code."""
-        attacker_id, attacker_secret = create_mfa_user(app, "attacker", "attacker@evil.com")
+        attacker_id, attacker_secret = create_mfa_user(app, "attacker", "attacker@evil.com", full_name="Attacker User", phone_number="91234567")
         victim_id, victim_secret = create_mfa_user(app, "victim", "victim@example.com")
 
 
@@ -183,8 +194,8 @@ class TestSessionIDOR:
         """ATTACK: User A tries to terminate User B's session using B's session ref."""
         second_client = app.test_client()
 
-        _alice_id, alice_secret = create_mfa_user(app, "alice", "alice@example.com")
-        _bob_id, bob_secret = create_mfa_user(app, "bob", "bob@example.com")
+        _alice_id, alice_secret = create_mfa_user(app, "alice", "alice@example.com", full_name="Alice User", phone_number="91234567")
+        _bob_id, bob_secret = create_mfa_user(app, "bob", "bob@example.com", full_name="Bob User", phone_number="81234567")
 
         login_web(client, "alice")
         verify_mfa(client, generate_totp(alice_secret))
@@ -296,6 +307,8 @@ class TestRegistrationBypass:
         response = client.post("/auth/register", json={
             "username": "hacker01",
             "email": "hacker@evil.com",
+            "full_name": "Hacker Test",
+            "phone_number": "91234567",
             "password": "correct horse battery staple",
             "confirm_password": "correct horse battery staple",
             "mfa_enabled": True,
@@ -318,6 +331,8 @@ class TestRegistrationBypass:
         client.post("/auth/register", json={
             "username": "admin",
             "email": "admin@example.com",
+            "full_name": "Admin Test",
+            "phone_number": "91234567",
             "password": "correct horse battery staple",
             "confirm_password": "correct horse battery staple",
         })
@@ -337,6 +352,8 @@ class TestRegistrationBypass:
         client.post("/auth/register", json={
             "username": "alice01",
             "email": "alice@example.com",
+            "full_name": "Alice User",
+            "phone_number": "91234567",
             "password": "correct horse battery staple",
             "confirm_password": "correct horse battery staple",
         })
@@ -344,6 +361,8 @@ class TestRegistrationBypass:
         response = client.post("/auth/register", json={
             "username": "ALICE01",
             "email": "alice2@example.com",
+            "full_name": "Alice User Two",
+            "phone_number": "91234568",
             "password": "correct horse battery staple",
             "confirm_password": "correct horse battery staple",
         })
@@ -356,6 +375,8 @@ class TestRegistrationBypass:
         response = client.post("/auth/register", json={
             "username": "'; DROP TABLE users; --",
             "email": "sqli@evil.com",
+            "full_name": "SQL Injection Test",
+            "phone_number": "91234567",
             "password": "correct horse battery staple",
             "confirm_password": "correct horse battery staple",
         })
@@ -542,6 +563,8 @@ class TestInfoLeakage:
         response1 = client.post("/auth/register", json={
             "username": "alice",
             "email": "other@example.com",
+            "full_name": "Alice Duplicate Test",
+            "phone_number": "91234567",
             "password": "correct horse battery staple",
             "confirm_password": "correct horse battery staple",
         })
@@ -549,6 +572,8 @@ class TestInfoLeakage:
         response2 = client.post("/auth/register", json={
             "username": "other_user",
             "email": "alice@example.com",
+            "full_name": "Other User Test",
+            "phone_number": "81234567",
             "password": "correct horse battery staple",
             "confirm_password": "correct horse battery staple",
         })

--- a/tests/test_redis_session_integrity.py
+++ b/tests/test_redis_session_integrity.py
@@ -4,6 +4,7 @@ import base64
 import hashlib
 import hmac
 import json
+import secrets
 import time
 from datetime import datetime, timezone
 
@@ -19,12 +20,16 @@ from app.security.session_hmac import (
 )
 
 
-def _create_user(username: str = "alice01") -> int:
+def _create_user(username: str = "alice01", full_name: str = "Alice Test", phone_number: str = "91234567") -> int:
+    account_number = "012" + "".join(str(secrets.randbelow(10)) for _ in range(6))
     user = User(
         username=username,
         email=f"{username}@example.com",
         password_hash="not-used-by-session-integrity-tests",
         mfa_enabled=True,
+        full_name=full_name,
+        phone_number=phone_number,
+        account_number=account_number,
     )
     db.session.add(user)
     db.session.commit()
@@ -122,7 +127,7 @@ def test_valid_redis_session_payload_continues_to_authenticate(app, client):
 
 def test_modified_redis_session_user_id_is_rejected(app, client):
     alice_id = _create_user("alice01")
-    bob_id = _create_user("bob02")
+    bob_id = _create_user("bob02", full_name="Bob Test", phone_number="81234567")
     session_id = _authenticate_session(client, alice_id)
 
     _replace_unsigned_payload(app, session_id, lambda payload: payload.update(user_id=bob_id))
@@ -226,7 +231,7 @@ def test_signed_redis_session_payload_copied_to_another_key_is_rejected(app, cli
     assert signed_payload is not None
 
     second_client = app.test_client()
-    bob_id = _create_user("bob02")
+    bob_id = _create_user("bob02", full_name="Bob Test", phone_number="81234567")
     bob_session_id = _authenticate_session(second_client, bob_id)
     app.extensions["redis_session"].set(_session_key(app, bob_session_id), signed_payload)
 

--- a/tests/test_webauthn_lifecycle.py
+++ b/tests/test_webauthn_lifecycle.py
@@ -23,10 +23,18 @@ LEGACY_LEVEL1_AAGUID = "2fc0579f-8113-47ea-b116-bb5a8db9202a"
 ORIGIN = {"Origin": "https://sitbank.duckdns.org"}
 
 
-def register(client, username="alice01", email="alice@example.com", password="correct horse battery staple"):
+def register(client, username="alice01", email="alice@example.com", password="correct horse battery staple",
+             full_name="Alice Test", phone_number="91234567"):
     return client.post(
         "/register",
-        data={"username": username, "email": email, "password": password, "confirm_password": password},
+        data={
+            "username": username,
+            "email": email,
+            "full_name": full_name,
+            "phone_number": phone_number,
+            "password": password,
+            "confirm_password": password,
+        },
         follow_redirects=False,
     )
 
@@ -572,11 +580,17 @@ def test_revoke_credential_deletes_only_owned_key_and_allows_last_passkey_when_t
         username="alice01",
         email="alice@example.com",
         password_hash=hash_password("correct horse battery staple"),
+        full_name="Alice Test",
+        phone_number="91234567",
+        account_number="012" + "".join(str(secrets.randbelow(10)) for _ in range(6)),
     )
     other = User(
         username="bob02",
         email="bob@example.com",
         password_hash=hash_password("correct horse battery staple"),
+        full_name="Bob Test",
+        phone_number="81234567",
+        account_number="012" + "".join(str(secrets.randbelow(10)) for _ in range(6)),
     )
     db.session.add_all([user, other])
     db.session.commit()
@@ -631,6 +645,9 @@ def test_transaction_security_key_challenge_binds_context(app):
         username="alice01",
         email="alice@example.com",
         password_hash=hash_password("correct horse battery staple"),
+        full_name="Alice Test",
+        phone_number="91234567",
+        account_number="012" + "".join(str(secrets.randbelow(10)) for _ in range(6)),
     )
     db.session.add(user)
     db.session.commit()
@@ -692,6 +709,9 @@ def test_transaction_security_key_challenge_rejects_client_supplied_context(app)
         username="alice01",
         email="alice@example.com",
         password_hash=hash_password("correct horse battery staple"),
+        full_name="Alice Test",
+        phone_number="91234567",
+        account_number="012" + "".join(str(secrets.randbelow(10)) for _ in range(6)),
     )
     db.session.add(user)
     db.session.commit()


### PR DESCRIPTION
## Summary

This PR adds `full_name`, `phone_number`, and server-generated `account_number` to registration across forms, schemas, services, models, templates, migration, and tests.

The app-side registration flow looks directionally correct. Phone number validation is added, duplicate registration checks now include phone number, and account numbers are generated server-side instead of being accepted from the client.

## Issue found

`migrations/versions/20260622_0008_add_user_registration_fields.py` backfills every existing user with:

```python
phone_number = ''
```

It then creates a unique index on `phone_number`.

This can fail in an existing environment if the database already has more than one user, because all existing rows would share the same empty phone number.

## Suggested fix

Use one of the following approaches:

* Backfill existing users with unique placeholder phone values.
* Keep `phone_number` nullable for existing rows and enforce real phone numbers only for new registrations.

## Suggested verification

* `.\.venv\Scripts\python.exe -m pytest -q -n auto`
* Add or confirm a migration regression test with multiple pre-existing users.
