### PR TITLE
Fix smoke test registration payload to include full_name and phone_nu…

### DIFF
--- a/ops/container/create_dast_session.py
+++ b/ops/container/create_dast_session.py
@@ -114,6 +114,8 @@ def create_authenticated_cookie(
         "/auth/register",
          payload={
              "username": username,
+             "full_name": f"DAST User {suffix}",
+             "phone_number": f"9{secrets.randbelow(9000000) + 1000000}",
              "email": f"{username}@example.test",
              "password": password,
              "confirm_password": password,


### PR DESCRIPTION
…mber

## Summary

Reviewed PR #106 / commit `028ffbf`.

This is a focused DAST compatibility fix.

Since PR #105 made `full_name` and `phone_number` required during registration, the authenticated ZAP/DAST helper now includes those fields when creating its temporary test user.

## Assessment

This looks appropriate and keeps authenticated DAST aligned with the new registration contract.

No security concern from this specific change. The generated DAST user data is synthetic, and the phone number format matches the app validation rule.

## Suggested verification

* Run the image-test / authenticated DAST workflow path.
* Confirm `/auth/register` succeeds for the generated DAST user before ZAP starts crawling.
