### PR TITLE
Revamp dashboard to banking-focused UI with balance/account visibilit…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ appendonly.aof*
 *.pem
 *.pdf
 .vscode/
+compose.dev.yml

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1637,6 +1637,166 @@ th {
   opacity: 0.5;
 }
 
+/* ── Banking dashboard ─────────────────────────────── */
+
+.bank-section-title {
+  margin-bottom: var(--space-4);
+}
+
+.bank-account-card {
+  border-radius: var(--radius);
+  background: linear-gradient(135deg, var(--primary) 0%, var(--accent) 100%);
+  padding: var(--space-7);
+  box-shadow: var(--shadow);
+}
+
+.bank-account-card-inner {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--space-6);
+  flex-wrap: wrap;
+}
+
+.bank-account-identity {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.bank-card-eyebrow {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.bank-card-name {
+  color: #ffffff;
+  font-size: 1.6rem;
+}
+
+.bank-card-number {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.82);
+  font-family: Consolas, "Liberation Mono", monospace;
+  font-size: 1.05rem;
+  letter-spacing: 0.12em;
+}
+
+.bank-account-balance {
+  display: grid;
+  gap: var(--space-1);
+  text-align: right;
+}
+
+.balance-amount {
+  margin: 0;
+  color: #ffffff;
+  font-size: 2.4rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.card-eye-btn {
+  background: none;
+  border: none;
+  padding: var(--space-1);
+  cursor: pointer;
+  color: rgba(255, 255, 255, 0.7);
+  display: inline-flex;
+  align-items: center;
+  border-radius: 4px;
+  transition: color 0.15s;
+  flex-shrink: 0;
+}
+
+.card-eye-btn:hover {
+  color: #ffffff;
+}
+
+.card-eye-btn .icon {
+  width: 20px;
+  height: 20px;
+}
+
+.bank-account-frozen-notice {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: var(--space-5);
+  border-top: 1px solid rgba(255, 255, 255, 0.22);
+  padding-top: var(--space-4);
+  color: rgba(255, 255, 255, 0.88);
+  font-size: 0.92rem;
+  font-weight: 650;
+}
+
+.bank-quick-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--space-4);
+}
+
+.bank-quick-btn {
+  display: grid;
+  align-content: center;
+  justify-items: center;
+  gap: var(--space-3);
+  min-height: 112px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: var(--space-5);
+  background: var(--surface);
+  color: var(--primary-hover);
+  font-weight: 650;
+  text-align: center;
+  text-decoration: none;
+  box-shadow: var(--shadow-soft);
+  transition:
+    border-color 150ms ease,
+    background-color 150ms ease,
+    color 150ms ease,
+    transform 150ms ease;
+}
+
+.bank-quick-btn:hover {
+  border-color: var(--primary);
+  background: var(--primary-soft);
+  color: var(--primary-hover);
+  transform: translateY(-2px);
+}
+
+.bank-quick-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 46px;
+  height: 46px;
+  border-radius: var(--radius);
+  background: var(--primary-soft);
+  color: var(--primary);
+}
+
+.bank-quick-icon .icon {
+  width: 24px;
+  height: 24px;
+}
+
+.account-menu-section-label {
+  padding: var(--space-2) var(--space-3) var(--space-1);
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  border-top: 1px solid var(--line);
+  margin-top: var(--space-1);
+}
+
+/* ── End banking dashboard ─────────────────────────── */
+
 @media (max-width: 980px) {
   .hero,
   .auth-shell {
@@ -1670,6 +1830,14 @@ th {
 }
 
 @media (max-width: 760px) {
+  .bank-quick-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .bank-account-balance {
+    text-align: left;
+  }
+
   :root {
     --content-gutter: 24px;
   }

--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -1,0 +1,20 @@
+(function () {
+  function makeToggle(btnId, maskedId, fullId, iconId, labelShow, labelHide) {
+    var btn    = document.getElementById(btnId);
+    var masked = document.getElementById(maskedId);
+    var full   = document.getElementById(fullId);
+    var icon   = document.getElementById(iconId);
+    if (!btn || !masked || !full || !icon) return;
+    btn.addEventListener('click', function () {
+      var revealing = full.hidden;
+      masked.hidden = revealing;
+      full.hidden   = !revealing;
+      icon.setAttribute('href', revealing ? '#icon-eye' : '#icon-eye-off');
+      btn.setAttribute('aria-label', revealing ? labelHide : labelShow);
+      btn.setAttribute('aria-pressed', String(revealing));
+    });
+  }
+
+  makeToggle('bal-eye-btn',  'card-balance-masked', 'card-balance-full', 'bal-eye-icon',  'Show balance',        'Hide balance');
+  makeToggle('acct-eye-btn', 'card-acct-masked',    'card-acct-full',    'acct-eye-icon', 'Show account number', 'Hide account number');
+}());

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -94,6 +94,14 @@
         <circle cx="12" cy="8" r="4"></circle>
         <path d="M4.5 21a7.5 7.5 0 0 1 15 0"></path>
       </symbol>
+      <symbol id="icon-eye" viewBox="0 0 24 24">
+        <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+        <circle cx="12" cy="12" r="3"></circle>
+      </symbol>
+      <symbol id="icon-eye-off" viewBox="0 0 24 24">
+        <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path>
+        <line x1="1" y1="1" x2="23" y2="23"></line>
+      </symbol>
     </svg>
     <a class="skip-link" href="#main-content">Skip to main content</a>
     <header class="site-header">
@@ -112,27 +120,12 @@
         </button>
 
         <nav class="nav" id="primary-nav" aria-label="Primary navigation" data-nav-menu>
+          {% if not g.current_user %}
           <div class="nav-links">
-            {% if g.current_user %}
-              {% if g.current_user.mfa_enabled %}
-                <a href="{{ url_for('web.dashboard') }}"{% if request.endpoint == "web.dashboard" %} aria-current="page"{% endif %}>Dashboard</a>
-                <a href="{{ url_for('web.profile') }}"{% if request.endpoint in ("web.profile", "web.profile_submit") %} aria-current="page"{% endif %}>Profile</a>
-              {% endif %}
-              <a href="{{ url_for('web.mfa_setup') }}"{% if request.endpoint in ("web.mfa_setup", "web.mfa_setup_submit") %} aria-current="page"{% endif %}>MFA</a>
-              {% if g.current_user.mfa_enabled %}
-                <a href="{{ url_for('web.security_keys') }}"{% if request.endpoint in ("web.security_keys", "web.security_key_revoke") %} aria-current="page"{% endif %}>Passkeys</a>
-                <a href="{{ url_for('web.sessions_dashboard') }}"{% if request.endpoint == "web.sessions_dashboard" %} aria-current="page"{% endif %}>Sessions</a>
-                {% if g.high_risk_ready %}
-                  <a href="{{ url_for('web.freeze_account') }}"{% if request.endpoint == "web.freeze_account" %} aria-current="page"{% endif %}>Freeze</a>
-                {% else %}
-                  <a class="is-disabled" aria-disabled="true">Freeze</a>
-                {% endif %}
-              {% endif %}
-            {% else %}
-              <a href="{{ url_for('web.login') }}"{% if request.endpoint == "web.login" %} aria-current="page"{% endif %}>Login</a>
-              <a class="button button-small" href="{{ url_for('web.register_form') }}">Register</a>
-            {% endif %}
+            <a href="{{ url_for('web.login') }}"{% if request.endpoint == "web.login" %} aria-current="page"{% endif %}>Login</a>
+            <a class="button button-small" href="{{ url_for('web.register_form') }}">Register</a>
           </div>
+          {% endif %}
           <div class="nav-actions">
             <button class="theme-toggle icon-button" type="button" data-theme-toggle aria-pressed="false" aria-label="Switch to dark mode" title="Switch to dark mode">
               <span class="theme-icon" aria-hidden="true" data-theme-toggle-icon>
@@ -163,6 +156,7 @@
                   {% else %}
                     <a role="menuitem" class="is-disabled" aria-disabled="true">Change Password</a>
                   {% endif %}
+                  <div class="account-menu-section-label" role="separator">Security Settings</div>
                   <a role="menuitem" href="{{ url_for('web.mfa_setup') }}">Authenticator MFA</a>
                   {% if g.current_user.mfa_enabled %}
                     <a role="menuitem" href="{{ url_for('web.security_keys') }}">Passkeys</a>
@@ -272,5 +266,6 @@
         </section>
       </div>
     </footer>
+    {% block scripts %}{% endblock %}
   </body>
 </html>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -57,6 +57,35 @@
   </div>
   {% endif %}
 
+  {% if user.mfa_enabled %}
+  {% if recovery_codes_low %}
+  <div class="notice warning">
+    <span class="notice-icon" aria-hidden="true">
+      <svg class="icon" focusable="false"><use href="#icon-alert"></use></svg>
+    </span>
+    <div>
+      <p>{{ recovery_codes_remaining }} unused recovery codes remain. <strong>Regenerate soon</strong> to avoid being locked out.</p>
+      <a class="button secondary small" style="margin-top: var(--space-3); display: inline-flex; width: auto;" href="{{ url_for('web.mfa_setup') }}">Manage recovery codes</a>
+    </div>
+  </div>
+  {% else %}
+  <div class="notice info">
+    <span class="notice-icon" aria-hidden="true">
+      <svg class="icon" focusable="false"><use href="#icon-info"></use></svg>
+    </span>
+    <p>{{ recovery_codes_remaining }} unused recovery codes remain.</p>
+  </div>
+  {% endif %}
+  {% if credential_count == 0 %}
+  <div class="notice info">
+    <span class="notice-icon" aria-hidden="true">
+      <svg class="icon" focusable="false"><use href="#icon-info"></use></svg>
+    </span>
+    <p>No passkeys are registered. Add a passkey for faster, more secure login.</p>
+  </div>
+  {% endif %}
+  {% endif %}
+
   <!-- Quick Actions -->
   <div>
     <h2 class="bank-section-title">Quick Actions</h2>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -4,116 +4,114 @@
 
 {% block content %}
 <section class="dashboard">
-  <div class="dashboard-header">
-    <div class="account-identity">
-      <p class="eyebrow">Security dashboard</p>
-      <h1>Welcome back, {{ user.username }}</h1>
-      <p class="muted">{{ user.email }}</p>
-    </div>
-    <div class="button-row" aria-label="Primary security actions">
-      <a class="button secondary" href="{{ url_for('web.sessions_dashboard') }}">Manage sessions</a>
-      {% if not user.is_frozen %}
-        {% if user.mfa_enabled %}
-          <a class="button secondary" href="{{ url_for('web.freeze_account') }}">Freeze account</a>
+
+  <!-- Account Card -->
+  <div class="bank-account-card">
+    <div class="bank-account-card-inner">
+      <div class="bank-account-identity">
+        <p class="bank-card-eyebrow">Savings Account</p>
+        <h1 class="bank-card-name">{{ user.full_name or user.username }}</h1>
+        {% if user.account_number %}
+        <div style="display: grid; gap: var(--space-1);">
+          <p class="bank-card-eyebrow">Account No.</p>
+          <p class="bank-card-number" style="display: flex; align-items: center; gap: var(--space-2);">
+            <span id="card-acct-masked">•••-•••-{{ user.account_number[-3:] }}</span>
+            <span id="card-acct-full" hidden>{{ user.account_number[:3] }}-{{ user.account_number[3:6] }}-{{ user.account_number[6:] }}</span>
+            <button id="acct-eye-btn" class="card-eye-btn" type="button" aria-label="Show account number" aria-pressed="false">
+              <svg class="icon" focusable="false" aria-hidden="true"><use id="acct-eye-icon" href="#icon-eye-off"></use></svg>
+            </button>
+          </p>
+        </div>
         {% else %}
-          <a class="button secondary is-disabled" aria-disabled="true">Freeze account</a>
+        <p class="bank-card-number">— — —</p>
         {% endif %}
-      {% endif %}
+      </div>
+      <div class="bank-account-balance">
+        <p class="bank-card-eyebrow">Available Balance</p>
+        <p class="balance-amount" style="margin: 0; display: flex; align-items: center; justify-content: flex-end; gap: var(--space-2);">
+          <span>SGD <span id="card-balance-masked">••••••</span><span id="card-balance-full" hidden>0.00</span></span>
+          <button id="bal-eye-btn" class="card-eye-btn" type="button" aria-label="Show balance" aria-pressed="false">
+            <svg class="icon" focusable="false" aria-hidden="true"><use id="bal-eye-icon" href="#icon-eye-off"></use></svg>
+          </button>
+        </p>
+      </div>
+    </div>
+    {% if user.is_frozen %}
+    <div class="bank-account-frozen-notice">
+      <svg class="icon" focusable="false" aria-hidden="true"><use href="#icon-alert"></use></svg>
+      Account frozen — contact support to unfreeze
+    </div>
+    {% endif %}
+  </div>
+
+  {% if not user.mfa_enabled %}
+  <!-- MFA setup banner -->
+  <div class="notice warning">
+    <span class="notice-icon" aria-hidden="true">
+      <svg class="icon" focusable="false"><use href="#icon-alert"></use></svg>
+    </span>
+    <div>
+      <p><strong>Set up Authenticator MFA</strong> to unlock transfers, payments, and all account actions.</p>
+      <a class="button secondary small" style="margin-top: var(--space-3); display: inline-flex; width: auto;" href="{{ url_for('web.mfa_setup') }}">Set up MFA</a>
+    </div>
+  </div>
+  {% endif %}
+
+  <!-- Quick Actions -->
+  <div>
+    <h2 class="bank-section-title">Quick Actions</h2>
+    <div class="bank-quick-grid">
+      <a class="bank-quick-btn is-disabled" aria-disabled="true">
+        <span class="bank-quick-icon" aria-hidden="true">
+          <svg class="icon" focusable="false"><use href="#icon-refresh"></use></svg>
+        </span>
+        <span>Local Transfer</span>
+        <span class="badge neutral">Coming soon</span>
+      </a>
+      <a class="bank-quick-btn is-disabled" aria-disabled="true">
+        <span class="bank-quick-icon" aria-hidden="true">
+          <svg class="icon" focusable="false"><use href="#icon-shield-check"></use></svg>
+        </span>
+        <span>PayUp</span>
+        <span class="badge neutral">Coming soon</span>
+      </a>
+      <a class="bank-quick-btn is-disabled" aria-disabled="true">
+        <span class="bank-quick-icon" aria-hidden="true">
+          <svg class="icon" focusable="false"><use href="#icon-session"></use></svg>
+        </span>
+        <span>Past Transaction</span>
+        <span class="badge neutral">Coming soon</span>
+      </a>
+      <a class="bank-quick-btn is-disabled" aria-disabled="true">
+        <span class="bank-quick-icon" aria-hidden="true">
+          <svg class="icon" focusable="false"><use href="#icon-education"></use></svg>
+        </span>
+        <span>Monthly Statement</span>
+        <span class="badge neutral">Coming soon</span>
+      </a>
     </div>
   </div>
 
-  <div class="status-grid">
-    <article class="status-card">
-      <span class="card-icon" aria-hidden="true">
-        <svg class="icon" focusable="false"><use href="#icon-lock"></use></svg>
-      </span>
-      <h2>Authenticator MFA</h2>
-      <div class="status-card-body">
-        {% if user.mfa_enabled %}
-          <p class="badge">Enabled</p>
-          <p class="muted">Password login is protected with a time-based authenticator code.</p>
-          <p class="muted">{{ recovery_codes_remaining }} unused recovery code{{ "" if recovery_codes_remaining == 1 else "s" }} remain.</p>
-          {% if recovery_codes_low %}
-            <p class="badge warning">Regenerate soon</p>
-          {% endif %}
-        {% else %}
-          <p class="badge warning">Setup needed</p>
-          <p class="muted">Add an authenticator app so normal login uses password plus MFA.</p>
-        {% endif %}
-      </div>
-      <div class="status-card-actions">
-        <a class="button secondary" href="{{ url_for('web.mfa_setup') }}">Manage MFA</a>
-      </div>
-    </article>
-    <article class="status-card">
-      <span class="card-icon" aria-hidden="true">
-        <svg class="icon" focusable="false"><use href="#icon-shield-check"></use></svg>
-      </span>
-      <h2>Passkeys</h2>
-      <div class="status-card-body">
-        {% if credential_count > 0 %}
-          <p class="badge">Available</p>
-          <p class="muted">{{ credential_count }} passkey{{ "" if credential_count == 1 else "s" }} registered for optional sign-in and protected action step-up.</p>
-        {% else %}
-          <p class="badge neutral">Optional</p>
-          <p class="muted">No passkeys are registered. Authenticator MFA remains the required baseline.</p>
-        {% endif %}
-      </div>
-      <div class="status-card-actions">
-        <a class="button secondary" href="{{ url_for('web.security_keys') }}">Manage passkeys</a>
-      </div>
-    </article>
-    <article class="status-card">
-      <span class="card-icon" aria-hidden="true">
-        <svg class="icon" focusable="false"><use href="#icon-freeze"></use></svg>
-      </span>
-      <h2>Account Freeze</h2>
-      <div class="status-card-body">
-        {% if user.is_frozen %}
-          <p class="badge danger">Frozen</p>
-          <p class="muted">Unfreeze requires manual support review.</p>
-        {% elif not user.mfa_enabled %}
-          <p class="badge warning">MFA required</p>
-          <p class="muted">Emergency freeze is locked until authenticator MFA is enabled.</p>
-        {% else %}
-          <p class="badge">Ready</p>
-          <p class="muted">Emergency freeze is available after MFA or passkey verification.</p>
-        {% endif %}
-      </div>
-      <div class="status-card-actions">
-        {% if not user.is_frozen %}
-          {% if user.mfa_enabled %}
-            <a class="button secondary" href="{{ url_for('web.freeze_account') }}">Freeze account</a>
-          {% else %}
-            <a class="button secondary is-disabled" aria-disabled="true">Freeze account</a>
-          {% endif %}
-        {% endif %}
-      </div>
-    </article>
-    <article class="status-card">
-      <span class="card-icon" aria-hidden="true">
-        <svg class="icon" focusable="false"><use href="#icon-session"></use></svg>
-      </span>
-      <h2>Active sessions</h2>
-      <div class="status-card-body">
-        <p class="badge neutral">Session controls</p>
-        <p class="muted">View current access and terminate sessions you do not recognise.</p>
-      </div>
-      <div class="status-card-actions">
-        <a class="button secondary" href="{{ url_for('web.sessions_dashboard') }}">Manage sessions</a>
-      </div>
-    </article>
+  <!-- Recent Transactions -->
+  <div class="panel">
+    <div class="section-header" style="margin-bottom: var(--space-5); justify-content: space-between; align-items: center;">
+      <h2>Recent Transactions</h2>
+      <a href="#" class="muted" style="font-size: 0.82rem; white-space: nowrap; align-self: center;">More...</a>
+    </div>
+    {% if transactions %}
+      {% for txn in transactions[:5] %}
+      {# transaction rows go here #}
+      {% endfor %}
+    {% else %}
+    <div class="empty-state" style="margin-top: var(--space-6);">
+      <p class="muted">No recent transactions to display.</p>
+    </div>
+    {% endif %}
   </div>
 
-  <section class="quick-grid" aria-label="Security shortcuts">
-    <article class="card quick-card">
-      <h2>Account protection</h2>
-      <p class="muted">Review authenticator MFA, transaction key status, session controls, and freeze readiness from one place.</p>
-    </article>
-    <article class="card quick-card">
-      <h2>Account scope</h2>
-      <p class="muted">This portal currently shows account access and security controls. Balances, account numbers, and transactions are not available.</p>
-    </article>
-  </section>
 </section>
+{% endblock %}
+
+{% block scripts %}
+<script src="{{ url_for('static', filename='js/dashboard.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
…y toggle

## Summary

Updates the authenticated dashboard UI from the previous security-card grid into a more banking-focused account overview.

The dashboard now shows a bank account card with balance and account number details, independent visibility toggles, updated quick-action labels, and a capped Recent Transactions panel. It also adds shared template and styling support for page-specific JavaScript and gradient-card eye buttons.

## What changed

* Replaced the security-card grid with a bank account card showing:

  * Balance
  * Account number
* Renamed quick actions to:

  * Local Transfer
  * PayUp
  * Past Transaction
  * Monthly Statement
* Added independent eye toggle buttons for:

  * Balance
  * Account number
* Masked account number in `XXX-XXX-XXX` format, showing only the last 3 digits by default.
* Added a Recent Transactions panel with:

  * `More...` link
  * 5-item display cap
* Added `icon-eye` and `icon-eye-off` SVG symbols to the sprite.
* Added a `scripts` block to the base template for page-specific JavaScript.
* Added `card-eye-btn` styles for ghost buttons on the gradient account card.
* Excluded `compose.dev.yml` from git because it is local-dev only.

