### PR TITLE
Fix CSP inline-style violations, relocate security notices, add dashboard tests

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1683,6 +1683,14 @@ th {
   font-family: Consolas, "Liberation Mono", monospace;
   font-size: 1.05rem;
   letter-spacing: 0.12em;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.card-acct-label-group {
+  display: grid;
+  gap: var(--space-1);
 }
 
 .bank-account-balance {
@@ -1697,6 +1705,31 @@ th {
   font-size: 2.4rem;
   font-weight: 700;
   line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-2);
+}
+
+.dashboard-txn-header {
+  margin-bottom: var(--space-5);
+  align-items: center;
+}
+
+.dashboard-txn-more {
+  font-size: 0.82rem;
+  white-space: nowrap;
+  align-self: center;
+}
+
+.dashboard-txn-empty {
+  margin-top: var(--space-6);
+}
+
+.notice-action {
+  margin-top: var(--space-3);
+  display: inline-flex;
+  width: auto;
 }
 
 .card-eye-btn {

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -12,9 +12,10 @@
         <p class="bank-card-eyebrow">Savings Account</p>
         <h1 class="bank-card-name">{{ user.full_name or user.username }}</h1>
         {% if user.account_number %}
-        <div style="display: grid; gap: var(--space-1);">
+        <div class="card-acct-label-group">
           <p class="bank-card-eyebrow">Account No.</p>
-          <p class="bank-card-number" style="display: flex; align-items: center; gap: var(--space-2);">
+          {# Full number in DOM is UX masking only — not a security boundary #}
+          <p class="bank-card-number">
             <span id="card-acct-masked">•••-•••-{{ user.account_number[-3:] }}</span>
             <span id="card-acct-full" hidden>{{ user.account_number[:3] }}-{{ user.account_number[3:6] }}-{{ user.account_number[6:] }}</span>
             <button id="acct-eye-btn" class="card-eye-btn" type="button" aria-label="Show account number" aria-pressed="false">
@@ -28,7 +29,7 @@
       </div>
       <div class="bank-account-balance">
         <p class="bank-card-eyebrow">Available Balance</p>
-        <p class="balance-amount" style="margin: 0; display: flex; align-items: center; justify-content: flex-end; gap: var(--space-2);">
+        <p class="balance-amount">
           <span>SGD <span id="card-balance-masked">••••••</span><span id="card-balance-full" hidden>0.00</span></span>
           <button id="bal-eye-btn" class="card-eye-btn" type="button" aria-label="Show balance" aria-pressed="false">
             <svg class="icon" focusable="false" aria-hidden="true"><use id="bal-eye-icon" href="#icon-eye-off"></use></svg>
@@ -52,39 +53,11 @@
     </span>
     <div>
       <p><strong>Set up Authenticator MFA</strong> to unlock transfers, payments, and all account actions.</p>
-      <a class="button secondary small" style="margin-top: var(--space-3); display: inline-flex; width: auto;" href="{{ url_for('web.mfa_setup') }}">Set up MFA</a>
+      <a class="button secondary small notice-action" href="{{ url_for('web.mfa_setup') }}">Set up MFA</a>
     </div>
   </div>
   {% endif %}
 
-  {% if user.mfa_enabled %}
-  {% if recovery_codes_low %}
-  <div class="notice warning">
-    <span class="notice-icon" aria-hidden="true">
-      <svg class="icon" focusable="false"><use href="#icon-alert"></use></svg>
-    </span>
-    <div>
-      <p>{{ recovery_codes_remaining }} unused recovery codes remain. <strong>Regenerate soon</strong> to avoid being locked out.</p>
-      <a class="button secondary small" style="margin-top: var(--space-3); display: inline-flex; width: auto;" href="{{ url_for('web.mfa_setup') }}">Manage recovery codes</a>
-    </div>
-  </div>
-  {% else %}
-  <div class="notice info">
-    <span class="notice-icon" aria-hidden="true">
-      <svg class="icon" focusable="false"><use href="#icon-info"></use></svg>
-    </span>
-    <p>{{ recovery_codes_remaining }} unused recovery codes remain.</p>
-  </div>
-  {% endif %}
-  {% if credential_count == 0 %}
-  <div class="notice info">
-    <span class="notice-icon" aria-hidden="true">
-      <svg class="icon" focusable="false"><use href="#icon-info"></use></svg>
-    </span>
-    <p>No passkeys are registered. Add a passkey for faster, more secure login.</p>
-  </div>
-  {% endif %}
-  {% endif %}
 
   <!-- Quick Actions -->
   <div>
@@ -123,16 +96,16 @@
 
   <!-- Recent Transactions -->
   <div class="panel">
-    <div class="section-header" style="margin-bottom: var(--space-5); justify-content: space-between; align-items: center;">
+    <div class="section-header dashboard-txn-header">
       <h2>Recent Transactions</h2>
-      <a href="#" class="muted" style="font-size: 0.82rem; white-space: nowrap; align-self: center;">More...</a>
+      <a href="#" class="muted dashboard-txn-more">More...</a>
     </div>
     {% if transactions %}
       {% for txn in transactions[:5] %}
       {# transaction rows go here #}
       {% endfor %}
     {% else %}
-    <div class="empty-state" style="margin-top: var(--space-6);">
+    <div class="empty-state dashboard-txn-empty">
       <p class="muted">No recent transactions to display.</p>
     </div>
     {% endif %}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+import time
+
+import pyotp
+
+from app.extensions import db
+from app.models import User
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def register(client, username="alice01", email="alice@example.com",
+             password="correct horse battery staple",
+             full_name="Alice Test", phone_number="91234567"):
+    return client.post("/register", data={
+        "username": username,
+        "email": email,
+        "full_name": full_name,
+        "phone_number": phone_number,
+        "password": password,
+        "confirm_password": password,
+    }, follow_redirects=False)
+
+
+def login(client, identifier="alice01", password="correct horse battery staple"):
+    return client.post("/login", data={
+        "identifier": identifier,
+        "password": password,
+    }, follow_redirects=False)
+
+
+def enable_mfa(username="alice01"):
+    from app.security.crypto import encrypt_mfa_secret
+    user = db.session.execute(db.select(User).where(User.username == username)).scalar_one()
+    secret = pyotp.random_base32(length=32)
+    user.mfa_secret_nonce, user.mfa_secret_ciphertext = encrypt_mfa_secret(secret, user.id)
+    user.mfa_enabled = True
+    db.session.commit()
+    return user, secret
+
+
+def mark_recent_mfa(client, user):
+    user.mfa_enabled = True
+    db.session.commit()
+    now = int(time.time())
+    with client.session_transaction() as sess:
+        sess["auth_context"] = "password+mfa_bootstrap"
+        sess["mfa_verified_at"] = now
+        sess["fresh_mfa_verified_at"] = now
+        sess.pop("risk_fingerprint", None)
+
+
+def get_user(username="alice01"):
+    return db.session.execute(db.select(User).where(User.username == username)).scalar_one()
+
+
+def set_account_number(user, number="123456789"):
+    user.account_number = number
+    db.session.commit()
+
+
+# ── Access control ──────────────────────────────────────────────────────────────
+
+def test_dashboard_requires_login(client):
+    response = client.get("/dashboard")
+    assert response.status_code == 302
+    assert "/login" in response.headers["Location"]
+
+
+def test_dashboard_accessible_after_login(client):
+    register(client)
+    login(client)
+    assert client.get("/dashboard").status_code == 200
+
+
+# ── Bank account card ──────────────────────────────────────────────────────────
+
+def test_dashboard_shows_bank_account_card(client):
+    register(client)
+    login(client)
+    markup = client.get("/dashboard").data.decode("utf-8")
+    assert "bank-account-card" in markup
+    assert "Savings Account" in markup
+    assert "Available Balance" in markup
+
+
+def test_dashboard_shows_full_name_on_card(client):
+    register(client, full_name="Alice Test")
+    login(client)
+    markup = client.get("/dashboard").data.decode("utf-8")
+    assert "Alice Test" in markup
+
+
+def test_dashboard_shows_masked_balance_by_default(client):
+    register(client)
+    login(client)
+    markup = client.get("/dashboard").data.decode("utf-8")
+    assert "card-balance-masked" in markup
+    assert "card-balance-full" in markup
+
+
+def test_dashboard_balance_eye_toggle_button_present(client):
+    register(client)
+    login(client)
+    markup = client.get("/dashboard").data.decode("utf-8")
+    assert "bal-eye-btn" in markup
+
+
+def test_dashboard_shows_account_number_label(client):
+    register(client)
+    login(client)
+    user = get_user()
+    set_account_number(user, "123456789")
+    markup = client.get("/dashboard").data.decode("utf-8")
+    assert "Account No." in markup
+
+
+def test_dashboard_masks_account_number_showing_last_three_digits(client):
+    register(client)
+    login(client)
+    user = get_user()
+    set_account_number(user, "123456789")
+    markup = client.get("/dashboard").data.decode("utf-8")
+    assert "card-acct-masked" in markup
+    assert "789" in markup
+
+
+def test_dashboard_account_number_full_format_uses_dashes(client):
+    register(client)
+    login(client)
+    user = get_user()
+    set_account_number(user, "123456789")
+    markup = client.get("/dashboard").data.decode("utf-8")
+    assert "123-456-789" in markup
+
+
+def test_dashboard_account_number_masked_format_uses_dashes(client):
+    register(client)
+    login(client)
+    user = get_user()
+    set_account_number(user, "123456789")
+    markup = client.get("/dashboard").data.decode("utf-8")
+    assert "•••-•••-789" in markup
+
+
+def test_dashboard_account_number_eye_toggle_button_present(client):
+    register(client)
+    login(client)
+    user = get_user()
+    set_account_number(user, "123456789")
+    markup = client.get("/dashboard").data.decode("utf-8")
+    assert "acct-eye-btn" in markup
+
+
+def test_dashboard_loads_eye_toggle_script(client):
+    register(client)
+    login(client)
+    markup = client.get("/dashboard").data.decode("utf-8")
+    assert "dashboard.js" in markup
+
+
+# ── Quick actions ──────────────────────────────────────────────────────────────
+
+def test_dashboard_quick_actions_have_correct_labels(client):
+    register(client)
+    login(client)
+    markup = client.get("/dashboard").data.decode("utf-8")
+    assert "Local Transfer" in markup
+    assert "PayUp" in markup
+    assert "Past Transaction" in markup
+    assert "Monthly Statement" in markup
+
+
+def test_dashboard_all_quick_actions_are_coming_soon(client):
+    register(client)
+    login(client)
+    markup = client.get("/dashboard").data.decode("utf-8")
+    assert markup.count("Coming soon") == 4
+
+
+def test_dashboard_quick_actions_are_disabled(client):
+    register(client)
+    login(client)
+    markup = client.get("/dashboard").data.decode("utf-8")
+    assert markup.count("is-disabled") >= 4
+
+
+# ── Recent transactions panel ──────────────────────────────────────────────────
+
+def test_dashboard_shows_recent_transactions_heading(client):
+    register(client)
+    login(client)
+    markup = client.get("/dashboard").data.decode("utf-8")
+    assert "Recent Transactions" in markup
+
+
+def test_dashboard_shows_empty_state_when_no_transactions(client):
+    register(client)
+    login(client)
+    markup = client.get("/dashboard").data.decode("utf-8")
+    assert "No recent transactions to display." in markup
+
+
+def test_dashboard_recent_transactions_has_more_link(client):
+    register(client)
+    login(client)
+    markup = client.get("/dashboard").data.decode("utf-8")
+    assert "More..." in markup
+
+
+# ── MFA banner ─────────────────────────────────────────────────────────────────
+
+def test_dashboard_shows_mfa_setup_banner_when_mfa_not_enabled(client):
+    register(client)
+    login(client)
+    markup = client.get("/dashboard").data.decode("utf-8")
+    assert "Set up Authenticator MFA" in markup
+
+
+def test_dashboard_hides_mfa_setup_banner_when_mfa_enabled(client):
+    register(client)
+    login(client)
+    user, _ = enable_mfa()
+    mark_recent_mfa(client, user)
+    markup = client.get("/dashboard").data.decode("utf-8")
+    assert "Set up Authenticator MFA" not in markup
+
+
+# ── Security notices relocated off dashboard ───────────────────────────────────
+
+def test_dashboard_does_not_show_recovery_codes_count(client):
+    from app.auth.recovery_codes import generate_recovery_codes_for_user
+    register(client)
+    login(client)
+    user, _ = enable_mfa()
+    mark_recent_mfa(client, user)
+    generate_recovery_codes_for_user(user)
+    markup = client.get("/dashboard").data.decode("utf-8")
+    assert "unused recovery codes remain." not in markup
+
+
+def test_dashboard_does_not_show_low_recovery_codes_warning(client):
+    from app.auth.recovery_codes import generate_recovery_codes_for_user
+    register(client)
+    login(client)
+    user, _ = enable_mfa()
+    mark_recent_mfa(client, user)
+    generate_recovery_codes_for_user(user, count=2)
+    markup = client.get("/dashboard").data.decode("utf-8")
+    assert "Regenerate soon" not in markup
+
+
+def test_dashboard_does_not_show_passkeys_notice(client):
+    register(client)
+    login(client)
+    user, _ = enable_mfa()
+    mark_recent_mfa(client, user)
+    markup = client.get("/dashboard").data.decode("utf-8")
+    assert "No passkeys are registered" not in markup
+
+
+def test_recovery_codes_count_shown_on_mfa_page(client):
+    from app.auth.recovery_codes import generate_recovery_codes_for_user
+    register(client)
+    login(client)
+    user, _ = enable_mfa()
+    mark_recent_mfa(client, user)
+    generate_recovery_codes_for_user(user)
+    markup = client.get("/mfa/setup").data.decode("utf-8")
+    assert "unused recovery codes remain." in markup
+
+
+def test_low_recovery_codes_warning_shown_on_mfa_page(client):
+    from app.auth.recovery_codes import generate_recovery_codes_for_user
+    register(client)
+    login(client)
+    user, _ = enable_mfa()
+    mark_recent_mfa(client, user)
+    generate_recovery_codes_for_user(user, count=2)
+    markup = client.get("/mfa/setup").data.decode("utf-8")
+    assert "2 unused recovery codes remain." in markup
+    assert "Regenerate soon" in markup
+
+
+def test_passkeys_notice_shown_on_security_keys_page(client):
+    register(client)
+    login(client)
+    user, _ = enable_mfa()
+    mark_recent_mfa(client, user)
+    markup = client.get("/security-keys").data.decode("utf-8")
+    assert "No passkeys registered" in markup
+
+
+# ── Frozen account ─────────────────────────────────────────────────────────────
+
+def test_dashboard_shows_frozen_notice_when_account_is_frozen(client):
+    register(client)
+    login(client)
+    user = get_user()
+    user.is_frozen = True
+    db.session.commit()
+    markup = client.get("/dashboard").data.decode("utf-8")
+    assert "Account frozen" in markup
+
+
+def test_dashboard_does_not_show_frozen_notice_for_active_account(client):
+    register(client)
+    login(client)
+    markup = client.get("/dashboard").data.decode("utf-8")
+    assert "Account frozen" not in markup

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -51,6 +51,15 @@ def mark_recent_mfa(client, user):
         sess.pop("risk_fingerprint", None)
 
 
+def login_with_mfa(client, full_name="Alice Test"):
+    """Register, log in, enable MFA, mark it fresh — returns the user."""
+    register(client, full_name=full_name)
+    login(client)
+    user, _ = enable_mfa()
+    mark_recent_mfa(client, user)
+    return user
+
+
 def get_user(username="alice01"):
     return db.session.execute(db.select(User).where(User.username == username)).scalar_one()
 
@@ -68,17 +77,23 @@ def test_dashboard_requires_login(client):
     assert "/login" in response.headers["Location"]
 
 
-def test_dashboard_accessible_after_login(client):
+def test_dashboard_requires_mfa(client):
     register(client)
     login(client)
+    response = client.get("/dashboard")
+    assert response.status_code == 302
+    assert "/mfa/setup" in response.headers["Location"]
+
+
+def test_dashboard_accessible_with_mfa(client):
+    login_with_mfa(client)
     assert client.get("/dashboard").status_code == 200
 
 
 # ── Bank account card ──────────────────────────────────────────────────────────
 
 def test_dashboard_shows_bank_account_card(client):
-    register(client)
-    login(client)
+    login_with_mfa(client)
     markup = client.get("/dashboard").data.decode("utf-8")
     assert "bank-account-card" in markup
     assert "Savings Account" in markup
@@ -86,40 +101,33 @@ def test_dashboard_shows_bank_account_card(client):
 
 
 def test_dashboard_shows_full_name_on_card(client):
-    register(client, full_name="Alice Test")
-    login(client)
+    login_with_mfa(client, full_name="Alice Test")
     markup = client.get("/dashboard").data.decode("utf-8")
     assert "Alice Test" in markup
 
 
 def test_dashboard_shows_masked_balance_by_default(client):
-    register(client)
-    login(client)
+    login_with_mfa(client)
     markup = client.get("/dashboard").data.decode("utf-8")
     assert "card-balance-masked" in markup
     assert "card-balance-full" in markup
 
 
 def test_dashboard_balance_eye_toggle_button_present(client):
-    register(client)
-    login(client)
+    login_with_mfa(client)
     markup = client.get("/dashboard").data.decode("utf-8")
     assert "bal-eye-btn" in markup
 
 
 def test_dashboard_shows_account_number_label(client):
-    register(client)
-    login(client)
-    user = get_user()
+    user = login_with_mfa(client)
     set_account_number(user, "123456789")
     markup = client.get("/dashboard").data.decode("utf-8")
     assert "Account No." in markup
 
 
 def test_dashboard_masks_account_number_showing_last_three_digits(client):
-    register(client)
-    login(client)
-    user = get_user()
+    user = login_with_mfa(client)
     set_account_number(user, "123456789")
     markup = client.get("/dashboard").data.decode("utf-8")
     assert "card-acct-masked" in markup
@@ -127,35 +135,28 @@ def test_dashboard_masks_account_number_showing_last_three_digits(client):
 
 
 def test_dashboard_account_number_full_format_uses_dashes(client):
-    register(client)
-    login(client)
-    user = get_user()
+    user = login_with_mfa(client)
     set_account_number(user, "123456789")
     markup = client.get("/dashboard").data.decode("utf-8")
     assert "123-456-789" in markup
 
 
 def test_dashboard_account_number_masked_format_uses_dashes(client):
-    register(client)
-    login(client)
-    user = get_user()
+    user = login_with_mfa(client)
     set_account_number(user, "123456789")
     markup = client.get("/dashboard").data.decode("utf-8")
     assert "•••-•••-789" in markup
 
 
 def test_dashboard_account_number_eye_toggle_button_present(client):
-    register(client)
-    login(client)
-    user = get_user()
+    user = login_with_mfa(client)
     set_account_number(user, "123456789")
     markup = client.get("/dashboard").data.decode("utf-8")
     assert "acct-eye-btn" in markup
 
 
 def test_dashboard_loads_eye_toggle_script(client):
-    register(client)
-    login(client)
+    login_with_mfa(client)
     markup = client.get("/dashboard").data.decode("utf-8")
     assert "dashboard.js" in markup
 
@@ -163,8 +164,7 @@ def test_dashboard_loads_eye_toggle_script(client):
 # ── Quick actions ──────────────────────────────────────────────────────────────
 
 def test_dashboard_quick_actions_have_correct_labels(client):
-    register(client)
-    login(client)
+    login_with_mfa(client)
     markup = client.get("/dashboard").data.decode("utf-8")
     assert "Local Transfer" in markup
     assert "PayUp" in markup
@@ -173,15 +173,13 @@ def test_dashboard_quick_actions_have_correct_labels(client):
 
 
 def test_dashboard_all_quick_actions_are_coming_soon(client):
-    register(client)
-    login(client)
+    login_with_mfa(client)
     markup = client.get("/dashboard").data.decode("utf-8")
     assert markup.count("Coming soon") == 4
 
 
 def test_dashboard_quick_actions_are_disabled(client):
-    register(client)
-    login(client)
+    login_with_mfa(client)
     markup = client.get("/dashboard").data.decode("utf-8")
     assert markup.count("is-disabled") >= 4
 
@@ -189,52 +187,28 @@ def test_dashboard_quick_actions_are_disabled(client):
 # ── Recent transactions panel ──────────────────────────────────────────────────
 
 def test_dashboard_shows_recent_transactions_heading(client):
-    register(client)
-    login(client)
+    login_with_mfa(client)
     markup = client.get("/dashboard").data.decode("utf-8")
     assert "Recent Transactions" in markup
 
 
 def test_dashboard_shows_empty_state_when_no_transactions(client):
-    register(client)
-    login(client)
+    login_with_mfa(client)
     markup = client.get("/dashboard").data.decode("utf-8")
     assert "No recent transactions to display." in markup
 
 
 def test_dashboard_recent_transactions_has_more_link(client):
-    register(client)
-    login(client)
+    login_with_mfa(client)
     markup = client.get("/dashboard").data.decode("utf-8")
     assert "More..." in markup
-
-
-# ── MFA banner ─────────────────────────────────────────────────────────────────
-
-def test_dashboard_shows_mfa_setup_banner_when_mfa_not_enabled(client):
-    register(client)
-    login(client)
-    markup = client.get("/dashboard").data.decode("utf-8")
-    assert "Set up Authenticator MFA" in markup
-
-
-def test_dashboard_hides_mfa_setup_banner_when_mfa_enabled(client):
-    register(client)
-    login(client)
-    user, _ = enable_mfa()
-    mark_recent_mfa(client, user)
-    markup = client.get("/dashboard").data.decode("utf-8")
-    assert "Set up Authenticator MFA" not in markup
 
 
 # ── Security notices relocated off dashboard ───────────────────────────────────
 
 def test_dashboard_does_not_show_recovery_codes_count(client):
     from app.auth.recovery_codes import generate_recovery_codes_for_user
-    register(client)
-    login(client)
-    user, _ = enable_mfa()
-    mark_recent_mfa(client, user)
+    user = login_with_mfa(client)
     generate_recovery_codes_for_user(user)
     markup = client.get("/dashboard").data.decode("utf-8")
     assert "unused recovery codes remain." not in markup
@@ -242,30 +216,21 @@ def test_dashboard_does_not_show_recovery_codes_count(client):
 
 def test_dashboard_does_not_show_low_recovery_codes_warning(client):
     from app.auth.recovery_codes import generate_recovery_codes_for_user
-    register(client)
-    login(client)
-    user, _ = enable_mfa()
-    mark_recent_mfa(client, user)
+    user = login_with_mfa(client)
     generate_recovery_codes_for_user(user, count=2)
     markup = client.get("/dashboard").data.decode("utf-8")
     assert "Regenerate soon" not in markup
 
 
 def test_dashboard_does_not_show_passkeys_notice(client):
-    register(client)
-    login(client)
-    user, _ = enable_mfa()
-    mark_recent_mfa(client, user)
+    login_with_mfa(client)
     markup = client.get("/dashboard").data.decode("utf-8")
     assert "No passkeys are registered" not in markup
 
 
 def test_recovery_codes_count_shown_on_mfa_page(client):
     from app.auth.recovery_codes import generate_recovery_codes_for_user
-    register(client)
-    login(client)
-    user, _ = enable_mfa()
-    mark_recent_mfa(client, user)
+    user = login_with_mfa(client)
     generate_recovery_codes_for_user(user)
     markup = client.get("/mfa/setup").data.decode("utf-8")
     assert "unused recovery codes remain." in markup
@@ -273,10 +238,7 @@ def test_recovery_codes_count_shown_on_mfa_page(client):
 
 def test_low_recovery_codes_warning_shown_on_mfa_page(client):
     from app.auth.recovery_codes import generate_recovery_codes_for_user
-    register(client)
-    login(client)
-    user, _ = enable_mfa()
-    mark_recent_mfa(client, user)
+    user = login_with_mfa(client)
     generate_recovery_codes_for_user(user, count=2)
     markup = client.get("/mfa/setup").data.decode("utf-8")
     assert "2 unused recovery codes remain." in markup
@@ -284,10 +246,7 @@ def test_low_recovery_codes_warning_shown_on_mfa_page(client):
 
 
 def test_passkeys_notice_shown_on_security_keys_page(client):
-    register(client)
-    login(client)
-    user, _ = enable_mfa()
-    mark_recent_mfa(client, user)
+    login_with_mfa(client)
     markup = client.get("/security-keys").data.decode("utf-8")
     assert "No passkeys registered" in markup
 
@@ -295,9 +254,7 @@ def test_passkeys_notice_shown_on_security_keys_page(client):
 # ── Frozen account ─────────────────────────────────────────────────────────────
 
 def test_dashboard_shows_frozen_notice_when_account_is_frozen(client):
-    register(client)
-    login(client)
-    user = get_user()
+    user = login_with_mfa(client)
     user.is_frozen = True
     db.session.commit()
     markup = client.get("/dashboard").data.decode("utf-8")
@@ -305,7 +262,6 @@ def test_dashboard_shows_frozen_notice_when_account_is_frozen(client):
 
 
 def test_dashboard_does_not_show_frozen_notice_for_active_account(client):
-    register(client)
-    login(client)
+    login_with_mfa(client)
     markup = client.get("/dashboard").data.decode("utf-8")
     assert "Account frozen" not in markup

--- a/tests/test_group_a_security.py
+++ b/tests/test_group_a_security.py
@@ -935,7 +935,7 @@ def test_recovery_code_satisfies_pending_totp_login_once_and_notifies(app, clien
     client.post("/logout")
     login_response = login(client)
     verified = client.post("/auth/mfa/verify", json={"totp_code": recovery_codes[0]})
-    dashboard = client.get("/dashboard")
+    mfa_page = client.get("/mfa/setup")
     client.post("/logout")
     login(client)
     reused = client.post("/auth/mfa/verify", json={"totp_code": recovery_codes[0]})
@@ -943,8 +943,8 @@ def test_recovery_code_satisfies_pending_totp_login_once_and_notifies(app, clien
     assert login_response.status_code == 302
     assert verified.status_code == 200
     assert verified.get_json()["recovery_codes_remaining"] == 9
-    assert dashboard.status_code == 200
-    assert "9 unused recovery codes remain." in dashboard.data.decode("utf-8")
+    assert mfa_page.status_code == 200
+    assert "9 unused recovery codes remain." in mfa_page.data.decode("utf-8")
     assert reused.status_code == 401
     assert reused.get_json()["error"] == "Invalid authentication code."
     assert db.session.query(RecoveryCode).filter_by(user_id=user.id).filter(RecoveryCode.used_at.is_not(None)).count() == 1
@@ -1042,7 +1042,7 @@ def test_dashboard_warns_when_recovery_codes_are_low(client):
     user, _secret = enable_mfa_for_user()
     generate_recovery_codes_for_user(user, count=2)
 
-    response = client.get("/dashboard")
+    response = client.get("/mfa/setup")
     markup = response.data.decode("utf-8")
 
     assert response.status_code == 200
@@ -1656,8 +1656,10 @@ def test_authenticated_layout_contains_working_profile_menu_destinations(client)
     assert "Freeze Account" in markup
     assert "Log Out" in markup
     assert markup.index('href="/mfa/setup"') < markup.index('href="/security-keys"') < markup.index('href="/sessions"')
-    assert "No passkeys are registered" in markup
     assert "Transaction-ready" not in markup
+
+    keys_markup = client.get("/security-keys").data.decode("utf-8")
+    assert "No passkeys registered" in keys_markup
 
 
 def test_security_key_setup_prompts_for_authenticator_mfa_first(client):


### PR DESCRIPTION
## Summary

Cleans up the dashboard so it remains compatible with the app CSP while keeping security notices scoped to the pages where users can act on them.

Dashboard-specific inline `style` attributes were removed because they conflicted with `style-src-attr 'none'`. The required layout styling has been moved into `app/static/css/app.css`.

The dashboard also no longer shows recovery-code or passkey setup notices. Recovery-code status remains on `/mfa/setup`, and the no-passkey empty state remains on `/security-keys`.

## What changed

* Removed dashboard inline `style` attributes that conflicted with the app CSP.
* Moved dashboard-specific layout styles into `app/static/css/app.css`, including:

  * Account-number label grouping
  * Balance row alignment
  * Transaction header and empty-state spacing
  * MFA notice action button spacing
* Removed dashboard-level security notices for:

  * Recovery-code count / low recovery-code warning
  * No-passkeys registered prompt
* Kept security notices scoped to their relevant pages:

  * Recovery-code status on `/mfa/setup`
  * Passkey empty state on `/security-keys`
* Added `tests/test_dashboard.py` coverage for:

  * Dashboard auth/MFA access control
  * Banking card rendering
  * Masked balance and account number UI
  * Quick actions
  * Recent transactions empty state
  * Security notices being absent from dashboard
  * Recovery/passkey notices appearing on the correct pages
  * Frozen account dashboard notice
* Updated existing Group A security coverage to match the relocated recovery-code dashboard behavior.
