### PR TITLE
Enforce PR title and commit message policy

### DIFF
--- a/.github/workflows/commit-message-policy.yml
+++ b/.github/workflows/commit-message-policy.yml
@@ -17,8 +17,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out pull request history
-        # actions/checkout@v4 pinned to the immutable tag target.
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/commit-message-policy.yml
+++ b/.github/workflows/commit-message-policy.yml
@@ -1,0 +1,97 @@
+name: Commit message policy
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+
+permissions:
+  contents: read
+
+jobs:
+  commit-message-policy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out pull request history
+        # actions/checkout@v4 pinned to the immutable tag target.
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate commit subjects
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -Eeuo pipefail
+
+          allowed_verbs='Add|Fix|Update|Remove|Refactor|Document|Improve|Secure|Configure|Align|Restore|Prevent|Validate|Enforce|Implement|Rename|Replace|Move|Create|Delete|Test'
+          failed=0
+
+          annotation_escape() {
+            local value="$1"
+            value="${value//'%'/'%25'}"
+            value="${value//$'\r'/'%0D'}"
+            value="${value//$'\n'/'%0A'}"
+            printf '%s' "$value"
+          }
+
+          report_error() {
+            local sha="$1"
+            local subject="$2"
+            local message="$3"
+            local escaped_subject
+            escaped_subject="$(annotation_escape "${subject}")"
+            echo "::error title=Invalid commit subject::${sha}: ${message} Subject: ${escaped_subject}"
+            failed=1
+          }
+
+          while IFS= read -r line; do
+            sha="${line%% *}"
+            subject="${line#* }"
+
+            if [[ "${subject}" =~ ^Merge[[:space:]] ]] || [[ "${subject}" =~ ^Revert[[:space:]] ]]; then
+              continue
+            fi
+
+            lower_subject="${subject,,}"
+
+            if (( ${#subject} < 12 )); then
+              report_error "${sha}" "${subject}" "Commit subject must be at least 12 characters."
+              continue
+            fi
+
+            if (( ${#subject} > 72 )); then
+              report_error "${sha}" "${subject}" "Commit subject must be at most 72 characters."
+              continue
+            fi
+
+            if [[ "${subject}" == *. ]]; then
+              report_error "${sha}" "${subject}" "Commit subject must not end with a full stop."
+              continue
+            fi
+
+            case "${lower_subject}" in
+              fix|update|changes|change|wip|test|misc|stuff|done|bug|final|commit)
+                report_error "${sha}" "${subject}" "Commit subject is too generic."
+                continue
+                ;;
+            esac
+
+            if [[ ! "${subject}" =~ ^(${allowed_verbs})[[:space:]] ]]; then
+              report_error "${sha}" "${subject}" "Commit subject must start with an approved capitalized imperative verb."
+              continue
+            fi
+          done < <(git log --format='%H %s' "${BASE_SHA}..${HEAD_SHA}")
+
+          if (( failed != 0 )); then
+            exit 1
+          fi
+
+          echo "Commit message policy passed."

--- a/.github/workflows/pr-title-policy.yml
+++ b/.github/workflows/pr-title-policy.yml
@@ -1,0 +1,69 @@
+name: PR title policy
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions: {}
+
+jobs:
+  pr-title-policy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Validate PR title
+        shell: bash
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -Eeuo pipefail
+
+          allowed_verbs='Add|Fix|Update|Remove|Refactor|Document|Improve|Secure|Configure|Align|Restore|Prevent|Validate|Enforce|Implement|Rename|Replace|Move|Create|Delete|Test'
+
+          annotation_escape() {
+            local value="$1"
+            value="${value//'%'/'%25'}"
+            value="${value//$'\r'/'%0D'}"
+            value="${value//$'\n'/'%0A'}"
+            printf '%s' "$value"
+          }
+
+          fail() {
+            local message="$1"
+            local escaped_title
+            escaped_title="$(annotation_escape "${PR_TITLE}")"
+            echo "::error title=Invalid PR title::${message} Current title: ${escaped_title}"
+            exit 1
+          }
+
+          title="${PR_TITLE}"
+          lower_title="${title,,}"
+
+          if (( ${#title} < 12 )); then
+            fail "PR title must be at least 12 characters."
+          fi
+
+          if (( ${#title} > 72 )); then
+            fail "PR title must be at most 72 characters."
+          fi
+
+          if [[ "${title}" == *. ]]; then
+            fail "PR title must not end with a full stop."
+          fi
+
+          case "${lower_title}" in
+            fix|update|changes|change|wip|test|misc|stuff|done|bug|final|commit)
+              fail "PR title is too generic."
+              ;;
+          esac
+
+          if [[ ! "${title}" =~ ^(${allowed_verbs})[[:space:]] ]]; then
+            fail "PR title must start with an approved capitalized imperative verb."
+          fi
+
+          echo "PR title policy passed."

--- a/docs/CONTRIBUTION_MESSAGE_POLICY.md
+++ b/docs/CONTRIBUTION_MESSAGE_POLICY.md
@@ -1,0 +1,41 @@
+# Contribution Message Policy
+
+SITBank pull request titles and pull request commit subjects must use concise
+sentence-style imperative wording.
+
+## Required Format
+
+Each PR title and commit subject must:
+
+- Start with one approved capitalized imperative verb:
+  `Add`, `Fix`, `Update`, `Remove`, `Refactor`, `Document`, `Improve`,
+  `Secure`, `Configure`, `Align`, `Restore`, `Prevent`, `Validate`, `Enforce`,
+  `Implement`, `Rename`, `Replace`, `Move`, `Create`, `Delete`, or `Test`
+- Be at least 12 characters.
+- Be at most 72 characters.
+- Not end with a full stop.
+- Not be a lazy or generic message such as `fix`, `update`, `changes`, `change`,
+  `wip`, `test`, `misc`, `stuff`, `done`, `bug`, `final`, or `commit`.
+
+Git-generated `Merge ...` and `Revert ...` commit subjects are allowed for the
+commit-message check.
+
+## Good Examples
+
+- `Fix staging admin container startup`
+- `Add dashboard security regression tests`
+- `Remove inline styles blocked by CSP`
+- `Update production deployment gating`
+
+## Bad Examples
+
+- `fix`
+- `update`
+- `WIP`
+- `changes`
+- `Fixed bug.`
+
+## Why This Exists
+
+Clear PR titles and commit subjects make audit trails easier to review, improve
+release notes, and reduce ambiguity during incident response or rollback.


### PR DESCRIPTION
## Summary

Adds repository-level PR title and commit-message policy enforcement without changing application code.

This introduces GitHub Actions checks for PR titles and commit subjects, plus contributor documentation explaining the required message style. The policy enforces clear, sentence-style subjects that start with an approved capitalized imperative verb.

## What changed

* Added `.github/workflows/pr-title-policy.yml`.
* Added `.github/workflows/commit-message-policy.yml`.
* Added `docs/contribution-message-policy.md`.
* Enforced PR titles to start with one approved capitalized imperative verb.
* Enforced PR commit subjects to start with one approved capitalized imperative verb.
* Enforced subject length between 12 and 72 characters.
* Rejected trailing full stops.
* Rejected generic subjects such as:

  * `fix`
  * `update`
  * `WIP`
  * `changes`
  * `commit`
* Allowed Git-generated `Merge ...` and `Revert ...` commit subjects.
* Checked all commit subjects in `${BASE_SHA}..${HEAD_SHA}`.
* Added GitHub `::error::` annotations for policy failures.

## Notes

This is a repository hygiene and contribution-quality change only. It does not modify application runtime behavior.
