### PR TITLE
Fix required audit transaction boundaries

### DIFF
--- a/app/auth/password_reset.py
+++ b/app/auth/password_reset.py
@@ -168,17 +168,19 @@ def _verify_reset_authentication_code(code: str, *, submitted_factor: str) -> di
         factor = "totp"
     else:
         _enforce_reset_backoff("password_reset_recovery_code", transaction["transaction_id"])
-        if not consume_recovery_code(user, code):
+        if not consume_recovery_code(user, code, commit=False):
             record_failure("password_reset_recovery_code", transaction["transaction_id"])
             _record_transaction_failure(transaction, "recovery_code_failed")
             audit_event("password_reset_mfa_failed", "failure", user=user, metadata={"factor": "recovery_code"})
             raise AuthError(GENERIC_AUTHENTICATION_CODE_ERROR, 401)
         clear_failures("password_reset_recovery_code", transaction["transaction_id"])
-        _send_recovery_code_used_notification(user)
         transaction["recovery_code_verified"] = True
         factor = "recovery_code"
 
     audit_event_required("password_reset_mfa_verified", "success", user=user, metadata={"factor": factor})
+    db.session.commit()
+    if factor == "recovery_code":
+        _send_recovery_code_used_notification(user)
     transaction["mfa_verified"] = True
     transaction["mfa_verified_at"] = _now_timestamp()
     _store_transaction(transaction)
@@ -238,6 +240,7 @@ def complete_password_reset(new_password: str, confirm_new_password: str) -> dic
             "password_screening": "local_only_fallback" if password_policy_warnings else "local_and_live",
         },
     )
+    db.session.commit()
     _clear_reset_transaction(transaction)
     session.clear()
     clear_failures("login", _auth_principal(user.username))

--- a/app/auth/recovery_codes.py
+++ b/app/auth/recovery_codes.py
@@ -54,7 +54,13 @@ def generate_recovery_codes_for_user(
     return codes
 
 
-def consume_recovery_code(user: User, code: str, *, purpose: str = RECOVERY_CODE_PURPOSE_TOTP) -> bool:
+def consume_recovery_code(
+    user: User,
+    code: str,
+    *,
+    purpose: str = RECOVERY_CODE_PURPOSE_TOTP,
+    commit: bool = True,
+) -> bool:
     result = db.session.execute(
         db.update(RecoveryCode)
         .where(
@@ -66,9 +72,11 @@ def consume_recovery_code(user: User, code: str, *, purpose: str = RECOVERY_CODE
         .values(used_at=_utcnow())
     )
     if result.rowcount != 1:
-        db.session.rollback()
+        if commit:
+            db.session.rollback()
         return False
-    db.session.commit()
+    if commit:
+        db.session.commit()
     return True
 
 

--- a/app/auth/services.py
+++ b/app/auth/services.py
@@ -322,6 +322,7 @@ def verify_mfa_setup(user: User, code: str) -> dict[str, Any]:
         session_id=session_id,
         metadata={"recovery_code_count": len(recovery_codes)},
     )
+    db.session.commit()
     return {
         "message": "MFA enabled",
         "session_ref": public_session_reference(session_id),
@@ -391,6 +392,7 @@ def verify_mfa_replacement(user: User, code: str) -> dict[str, Any]:
         session_id=session_id,
         metadata={"revoked_other_sessions": revoked, "recovery_code_count": len(recovery_codes)},
     )
+    db.session.commit()
     return {
         "message": "Authenticator MFA replaced",
         "session_ref": public_session_reference(session_id),
@@ -448,6 +450,7 @@ def regenerate_totp_recovery_codes(user: User) -> dict[str, Any]:
         user=user,
         metadata={"recovery_code_count": len(recovery_codes)},
     )
+    db.session.commit()
     return {
         "message": "Recovery codes regenerated",
         "recovery_codes": recovery_codes,
@@ -731,7 +734,7 @@ def _verify_pending_login_authentication_code(user: User, code: str) -> str:
         _record_user_security_failure(user, "mfa", "mfa_failed_attempts")
         raise
 
-    if not consume_recovery_code(user, code):
+    if not consume_recovery_code(user, code, commit=False):
         record_failure("mfa_recovery_code", str(user.id))
         audit_event("mfa_recovery_code_verify", "failure", user=user)
         _record_user_security_failure(user, "mfa", "mfa_failed_attempts")
@@ -740,8 +743,9 @@ def _verify_pending_login_authentication_code(user: User, code: str) -> str:
     clear_failures("mfa_recovery_code", str(user.id))
     _clear_user_security_failures(user, "mfa")
     remaining = unused_recovery_code_count(user)
-    _send_mfa_recovery_code_used_notification(user)
     audit_event_required("mfa_recovery_code_verify", "success", user=user, metadata={"remaining_codes": remaining})
+    db.session.commit()
+    _send_mfa_recovery_code_used_notification(user)
     return "recovery_code"
 
 

--- a/app/banking/services.py
+++ b/app/banking/services.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping, MutableMapping
 from marshmallow import ValidationError
 
 from app.auth.services import AuthError, ensure_account_not_frozen
+from app.extensions import db
 from app.banking.schemas import PublicTransactionSchema
 from app.models import User
 from app.security.audit import audit_event, audit_event_required, audit_reference
@@ -247,8 +248,13 @@ def audit_banking_action(
         event_metadata["payee_account_ref"] = audit_reference("payee_account", payee_account)
     if idempotency_key is not None:
         event_metadata["idempotency_key_ref"] = audit_reference("idempotency_key", idempotency_key)
-    writer = audit_event_required if _requires_durable_audit(action, outcome) else audit_event
+    requires_durable_audit = _requires_durable_audit(action, outcome)
+    writer = audit_event_required if requires_durable_audit else audit_event
     writer(f"banking_{action}", outcome, user=user, metadata=event_metadata)
+    if requires_durable_audit:
+        # This helper is audit-only in the current banking scaffold; future
+        # ledger mutations should own their transaction and commit explicitly.
+        db.session.commit()
 
 
 def _ensure_banking_action_allowed(user: User, action: str, label: str) -> None:

--- a/app/security/audit.py
+++ b/app/security/audit.py
@@ -144,6 +144,12 @@ def audit_event_required(
     metadata: dict[str, Any] | None = None,
     session_id: str | None = None,
 ) -> None:
+    """Flush a required audit row without owning the caller's transaction.
+
+    Callers that mutate business state must commit after this returns, or roll
+    back if it raises. Keeping that boundary explicit prevents audit logging
+    from accidentally committing or rolling back unrelated pending state.
+    """
     _audit_event(
         event_type,
         outcome,
@@ -187,8 +193,9 @@ def _audit_event(
     created_at = datetime.now(timezone.utc)
 
     try:
-        _lock_audit_chain_for_insert()
-        previous_event_hash = _latest_audit_event_hash()
+        with db.session.no_autoflush:
+            _lock_audit_chain_for_insert()
+            previous_event_hash = _latest_audit_event_hash()
         event = SecurityAuditEvent(
             event_type=clean_event_type,
             outcome=clean_outcome,
@@ -204,10 +211,14 @@ def _audit_event(
         )
         event.event_hash = _compute_audit_event_hash(event)
         db.session.add(event)
-        db.session.flush()
-        db.session.commit()
+        if required:
+            db.session.flush([event])
+        else:
+            db.session.flush()
+            db.session.commit()
     except Exception as exc:
-        db.session.rollback()
+        if not required:
+            db.session.rollback()
         _log_audit_write_failed(
             event_type=clean_event_type,
             outcome=clean_outcome,

--- a/tests/test_audit_alerting.py
+++ b/tests/test_audit_alerting.py
@@ -110,10 +110,10 @@ def test_audit_write_failure_warning_is_sanitized(app, caplog, monkeypatch):
 def test_required_audit_write_failure_raises_and_logs_sanitized_warning(app, caplog, monkeypatch):
     from app.security.audit import AuditWriteError, audit_event_required
 
-    def fail_commit():
+    def fail_flush(_objects=None):
         raise RuntimeError("database password leaked")
 
-    monkeypatch.setattr(db.session, "commit", fail_commit)
+    monkeypatch.setattr(db.session, "flush", fail_flush)
     caplog.set_level("WARNING", logger=app.logger.name)
 
     with app.test_request_context("/audit/required", method="POST"):
@@ -134,6 +134,87 @@ def test_required_audit_write_failure_raises_and_logs_sanitized_warning(app, cap
     assert payload["metadata"]["authorization"] == "[redacted]"
     assert "database password leaked" not in logs
     assert "token-secret" not in logs
+
+def test_required_audit_waits_for_caller_commit_before_persisting(app):
+    from app.security.audit import audit_event_required
+
+    user = User(
+        username="auditboundary",
+        email="auditboundary@example.com",
+        password_hash=hash_password("correct horse battery staple"),
+        full_name="Audit Boundary",
+        phone_number="81234567",
+        account_number="012345678",
+    )
+    db.session.add(user)
+    db.session.commit()
+    user_id = user.id
+
+    user.full_name = "Unexpected Commit"
+    with app.test_request_context("/audit/required-boundary", method="POST"):
+        audit_event_required("required_boundary", "success", user=user)
+
+    db.session.rollback()
+
+    persisted = db.session.get(User, user_id)
+    assert persisted.full_name == "Audit Boundary"
+    assert db.session.query(SecurityAuditEvent).filter_by(event_type="required_boundary").count() == 0
+
+def test_required_audit_success_is_committed_by_the_caller(app):
+    from app.security.audit import audit_event_required
+
+    user = User(
+        username="auditcommit",
+        email="auditcommit@example.com",
+        password_hash=hash_password("correct horse battery staple"),
+        full_name="Audit Commit",
+        phone_number="82345678",
+        account_number="012456789",
+    )
+    db.session.add(user)
+    db.session.commit()
+    user_id = user.id
+
+    user.full_name = "Caller Commit"
+    with app.test_request_context("/audit/required-commit", method="POST"):
+        audit_event_required("required_commit", "success", user=user)
+    db.session.commit()
+
+    persisted = db.session.get(User, user_id)
+    event = db.session.query(SecurityAuditEvent).filter_by(event_type="required_commit").one()
+    assert persisted.full_name == "Caller Commit"
+    assert event.outcome == "success"
+    assert event.user_id == user_id
+
+def test_required_audit_failure_leaves_business_rollback_to_caller(app, monkeypatch):
+    from app.security import audit as audit_module
+
+    user = User(
+        username="auditfailure",
+        email="auditfailure@example.com",
+        password_hash=hash_password("correct horse battery staple"),
+        full_name="Audit Failure",
+        phone_number="83456789",
+        account_number="012567890",
+    )
+    db.session.add(user)
+    db.session.commit()
+    user_id = user.id
+
+    def fail_latest_hash():
+        raise RuntimeError("audit writer unavailable")
+
+    monkeypatch.setattr(audit_module, "_latest_audit_event_hash", fail_latest_hash)
+    user.full_name = "Should Roll Back"
+    with app.test_request_context("/audit/required-fail", method="POST"):
+        with pytest.raises(audit_module.AuditWriteError):
+            audit_module.audit_event_required("required_failure", "success", user=user)
+
+    db.session.rollback()
+
+    persisted = db.session.get(User, user_id)
+    assert persisted.full_name == "Audit Failure"
+    assert db.session.query(SecurityAuditEvent).filter_by(event_type="required_failure").count() == 0
 
 def test_webauthn_audit_wrapper_can_use_required_writer(monkeypatch):
     from app.security import audit as audit_module

--- a/tests/test_banking_transaction_security.py
+++ b/tests/test_banking_transaction_security.py
@@ -110,7 +110,7 @@ def test_public_transaction_idempotency_binds_key_to_exact_payload():
 
     assert first == replay
 
-def test_banking_transaction_approval_uses_required_audit_writer(monkeypatch):
+def test_banking_transaction_approval_uses_required_audit_writer(app, monkeypatch):
     from app.banking import services as banking_services
 
     calls = []

--- a/tests/test_password_reset.py
+++ b/tests/test_password_reset.py
@@ -6,6 +6,7 @@ import secrets
 from urllib.parse import parse_qs, urlparse
 
 import pyotp
+import pytest
 from sqlalchemy import func
 
 from app.auth.password_reset import generate_recovery_codes_for_user
@@ -214,6 +215,31 @@ def test_password_reset_completion_uses_required_audit_writer(app, client, monke
         user = db.session.get(User, user_id)
         assert user is not None
         assert verify_password(NEW_PASSWORD, user.password_hash)
+
+def test_password_reset_completion_required_audit_failure_does_not_commit_password(app, client, monkeypatch):
+    from app.auth import password_reset
+    from app.security.audit import AuditWriteError
+
+    user_id = _begin_no_mfa_reset(app, client, username="resetauditfail", email="resetauditfail@example.com")
+    original_hash = db.session.get(User, user_id).password_hash
+
+    def fail_required_audit(*_args, **_kwargs):
+        raise AuditWriteError("required audit unavailable")
+
+    monkeypatch.setattr(password_reset, "audit_event_required", fail_required_audit)
+    app.config["PROPAGATE_EXCEPTIONS"] = True
+
+    with pytest.raises(AuditWriteError):
+        client.post(
+            "/auth/password-reset/complete",
+            json={"new_password": NEW_PASSWORD, "confirm_new_password": NEW_PASSWORD},
+        )
+
+    db.session.rollback()
+    user = db.session.get(User, user_id)
+    assert user.password_hash == original_hash
+    assert not verify_password(NEW_PASSWORD, user.password_hash)
+    assert db.session.query(SecurityAuditEvent).filter_by(event_type="password_reset_completed").count() == 0
 
 
 def test_password_reset_accepts_8_character_password(app, client, monkeypatch):


### PR DESCRIPTION
## Summary

Fix required audit logging transaction boundaries so `audit_event_required()` no longer silently commits or rolls back unrelated caller business state.

## Why

Required audit events are used in high-risk flows that should fail closed if auditing cannot be recorded. The previous helper used the shared SQLAlchemy session and called `commit()` / `rollback()` internally, which could accidentally persist pending business changes early or roll back caller-owned state unexpectedly.

The audit-anchor prompt was also checked against the repo. The current production policy is already explicit: `SECURITY_AUDIT_HMAC_KEY` is mandatory, while `SECURITY_AUDIT_ANCHOR_PATH` remains optional until a trusted anchor is exported.

## What changed

* Changed `audit_event_required()` to flush the audit row without owning the caller transaction.
* Added explicit caller commits after required audit succeeds in MFA, recovery-code, password-reset, and banking audit-only flows.
* Added regression tests for hidden commit prevention, caller-managed commits, required-audit failure rollback behavior, and password-reset failure safety.

## Security impact

Improves audit fail-closed behavior by making transaction ownership explicit. Critical business changes are no longer accidentally committed by the audit helper before the caller decides to commit. Audit HMAC/hash-chain integrity and sanitization behavior are preserved.

## Deployment impact

No EC2 bootstrap, staging-specific setup, production-specific setup, database migration, or secret changes required. Normal application deployment is enough.

## Verification

* `python -m compileall app tests`
* `python -m pytest -q tests/test_audit_alerting.py tests/test_password_reset.py tests/test_mfa_lifecycle.py tests/test_banking_transaction_security.py`
* `python -m pytest -q tests/test_config.py`
* `python -m pytest -q tests/test_deployment.py::test_audit_operations_runbook_and_append_only_privileges_are_present`
* `git diff --check`

## Notes

`SECURITY_AUDIT_ANCHOR_PATH` was not made mandatory because the existing docs and tests already define the current policy as optional until operators export a trusted anchor.