### PR TITLE
Implement passkey-first customer MFA onboarding

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -134,11 +134,12 @@ def register_current_user_loader(app: Flask) -> None:
         if user_id is not None:
             g.current_user = db.session.get(User, user_id)
             if g.current_user is not None:
+                from app.auth.mfa_policy import has_enrolled_mfa_method
                 from app.auth.webauthn_services import webauthn_credential_count
 
                 g.webauthn_credential_count = webauthn_credential_count(g.current_user)
                 g.passkey_ready = g.webauthn_credential_count > 0
-                g.mfa_ready = bool(g.current_user.mfa_enabled)
+                g.mfa_ready = has_enrolled_mfa_method(g.current_user)
                 g.high_risk_ready = g.mfa_ready
 
 

--- a/app/auth/mfa_policy.py
+++ b/app/auth/mfa_policy.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from flask import session
+
+from app.extensions import db
+from app.models import User, WebAuthnCredential
+
+
+PASSWORD_BOOTSTRAP_AUTH_CONTEXT = "password_bootstrap"
+
+
+def enrolled_webauthn_credential_count(user: User) -> int:
+    if user.id is None:
+        return 0
+    return int(
+        db.session.execute(
+            db.select(db.func.count(WebAuthnCredential.id)).where(
+                WebAuthnCredential.user_id == user.id
+            )
+        ).scalar_one()
+    )
+
+
+def has_enrolled_mfa_method(user: User) -> bool:
+    return bool(user.mfa_enabled or enrolled_webauthn_credential_count(user) > 0)
+
+
+def has_password_bootstrap_session(user: User) -> bool:
+    return (
+        session.get("user_id") == user.id
+        and session.get("auth_context") == PASSWORD_BOOTSTRAP_AUTH_CONTEXT
+    )

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -6,6 +6,7 @@ from flask_wtf.csrf import generate_csrf
 from marshmallow import Schema, ValidationError
 
 from app.extensions import limiter
+from app.auth.mfa_policy import has_enrolled_mfa_method
 from app.security.rate_limits import mfa_principal, request_principal
 
 from .decorators import login_required, not_frozen_required
@@ -100,19 +101,21 @@ AUTH_MFA_ONBOARDING_ALLOWED_ENDPOINTS = {
     "auth.password_reset_webauthn_verify",
     "auth.password_reset_complete",
     "auth.manual_recovery_request",
+    "auth.webauthn_register_options",
+    "auth.webauthn_register_verify",
 }
 
 
 @auth_bp.before_request
 def enforce_api_mfa_onboarding():
     user = getattr(g, "current_user", None)
-    if user is None or user.mfa_enabled:
+    if user is None or has_enrolled_mfa_method(user):
         return None
     if request.endpoint in AUTH_MFA_ONBOARDING_ALLOWED_ENDPOINTS:
         return None
     return jsonify(
         {
-            "error": "Authenticator MFA setup required",
+            "error": "MFA setup required",
             "code": "mfa_setup_required",
         }
     ), 403
@@ -270,8 +273,8 @@ def webauthn_register_verify():
 @limiter.limit("5 per 5 minutes", key_func=get_remote_address)
 @limiter.limit("5 per 5 minutes", key_func=request_principal)
 def webauthn_authenticate_options():
-    data = WebAuthnAuthenticationOptionsSchema().load(request.get_json(silent=False) or {})
-    return jsonify(begin_authentication_options(data["identifier"]))
+    WebAuthnAuthenticationOptionsSchema().load(request.get_json(silent=True) or {})
+    return jsonify(begin_authentication_options())
 
 
 @auth_bp.post("/webauthn/authenticate/verify")

--- a/app/auth/schemas.py
+++ b/app/auth/schemas.py
@@ -166,7 +166,8 @@ class WebAuthnRegistrationVerifySchema(Schema):
 
 
 class WebAuthnAuthenticationOptionsSchema(Schema):
-    identifier = fields.Str(required=True, validate=validate.Length(min=1, max=255))
+    class Meta:
+        unknown = EXCLUDE
 
 
 class WebAuthnAuthenticationVerifySchema(Schema):

--- a/app/auth/services.py
+++ b/app/auth/services.py
@@ -20,6 +20,11 @@ from sqlalchemy.exc import IntegrityError
 
 from app.extensions import db
 from app.models import User
+from app.auth.mfa_policy import (
+    PASSWORD_BOOTSTRAP_AUTH_CONTEXT,
+    enrolled_webauthn_credential_count,
+    has_enrolled_mfa_method,
+)
 from app.security.audit import audit_event, audit_event_required, principal_reference
 from app.security.crypto import decrypt_mfa_secret, encrypt_mfa_secret
 from app.security.passwords import (
@@ -35,6 +40,7 @@ from app.security.sessions import (
     begin_password_authenticated_session,
     current_session_id,
     establish_authenticated_session,
+    has_recent_fresh_mfa,
     list_active_sessions,
     list_past_sessions,
     mark_fresh_mfa,
@@ -268,10 +274,19 @@ def authenticate_primary(identifier: str, password: str) -> dict[str, Any]:
             "mfa_required": True,
         }
 
+    if enrolled_webauthn_credential_count(user) > 0:
+        begin_password_authenticated_session(user.id)
+        audit_event("login_password", "success", user=user, metadata={"passkey_required": True})
+        return {
+            "message": "Passkey verification required",
+            "mfa_required": True,
+            "webauthn_required": True,
+        }
+
     session_id = establish_authenticated_session(
         user_id=user.id,
         mfa_verified=False,
-        auth_context="password_bootstrap",
+        auth_context=PASSWORD_BOOTSTRAP_AUTH_CONTEXT,
     )
     audit_event("login", "success", user=user, session_id=session_id, metadata={"mfa_required": False})
     return {
@@ -288,6 +303,9 @@ def generate_mfa_setup(user: User) -> dict[str, str]:
     if user.mfa_enabled:
         audit_event("mfa_setup_generate", "failure", user=user, metadata={"reason": "already_enabled"})
         raise AuthError("MFA is already enabled", 409)
+    if has_enrolled_mfa_method(user) and not has_recent_fresh_mfa():
+        audit_event("mfa_setup_generate", "failure", user=user, metadata={"reason": "fresh_mfa_required"})
+        raise AuthError("Recent MFA verification is required before adding another MFA method", 403)
 
     secret = pyotp.random_base32(length=32)
     nonce, ciphertext = encrypt_mfa_secret(secret, user.id)
@@ -683,13 +701,16 @@ def verify_high_risk_authorization(
     from app.auth.webauthn_services import consume_step_up_token
 
     require_stable_session_for_sensitive_action(action)
-    if not user.mfa_enabled:
+    if not has_enrolled_mfa_method(user):
         audit_event(action, "failure", user=user, metadata={"reason": "mfa_not_enabled"})
         raise AuthError("MFA is required for this action", 403)
     if stepup_token:
         consume_step_up_token(user, action, stepup_token)
         audit_event(action, "passkey_success", user=user)
     elif code:
+        if not user.mfa_enabled:
+            audit_event(action, "failure", user=user, metadata={"reason": "totp_not_enabled"})
+            raise AuthError("Use a passkey to verify this action", 403)
         if not _verify_totp_for_user(user, code, action):
             _handle_mfa_verification_failure(user, action)
         audit_event(action, "mfa_success", user=user)

--- a/app/auth/webauthn_services.py
+++ b/app/auth/webauthn_services.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from flask import current_app, request, session
-from sqlalchemy import func, or_
+from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from webauthn import (
     generate_authentication_options,
@@ -29,6 +29,7 @@ from webauthn.helpers.structs import (
 
 from app.extensions import db
 from app.models import User, WebAuthnCredential
+from app.auth.mfa_policy import has_enrolled_mfa_method, has_password_bootstrap_session
 from app.security.audit import audit_event, audit_reference, audit_webauthn_event
 from app.security.sessions import (
     current_session_id,
@@ -141,7 +142,8 @@ def begin_registration_options(user: User, label: str) -> dict[str, Any]:
         timeout=current_app.config["WEBAUTHN_TIMEOUT_MS"],
         attestation=AttestationConveyancePreference.NONE,
         authenticator_selection=AuthenticatorSelectionCriteria(
-            resident_key=ResidentKeyRequirement.PREFERRED,
+            resident_key=ResidentKeyRequirement.REQUIRED,
+            require_resident_key=True,
             user_verification=UserVerificationRequirement.REQUIRED,
         ),
         exclude_credentials=[PublicKeyCredentialDescriptor(id=item.credential_id) for item in credentials],
@@ -239,72 +241,41 @@ def verify_registration(user: User, credential: dict[str, Any]) -> dict[str, Any
     }
 
 
-def begin_authentication_options(identifier: str) -> dict[str, Any]:
+def begin_authentication_options() -> dict[str, Any]:
     enforce_request_origin()
-    user = _find_user_by_identifier(identifier)
-    credentials: list[WebAuthnCredential] = []
-    registered_count = 0
-    user_id: int | None = None
-    if user is not None:
-        try:
-            ensure_account_can_authenticate(user)
-        except AuthError:
-            user = None
-    if user is not None:
-        user_credentials = _credentials_for_user(user)
-        registered_count = len(user_credentials)
-        if registered_count > 0:
-            credentials = user_credentials
-            user_id = user.id
-
     options = generate_authentication_options(
         rp_id=current_app.config["WEBAUTHN_RP_ID"],
         timeout=current_app.config["WEBAUTHN_TIMEOUT_MS"],
-        allow_credentials=[
-            PublicKeyCredentialDescriptor(
-                id=item.credential_id,
-                transports=_transports_for_descriptor(item),
-            )
-            for item in credentials
-        ],
         user_verification=UserVerificationRequirement.REQUIRED,
     )
     session[AUTH_CHALLENGE_KEY] = bytes_to_base64url(options.challenge)
-    session[AUTH_USER_KEY] = user_id
+    session.pop(AUTH_USER_KEY, None)
     session.modified = True
     audit_webauthn_event(
         "authenticate_options",
         "success",
-        user=user,
-        metadata={
-            "credential_count": len(credentials),
-            "registered_credential_count": registered_count,
-            "required_credential_count": _required_webauthn_login_credential_count(),
-        },
+        metadata={"discoverable": True},
     )
-    return options_to_json_dict(options)
+    payload = options_to_json_dict(options)
+    payload.pop("allowCredentials", None)
+    return payload
 
 
 def verify_authentication(credential: dict[str, Any]) -> dict[str, Any]:
     enforce_request_origin()
     challenge = session.get(AUTH_CHALLENGE_KEY)
-    pending_user_id = session.get(AUTH_USER_KEY)
-    if not challenge or not pending_user_id:
+    if not challenge:
         audit_webauthn_event("authenticate", "failure", metadata={"reason": "missing_challenge"})
         raise AuthError(GENERIC_WEBAUTHN_ERROR, 401)
 
     credential_id = _credential_id_from_payload(credential)
     item = db.session.execute(
-        db.select(WebAuthnCredential).where(
-            WebAuthnCredential.user_id == int(pending_user_id),
-            WebAuthnCredential.credential_id == credential_id,
-        )
+        db.select(WebAuthnCredential).where(WebAuthnCredential.credential_id == credential_id)
     ).scalar_one_or_none()
     if item is None:
         audit_webauthn_event(
             "authenticate",
             "failure",
-            user_id=int(pending_user_id),
             credential_id=credential_id,
             metadata={"reason": "unknown_or_unowned_credential"},
         )
@@ -318,6 +289,16 @@ def verify_authentication(credential: dict[str, Any]) -> dict[str, Any]:
             user_id=item.user_id,
             credential_id=item.credential_id,
             metadata={"reason": "missing_user"},
+        )
+        raise AuthError(GENERIC_WEBAUTHN_ERROR, 401)
+    pending_user_id = session.get("pending_mfa_user_id")
+    if pending_user_id is not None and int(pending_user_id) != int(user.id):
+        audit_webauthn_event(
+            "authenticate",
+            "failure",
+            user=user,
+            credential_id=item.credential_id,
+            metadata={"reason": "pending_user_mismatch"},
         )
         raise AuthError(GENERIC_WEBAUTHN_ERROR, 401)
     try:
@@ -926,18 +907,6 @@ def verify_transaction_security_key_challenge(user: User, credential: dict[str, 
     }
 
 
-def _find_user_by_identifier(identifier: str) -> User | None:
-    normalized = identifier.strip().casefold()
-    return db.session.execute(
-        db.select(User).where(
-            or_(
-                func.lower(User.username) == normalized,
-                func.lower(User.email) == normalized,
-            )
-        )
-    ).scalar_one_or_none()
-
-
 def _registration_failure_metadata(exc: Exception, verification, failure_stage: str) -> dict[str, Any]:
     metadata: dict[str, Any] = {
         "reason": type(exc).__name__,
@@ -1093,6 +1062,8 @@ def _ensure_registration_session_allowed(user: User) -> None:
         raise AuthError("Authentication required", 401)
 
     existing_count = webauthn_credential_count(user)
+    if existing_count == 0 and not has_enrolled_mfa_method(user) and has_password_bootstrap_session(user):
+        return
     if existing_count == 0 and has_recent_fresh_mfa():
         return
     if existing_count > 0 and _has_recent_lifecycle_authorization():

--- a/app/security/audit.py
+++ b/app/security/audit.py
@@ -304,14 +304,17 @@ def audit_webauthn_event(
     session_id: str | None = None,
     required: bool = False,
 ) -> None:
-    credential_ref = credential_id
+    credential_ref = None
     if isinstance(credential_id, bytes):
-        credential_ref = bytes_to_base64url(credential_id) if bytes_to_base64url else credential_id.hex()
+        credential_value = bytes_to_base64url(credential_id) if bytes_to_base64url else credential_id.hex()
+        credential_ref = audit_reference("webauthn_credential", credential_value) or "[unavailable]"
+    elif credential_id:
+        credential_ref = audit_reference("webauthn_credential", credential_id) or "[unavailable]"
 
     event_metadata = {
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "action": action,
-        "credential_id": credential_ref,
+        "credential_ref": credential_ref,
         "label": label,
         "aaguid": aaguid,
     }

--- a/app/static/js/webauthn.js
+++ b/app/static/js/webauthn.js
@@ -113,10 +113,14 @@
 
   function prepareAuthenticationOptions(options) {
     options.challenge = base64urlToBuffer(options.challenge);
-    options.allowCredentials = (options.allowCredentials || []).map(function (credential) {
-      credential.id = base64urlToBuffer(credential.id);
-      return credential;
-    });
+    if (Array.isArray(options.allowCredentials)) {
+      options.allowCredentials = options.allowCredentials.map(function (credential) {
+        credential.id = base64urlToBuffer(credential.id);
+        return credential;
+      });
+    } else {
+      delete options.allowCredentials;
+    }
     return options;
   }
 
@@ -197,9 +201,8 @@
       loginForm.addEventListener("submit", function (event) {
         event.preventDefault();
         var errorNode = document.querySelector("[data-webauthn-login-error]");
-        var identifier = loginForm.querySelector('input[name="identifier"]').value;
         clearError(errorNode);
-        postJson("/auth/webauthn/authenticate/options", { identifier: identifier }, csrfToken(loginForm))
+        postJson("/auth/webauthn/authenticate/options", {}, csrfToken(loginForm))
           .then(function (options) {
             return navigator.credentials.get({ publicKey: prepareAuthenticationOptions(options) });
           })

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -149,7 +149,7 @@
                   </span>
                 </button>
                 <div class="account-panel" id="account-menu-panel" role="menu" aria-labelledby="account-menu-button" data-account-panel hidden>
-                  {% if g.current_user.mfa_enabled %}
+                  {% if g.mfa_ready %}
                     <a role="menuitem" href="{{ url_for('web.dashboard') }}">Dashboard</a>
                     <a role="menuitem" href="{{ url_for('web.profile') }}">Edit Profile</a>
                     {% if g.high_risk_ready %}
@@ -162,7 +162,7 @@
                   {% endif %}
                   <div class="account-menu-section-label" role="separator">Security Settings</div>
                   <a role="menuitem" href="{{ url_for('web.mfa_setup') }}">Authenticator MFA</a>
-                  {% if g.current_user.mfa_enabled %}
+                  {% if g.mfa_ready %}
                     <a role="menuitem" href="{{ url_for('web.security_keys') }}">Passkeys</a>
                     <a role="menuitem" href="{{ url_for('web.sessions_dashboard') }}">Active Sessions</a>
                     {% if g.high_risk_ready %}
@@ -231,7 +231,7 @@
           <h2 class="footer-heading">Sitemap</h2>
           <ul class="footer-links">
             {% if g.current_user %}
-              {% if g.current_user.mfa_enabled %}
+              {% if g.mfa_ready %}
                 <li><a href="{{ url_for('web.dashboard') }}">Dashboard</a></li>
                 <li><a href="{{ url_for('web.profile') }}">Profile</a></li>
                 {% if g.high_risk_ready %}
@@ -241,7 +241,7 @@
                 {% endif %}
               {% endif %}
               <li><a href="{{ url_for('web.mfa_setup') }}">MFA</a></li>
-              {% if g.current_user.mfa_enabled %}
+              {% if g.mfa_ready %}
                 <li><a href="{{ url_for('web.security_keys') }}">Passkeys</a></li>
                 <li><a href="{{ url_for('web.sessions_dashboard') }}">Sessions</a></li>
                 {% if g.high_risk_ready %}
@@ -262,13 +262,13 @@
           <h2 class="footer-heading">Account Security</h2>
           <ul class="footer-links">
             {% if g.current_user %}
-              {% if g.current_user.mfa_enabled and g.high_risk_ready %}
+              {% if g.mfa_ready and g.high_risk_ready %}
                 <li><a href="{{ url_for('web.password_change') }}">Change password</a></li>
               {% else %}
                 <li><a class="is-disabled" aria-disabled="true">Change password</a></li>
               {% endif %}
               <li><a href="{{ url_for('web.mfa_setup') }}">Manage authenticator MFA</a></li>
-              {% if g.current_user.mfa_enabled %}
+              {% if g.mfa_ready %}
                 <li><a href="{{ url_for('web.security_keys') }}">Manage passkeys</a></li>
                 <li><a href="{{ url_for('web.sessions_dashboard') }}">Review active sessions</a></li>
                 {% if g.high_risk_ready %}

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -41,14 +41,14 @@
     {% endif %}
   </div>
 
-  {% if not user.mfa_enabled %}
+  {% if not g.mfa_ready %}
   <!-- MFA setup banner -->
   <div class="notice warning">
     <span class="notice-icon" aria-hidden="true">
       <svg class="icon" focusable="false"><use href="#icon-alert"></use></svg>
     </span>
     <div>
-      <p><strong>Set up Authenticator MFA</strong> to unlock transfers, payments, and all account actions.</p>
+      <p><strong>Set up MFA</strong> to unlock transfers, payments, and all account actions.</p>
       <a class="button secondary small notice-action" href="{{ url_for('web.mfa_setup') }}">Set up MFA</a>
     </div>
   </div>

--- a/app/templates/freeze.html
+++ b/app/templates/freeze.html
@@ -38,7 +38,7 @@
         </ul>
       </article>
     </div>
-  {% elif not user.mfa_enabled %}
+  {% elif not g.mfa_ready %}
     <div class="freeze-grid">
       <article class="freeze-panel">
         <div class="notice warning">
@@ -47,7 +47,7 @@
           </span>
           <div>
             <h2>MFA is required</h2>
-            <p class="muted">Account freeze requires an authenticator code before it can be used.</p>
+            <p class="muted">Account freeze requires an authenticator app, passkey, or security key before it can be used.</p>
           </div>
         </div>
         <div class="freeze-actions">
@@ -57,7 +57,7 @@
       </article>
       <article class="freeze-panel">
         <h2>Freeze readiness</h2>
-        <p class="muted">MFA protects this high-risk workflow by confirming the signed-in user with a current authenticator code.</p>
+        <p class="muted">MFA protects this high-risk workflow by confirming the signed-in user with a current authenticator code or passkey.</p>
         <ul class="freeze-list">
           <li>Enable MFA before attempting an emergency freeze.</li>
           <li>Review active sessions if you suspect unusual access.</li>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -48,13 +48,8 @@
     <form method="post" action="{{ url_for('auth.webauthn_authenticate_options') }}" data-webauthn-login-form novalidate>
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 
-      <div class="form-group">
-        <label for="security-key-identifier">Username or email for passkey login</label>
-        <input id="security-key-identifier" name="identifier" type="text" autocomplete="username" maxlength="255">
-        <p class="hint">Available after a passkey or security key is registered.</p>
-      </div>
-
       <button class="button secondary full" type="submit">Sign in with passkey</button>
+      <p class="hint">Use Windows Hello, your device passkey, a password-manager passkey, or a hardware security key.</p>
       <p class="field-error" data-webauthn-login-error hidden></p>
     </form>
     <p class="switch-link"><a href="{{ url_for('web.forgot_password') }}">Forgot password?</a></p>

--- a/app/templates/mfa_setup.html
+++ b/app/templates/mfa_setup.html
@@ -1,14 +1,14 @@
 {% extends "base.html" %}
 
-{% block title %}Authenticator MFA | SITBank{% endblock %}
+{% block title %}MFA Setup | SITBank{% endblock %}
 
 {% block content %}
 <section class="security-page mfa-page">
   <div class="dashboard-header">
     <div class="page-heading">
       <p class="eyebrow">Authenticator protection</p>
-      <h1>Authenticator MFA</h1>
-      <p class="muted">Use one active authenticator app for normal sign-in and protected account actions.</p>
+      <h1>MFA setup</h1>
+      <p class="muted">Use an authenticator app, a passkey, or a security key for normal sign-in and protected account actions.</p>
     </div>
     <div class="button-row">
       <a class="button secondary" href="{{ url_for('web.dashboard') }}">Back to dashboard</a>
@@ -164,6 +164,52 @@
       </article>
     </div>
   {% else %}
+    <div class="notice">
+      <span class="notice-icon" aria-hidden="true">
+        <svg class="icon" focusable="false"><use href="#icon-info"></use></svg>
+      </span>
+      <div>
+        <h2>Choose your first MFA method</h2>
+        <p class="muted">Set up an authenticator app, or register a passkey or security key. Passkeys can use Windows Hello, your device passkey, a password-manager passkey, or a hardware security key.</p>
+      </div>
+    </div>
+
+    <div class="profile-grid">
+      <article class="profile-panel profile-card">
+        <div class="profile-panel-title">
+          <p class="eyebrow">Passkey or security key</p>
+          <h2>Register a passkey</h2>
+        </div>
+        <p class="muted">Your browser and passkey provider choose the prompt. SITBank verifies origin, RP ID, challenge, and user verification before accepting it.</p>
+        <form method="post" action="{{ url_for('web.security_keys') }}" data-webauthn-register-form novalidate>
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <div class="form-group">
+            <label for="onboarding-security-key-label">Passkey label</label>
+            <input id="onboarding-security-key-label" name="label" maxlength="80" autocomplete="off" placeholder="Windows Hello" required>
+          </div>
+          <button class="button full" type="submit">Register passkey</button>
+          <p class="field-error" data-webauthn-register-error hidden></p>
+        </form>
+      </article>
+
+      <article class="profile-panel profile-card">
+        <div class="profile-panel-title">
+          <p class="eyebrow">Authenticator app</p>
+          <h2>Set up TOTP</h2>
+        </div>
+        <p class="muted">Use a 6-digit code from an authenticator app. Recovery codes are generated after verification.</p>
+        {% if setup %}
+          <p class="badge">Setup code generated</p>
+        {% else %}
+          <form method="post" action="{{ url_for('web.mfa_setup_submit') }}">
+            {{ start_form.hidden_tag() }}
+            <input type="hidden" name="action" value="start">
+            <button class="button full" type="submit">Generate authenticator setup</button>
+          </form>
+        {% endif %}
+      </article>
+    </div>
+
     <div class="mfa-steps">
       <article class="mfa-step{% if setup %} is-complete{% endif %}">
         <div class="mfa-step-header">
@@ -186,7 +232,7 @@
             <form method="post" action="{{ url_for('web.mfa_setup_submit') }}">
               {{ start_form.hidden_tag() }}
               <input type="hidden" name="action" value="start">
-              <button class="button full" type="submit">Generate MFA setup</button>
+              <button class="button full" type="submit">Generate authenticator setup</button>
             </form>
           {% endif %}
         </div>

--- a/app/templates/mfa_verify.html
+++ b/app/templates/mfa_verify.html
@@ -7,27 +7,42 @@
   <div class="page-heading">
     <p class="eyebrow">Second step</p>
     <h1>MFA Verification</h1>
-    <p class="muted">Enter an authenticator or recovery code to finish signing in.</p>
+    <p class="muted">
+      {% if webauthn_required %}
+        Use your passkey or security key to finish signing in.
+      {% else %}
+        Enter an authenticator or recovery code to finish signing in.
+      {% endif %}
+    </p>
   </div>
 
-  <div class="notice">
-    <span class="notice-icon" aria-hidden="true">
-      <svg class="icon" focusable="false"><use href="#icon-refresh"></use></svg>
-    </span>
-    <p class="muted">Each authenticator code can only be used once. If you just used it, wait for the next one.</p>
-  </div>
-
-  <form method="post" action="{{ url_for('web.mfa_verify_submit') }}" novalidate>
-    {{ form.hidden_tag() }}
-
-    <div class="form-group">
-      <label for="{{ form.totp_code.id }}">Authentication code</label>
-      {{ form.totp_code(autocomplete="one-time-code", maxlength="80") }}
-      {% for error in form.totp_code.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
+  {% if webauthn_required %}
+    <form method="post" action="{{ url_for('auth.webauthn_authenticate_options') }}" data-webauthn-login-form novalidate>
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <button class="button full" type="submit">Sign in with passkey</button>
+      <p class="hint">Use Windows Hello, your device passkey, a password-manager passkey, or a hardware security key.</p>
+      <p class="field-error" data-webauthn-login-error hidden></p>
+    </form>
+  {% else %}
+    <div class="notice">
+      <span class="notice-icon" aria-hidden="true">
+        <svg class="icon" focusable="false"><use href="#icon-refresh"></use></svg>
+      </span>
+      <p class="muted">Each authenticator code can only be used once. If you just used it, wait for the next one.</p>
     </div>
 
-    <button class="button full" type="submit">Verify code</button>
-  </form>
+    <form method="post" action="{{ url_for('web.mfa_verify_submit') }}" novalidate>
+      {{ form.hidden_tag() }}
+
+      <div class="form-group">
+        <label for="{{ form.totp_code.id }}">Authentication code</label>
+        {{ form.totp_code(autocomplete="one-time-code", maxlength="80") }}
+        {% for error in form.totp_code.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
+      </div>
+
+      <button class="button full" type="submit">Verify code</button>
+    </form>
+  {% endif %}
   <p class="switch-link"><a href="{{ url_for('web.login') }}">Back to login</a></p>
 </section>
 {% endblock %}

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -38,9 +38,9 @@
         <div class="profile-status-row">
           <dt>Password</dt>
           <dd class="profile-status-copy">
-            {% if not user.mfa_enabled %}
+            {% if not g.mfa_ready %}
               <strong class="profile-status-title">Setup MFA first</strong>
-              <span class="compact">Enable authenticator MFA before changing your password.</span>
+              <span class="compact">Set up an authenticator app or passkey before changing your password.</span>
               <a class="button button-small secondary is-disabled" aria-disabled="true">Change password</a>
             {% else %}
               <strong class="profile-status-title">Change available</strong>
@@ -50,10 +50,10 @@
           </dd>
         </div>
         <div class="profile-status-row">
-          <dt>Authenticator MFA</dt>
+          <dt>MFA</dt>
           <dd class="profile-status-copy">
-            <strong class="profile-status-title">{{ "Enabled" if user.mfa_enabled else "Setup needed" }}</strong>
-            <span class="compact">Use an authenticator app for normal login MFA.</span>
+            <strong class="profile-status-title">{{ "Enabled" if g.mfa_ready else "Setup needed" }}</strong>
+            <span class="compact">Use an authenticator app, passkey, or security key for login MFA.</span>
             <a class="button button-small secondary" href="{{ url_for('web.mfa_setup') }}">Manage MFA</a>
           </dd>
         </div>
@@ -74,7 +74,7 @@
         <h2>Update profile details</h2>
       </div>
       <p class="muted">Changes to your sign-in details are securely recorded and require MFA or passkey verification.</p>
-      {% if user.mfa_enabled %}
+      {% if g.mfa_ready %}
         <form method="post" action="{{ url_for('web.profile_submit') }}" data-webauthn-step-up-form data-step-up-action="profile_update" novalidate>
           {{ form.hidden_tag() }}
           <div class="form-group">
@@ -91,7 +91,7 @@
             <label for="{{ form.mfa_step_up_preference.id }}">Preferred verification</label>
             {{ form.mfa_step_up_preference() }}
             {% for error in form.mfa_step_up_preference.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
-            <p class="hint">TOTP remains required for the account. This only changes which step-up method the UI presents first.</p>
+            <p class="hint">Choose which verification method the UI presents first when more than one is available.</p>
           </div>
           <div class="form-group">
             <label for="{{ form.totp_code.id }}">Authenticator code</label>
@@ -108,8 +108,8 @@
             <svg class="icon" focusable="false"><use href="#icon-shield-check"></use></svg>
           </span>
           <div>
-            <h3>Authenticator MFA required</h3>
-            <p class="muted">Profile updates stay locked until authenticator MFA is enabled.</p>
+            <h3>MFA required</h3>
+            <p class="muted">Profile updates stay locked until an authenticator app, passkey, or security key is enrolled.</p>
           </div>
         </div>
         <a class="button secondary" href="{{ url_for('web.mfa_setup') }}">Manage MFA</a>

--- a/app/templates/security_keys.html
+++ b/app/templates/security_keys.html
@@ -22,19 +22,19 @@
       </span>
       <div>
         <h2>Passkeys are optional</h2>
-        <p class="muted">Authenticator MFA is the baseline. Add a passkey if you want faster sign-in or passkey step-up for protected actions.</p>
+        <p class="muted">Add a passkey if you want faster sign-in or passkey step-up for protected actions.</p>
       </div>
     </div>
   {% endif %}
 
-  {% if not user.mfa_enabled %}
+  {% if not g.mfa_ready %}
     <div class="notice warning">
       <span class="notice-icon" aria-hidden="true">
         <svg class="icon" focusable="false"><use href="#icon-info"></use></svg>
       </span>
       <div>
-        <h2>Set up authenticator MFA first</h2>
-        <p class="muted">Passkey registration requires a recent normal MFA verification. Enable authenticator MFA, then return here to register your passkey.</p>
+        <h2>Set up MFA first</h2>
+        <p class="muted">Choose an authenticator app or passkey before normal account use.</p>
         <div class="actions">
           <a class="button secondary" href="{{ url_for('web.mfa_setup') }}">Set up MFA</a>
         </div>
@@ -47,15 +47,19 @@
       </span>
       <div>
         <h2>Recent MFA required</h2>
-        <p class="muted">Passkey registration and revocation require a recent MFA check. Enter your authenticator code to continue.</p>
-        <form class="compact-verification-form" method="post" action="{{ url_for('web.security_keys_mfa_refresh') }}">
-          {{ refresh_mfa_form.hidden_tag() }}
-          <div class="form-group compact">
-            <label for="security-keys-refresh-totp">Authenticator code</label>
-            {{ refresh_mfa_form.totp_code(id="security-keys-refresh-totp", inputmode="numeric", autocomplete="one-time-code", maxlength="6", placeholder="6-digit code") }}
-          </div>
-          <button class="button secondary" type="submit">Verify code</button>
-        </form>
+        {% if user.mfa_enabled %}
+          <p class="muted">Passkey registration and revocation require a recent MFA check. Enter your authenticator code to continue.</p>
+          <form class="compact-verification-form" method="post" action="{{ url_for('web.security_keys_mfa_refresh') }}">
+            {{ refresh_mfa_form.hidden_tag() }}
+            <div class="form-group compact">
+              <label for="security-keys-refresh-totp">Authenticator code</label>
+              {{ refresh_mfa_form.totp_code(id="security-keys-refresh-totp", inputmode="numeric", autocomplete="one-time-code", maxlength="6", placeholder="6-digit code") }}
+            </div>
+            <button class="button secondary" type="submit">Verify code</button>
+          </form>
+        {% else %}
+          <p class="muted">Sign in with your passkey again before adding or revoking another passkey.</p>
+        {% endif %}
       </div>
     </div>
   {% endif %}
@@ -74,7 +78,7 @@
           <input id="security-key-label" name="label" maxlength="80" autocomplete="off" placeholder="Windows Hello" required>
         </div>
         <p class="hint">The browser and installed passkey provider decide which prompt appears. Origin, RP ID, challenge, and user verification are checked server-side before the passkey is accepted.</p>
-        <button class="button full" type="submit"{% if not user.mfa_enabled or not recent_mfa %} disabled{% endif %}>Register passkey</button>
+        <button class="button full" type="submit"{% if not g.mfa_ready or not recent_mfa %} disabled{% endif %}>Register passkey</button>
         <p class="field-error" data-webauthn-register-error hidden></p>
       </form>
     </article>
@@ -115,7 +119,7 @@
       {% else %}
         <div class="empty-state compact">
           <h2>No passkeys registered</h2>
-          <p class="muted">Authenticator MFA is active without a passkey. Add one whenever you want optional passkey sign-in or step-up.</p>
+          <p class="muted">Add one whenever you want optional passkey sign-in or step-up.</p>
         </div>
       {% endif %}
     </article>

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -36,6 +36,7 @@ from app.auth.password_reset import (
     request_password_reset,
     verify_reset_totp,
 )
+from app.auth.mfa_policy import enrolled_webauthn_credential_count, has_enrolled_mfa_method
 from app.auth.services import (
     AuthError,
     active_sessions_for_user,
@@ -91,11 +92,11 @@ WEB_MFA_ONBOARDING_ALLOWED_ENDPOINTS = {
 @web_bp.before_request
 def enforce_mfa_onboarding():
     user = getattr(g, "current_user", None)
-    if user is None or user.mfa_enabled:
+    if user is None or has_enrolled_mfa_method(user):
         return None
     if request.endpoint in WEB_MFA_ONBOARDING_ALLOWED_ENDPOINTS:
         return None
-    flash("Set up authenticator MFA before continuing.", "warning")
+    flash("Set up an authenticator app or passkey before continuing.", "warning")
     return redirect(url_for("web.mfa_setup"))
 
 
@@ -212,10 +213,13 @@ def login_submit():
         return render_template("login.html", form=form), exc.status_code
 
     if result.get("mfa_required"):
-        flash("Enter your authenticator code to finish signing in.", "info")
+        if result.get("webauthn_required"):
+            flash("Use your passkey to finish signing in.", "info")
+        else:
+            flash("Enter your authenticator code to finish signing in.", "info")
         return redirect(url_for("web.mfa_verify"))
     if result.get("mfa_setup_required"):
-        flash("Set up authenticator MFA before continuing.", "warning")
+        flash("Choose an MFA method before continuing.", "warning")
         return redirect(url_for("web.mfa_setup"))
 
     flash("Login successful.", "success")
@@ -344,7 +348,20 @@ def mfa_verify():
     if not session.get("pending_mfa_user_id"):
         flash("Please log in first.", "warning")
         return redirect(url_for("web.login"))
-    return render_template("mfa_verify.html", form=AuthenticationCodeForm())
+    from app.extensions import db
+    from app.models import User
+
+    pending_user = db.session.get(User, int(session["pending_mfa_user_id"]))
+    webauthn_required = bool(
+        pending_user is not None
+        and not pending_user.mfa_enabled
+        and enrolled_webauthn_credential_count(pending_user) > 0
+    )
+    return render_template(
+        "mfa_verify.html",
+        form=AuthenticationCodeForm(),
+        webauthn_required=webauthn_required,
+    )
 
 
 @web_bp.post("/mfa/verify")
@@ -700,8 +717,8 @@ def mfa_setup_submit():
 @web_login_required
 @web_not_frozen_required
 def password_change():
-    if not g.current_user.mfa_enabled:
-        flash("Set up authenticator MFA before changing your password.", "warning")
+    if not has_enrolled_mfa_method(g.current_user):
+        flash("Set up MFA before changing your password.", "warning")
         return redirect(url_for("web.mfa_setup"))
     return render_template(
         "password_change.html",
@@ -716,8 +733,8 @@ def password_change():
 @limiter.limit("5 per 5 minutes", key_func=get_remote_address)
 @limiter.limit("5 per 5 minutes", key_func=mfa_principal)
 def password_change_submit():
-    if not g.current_user.mfa_enabled:
-        flash("Set up authenticator MFA before changing your password.", "warning")
+    if not has_enrolled_mfa_method(g.current_user):
+        flash("Set up MFA before changing your password.", "warning")
         return redirect(url_for("web.mfa_setup"))
 
     form = PasswordChangeForm()

--- a/tests/test_audit_alerting.py
+++ b/tests/test_audit_alerting.py
@@ -236,6 +236,9 @@ def test_webauthn_audit_wrapper_can_use_required_writer(monkeypatch):
     assert calls
     assert calls[0][0] == "webauthn_register"
     assert calls[0][1] == "success"
+    metadata = calls[0][2]["metadata"]
+    assert metadata["credential_ref"]
+    assert "credential_id" not in metadata
 
 def test_audit_system_writer_uses_append_only_runtime_read_path(app, monkeypatch):
     from app.security import audit as audit_module

--- a/tests/test_authenticated_portal_ui.py
+++ b/tests/test_authenticated_portal_ui.py
@@ -168,7 +168,7 @@ def test_no_passkey_empty_state_lives_on_passkey_page_not_dashboard(client):
     assert keys_response.status_code == 200
     assert "No passkeys are registered" not in dashboard_markup
     assert "No passkeys registered" in keys_markup
-    assert "Authenticator MFA is active without a passkey" in keys_markup
+    assert "Add one whenever you want optional passkey sign-in or step-up." in keys_markup
 
 def test_public_layout_does_not_expose_authenticated_account_actions(client):
     response = client.get("/login")
@@ -178,7 +178,7 @@ def test_public_layout_does_not_expose_authenticated_account_actions(client):
     assert "data-account-menu" not in markup
     assert "Edit Profile" not in markup
     assert "data-webauthn-login-form" in markup
-    assert "Available after a passkey or security key is registered." in markup
+    assert "Windows Hello" in markup
     assert 'href="/profile"' not in markup
     assert 'action="/logout"' not in markup
 

--- a/tests/test_mfa_lifecycle.py
+++ b/tests/test_mfa_lifecycle.py
@@ -501,7 +501,7 @@ def test_api_onboarding_requires_totp_before_authenticated_endpoints(client):
 
     assert sessions_response.status_code == 403
     assert sessions_response.get_json() == {
-        "error": "Authenticator MFA setup required",
+        "error": "MFA setup required",
         "code": "mfa_setup_required",
     }
     assert csrf_response.status_code == 200

--- a/tests/test_pentest_auth_bypass.py
+++ b/tests/test_pentest_auth_bypass.py
@@ -283,7 +283,7 @@ class TestFrozenAccountBypass:
 
         response = client.post(
             "/auth/webauthn/authenticate/options",
-            json={"identifier": "frozen_user"},
+            json={},
             headers={"Origin": "https://legacy.example.invalid"},
         )
         result = response.get_json()

--- a/tests/test_webauthn_lifecycle.py
+++ b/tests/test_webauthn_lifecycle.py
@@ -119,14 +119,16 @@ def mint_stepup_token(client, user, action):
     return token
 
 
-def test_registration_requires_recent_mfa_before_first_key(client):
+def test_registration_allows_first_passkey_after_password_bootstrap(client):
     register(client)
     login(client)
 
     response = client.post("/auth/webauthn/register/options", json={"label": "Primary YubiKey"}, headers=ORIGIN)
+    payload = response.get_json()
 
-    assert response.status_code == 403
-    assert response.get_json()["error"] == "Authenticator MFA setup required"
+    assert response.status_code == 200
+    assert payload["authenticatorSelection"]["residentKey"] == "required"
+    assert payload["authenticatorSelection"]["requireResidentKey"] is True
 
 
 def test_webauthn_options_fail_closed_without_exact_origin(client):
@@ -172,7 +174,8 @@ def test_registration_options_are_generic_so_browser_can_choose_passkey_provider
     assert "authenticatorAttachment" not in payload["authenticatorSelection"]
     assert "hints" not in payload
     assert payload["authenticatorSelection"]["userVerification"] == "required"
-    assert payload["authenticatorSelection"]["residentKey"] == "preferred"
+    assert payload["authenticatorSelection"]["residentKey"] == "required"
+    assert payload["authenticatorSelection"]["requireResidentKey"] is True
 
 
 def test_registration_allows_optional_passkey_without_mds_aaguid(client, monkeypatch):
@@ -387,8 +390,9 @@ def test_password_login_allowed_after_security_key_enrollment(client):
     response = client.post("/auth/login", json={"identifier": "alice01", "password": "correct horse battery staple"})
 
     assert response.status_code == 200
-    assert response.get_json()["message"] == "MFA setup required"
-    assert response.get_json()["mfa_setup_required"] is True
+    assert response.get_json()["message"] == "Passkey verification required"
+    assert response.get_json()["mfa_required"] is True
+    assert response.get_json()["webauthn_required"] is True
 
 
 def test_password_totp_login_allowed_after_security_key_enrollment(client):
@@ -441,7 +445,7 @@ def test_authentication_updates_specific_credential_counter_and_last_used(client
     add_credential(user, credential_id=b"credential-two", label="Backup Key", sign_count=20)
     credential_ref = bytes_to_base64url(item.credential_id)
 
-    options_response = client.post("/auth/webauthn/authenticate/options", json={"identifier": "alice01"}, headers=ORIGIN)
+    options_response = client.post("/auth/webauthn/authenticate/options", json={}, headers=ORIGIN)
 
     def fake_verify_authentication_response(**_kwargs):
         return SimpleNamespace(
@@ -476,6 +480,7 @@ def test_authentication_updates_specific_credential_counter_and_last_used(client
     db.session.refresh(item)
 
     assert options_response.status_code == 200
+    assert "allowCredentials" not in options_response.get_json()
     assert response.status_code == 200
     assert item.sign_count == 11
     assert item.credential_device_type == "single_device"
@@ -489,7 +494,7 @@ def test_passkey_login_accepts_one_registered_credential(client, monkeypatch):
     item = add_credential(user, credential_id=b"credential-one", sign_count=10)
     credential_ref = bytes_to_base64url(item.credential_id)
 
-    options_response = client.post("/auth/webauthn/authenticate/options", json={"identifier": "alice01"}, headers=ORIGIN)
+    options_response = client.post("/auth/webauthn/authenticate/options", json={}, headers=ORIGIN)
 
     def fake_verify_authentication_response(**_kwargs):
         return SimpleNamespace(
@@ -523,7 +528,7 @@ def test_passkey_login_accepts_one_registered_credential(client, monkeypatch):
     )
 
     assert options_response.status_code == 200
-    assert len(options_response.get_json()["allowCredentials"]) == 1
+    assert "allowCredentials" not in options_response.get_json()
     assert response.status_code == 200
     assert response.get_json()["message"] == "Login successful"
     assert db.session.get(WebAuthnCredential, item.id) is not None
@@ -535,7 +540,7 @@ def test_signature_counter_anomaly_locks_user_and_audits(client, monkeypatch):
     item = add_credential(user, credential_id=b"credential-one", sign_count=10)
     add_credential(user, credential_id=b"credential-two", label="Backup Key", sign_count=20)
     credential_ref = bytes_to_base64url(item.credential_id)
-    client.post("/auth/webauthn/authenticate/options", json={"identifier": "alice01"}, headers=ORIGIN)
+    client.post("/auth/webauthn/authenticate/options", json={}, headers=ORIGIN)
 
     def fake_verify_authentication_response(**_kwargs):
         return SimpleNamespace(


### PR DESCRIPTION
## Summary

Implement customer MFA onboarding that allows either authenticator TOTP or passkey/security key as the first MFA method, and move primary passkey login to a username-less discoverable credential flow.

## Why

The previous customer onboarding flow was TOTP-first, which blocked passkey-only onboarding. The passkey login options flow also accepted a username/email before returning credential-specific options, which could reveal whether an account had registered passkeys.

## What changed

* Treat customers as MFA-enrolled when they have either TOTP enabled or at least one WebAuthn credential.
* Allow first passkey/security-key registration after a valid password-authenticated onboarding session.
* Remove identifier input from primary passkey login and omit user-specific `allowCredentials`.
* Require discoverable/resident credentials for new passkey registration.
* Update MFA/login/profile/passkey UI copy to support authenticator apps, platform passkeys, password-manager passkeys, and hardware keys.
* Store WebAuthn audit credential references instead of raw credential IDs.
* Update WebAuthn, MFA, UI, pentest, audit, password reset, account security, and admin isolation tests.

## Security impact

Improves authentication privacy by preventing pre-authentication WebAuthn credential enumeration. Preserves CSRF, rate limits, WebAuthn origin/RP ID verification, user verification, challenge binding, TOTP recovery-code boundaries, and admin fail-closed isolation. No secrets or permissions are changed.

## Deployment impact

* EC2 bootstrap: no
* staging deployment: yes, normal app rollout
* production deployment: yes, normal app rollout after staging verification
* database migration: no
* secret changes: no
* no deployment action: no, code must be deployed for behavior to change

## Verification

* `python -m compileall app tests -q`
* `python -m pytest tests/test_webauthn_lifecycle.py -q`
* `python -m pytest tests/test_mfa_lifecycle.py -q`
* `python -m pytest tests/test_authenticated_portal_ui.py -q`
* `python -m pytest tests/test_pentest_auth_bypass.py -q`
* `python -m pytest tests/test_auth_registration_login.py tests/test_password_reset.py tests/test_account_security_actions.py -q`
* `python -m pytest tests/test_admin_isolation.py -q`
* `python -m pytest tests/test_audit_alerting.py::test_webauthn_audit_wrapper_can_use_required_writer -q`
* `git diff --check`

## Notes

No database migration is included. Existing legacy non-discoverable passkeys may need user re-registration if they cannot satisfy username-less discoverable login.