### PR TITLE
Enforce TLS for production SMTP email

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -362,10 +362,11 @@ Reset MFA policy:
 
 Production must use SMTP-backed reset email delivery with
 `PASSWORD_RESET_EMAIL_BACKEND=smtp`, an HTTPS `PASSWORD_RESET_BASE_URL`,
-`PASSWORD_RESET_EMAIL_FROM`, `SMTP_HOST`, and root-managed
+`PASSWORD_RESET_EMAIL_FROM`, `SMTP_HOST`, `SMTP_USE_TLS=true`, and root-managed
 `SMTP_USERNAME_FILE` / `SMTP_PASSWORD_FILE` secrets. Console reset email is
-allowed only outside production. Security alert webhooks are never used to
-deliver password reset links.
+allowed only outside production, and plaintext SMTP delivery is rejected in
+production. Security alert webhooks are never used to deliver password reset
+links.
 
 ## AWS OIDC and Systems Manager
 

--- a/config.py
+++ b/config.py
@@ -197,6 +197,37 @@ def _choice_env(name: str, *, default: str, choices: set[str]) -> str:
     return value
 
 
+def _validate_password_reset_email_config(
+    *,
+    app_env: str,
+    password_reset_enabled: bool,
+    email_backend: str,
+    email_from: str,
+    smtp_host: str,
+    smtp_use_tls: bool,
+    smtp_username: str | None,
+    smtp_password: str | None,
+) -> None:
+    if not password_reset_enabled or app_env != "production":
+        return
+
+    if email_backend == "console":
+        raise RuntimeError("PASSWORD_RESET_EMAIL_BACKEND=console is not allowed in production")
+    if not email_from:
+        raise RuntimeError("PASSWORD_RESET_EMAIL_FROM is required when password reset is enabled")
+    if email_backend == "smtp":
+        if not smtp_host:
+            raise RuntimeError("SMTP_HOST is required when production password reset uses SMTP")
+        if not smtp_use_tls:
+            raise RuntimeError(
+                "SMTP_USE_TLS=true is required when production password reset uses SMTP"
+            )
+        if not smtp_username:
+            raise RuntimeError("SMTP_USERNAME or SMTP_USERNAME_FILE is required in production")
+        if not smtp_password:
+            raise RuntimeError("SMTP_PASSWORD or SMTP_PASSWORD_FILE is required in production")
+
+
 def _float_env(name: str, *, default: str, minimum: float, maximum: float) -> float:
     raw_value = os.getenv(name, default)
     try:
@@ -658,18 +689,16 @@ class Config:
     SMTP_USE_TLS = _optional_bool("SMTP_USE_TLS", default=True)
     SMTP_USERNAME = _optional_env_or_file("SMTP_USERNAME")
     SMTP_PASSWORD = _optional_env_or_file("SMTP_PASSWORD")
-    if PASSWORD_RESET_ENABLED and APP_ENV == "production":
-        if PASSWORD_RESET_EMAIL_BACKEND == "console":
-            raise RuntimeError("PASSWORD_RESET_EMAIL_BACKEND=console is not allowed in production")
-        if not PASSWORD_RESET_EMAIL_FROM:
-            raise RuntimeError("PASSWORD_RESET_EMAIL_FROM is required when password reset is enabled")
-        if PASSWORD_RESET_EMAIL_BACKEND == "smtp":
-            if not SMTP_HOST:
-                raise RuntimeError("SMTP_HOST is required when production password reset uses SMTP")
-            if not SMTP_USERNAME:
-                raise RuntimeError("SMTP_USERNAME or SMTP_USERNAME_FILE is required in production")
-            if not SMTP_PASSWORD:
-                raise RuntimeError("SMTP_PASSWORD or SMTP_PASSWORD_FILE is required in production")
+    _validate_password_reset_email_config(
+        app_env=APP_ENV,
+        password_reset_enabled=PASSWORD_RESET_ENABLED,
+        email_backend=PASSWORD_RESET_EMAIL_BACKEND,
+        email_from=PASSWORD_RESET_EMAIL_FROM,
+        smtp_host=SMTP_HOST,
+        smtp_use_tls=SMTP_USE_TLS,
+        smtp_username=SMTP_USERNAME,
+        smtp_password=SMTP_PASSWORD,
+    )
 
     SECURITY_ALERT_ENABLED = _optional_bool(
         "SECURITY_ALERT_ENABLED",

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -40,9 +40,9 @@ Install `/etc/sitbank/secrets/security_alert_webhook_url` or
 operator-managed HTTPS alert webhook for that environment. Install
 `smtp_username` and `smtp_password` secret files for the reset email provider,
 and set `PASSWORD_RESET_EMAIL_BACKEND=smtp`, `PASSWORD_RESET_EMAIL_FROM`,
-`PASSWORD_RESET_BASE_URL`, `SMTP_HOST`, `SMTP_PORT`, and `SMTP_USE_TLS` in the
-container runtime environment. Production rejects console reset email and
-non-HTTPS reset base URLs.
+`PASSWORD_RESET_BASE_URL`, `SMTP_HOST`, `SMTP_PORT`, and `SMTP_USE_TLS=true` in
+the container runtime environment. Production rejects console reset email,
+non-HTTPS reset base URLs, and plaintext SMTP delivery.
 
 Deploy the signed image through the restricted wrapper so it runs
 `production-check`, `db upgrade`, `apply-runtime-db-privileges`,

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -188,6 +188,7 @@ Expected reset email configuration in production:
 - `PASSWORD_RESET_BASE_URL=https://sitbank.duckdns.org`
 - `PASSWORD_RESET_EMAIL_FROM=<approved sender>`
 - `SMTP_HOST=<approved provider host>`
+- `SMTP_USE_TLS=true`
 - `SMTP_USERNAME_FILE=/run/secrets/smtp_username`
 - `SMTP_PASSWORD_FILE=/run/secrets/smtp_password`
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,6 +16,7 @@ from config import (
     _required_session_hmac_keys,
     _required_webauthn_origin,
     _required_webauthn_rp_id,
+    _validate_password_reset_email_config,
 )
 
 
@@ -58,6 +59,70 @@ def test_password_reset_base_url_must_be_https_in_production(monkeypatch):
             "PASSWORD_RESET_BASE_URL",
             default="https://sitbank.duckdns.org",
         )
+
+
+def _valid_production_email_config(**overrides):
+    values = {
+        "app_env": "production",
+        "password_reset_enabled": True,
+        "email_backend": "smtp",
+        "email_from": "security@sitbank.example",
+        "smtp_host": "smtp.example.test",
+        "smtp_use_tls": True,
+        "smtp_username": "smtp-user-secret",
+        "smtp_password": "smtp-password-secret",
+    }
+    values.update(overrides)
+    return values
+
+
+def test_production_smtp_email_requires_transport_tls():
+    _validate_password_reset_email_config(**_valid_production_email_config())
+
+    with pytest.raises(RuntimeError, match="SMTP_USE_TLS=true") as excinfo:
+        _validate_password_reset_email_config(
+            **_valid_production_email_config(smtp_use_tls=False)
+        )
+
+    message = str(excinfo.value)
+    assert "smtp-user-secret" not in message
+    assert "smtp-password-secret" not in message
+
+
+def test_production_smtp_email_requires_host_and_credentials_without_secret_leakage():
+    for field_name, expected_message in (
+        ("smtp_host", "SMTP_HOST"),
+        ("smtp_username", "SMTP_USERNAME"),
+        ("smtp_password", "SMTP_PASSWORD"),
+    ):
+        with pytest.raises(RuntimeError, match=expected_message) as excinfo:
+            _validate_password_reset_email_config(
+                **_valid_production_email_config(**{field_name: None})
+            )
+
+        message = str(excinfo.value)
+        assert "smtp-user-secret" not in message
+        assert "smtp-password-secret" not in message
+
+
+def test_production_email_rejects_console_backend():
+    with pytest.raises(RuntimeError, match="console is not allowed"):
+        _validate_password_reset_email_config(
+            **_valid_production_email_config(email_backend="console")
+        )
+
+
+def test_non_production_console_email_backend_remains_allowed():
+    _validate_password_reset_email_config(
+        app_env="development",
+        password_reset_enabled=True,
+        email_backend="console",
+        email_from="",
+        smtp_host="",
+        smtp_use_tls=False,
+        smtp_username=None,
+        smtp_password=None,
+    )
 
 
 def test_redis_url_cannot_override_application_connection_policy(monkeypatch):


### PR DESCRIPTION
## Summary

Enforces TLS for production SMTP password reset and security email delivery.

## Why

Production email can carry sensitive recovery and security content. The SMTP sender already honored `SMTP_USE_TLS=false`, but production config validation did not reject that plaintext delivery path.

## What changed

* Added production email config validation requiring `SMTP_USE_TLS=true` when SMTP reset email is enabled.
* Preserved existing production checks for console backend, sender, SMTP host, username, and password.
* Added regression tests for TLS enforcement, missing SMTP config, non-production console behavior, and secret-safe error messages.
* Updated deployment and security docs to document the production TLS requirement.

## Security impact

Production now fails closed instead of allowing plaintext SMTP delivery. SMTP username and password values are not included in validation errors. This strengthens password reset and security notification delivery without changing auth flows, permissions, database state, or secret storage.

## Deployment impact

* EC2 bootstrap: not required
* staging deployment: required to apply the app validation change
* production deployment: required to apply the app validation change
* database migration: not required
* secret changes: not required, but operators should confirm `SMTP_USE_TLS=true`
* no deployment action: no

## Verification

* `python -m pytest -q tests/test_config.py`
* `python -m pytest -q tests/test_password_reset.py`
* `python -m pytest -q tests/test_deployment.py -k "container_bundle_separates_secrets_from_non_secret_environment or container_bundle_accepts_staging_prefix or runtime_secret_inventory_matches_config_and_renderer or environment_only_bundle_does_not_export_long_lived_secrets or environment_only_bundle_accepts_staging_prefix or trivy_exception_is_narrow_documented_and_temporary or production_edge_runbook_documents_network_waf_and_verification_steps"`
* `python -m pytest -q tests/test_authenticated_portal_ui.py::test_production_env_docs_require_pbkdf2_pepper_not_bcrypt`

## Notes

Production startup will now reject SMTP reset email config if `SMTP_USE_TLS=false`.