### PR TITLE
Enforce invite-only customer registration

### DIFF
--- a/app/auth/forms.py
+++ b/app/auth/forms.py
@@ -22,6 +22,7 @@ def password_length(*, minimum: int | None = None):
 
 
 class RegisterForm(FlaskForm):
+    invite_token = HiddenField()
     username = StringField(
         "Username",
         validators=[

--- a/app/auth/registration_invites.py
+++ b/app/auth/registration_invites.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import csv
+import hashlib
+import hmac
+import re
+import secrets
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import quote
+
+from flask import current_app
+from sqlalchemy.exc import IntegrityError
+
+from app.extensions import db
+from app.models import RegistrationInvite, User
+from app.security.audit import audit_event, audit_event_required, audit_system_event, principal_reference
+
+
+INVITE_TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]{16,256}$")
+GENERIC_INVITE_ERROR = "Registration requires a valid invitation."
+
+
+class RegistrationInviteRejected(ValueError):
+    def __init__(self, reason: str, *, status_code: int = 403) -> None:
+        super().__init__(GENERIC_INVITE_ERROR)
+        self.reason = reason
+        self.status_code = status_code
+
+
+def normalize_registration_email(email: str) -> str:
+    return str(email or "").strip().casefold()
+
+
+def registration_invite_url(token: str, *, base_url: str | None = None) -> str:
+    root = (base_url or current_app.config.get("PASSWORD_RESET_BASE_URL") or "").strip().rstrip("/")
+    if not root:
+        root = current_app.config["WEBAUTHN_RP_ORIGIN"].strip().rstrip("/")
+    return f"{root}/register?invite={quote(token, safe='')}"
+
+
+def create_registration_invite(
+    email: str,
+    *,
+    expires_at: datetime,
+    created_by_user_id: int | None = None,
+    audit: bool = True,
+) -> tuple[RegistrationInvite, str]:
+    normalized_email = normalize_registration_email(email)
+    if not normalized_email:
+        raise ValueError("email is required")
+    if _ensure_aware_utc(expires_at) <= _utcnow():
+        raise ValueError("expires_at must be in the future")
+
+    for _attempt in range(3):
+        token = secrets.token_urlsafe(32)
+        invite = RegistrationInvite(
+            token_hash=registration_invite_token_hash(token),
+            intended_email_normalized=normalized_email,
+            created_by_user_id=created_by_user_id,
+            expires_at=_ensure_aware_utc(expires_at),
+        )
+        db.session.add(invite)
+        try:
+            db.session.commit()
+        except IntegrityError:
+            db.session.rollback()
+            continue
+        if audit:
+            audit_system_event(
+                "registration_invite",
+                "created",
+                user_id=created_by_user_id,
+                metadata=_invite_metadata(invite, created_by_user_id=created_by_user_id),
+            )
+        return invite, token
+
+    raise RuntimeError("Could not generate a unique registration invite token")
+
+
+def create_registration_invites_from_csv(
+    csv_path: Path,
+    *,
+    expires_at: datetime,
+    created_by_user_id: int | None = None,
+) -> list[tuple[RegistrationInvite, str]]:
+    try:
+        with csv_path.open("r", encoding="utf-8-sig", newline="") as handle:
+            reader = csv.DictReader(handle)
+            if not reader.fieldnames or "email" not in {field.strip() for field in reader.fieldnames}:
+                raise ValueError("CSV must include an email column")
+            emails = [str(row.get("email") or "").strip() for row in reader if str(row.get("email") or "").strip()]
+    except OSError as exc:
+        raise ValueError(f"CSV could not be read: {type(exc).__name__}") from exc
+
+    created: list[tuple[RegistrationInvite, str]] = []
+    for email in emails:
+        created.append(
+            create_registration_invite(
+                email,
+                expires_at=expires_at,
+                created_by_user_id=created_by_user_id,
+            )
+        )
+
+    audit_system_event(
+        "registration_invite_bulk",
+        "created",
+        user_id=created_by_user_id,
+        metadata={"created_count": len(created), "created_by_user_id": created_by_user_id},
+    )
+    return created
+
+
+def revoke_registration_invite(
+    invite_id: int,
+    *,
+    revoked_by_user_id: int | None = None,
+) -> RegistrationInvite:
+    invite = db.session.get(RegistrationInvite, invite_id)
+    if invite is None:
+        raise ValueError("registration invite not found")
+    if invite.used_at is not None:
+        raise ValueError("used registration invites cannot be revoked")
+    if invite.revoked_at is None:
+        invite.revoked_at = _utcnow()
+        invite.revoked_by_user_id = revoked_by_user_id
+        db.session.commit()
+        audit_system_event(
+            "registration_invite",
+            "revoked",
+            user_id=revoked_by_user_id,
+            metadata=_invite_metadata(invite, revoked_by_user_id=revoked_by_user_id),
+        )
+    return invite
+
+
+def registration_invite_token_hash(token: str) -> str:
+    normalized = _clean_token(token)
+    key = str(current_app.config["SECRET_KEY"]).encode("utf-8")
+    payload = f"registration-invite:v1:{normalized}".encode("utf-8")
+    return hmac.new(key, payload, hashlib.sha256).hexdigest()
+
+
+def valid_registration_invite_for_form(token: str | None) -> RegistrationInvite | None:
+    try:
+        return _load_usable_invite(token, audit_failures=True, lock=False)
+    except RegistrationInviteRejected:
+        return None
+
+
+def require_registration_invite_for_email(token: str | None, email: str) -> RegistrationInvite:
+    invite = _load_usable_invite(token, audit_failures=True, lock=True)
+    submitted_email = normalize_registration_email(email)
+    if invite.intended_email_normalized != submitted_email:
+        invite.last_attempt_at = _utcnow()
+        _audit_invite_rejection(
+            "email_mismatch",
+            invite=invite,
+            submitted_email=submitted_email,
+        )
+        raise RegistrationInviteRejected("email_mismatch")
+    invite.last_attempt_at = _utcnow()
+    return invite
+
+
+def mark_registration_invite_used(invite: RegistrationInvite, user: User) -> None:
+    if invite.used_at is not None:
+        _audit_invite_rejection("used", invite=invite, submitted_email=user.email)
+        raise RegistrationInviteRejected("used")
+    if invite.revoked_at is not None:
+        _audit_invite_rejection("revoked", invite=invite, submitted_email=user.email)
+        raise RegistrationInviteRejected("revoked")
+    if _ensure_aware_utc(invite.expires_at) <= _utcnow():
+        _audit_invite_rejection("expired", invite=invite, submitted_email=user.email)
+        raise RegistrationInviteRejected("expired")
+    if invite.intended_email_normalized != normalize_registration_email(user.email):
+        _audit_invite_rejection("email_mismatch", invite=invite, submitted_email=user.email)
+        raise RegistrationInviteRejected("email_mismatch")
+
+    now = _utcnow()
+    invite.used_at = now
+    invite.used_by_user_id = user.id
+    invite.last_attempt_at = now
+    audit_event_required(
+        "registration_invite",
+        "used",
+        user=user,
+        metadata=_invite_metadata(invite, used_by_user_id=user.id),
+    )
+
+
+def _load_usable_invite(token: str | None, *, audit_failures: bool, lock: bool) -> RegistrationInvite:
+    try:
+        token_hash = registration_invite_token_hash(token or "")
+    except RegistrationInviteRejected as exc:
+        if audit_failures:
+            _audit_invite_rejection(exc.reason)
+        raise
+
+    statement = db.select(RegistrationInvite).where(RegistrationInvite.token_hash == token_hash)
+    if lock:
+        statement = statement.with_for_update()
+    invite = db.session.execute(statement).scalar_one_or_none()
+    if invite is None:
+        if audit_failures:
+            _audit_invite_rejection("invalid")
+        raise RegistrationInviteRejected("invalid")
+
+    reason = _invite_rejection_reason(invite)
+    if reason is not None:
+        invite.last_attempt_at = _utcnow()
+        if audit_failures:
+            _audit_invite_rejection(reason, invite=invite)
+        raise RegistrationInviteRejected(reason)
+    return invite
+
+
+def _invite_rejection_reason(invite: RegistrationInvite) -> str | None:
+    if invite.revoked_at is not None:
+        return "revoked"
+    if invite.used_at is not None:
+        return "used"
+    if _ensure_aware_utc(invite.expires_at) <= _utcnow():
+        return "expired"
+    return None
+
+
+def _clean_token(token: str) -> str:
+    cleaned = str(token or "").strip()
+    if not cleaned:
+        raise RegistrationInviteRejected("missing", status_code=400)
+    if not INVITE_TOKEN_RE.fullmatch(cleaned):
+        raise RegistrationInviteRejected("invalid")
+    return cleaned
+
+
+def _audit_invite_rejection(
+    reason: str,
+    *,
+    invite: RegistrationInvite | None = None,
+    submitted_email: str | None = None,
+) -> None:
+    metadata = {"reason": reason}
+    if invite is not None:
+        metadata.update(_invite_metadata(invite))
+    if submitted_email:
+        metadata["submitted_email_ref"] = principal_reference(submitted_email)
+    audit_event("registration_invite", "rejected", metadata=metadata)
+
+
+def _invite_metadata(
+    invite: RegistrationInvite,
+    *,
+    created_by_user_id: int | None = None,
+    used_by_user_id: int | None = None,
+    revoked_by_user_id: int | None = None,
+) -> dict[str, object]:
+    metadata: dict[str, object] = {
+        "invite_id": invite.id,
+        "intended_email_ref": principal_reference(invite.intended_email_normalized),
+    }
+    if created_by_user_id is not None:
+        metadata["created_by_user_id"] = created_by_user_id
+    if used_by_user_id is not None:
+        metadata["used_by_user_id"] = used_by_user_id
+    if revoked_by_user_id is not None:
+        metadata["revoked_by_user_id"] = revoked_by_user_id
+    return metadata
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _ensure_aware_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -159,6 +159,7 @@ def csrf_token():
 @limiter.limit("5 per 5 minutes", key_func=request_principal)
 def register():
     data = _load_payload(RegisterSchema(), RegisterForm)
+    data["invite_token"] = data.get("invite_token") or request.args.get("invite", "")
     user, warnings = register_user(data)
     return (
         jsonify(

--- a/app/auth/schemas.py
+++ b/app/auth/schemas.py
@@ -14,6 +14,7 @@ WEBAUTHN_LABEL_RE = r"^[A-Za-z0-9][A-Za-z0-9 ._()#:/+\-]{0,79}$"
 STEP_UP_ACTION_RE = r"^[a-z_]{3,64}$"
 STEP_UP_TOKEN_RE = r"^[A-Za-z0-9_-]{32,256}$"
 RESET_TOKEN_RE = r"^[A-Za-z0-9_-]{16,96}\.[A-Za-z0-9_-]{32,128}$"
+INVITE_TOKEN_RE = r"^[A-Za-z0-9_-]{0,256}$"
 
 
 def password_length(*, minimum: int | None = None):
@@ -30,6 +31,11 @@ def password_length(*, minimum: int | None = None):
 
 
 class RegisterSchema(Schema):
+    invite_token = fields.Str(
+        required=False,
+        load_only=True,
+        validate=validate.Regexp(INVITE_TOKEN_RE, error="Invalid invite token"),
+    )
     username = fields.Str(
         required=True,
         validate=[

--- a/app/auth/services.py
+++ b/app/auth/services.py
@@ -20,6 +20,11 @@ from sqlalchemy.exc import IntegrityError
 
 from app.extensions import db
 from app.models import User
+from app.auth.registration_invites import (
+    RegistrationInviteRejected,
+    mark_registration_invite_used,
+    require_registration_invite_for_email,
+)
 from app.auth.mfa_policy import (
     PASSWORD_BOOTSTRAP_AUTH_CONTEXT,
     enrolled_webauthn_credential_count,
@@ -188,6 +193,11 @@ def _generate_account_number() -> str:
 
 
 def register_user(data: dict[str, Any]) -> tuple[User, list[str]]:
+    try:
+        invite = require_registration_invite_for_email(data.get("invite_token"), data["email"])
+    except RegistrationInviteRejected as exc:
+        raise AuthError(str(exc), exc.status_code) from exc
+
     if data.get("password") != data.get("confirm_password"):
         audit_event("registration", "failure", metadata={"reason": "password_mismatch"})
         raise AuthError("Passwords must match", 400)
@@ -212,11 +222,16 @@ def register_user(data: dict[str, Any]) -> tuple[User, list[str]]:
     )
     db.session.add(user)
     try:
+        db.session.flush()
+        mark_registration_invite_used(invite, user)
         db.session.commit()
     except IntegrityError as exc:
         db.session.rollback()
         audit_event("registration", "failure", metadata={"reason": "integrity_error"})
         raise AuthError("Registration could not be completed with those details", 400) from exc
+    except RegistrationInviteRejected as exc:
+        db.session.rollback()
+        raise AuthError(str(exc), exc.status_code) from exc
     audit_event(
         "registration",
         "success",

--- a/app/models.py
+++ b/app/models.py
@@ -50,6 +50,33 @@ class User(db.Model):
         return f"<User id={self.id!r} username={self.username!r}>"
 
 
+class RegistrationInvite(db.Model):
+    __tablename__ = "registration_invites"
+
+    id = db.Column(db.Integer, primary_key=True)
+    token_hash = db.Column(db.String(64), nullable=False, unique=True, index=True)
+    intended_email_normalized = db.Column(db.String(255), nullable=False, index=True)
+    created_by_user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True, index=True)
+    created_at = db.Column(
+        db.DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+    expires_at = db.Column(db.DateTime(timezone=True), nullable=False, index=True)
+    used_at = db.Column(db.DateTime(timezone=True), nullable=True)
+    used_by_user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True, index=True)
+    revoked_at = db.Column(db.DateTime(timezone=True), nullable=True)
+    revoked_by_user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True, index=True)
+    last_attempt_at = db.Column(db.DateTime(timezone=True), nullable=True)
+
+    created_by = db.relationship("User", foreign_keys=[created_by_user_id])
+    used_by = db.relationship("User", foreign_keys=[used_by_user_id])
+    revoked_by = db.relationship("User", foreign_keys=[revoked_by_user_id])
+
+    def __repr__(self) -> str:
+        return f"<RegistrationInvite id={self.id!r} email={self.intended_email_normalized!r}>"
+
+
 class WebAuthnCredential(db.Model):
     __tablename__ = "webauthn_credentials"
 

--- a/app/ops/commands.py
+++ b/app/ops/commands.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import json
 import os
-from datetime import datetime, timezone
+import re
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -14,6 +15,12 @@ from sqlalchemy import text
 
 from app.extensions import db
 from app.models import User
+from app.auth.registration_invites import (
+    create_registration_invite,
+    create_registration_invites_from_csv,
+    registration_invite_url,
+    revoke_registration_invite,
+)
 from app.security.alerts import (
     build_security_alert_report,
     deliver_security_alerts,
@@ -41,6 +48,99 @@ from app.ops.db_privileges import (
 
 
 def register_ops_commands(app: Flask) -> None:
+    @app.cli.command("create-registration-invite")
+    @click.argument("email")
+    @click.option("--expires-in", default="7d", show_default=True, help="Invite lifetime, such as 30m, 12h, or 7d.")
+    @click.option("--created-by-user-id", type=int, default=None, help="Optional admin/operator user id.")
+    @click.option("--base-url", default=None, help="Override the public base URL used in the one-time invite link.")
+    def create_registration_invite_command(
+        email: str,
+        expires_in: str,
+        created_by_user_id: int | None,
+        base_url: str | None,
+    ) -> None:
+        """Create one invite-only registration token."""
+        expires_at = datetime.now(timezone.utc) + _parse_duration(expires_in)
+        try:
+            invite, token = create_registration_invite(
+                email,
+                expires_at=expires_at,
+                created_by_user_id=created_by_user_id,
+            )
+        except Exception as exc:
+            raise click.ClickException(str(exc)) from exc
+
+        click.echo(
+            json.dumps(
+                {
+                    "invite_id": invite.id,
+                    "email": invite.intended_email_normalized,
+                    "expires_at": invite.expires_at.astimezone(timezone.utc).isoformat(),
+                    "invite_url": registration_invite_url(token, base_url=base_url),
+                },
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+        )
+
+    @app.cli.command("create-registration-invites")
+    @click.argument("csv_path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+    @click.option("--expires-in", default="7d", show_default=True, help="Invite lifetime, such as 30m, 12h, or 7d.")
+    @click.option("--created-by-user-id", type=int, default=None, help="Optional admin/operator user id.")
+    @click.option("--base-url", default=None, help="Override the public base URL used in one-time invite links.")
+    def create_registration_invites_command(
+        csv_path: Path,
+        expires_in: str,
+        created_by_user_id: int | None,
+        base_url: str | None,
+    ) -> None:
+        """Create invite-only registration tokens from a CSV with an email column."""
+        expires_at = datetime.now(timezone.utc) + _parse_duration(expires_in)
+        try:
+            created = create_registration_invites_from_csv(
+                csv_path,
+                expires_at=expires_at,
+                created_by_user_id=created_by_user_id,
+            )
+        except Exception as exc:
+            raise click.ClickException(str(exc)) from exc
+
+        click.echo("email,invite_id,expires_at,invite_url")
+        for invite, token in created:
+            click.echo(
+                ",".join(
+                    [
+                        invite.intended_email_normalized,
+                        str(invite.id),
+                        invite.expires_at.astimezone(timezone.utc).isoformat(),
+                        registration_invite_url(token, base_url=base_url),
+                    ]
+                )
+            )
+
+    @app.cli.command("revoke-registration-invite")
+    @click.argument("invite_id", type=int)
+    @click.option("--revoked-by-user-id", type=int, default=None, help="Optional admin/operator user id.")
+    def revoke_registration_invite_command(invite_id: int, revoked_by_user_id: int | None) -> None:
+        """Revoke an unused registration invite."""
+        try:
+            invite = revoke_registration_invite(invite_id, revoked_by_user_id=revoked_by_user_id)
+        except Exception as exc:
+            raise click.ClickException(str(exc)) from exc
+        click.echo(
+            json.dumps(
+                {
+                    "invite_id": invite.id,
+                    "revoked": invite.revoked_at is not None,
+                    "revoked_at": invite.revoked_at.astimezone(timezone.utc).isoformat()
+                    if invite.revoked_at
+                    else None,
+                },
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+        )
+
     @app.cli.command("verify-migration-baseline")
     def verify_migration_baseline() -> None:
         """Verify an existing schema before adopting the initial revision."""
@@ -446,6 +546,23 @@ def _users_with_mfa_secret() -> list[User]:
             )
         ).scalars()
     )
+
+
+def _parse_duration(value: str) -> timedelta:
+    match = re.fullmatch(r"\s*(\d+)\s*([smhd])\s*", value or "", flags=re.IGNORECASE)
+    if not match:
+        raise click.ClickException("Duration must look like 30m, 12h, or 7d")
+    amount = int(match.group(1))
+    unit = match.group(2).casefold()
+    if amount <= 0:
+        raise click.ClickException("Duration must be positive")
+    if unit == "s":
+        return timedelta(seconds=amount)
+    if unit == "m":
+        return timedelta(minutes=amount)
+    if unit == "h":
+        return timedelta(hours=amount)
+    return timedelta(days=amount)
 
 
 def _load_audit_anchor(anchor_path: Path) -> dict:

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -7,7 +7,7 @@
   <div class="auth-intro">
     <p class="eyebrow">New customer profile</p>
     <h1>Create your online banking profile</h1>
-    <p class="lede">Register for the secure banking portal with a password that meets the account protection policy.</p>
+    <p class="lede">Use your invitation link to create a secure banking portal profile.</p>
     <div class="notice">
       <span class="notice-icon" aria-hidden="true">
         <svg class="icon" focusable="false"><use href="#icon-info"></use></svg>

--- a/app/templates/register_invite_required.html
+++ b/app/templates/register_invite_required.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+
+{% block title %}Invitation required | SITBank{% endblock %}
+
+{% block content %}
+<section class="auth-shell">
+  <div class="auth-intro">
+    <p class="eyebrow">Customer onboarding</p>
+    <h1>Invitation required</h1>
+    <p class="lede">SITBank account creation is available only through an approved invitation link.</p>
+    <div class="notice">
+      <span class="notice-icon" aria-hidden="true">
+        <svg class="icon" focusable="false"><use href="#icon-info"></use></svg>
+      </span>
+      <p class="muted">
+        {% if invalid %}
+          This invitation is invalid or no longer available.
+        {% else %}
+          Contact the project administrator if you need access.
+        {% endif %}
+      </p>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -36,6 +36,7 @@ from app.auth.password_reset import (
     request_password_reset,
     verify_reset_totp,
 )
+from app.auth.registration_invites import valid_registration_invite_for_form
 from app.auth.mfa_policy import enrolled_webauthn_credential_count, has_enrolled_mfa_method
 from app.auth.services import (
     AuthError,
@@ -149,7 +150,16 @@ def prevent_sensitive_page_caching(response):
 def register_form():
     if getattr(g, "current_user", None) is not None:
         return redirect(url_for("web.dashboard"))
-    return render_template("register.html", form=RegisterForm())
+    token = request.args.get("invite", "")
+    if not token:
+        return render_template("register_invite_required.html", invalid=False)
+    invite = valid_registration_invite_for_form(token)
+    if invite is None:
+        return render_template("register_invite_required.html", invalid=True), 403
+    form = RegisterForm()
+    form.invite_token.data = token
+    form.email.data = invite.intended_email_normalized
+    return render_template("register.html", form=form)
 
 
 @web_bp.post("/register")
@@ -166,6 +176,7 @@ def register_submit():
     try:
         _user, warnings = register_user(
             {
+                "invite_token": form.invite_token.data or request.args.get("invite", ""),
                 "username": form.username.data,
                 "full_name": form.full_name.data,
                 "phone_number": form.phone_number.data,

--- a/migrations/versions/20260624_0010_registration_invites.py
+++ b/migrations/versions/20260624_0010_registration_invites.py
@@ -1,0 +1,82 @@
+"""Add invite-only registration controls.
+
+Revision ID: 20260624_0010
+Revises: 20260624_0009
+Create Date: 2026-06-24 00:10:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260624_0010"
+down_revision = "20260624_0009"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "registration_invites",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("token_hash", sa.String(length=64), nullable=False),
+        sa.Column("intended_email_normalized", sa.String(length=255), nullable=False),
+        sa.Column("created_by_user_id", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("used_by_user_id", sa.Integer(), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revoked_by_user_id", sa.Integer(), nullable=True),
+        sa.Column("last_attempt_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["created_by_user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["revoked_by_user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["used_by_user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_registration_invites_created_by_user_id",
+        "registration_invites",
+        ["created_by_user_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_registration_invites_expires_at",
+        "registration_invites",
+        ["expires_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_registration_invites_intended_email_normalized",
+        "registration_invites",
+        ["intended_email_normalized"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_registration_invites_revoked_by_user_id",
+        "registration_invites",
+        ["revoked_by_user_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_registration_invites_token_hash",
+        "registration_invites",
+        ["token_hash"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_registration_invites_used_by_user_id",
+        "registration_invites",
+        ["used_by_user_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_registration_invites_used_by_user_id", table_name="registration_invites")
+    op.drop_index("ix_registration_invites_token_hash", table_name="registration_invites")
+    op.drop_index("ix_registration_invites_revoked_by_user_id", table_name="registration_invites")
+    op.drop_index("ix_registration_invites_intended_email_normalized", table_name="registration_invites")
+    op.drop_index("ix_registration_invites_expires_at", table_name="registration_invites")
+    op.drop_index("ix_registration_invites_created_by_user_id", table_name="registration_invites")
+    op.drop_table("registration_invites")

--- a/ops/container/create_dast_session.py
+++ b/ops/container/create_dast_session.py
@@ -7,6 +7,7 @@ import secrets
 import urllib.error
 import urllib.parse
 import urllib.request
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pyotp
@@ -100,7 +101,9 @@ def create_authenticated_cookie(
     client = DastClient(base_url, allowed_hosts=allowed_hosts)
     suffix = secrets.token_hex(6)
     username = f"zap{suffix}"
+    email = f"{username}@example.test"
     password = f"DAST-{secrets.token_urlsafe(24)}-A9!"
+    invite_token = create_registration_invite_token(email)
 
     csrf_token = str(
         client.request(
@@ -112,14 +115,15 @@ def create_authenticated_cookie(
     client.request(
         "POST",
         "/auth/register",
-         payload={
-             "username": username,
-             "full_name": f"DAST User {suffix}",
-             "phone_number": f"9{secrets.randbelow(9000000) + 1000000}",
-             "email": f"{username}@example.test",
-             "password": password,
-             "confirm_password": password,
-         },
+        payload={
+            "invite_token": invite_token,
+            "username": username,
+            "full_name": f"DAST User {suffix}",
+            "phone_number": f"9{secrets.randbelow(9000000) + 1000000}",
+            "email": email,
+            "password": password,
+            "confirm_password": password,
+        },
         csrf_token=csrf_token,
         expected_status=201,
     )
@@ -158,6 +162,20 @@ def create_authenticated_cookie(
     if not session_cookie:
         raise RuntimeError("Authenticated DAST session cookie was not issued")
     return f"__Host-sitbank_session={session_cookie}"
+
+
+def create_registration_invite_token(email: str) -> str:
+    from app import create_app
+    from app.auth.registration_invites import create_registration_invite
+
+    app = create_app()
+    with app.app_context():
+        _invite, token = create_registration_invite(
+            email,
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=15),
+            audit=False,
+        )
+    return token
 
 
 def main() -> None:

--- a/tests/_auth_flow_helpers.py
+++ b/tests/_auth_flow_helpers.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import Session
 from webauthn.helpers.structs import CredentialDeviceType
 
 from app.extensions import db
-from app.models import RecoveryCode, SecurityAuditEvent, User, WebAuthnCredential
+from app.models import RecoveryCode, RegistrationInvite, SecurityAuditEvent, User, WebAuthnCredential
 from app.security.passwords import (
     PASSWORD_MAX_CHARS,
     PASSWORD_MIN_LENGTH,
@@ -26,11 +26,25 @@ from app.security.passwords import (
 )
 
 
+def registration_invite_token(email="alice@example.com", *, expires_at=None, audit=False):
+    from app.auth.registration_invites import create_registration_invite
+
+    invite, token = create_registration_invite(
+        email,
+        expires_at=expires_at or datetime.now(timezone.utc) + timedelta(days=1),
+        audit=audit,
+    )
+    return token
+
+
 def register(client, username="alice01", email="alice@example.com", password="correct horse battery staple",
-             full_name="Alice Test", phone_number="91234567"):
+             full_name="Alice Test", phone_number="91234567", invite_token=None, create_invite=True):
+    if invite_token is None and create_invite:
+        invite_token = registration_invite_token(email)
     return client.post(
         "/register",
         data={
+            "invite_token": invite_token or "",
             "username": username,
             "email": email,
             "full_name": full_name,

--- a/tests/test_auth_registration_login.py
+++ b/tests/test_auth_registration_login.py
@@ -20,6 +20,7 @@ def test_registration_uses_local_fallback_when_live_password_check_is_unavailabl
     response = client.post(
         "/register",
         data={
+            "invite_token": registration_invite_token("alice@example.com"),
             "username": "alice01",
             "email": "alice@example.com",
             "full_name": "Alice Test",
@@ -42,6 +43,169 @@ def test_registration_rejects_live_breached_password(client, monkeypatch):
     assert response.status_code == 400
     assert db.session.query(User).count() == 0
     assert b"Password is too common. Please try again" in response.data
+
+def test_register_requires_invite_token(client):
+    response = register(client, create_invite=False)
+
+    assert response.status_code == 400
+    assert b"Registration requires a valid invitation" in response.data
+    assert db.session.query(User).count() == 0
+
+
+def test_register_rejects_invalid_invite(client):
+    response = register(client, invite_token="not-a-real-registration-token")
+
+    assert response.status_code == 403
+    assert b"Registration requires a valid invitation" in response.data
+    assert db.session.query(User).count() == 0
+
+
+def test_register_rejects_expired_invite(client):
+    from app.auth.registration_invites import registration_invite_token_hash
+
+    token = registration_invite_token("alice@example.com")
+    invite = db.session.execute(
+        db.select(RegistrationInvite).where(RegistrationInvite.token_hash == registration_invite_token_hash(token))
+    ).scalar_one()
+    invite.expires_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+    db.session.commit()
+
+    response = register(client, invite_token=token)
+
+    assert response.status_code == 403
+    assert db.session.query(User).count() == 0
+    db.session.refresh(invite)
+    assert invite.last_attempt_at is not None
+
+
+def test_register_rejects_revoked_invite(client):
+    from app.auth.registration_invites import registration_invite_token_hash
+
+    token = registration_invite_token("alice@example.com")
+    invite = db.session.execute(
+        db.select(RegistrationInvite).where(RegistrationInvite.token_hash == registration_invite_token_hash(token))
+    ).scalar_one()
+    invite.revoked_at = datetime.now(timezone.utc)
+    db.session.commit()
+
+    response = register(client, invite_token=token)
+
+    assert response.status_code == 403
+    assert db.session.query(User).count() == 0
+    db.session.refresh(invite)
+    assert invite.used_at is None
+
+
+def test_register_rejects_reused_invite(client):
+    from app.auth.registration_invites import registration_invite_token_hash
+
+    token = registration_invite_token("alice@example.com")
+    created = register(client, invite_token=token)
+    reused = register(
+        client,
+        username="alice02",
+        email="alice@example.com",
+        phone_number="81234567",
+        invite_token=token,
+    )
+    invite = db.session.execute(
+        db.select(RegistrationInvite).where(RegistrationInvite.token_hash == registration_invite_token_hash(token))
+    ).scalar_one()
+
+    assert created.status_code == 302
+    assert reused.status_code == 403
+    assert db.session.query(User).count() == 1
+    assert invite.used_at is not None
+    assert invite.used_by_user_id is not None
+
+
+def test_register_rejects_email_mismatch(client):
+    token = registration_invite_token("alice@example.com")
+
+    response = register(client, email="alice+1@example.com", invite_token=token)
+
+    assert response.status_code == 403
+    assert db.session.query(User).count() == 0
+
+
+def test_register_consumes_invite_atomically(client, monkeypatch):
+    from sqlalchemy.exc import IntegrityError
+    from app.auth import services
+    from app.auth.registration_invites import registration_invite_token_hash
+
+    token = registration_invite_token("alice@example.com")
+    original_mark_used = services.mark_registration_invite_used
+
+    def fail_after_marking(invite, user):
+        original_mark_used(invite, user)
+        raise IntegrityError("forced", {}, None)
+
+    monkeypatch.setattr(services, "mark_registration_invite_used", fail_after_marking)
+
+    response = register(client, invite_token=token)
+    invite = db.session.execute(
+        db.select(RegistrationInvite).where(RegistrationInvite.token_hash == registration_invite_token_hash(token))
+    ).scalar_one()
+
+    assert response.status_code == 400
+    assert db.session.query(User).count() == 0
+    assert invite.used_at is None
+    assert invite.used_by_user_id is None
+
+
+def test_register_invite_token_hash_only_stored(client):
+    from app.auth.registration_invites import registration_invite_token_hash
+
+    token = registration_invite_token("alice@example.com")
+    invite = db.session.execute(
+        db.select(RegistrationInvite).where(RegistrationInvite.token_hash == registration_invite_token_hash(token))
+    ).scalar_one()
+
+    assert invite.token_hash != token
+    assert len(invite.token_hash) == 64
+    assert token not in invite.token_hash
+
+
+def test_invite_registration_audit_events(client):
+    token = registration_invite_token("alice@example.com", audit=True)
+
+    response = register(client, invite_token=token)
+    events = db.session.query(SecurityAuditEvent).filter_by(event_type="registration_invite").all()
+    outcomes = {event.outcome for event in events}
+
+    assert response.status_code == 302
+    assert {"created", "used"} <= outcomes
+    assert all("token" not in event.event_metadata for event in events)
+
+
+def test_bulk_invite_creation_from_csv(app, tmp_path):
+    csv_path = tmp_path / "invites.csv"
+    csv_path.write_text("email\nalice@example.com\nbob@example.com\n", encoding="utf-8")
+
+    result = app.test_cli_runner().invoke(
+        args=[
+            "create-registration-invites",
+            str(csv_path),
+            "--expires-in",
+            "1d",
+            "--base-url",
+            "https://sitbank.test",
+        ]
+    )
+
+    assert result.exit_code == 0
+    assert "alice@example.com" in result.output
+    assert "https://sitbank.test/register?invite=" in result.output
+    assert db.session.query(RegistrationInvite).count() == 2
+
+
+def test_invite_registration_preserves_mfa_onboarding(client):
+    created = register(client)
+    login_response = login(client)
+
+    assert created.status_code == 302
+    assert login_response.status_code == 302
+    assert login_response.headers["Location"].endswith("/mfa/setup")
 
 def test_registration_hashes_password_with_pbkdf2(client):
     response = register(client)
@@ -96,7 +260,7 @@ def test_long_unicode_password_can_register_login_and_change(client, monkeypatch
     assert verify_password(new_password, user.password_hash)
 
 def test_password_templates_do_not_truncate_and_show_max_length_guidance(client):
-    register_response = client.get("/register")
+    register_response = client.get(f"/register?invite={registration_invite_token('template@example.com')}")
     login_response = client.get("/login")
     register(client)
     login(client)
@@ -166,6 +330,7 @@ def test_oversized_api_registration_password_rejected_cleanly(client, monkeypatc
     response = client.post(
         "/auth/register",
         json={
+            "invite_token": registration_invite_token("oversized@example.com"),
             "username": "oversized01",
             "email": "oversized@example.com",
             "full_name": "Oversized Test",
@@ -230,6 +395,7 @@ def test_registration_requires_matching_confirm_password(client):
     response = client.post(
         "/register",
         data={
+            "invite_token": registration_invite_token("alice@example.com"),
             "username": "alice01",
             "email": "alice@example.com",
             "full_name": "Alice Test",
@@ -246,6 +412,7 @@ def test_registration_requires_full_name_and_valid_phone_number(client):
     missing_name = client.post(
         "/register",
         data={
+            "invite_token": registration_invite_token("alice@example.com"),
             "username": "alice01",
             "email": "alice@example.com",
             "phone_number": "91234567",
@@ -256,6 +423,7 @@ def test_registration_requires_full_name_and_valid_phone_number(client):
     invalid_phone = client.post(
         "/register",
         data={
+            "invite_token": registration_invite_token("alice@example.com"),
             "username": "alice01",
             "email": "alice@example.com",
             "full_name": "Alice Test",
@@ -289,6 +457,7 @@ def test_api_registration_rejects_client_supplied_account_number(client):
     response = client.post(
         "/auth/register",
         json={
+            "invite_token": registration_invite_token("alice@example.com"),
             "username": "alice01",
             "email": "alice@example.com",
             "full_name": "Alice Test",

--- a/tests/test_authenticated_portal_ui.py
+++ b/tests/test_authenticated_portal_ui.py
@@ -183,7 +183,7 @@ def test_public_layout_does_not_expose_authenticated_account_actions(client):
     assert 'action="/logout"' not in markup
 
 def test_authentication_pages_have_password_helpers_and_mfa_back_link(client):
-    register_page = client.get("/register")
+    register_page = client.get(f"/register?invite={registration_invite_token('ui-helper@example.com')}")
     login_page = client.get("/login")
     register(client)
     user, secret = enable_mfa_for_user()
@@ -203,6 +203,7 @@ def test_flash_messages_are_dismissible(client):
     response = client.post(
         "/register",
         data={
+            "invite_token": registration_invite_token("flash@example.com"),
             "username": "flash01",
             "email": "flash@example.com",
             "full_name": "Flash Test",

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+from datetime import datetime, timedelta, timezone
 
 import pyotp
 
@@ -13,7 +14,15 @@ from app.models import User
 def register(client, username="alice01", email="alice@example.com",
              password="correct horse battery staple",
              full_name="Alice Test", phone_number="91234567"):
+    from app.auth.registration_invites import create_registration_invite
+
+    _invite, invite_token = create_registration_invite(
+        email,
+        expires_at=datetime.now(timezone.utc) + timedelta(days=1),
+        audit=False,
+    )
     return client.post("/register", data={
+        "invite_token": invite_token,
         "username": username,
         "email": email,
         "full_name": full_name,

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -332,6 +332,8 @@ def test_dast_session_creator_requires_loopback_or_explicit_smoke_host():
 def test_dast_session_creator_matches_registration_contract():
     source = Path("ops/container/create_dast_session.py").read_text(encoding="utf-8")
 
+    assert "create_registration_invite(" in source
+    assert '"invite_token": invite_token' in source
     assert '"full_name": f"DAST User {suffix}"' in source
     assert '"phone_number": f"9{secrets.randbelow(9000000) + 1000000}"' in source
     assert '"account_number"' not in source
@@ -2611,6 +2613,7 @@ def test_migration_baseline_renders_offline_sql(app):
     assert result.exit_code == 0, result.output
     assert "CREATE TABLE users" in result.output
     assert "CREATE TABLE webauthn_credentials" in result.output
+    assert "CREATE TABLE registration_invites" in result.output
     assert "CREATE TABLE security_audit_events" in result.output
     assert "previous_event_hash" in result.output
     assert "event_hash" in result.output

--- a/tests/test_owasp_regressions.py
+++ b/tests/test_owasp_regressions.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+
 
 VALID_PASSWORD = "Correct-Horse-Battery-Staple-2026!"
 
@@ -35,9 +37,17 @@ def test_public_homepage_exposes_verification_and_student_disclaimer(client):
 
 
 def test_external_next_parameter_cannot_create_an_open_redirect(client):
+    from app.auth.registration_invites import create_registration_invite
+
+    _invite, invite_token = create_registration_invite(
+        "redirect@example.com",
+        expires_at=datetime.now(timezone.utc) + timedelta(days=1),
+        audit=False,
+    )
     register = client.post(
         "/register",
         data={
+            "invite_token": invite_token,
             "username": "redirect01",
             "email": "redirect@example.com",
             "full_name": "Redirect User",

--- a/tests/test_pentest_auth_bypass.py
+++ b/tests/test_pentest_auth_bypass.py
@@ -4,6 +4,7 @@ import hashlib
 import hmac
 import secrets
 import time
+from datetime import datetime, timedelta, timezone
 
 import pyotp
 import pytest
@@ -29,6 +30,17 @@ def create_user(app, username="attacker", email="attacker@evil.com", password="c
         db.session.add(user)
         db.session.commit()
         return user.id
+
+
+def create_invite_token(email):
+    from app.auth.registration_invites import create_registration_invite
+
+    _invite, token = create_registration_invite(
+        email,
+        expires_at=datetime.now(timezone.utc) + timedelta(days=1),
+        audit=False,
+    )
+    return token
 
 
 def create_mfa_user(app, username="victim", email="victim@example.com", password="correct horse battery staple",
@@ -305,6 +317,7 @@ class TestRegistrationBypass:
     def test_register_with_extra_privileged_fields(self, app, client):
         """ATTACK: Submit extra fields during registration to gain privileges."""
         response = client.post("/auth/register", json={
+            "invite_token": create_invite_token("hacker@evil.com"),
             "username": "hacker01",
             "email": "hacker@evil.com",
             "full_name": "Hacker Test",
@@ -329,6 +342,7 @@ class TestRegistrationBypass:
         """ATTACK: Register with a username that looks visually identical using Unicode."""
 
         client.post("/auth/register", json={
+            "invite_token": create_invite_token("admin@example.com"),
             "username": "admin",
             "email": "admin@example.com",
             "full_name": "Admin Test",
@@ -350,6 +364,7 @@ class TestRegistrationBypass:
     def test_register_case_insensitive_duplicate(self, app, client):
         """ATTACK: Register with uppercase variant of existing username."""
         client.post("/auth/register", json={
+            "invite_token": create_invite_token("alice@example.com"),
             "username": "alice01",
             "email": "alice@example.com",
             "full_name": "Alice User",
@@ -359,6 +374,7 @@ class TestRegistrationBypass:
         })
 
         response = client.post("/auth/register", json={
+            "invite_token": create_invite_token("alice2@example.com"),
             "username": "ALICE01",
             "email": "alice2@example.com",
             "full_name": "Alice User Two",
@@ -373,6 +389,7 @@ class TestRegistrationBypass:
     def test_register_with_sql_injection_username(self, app, client):
         """ATTACK: SQL injection via username field."""
         response = client.post("/auth/register", json={
+            "invite_token": create_invite_token("sqli@evil.com"),
             "username": "'; DROP TABLE users; --",
             "email": "sqli@evil.com",
             "full_name": "SQL Injection Test",
@@ -561,6 +578,7 @@ class TestInfoLeakage:
 
 
         response1 = client.post("/auth/register", json={
+            "invite_token": create_invite_token("other@example.com"),
             "username": "alice",
             "email": "other@example.com",
             "full_name": "Alice Duplicate Test",
@@ -570,6 +588,7 @@ class TestInfoLeakage:
         })
 
         response2 = client.post("/auth/register", json={
+            "invite_token": create_invite_token("alice@example.com"),
             "username": "other_user",
             "email": "alice@example.com",
             "full_name": "Other User Test",

--- a/tests/test_route_inventory_security.py
+++ b/tests/test_route_inventory_security.py
@@ -99,7 +99,7 @@ ROUTE_SECURITY_INVENTORY = {
         "csrf": "required",
         "rate_limit": "per_route",
         "step_up": "not_required",
-        "public_justification": "Account creation remains intentionally open but CSRF-protected and rate-limited.",
+        "public_justification": "Invite-gated account creation must be reachable before authentication but requires a valid token.",
     },
     "auth.login": {
         "endpoint": "auth.login",
@@ -429,7 +429,7 @@ ROUTE_SECURITY_INVENTORY = {
         "csrf": "not_applicable",
         "rate_limit": "edge_app",
         "step_up": "not_required",
-        "public_justification": "Registration form must be reachable before account creation.",
+        "public_justification": "Registration invite links must be reachable before account creation.",
     },
     "web.register_submit": {
         "endpoint": "web.register_submit",
@@ -440,7 +440,7 @@ ROUTE_SECURITY_INVENTORY = {
         "csrf": "required",
         "rate_limit": "per_route",
         "step_up": "not_required",
-        "public_justification": "Account creation remains intentionally open but CSRF-protected and rate-limited.",
+        "public_justification": "Invite-gated account creation must be reachable before authentication but requires a valid token.",
     },
     "web.login": {
         "endpoint": "web.login",
@@ -844,3 +844,4 @@ def test_login_and_registration_have_method_level_security_decisions(app):
     assert ROUTE_SECURITY_INVENTORY["web.register_form"]["csrf"] == "not_applicable"
     assert ROUTE_SECURITY_INVENTORY["web.register_submit"]["csrf"] == "required"
     assert ROUTE_SECURITY_INVENTORY["web.register_submit"]["rate_limit"] == "per_route"
+    assert "Invite-gated" in ROUTE_SECURITY_INVENTORY["web.register_submit"]["public_justification"]

--- a/tests/test_webauthn_lifecycle.py
+++ b/tests/test_webauthn_lifecycle.py
@@ -25,9 +25,17 @@ ORIGIN = {"Origin": "https://sitbank.duckdns.org"}
 
 def register(client, username="alice01", email="alice@example.com", password="correct horse battery staple",
              full_name="Alice Test", phone_number="91234567"):
+    from app.auth.registration_invites import create_registration_invite
+
+    _invite, invite_token = create_registration_invite(
+        email,
+        expires_at=datetime.now(timezone.utc) + timedelta(days=1),
+        audit=False,
+    )
     return client.post(
         "/register",
         data={
+            "invite_token": invite_token,
             "username": username,
             "email": email,
             "full_name": full_name,


### PR DESCRIPTION
## Summary

Replace public customer self-registration with invite-only registration using one-time, email-bound invite tokens.

## Why

Production registration previously allowed anyone who could reach `/register` or `/auth/register` to attempt account creation. For a banking-style app, onboarding should be approved, auditable, and limited to intended users.

## What changed

* Added a `registration_invites` model/table and migration.
* Added HMAC-hashed invite tokens with expiry, revocation, one-time use, and email binding.
* Updated web/API registration, CLI invite creation, bulk CSV invite creation, DAST setup, route inventory, and tests.

## Security impact

This closes unrestricted public account creation. Invite plaintext is shown only at creation time, only token HMACs are stored, and registration rejects missing, invalid, expired, revoked, reused, or email-mismatched invites. Invite lifecycle events are audited without storing plaintext tokens.

## Deployment impact

This PR requires:

* EC2 bootstrap: no
* staging deployment: yes
* production deployment: yes
* database migration: yes, run `flask db upgrade`
* secret changes: no
* no deployment action: no

## Verification

* `python -m compileall app tests ops/container/create_dast_session.py`
* `python -m pytest tests/test_route_inventory_security.py -q`
* `python -m pytest tests/test_auth_registration_login.py -q`
* `python -m pytest tests/test_deployment.py -q`
* Related UI, WebAuthn, pentest, session, password reset, audit, and config test files passed in split runs.

## Notes

A full `python -m pytest tests/ -q` run timed out after 10 minutes with no failures shown, so the suite was completed successfully in split runs.