### PR TITLE
Add registration invite listing command

### DIFF
--- a/app/ops/commands.py
+++ b/app/ops/commands.py
@@ -14,7 +14,7 @@ from flask import Flask
 from sqlalchemy import text
 
 from app.extensions import db
-from app.models import User
+from app.models import RegistrationInvite, User
 from app.auth.registration_invites import (
     create_registration_invite,
     create_registration_invites_from_csv,
@@ -140,6 +140,32 @@ def register_ops_commands(app: Flask) -> None:
                 sort_keys=True,
             )
         )
+
+    @app.cli.command("list-registration-invites")
+    @click.option("--all", "include_all", is_flag=True, help="Include used, revoked, and expired invites.")
+    @click.option("--limit", type=click.IntRange(1, 500), default=50, show_default=True)
+    def list_registration_invites_command(include_all: bool, limit: int) -> None:
+        """List registration invites without exposing invite tokens or token hashes."""
+        now = datetime.now(timezone.utc)
+        statement = db.select(RegistrationInvite).order_by(
+            RegistrationInvite.expires_at.asc(),
+            RegistrationInvite.id.asc(),
+        )
+        if not include_all:
+            statement = statement.where(
+                RegistrationInvite.used_at.is_(None),
+                RegistrationInvite.revoked_at.is_(None),
+                RegistrationInvite.expires_at > now,
+            )
+        invites = list(db.session.execute(statement.limit(limit)).scalars())
+        payload = {
+            "count": len(invites),
+            "invites": [
+                _registration_invite_payload(invite, now=now)
+                for invite in invites
+            ],
+        }
+        click.echo(json.dumps(payload, separators=(",", ":"), sort_keys=True))
 
     @app.cli.command("verify-migration-baseline")
     def verify_migration_baseline() -> None:
@@ -563,6 +589,43 @@ def _parse_duration(value: str) -> timedelta:
     if unit == "h":
         return timedelta(hours=amount)
     return timedelta(days=amount)
+
+
+def _registration_invite_payload(invite: RegistrationInvite, *, now: datetime) -> dict[str, object]:
+    return {
+        "invite_id": invite.id,
+        "email": invite.intended_email_normalized,
+        "status": _registration_invite_status(invite, now=now),
+        "created_at": _utc_iso_or_none(invite.created_at),
+        "expires_at": _utc_iso_or_none(invite.expires_at),
+        "used_at": _utc_iso_or_none(invite.used_at),
+        "used_by_user_id": invite.used_by_user_id,
+        "revoked_at": _utc_iso_or_none(invite.revoked_at),
+        "revoked_by_user_id": invite.revoked_by_user_id,
+        "last_attempt_at": _utc_iso_or_none(invite.last_attempt_at),
+    }
+
+
+def _registration_invite_status(invite: RegistrationInvite, *, now: datetime) -> str:
+    if invite.used_at is not None:
+        return "used"
+    if invite.revoked_at is not None:
+        return "revoked"
+    if _aware_utc(invite.expires_at) <= _aware_utc(now):
+        return "expired"
+    return "pending"
+
+
+def _utc_iso_or_none(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    return _aware_utc(value).isoformat()
+
+
+def _aware_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
 
 
 def _load_audit_anchor(anchor_path: Path) -> dict:

--- a/tests/test_auth_registration_login.py
+++ b/tests/test_auth_registration_login.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 from _auth_flow_helpers import *
 
 
@@ -197,6 +199,36 @@ def test_bulk_invite_creation_from_csv(app, tmp_path):
     assert "alice@example.com" in result.output
     assert "https://sitbank.test/register?invite=" in result.output
     assert db.session.query(RegistrationInvite).count() == 2
+
+
+def test_list_registration_invites_shows_pending_without_tokens(app):
+    from app.auth.registration_invites import registration_invite_token_hash
+
+    pending_token = registration_invite_token("pending@example.com")
+    expired_token = registration_invite_token("expired@example.com")
+    revoked_token = registration_invite_token("revoked@example.com")
+    expired = db.session.execute(
+        db.select(RegistrationInvite).where(RegistrationInvite.token_hash == registration_invite_token_hash(expired_token))
+    ).scalar_one()
+    revoked = db.session.execute(
+        db.select(RegistrationInvite).where(RegistrationInvite.token_hash == registration_invite_token_hash(revoked_token))
+    ).scalar_one()
+    expired.expires_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+    revoked.revoked_at = datetime.now(timezone.utc)
+    db.session.commit()
+
+    pending_result = app.test_cli_runner().invoke(args=["list-registration-invites"])
+    all_result = app.test_cli_runner().invoke(args=["list-registration-invites", "--all"])
+    pending_payload = json.loads(pending_result.output)
+    all_payload = json.loads(all_result.output)
+
+    assert pending_result.exit_code == 0
+    assert pending_payload["count"] == 1
+    assert pending_payload["invites"][0]["email"] == "pending@example.com"
+    assert pending_payload["invites"][0]["status"] == "pending"
+    assert pending_token not in pending_result.output
+    assert expired_token not in all_result.output
+    assert {invite["status"] for invite in all_payload["invites"]} == {"expired", "pending", "revoked"}
 
 
 def test_invite_registration_preserves_mfa_onboarding(client):


### PR DESCRIPTION
## Summary

Add a safe operator CLI command to list registration invitations and see which invites are still pending.

## Why

Invite-only registration now supports creating and revoking invites, but operators need a safe way to check pending invitations without manually querying the database or exposing invite token material.

## What changed

* Added `list-registration-invites`, defaulting to pending invites only.
* Added `--all` and `--limit` options for operator review.
* Added test coverage confirming pending filtering and that plaintext invite tokens are not printed.

## Security impact

Improves invite-onboarding operations without exposing plaintext invite tokens or token hashes. The command reports invite IDs, intended emails, statuses, and timestamps only.

## Deployment impact

This PR requires:

* EC2 bootstrap: no
* staging deployment: yes
* production deployment: yes
* database migration: no
* secret changes: no
* no deployment action: no

## Verification

* `python -m compileall app tests/test_auth_registration_login.py`
* `python -m pytest tests/test_auth_registration_login.py -q`

## Notes

Use `list-registration-invites` for pending invites. Use `list-registration-invites --all` to include used, revoked, and expired invites.