### PR TITLE
Add registration invite listing command (#124)

### DIFF
--- a/app/auth/registration_invites.py
+++ b/app/auth/registration_invites.py
@@ -15,6 +15,7 @@ from sqlalchemy.exc import IntegrityError
 from app.extensions import db
 from app.models import RegistrationInvite, User
 from app.security.audit import audit_event, audit_event_required, audit_system_event, principal_reference
+from app.security.email import send_security_email
 
 
 INVITE_TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]{16,256}$")
@@ -87,9 +88,17 @@ def create_registration_invites_from_csv(
     try:
         with csv_path.open("r", encoding="utf-8-sig", newline="") as handle:
             reader = csv.DictReader(handle)
-            if not reader.fieldnames or "email" not in {field.strip() for field in reader.fieldnames}:
+            email_field = next(
+                (field for field in (reader.fieldnames or []) if field.strip().casefold() == "email"),
+                None,
+            )
+            if email_field is None:
                 raise ValueError("CSV must include an email column")
-            emails = [str(row.get("email") or "").strip() for row in reader if str(row.get("email") or "").strip()]
+            emails = [
+                str(row.get(email_field) or "").strip()
+                for row in reader
+                if str(row.get(email_field) or "").strip()
+            ]
     except OSError as exc:
         raise ValueError(f"CSV could not be read: {type(exc).__name__}") from exc
 
@@ -110,6 +119,41 @@ def create_registration_invites_from_csv(
         metadata={"created_count": len(created), "created_by_user_id": created_by_user_id},
     )
     return created
+
+
+def send_registration_invite_email(
+    invite: RegistrationInvite,
+    token: str,
+    *,
+    base_url: str | None = None,
+) -> None:
+    invite_url = registration_invite_url(token, base_url=base_url)
+    expires_text = _ensure_aware_utc(invite.expires_at).strftime("%Y-%m-%d %H:%M UTC")
+    body = (
+        "You have been invited to register for SITBank.\n\n"
+        f"Use this one-time registration link:\n\n{invite_url}\n\n"
+        f"This link expires at {expires_text}. "
+        "It can only be used for the email address that received this message. "
+        "If you did not expect this invitation, ignore this email."
+    )
+    try:
+        send_security_email(
+            invite.intended_email_normalized,
+            "SITBank registration invitation",
+            body,
+        )
+    except Exception:
+        audit_system_event(
+            "registration_invite_email",
+            "failure",
+            metadata=_invite_metadata(invite),
+        )
+        raise
+    audit_system_event(
+        "registration_invite_email",
+        "sent",
+        metadata=_invite_metadata(invite),
+    )
 
 
 def revoke_registration_invite(

--- a/app/ops/commands.py
+++ b/app/ops/commands.py
@@ -20,6 +20,7 @@ from app.auth.registration_invites import (
     create_registration_invites_from_csv,
     registration_invite_url,
     revoke_registration_invite,
+    send_registration_invite_email,
 )
 from app.security.alerts import (
     build_security_alert_report,
@@ -53,11 +54,13 @@ def register_ops_commands(app: Flask) -> None:
     @click.option("--expires-in", default="7d", show_default=True, help="Invite lifetime, such as 30m, 12h, or 7d.")
     @click.option("--created-by-user-id", type=int, default=None, help="Optional admin/operator user id.")
     @click.option("--base-url", default=None, help="Override the public base URL used in the one-time invite link.")
+    @click.option("--send-email", is_flag=True, help="Email the one-time invite link instead of printing it.")
     def create_registration_invite_command(
         email: str,
         expires_in: str,
         created_by_user_id: int | None,
         base_url: str | None,
+        send_email: bool,
     ) -> None:
         """Create one invite-only registration token."""
         expires_at = datetime.now(timezone.utc) + _parse_duration(expires_in)
@@ -70,14 +73,25 @@ def register_ops_commands(app: Flask) -> None:
         except Exception as exc:
             raise click.ClickException(str(exc)) from exc
 
+        payload = {
+            "invite_id": invite.id,
+            "email": invite.intended_email_normalized,
+            "expires_at": invite.expires_at.astimezone(timezone.utc).isoformat(),
+        }
+        if send_email:
+            try:
+                send_registration_invite_email(invite, token, base_url=base_url)
+            except Exception as exc:
+                raise click.ClickException(
+                    f"Registration invite {invite.id} was created, but email delivery failed: {type(exc).__name__}"
+                ) from exc
+            payload["email_delivery"] = "sent"
+        else:
+            payload["invite_url"] = registration_invite_url(token, base_url=base_url)
+
         click.echo(
             json.dumps(
-                {
-                    "invite_id": invite.id,
-                    "email": invite.intended_email_normalized,
-                    "expires_at": invite.expires_at.astimezone(timezone.utc).isoformat(),
-                    "invite_url": registration_invite_url(token, base_url=base_url),
-                },
+                payload,
                 separators=(",", ":"),
                 sort_keys=True,
             )
@@ -88,11 +102,13 @@ def register_ops_commands(app: Flask) -> None:
     @click.option("--expires-in", default="7d", show_default=True, help="Invite lifetime, such as 30m, 12h, or 7d.")
     @click.option("--created-by-user-id", type=int, default=None, help="Optional admin/operator user id.")
     @click.option("--base-url", default=None, help="Override the public base URL used in one-time invite links.")
+    @click.option("--send-email", is_flag=True, help="Email each one-time invite link instead of printing it.")
     def create_registration_invites_command(
         csv_path: Path,
         expires_in: str,
         created_by_user_id: int | None,
         base_url: str | None,
+        send_email: bool,
     ) -> None:
         """Create invite-only registration tokens from a CSV with an email column."""
         expires_at = datetime.now(timezone.utc) + _parse_duration(expires_in)
@@ -104,6 +120,29 @@ def register_ops_commands(app: Flask) -> None:
             )
         except Exception as exc:
             raise click.ClickException(str(exc)) from exc
+
+        if send_email:
+            for invite, token in created:
+                try:
+                    send_registration_invite_email(invite, token, base_url=base_url)
+                except Exception as exc:
+                    raise click.ClickException(
+                        f"Registration invite {invite.id} was created, but email delivery failed for "
+                        f"{invite.intended_email_normalized}: {type(exc).__name__}"
+                    ) from exc
+            click.echo("email,invite_id,expires_at,email_delivery")
+            for invite, _token in created:
+                click.echo(
+                    ",".join(
+                        [
+                            invite.intended_email_normalized,
+                            str(invite.id),
+                            invite.expires_at.astimezone(timezone.utc).isoformat(),
+                            "sent",
+                        ]
+                    )
+                )
+            return
 
         click.echo("email,invite_id,expires_at,invite_url")
         for invite, token in created:

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -197,3 +197,110 @@ security alert payloads. Reset links belong only in customer recovery email.
 Manual recovery requests create pending records and audit events only; account
 freezing, unlocking, MFA removal, or re-enrollment must require a trusted
 future approval workflow.
+
+## Invite-Only Registration Operations
+
+Customer self-registration requires an unused invite token for the same email
+address the customer submits on the registration form. Invite tokens are stored
+only as HMAC hashes in the database. The raw invite link is available only at
+creation time or inside the outgoing invite email.
+
+Invite email delivery uses the same security email backend and SMTP settings as
+password reset email:
+
+- `PASSWORD_RESET_EMAIL_BACKEND=smtp`
+- `PASSWORD_RESET_EMAIL_FROM=<approved sender>`
+- `PASSWORD_RESET_BASE_URL=https://sitbank.duckdns.org`
+- `SMTP_HOST=<approved provider host>`
+- `SMTP_USE_TLS=true`
+- `SMTP_USERNAME_FILE=/run/secrets/smtp_username`
+- `SMTP_PASSWORD_FILE=/run/secrets/smtp_password`
+
+Create and email a single production invite:
+
+```bash
+sudo docker exec -it sitbank-app \
+  python -m flask --app wsgi:app create-registration-invite alice@example.com \
+    --expires-in 7d \
+    --base-url https://sitbank.duckdns.org \
+    --send-email
+```
+
+Without `--send-email`, the command prints a JSON object containing
+`invite_url` for manual delivery:
+
+```bash
+sudo docker exec -it sitbank-app \
+  python -m flask --app wsgi:app create-registration-invite alice@example.com \
+    --expires-in 7d \
+    --base-url https://sitbank.duckdns.org
+```
+
+List pending invites without exposing tokens or token hashes:
+
+```bash
+sudo docker exec -it sitbank-app \
+  python -m flask --app wsgi:app list-registration-invites
+```
+
+Include used, revoked, and expired invites when investigating history:
+
+```bash
+sudo docker exec -it sitbank-app \
+  python -m flask --app wsgi:app list-registration-invites --all --limit 100
+```
+
+Revoke an unused invite:
+
+```bash
+sudo docker exec -it sitbank-app \
+  python -m flask --app wsgi:app revoke-registration-invite 123
+```
+
+For bulk invites, prepare a CSV with an `email` header:
+
+```csv
+email
+alice@example.com
+bob@example.com
+```
+
+Bulk invite CSVs contain customer email addresses and must not be committed to
+the repository, pasted into tickets, or kept in long-lived shared folders. On
+the EC2 host, keep the operator copy as a temporary file such as
+`/tmp/sitbank-registration-invites.csv`, load it into the app container at
+`/tmp/registration-invites.csv`, run the CLI, then remove both temporary files.
+The app container has a writable `/tmp` tmpfs specifically for short-lived
+operator inputs; the rest of the container filesystem is read-only.
+
+Example production bulk-email run:
+
+```bash
+chmod 0600 /tmp/sitbank-registration-invites.csv
+sudo docker exec -i sitbank-app sh -c 'umask 077; cat > /tmp/registration-invites.csv' \
+  < /tmp/sitbank-registration-invites.csv
+sudo docker exec -it sitbank-app \
+  python -m flask --app wsgi:app create-registration-invites /tmp/registration-invites.csv \
+    --expires-in 7d \
+    --base-url https://sitbank.duckdns.org \
+    --send-email
+sudo docker exec -i sitbank-app rm -f /tmp/registration-invites.csv
+rm -f /tmp/sitbank-registration-invites.csv
+```
+
+Without `--send-email`, bulk creation prints a CSV result containing each
+`invite_url` for manual delivery. With `--send-email`, the command sends each
+link by email and prints `email,invite_id,expires_at,email_delivery` rows
+instead of raw links. If email delivery fails after creating an invite, the CLI
+exits non-zero and reports the invite ID so the operator can list, revoke, or
+recreate it without printing the token.
+
+Use `sitbank-staging-app` and the staging base URL for staging:
+
+```bash
+sudo docker exec -it sitbank-staging-app \
+  python -m flask --app wsgi:app create-registration-invite alice@example.com \
+    --expires-in 1d \
+    --base-url https://staging-sitbank.duckdns.org \
+    --send-email
+```

--- a/tests/test_auth_registration_login.py
+++ b/tests/test_auth_registration_login.py
@@ -201,6 +201,93 @@ def test_bulk_invite_creation_from_csv(app, tmp_path):
     assert db.session.query(RegistrationInvite).count() == 2
 
 
+def test_single_invite_can_be_emailed_without_printing_link(app):
+    from app.security.email import password_reset_outbox
+
+    result = app.test_cli_runner().invoke(
+        args=[
+            "create-registration-invite",
+            "Alice@Example.com",
+            "--expires-in",
+            "1d",
+            "--base-url",
+            "https://sitbank.test",
+            "--send-email",
+        ]
+    )
+    outbox = password_reset_outbox()
+    payload = json.loads(result.output)
+
+    assert result.exit_code == 0
+    assert payload["email"] == "alice@example.com"
+    assert payload["email_delivery"] == "sent"
+    assert "invite_url" not in payload
+    assert "https://sitbank.test/register?invite=" not in result.output
+    assert len(outbox) == 1
+    assert outbox[0]["to"] == "alice@example.com"
+    assert outbox[0]["subject"] == "SITBank registration invitation"
+    assert "https://sitbank.test/register?invite=" in outbox[0]["body"]
+
+
+def test_bulk_invites_can_be_emailed_without_printing_links(app, tmp_path):
+    from app.security.email import password_reset_outbox
+
+    csv_path = tmp_path / "invites.csv"
+    csv_path.write_text("email\nalice@example.com\nbob@example.com\n", encoding="utf-8")
+
+    result = app.test_cli_runner().invoke(
+        args=[
+            "create-registration-invites",
+            str(csv_path),
+            "--expires-in",
+            "1d",
+            "--base-url",
+            "https://sitbank.test",
+            "--send-email",
+        ]
+    )
+    outbox = password_reset_outbox()
+
+    assert result.exit_code == 0
+    assert "email,invite_id,expires_at,email_delivery" in result.output
+    assert "invite_url" not in result.output
+    assert "https://sitbank.test/register?invite=" not in result.output
+    assert "alice@example.com" in result.output
+    assert "bob@example.com" in result.output
+    assert [item["to"] for item in outbox] == ["alice@example.com", "bob@example.com"]
+    assert all(item["subject"] == "SITBank registration invitation" for item in outbox)
+    assert all("https://sitbank.test/register?invite=" in item["body"] for item in outbox)
+    assert db.session.query(RegistrationInvite).count() == 2
+
+
+def test_invite_email_failure_reports_created_invite_without_link(app, monkeypatch):
+    from app.auth import registration_invites
+
+    def fail_delivery(*_args, **_kwargs):
+        raise RuntimeError("smtp secret should not leak")
+
+    monkeypatch.setattr(registration_invites, "send_security_email", fail_delivery)
+
+    result = app.test_cli_runner().invoke(
+        args=[
+            "create-registration-invite",
+            "alice@example.com",
+            "--expires-in",
+            "1d",
+            "--base-url",
+            "https://sitbank.test",
+            "--send-email",
+        ]
+    )
+
+    assert result.exit_code != 0
+    assert "Registration invite " in result.output
+    assert " was created, but email delivery failed: RuntimeError" in result.output
+    assert "smtp secret should not leak" not in result.output
+    assert "https://sitbank.test/register?invite=" not in result.output
+    assert db.session.query(RegistrationInvite).count() == 1
+
+
 def test_list_registration_invites_shows_pending_without_tokens(app):
     from app.auth.registration_invites import registration_invite_token_hash
 


### PR DESCRIPTION
## Summary

Adds email delivery for invite-only customer registration links and documents the operator workflow for single and bulk invites.

## Why

Invite creation previously printed registration links for manual delivery only. That made operators handle one-time invite URLs directly and left the bulk invite CSV workflow under-documented. The invite flow should support emailing links through the existing secure email backend while keeping raw invite URLs out of CLI output when email delivery is used.

## What changed

* Added `--send-email` to single and bulk registration invite CLI commands.
* Reused the existing security email backend/SMTP configuration to send registration invitation emails.
* Documented invite-only operations, pending invite listing, revoke usage, and temporary bulk CSV handling under `/tmp`.

## Security impact

Invite tokens continue to be stored only as HMAC hashes. When `--send-email` is used, CLI output reports invite IDs and delivery status but does not print raw invite URLs. Email delivery uses the existing password-reset SMTP/console backend and existing SMTP secrets; this PR adds no new secrets or permissions. Delivery failures are surfaced as command failures without printing the invite link or underlying exception message.

## Deployment impact

Requires staging deployment and production deployment when ready. No EC2 bootstrap, database migration, or new secret changes are required if the existing SMTP/password-reset email configuration is already present.

## Verification

* `python -m pytest tests\test_auth_registration_login.py::test_single_invite_can_be_emailed_without_printing_link tests\test_auth_registration_login.py::test_bulk_invites_can_be_emailed_without_printing_links tests\test_auth_registration_login.py::test_invite_email_failure_reports_created_invite_without_link tests\test_auth_registration_login.py::test_bulk_invite_creation_from_csv tests\test_auth_registration_login.py::test_list_registration_invites_shows_pending_without_tokens -q`
* `python -m compileall app\auth\registration_invites.py app\ops\commands.py`
* `git diff --check`

## Notes

Bulk invite CSVs should be kept out of git and handled as temporary operator files, for example host `/tmp/sitbank-registration-invites.csv` copied into the app container as `/tmp/registration-invites.csv`, then deleted after the CLI run. A full `tests\test_auth_registration_login.py -q` run timed out locally after 300 seconds, but the focused invite coverage passed.