### PR TITLE
Add passkey MFA enumeration regression coverage

### DIFF
--- a/tests/test_authenticated_portal_ui.py
+++ b/tests/test_authenticated_portal_ui.py
@@ -143,7 +143,7 @@ def test_dashboard_bank_card_masks_account_details_and_loads_toggle_script(clien
     assert 'aria-label="Show balance"' in markup
     assert '/static/js/dashboard.js' in markup
 
-def test_security_key_setup_prompts_for_authenticator_mfa_first(client):
+def test_security_key_page_redirects_unenrolled_users_to_mfa_setup(client):
     register(client)
     login(client)
 

--- a/tests/test_mfa_lifecycle.py
+++ b/tests/test_mfa_lifecycle.py
@@ -492,7 +492,7 @@ def test_pending_api_mfa_expiry_returns_stable_error_code(app, client):
         "code": "mfa_challenge_expired",
     }
 
-def test_api_onboarding_requires_totp_before_authenticated_endpoints(client):
+def test_api_onboarding_requires_enrolled_mfa_before_authenticated_endpoints(client):
     register(client)
     login(client)
 

--- a/tests/test_password_reset.py
+++ b/tests/test_password_reset.py
@@ -9,6 +9,7 @@ from urllib.parse import parse_qs, urlparse
 import pyotp
 import pytest
 from sqlalchemy import func
+from webauthn.helpers import bytes_to_base64url
 
 from app.auth.password_reset import (
     complete_manual_recovery_request,
@@ -26,6 +27,7 @@ from app.security.passwords import PASSWORD_MAX_CHARS, PASSWORD_MIN_LENGTH, hash
 
 VALID_PASSWORD = "Correct-Horse-Battery-Staple-2026!"
 NEW_PASSWORD = "Reset-Correct-Horse-Battery-Staple-2026!"
+ORIGIN = {"Origin": "https://sitbank.duckdns.org"}
 
 
 def _create_user(username: str, email: str, password: str = VALID_PASSWORD,
@@ -49,11 +51,11 @@ def _create_totp_user(username: str, email: str, full_name: str = "Test User", p
     return user, secret
 
 
-def _add_webauthn_credential(user: User) -> None:
+def _add_webauthn_credential(user: User, credential_id: bytes = b"credential-id-0001") -> None:
     db.session.add(
         WebAuthnCredential(
             user_id=user.id,
-            credential_id=b"credential-id-0001",
+            credential_id=credential_id,
             credential_public_key=b"credential-public-key",
             sign_count=1,
             label="Primary key",
@@ -376,6 +378,38 @@ def test_passkey_only_user_cannot_fall_back_to_email_only_reset(app, client):
         assert wrong_factor_event is not None
         assert wrong_factor_event.event_metadata["reason"] == "wrong_factor"
         assert wrong_factor_event.event_metadata["submitted_factor"] == "authentication_code"
+
+
+def test_password_reset_webauthn_options_require_transaction_before_allow_credentials(app, client):
+    with app.app_context():
+        user = _create_user("resetwebauthn", "resetwebauthn@example.com")
+        other = _create_user("resetother", "resetother@example.com", phone_number="92345678")
+        _add_webauthn_credential(user, credential_id=b"reset-user-passkey")
+        _add_webauthn_credential(other, credential_id=b"other-user-passkey")
+
+    public_probe = client.post(
+        "/auth/password-reset/mfa/webauthn/options",
+        json={"email": "resetwebauthn@example.com"},
+        headers=ORIGIN,
+    )
+    _request_reset(client, "resetwebauthn@example.com")
+    token = _reset_token(app)
+    exchanged = _exchange(client, token)
+    transaction_response = client.post(
+        "/auth/password-reset/mfa/webauthn/options",
+        json={"email": "resetother@example.com"},
+        headers=ORIGIN,
+    )
+    payload = transaction_response.get_json()
+    allowed_ids = {credential["id"] for credential in payload["allowCredentials"]}
+
+    assert public_probe.status_code == 401
+    assert public_probe.get_json() == {"error": "No active password reset transaction"}
+    assert exchanged.status_code == 200
+    assert exchanged.get_json()["mfa_required"] == "webauthn"
+    assert transaction_response.status_code == 200
+    assert allowed_ids == {bytes_to_base64url(b"reset-user-passkey")}
+    assert bytes_to_base64url(b"other-user-passkey") not in allowed_ids
 
 
 def test_totp_recovery_code_still_works_when_passkey_is_registered(app, client):

--- a/tests/test_webauthn_lifecycle.py
+++ b/tests/test_webauthn_lifecycle.py
@@ -12,7 +12,12 @@ from webauthn.helpers import bytes_to_base64url
 from webauthn.helpers.structs import AttestationFormat, CredentialDeviceType
 
 from _auth_flow_helpers import verify_registration_email
-from app.auth.webauthn_services import begin_transaction_security_key_challenge, stage_transaction_security_key_context
+from app.auth.mfa_policy import has_enrolled_mfa_method
+from app.auth.webauthn_services import (
+    begin_transaction_security_key_challenge,
+    stage_transaction_security_key_context,
+    webauthn_credential_count,
+)
 from app.extensions import db
 from app.models import SecurityAuditEvent, User, WebAuthnCredential
 from app.security.crypto import encrypt_mfa_secret
@@ -79,6 +84,35 @@ def enable_totp(user):
     return secret
 
 
+def attestation_payload(credential_id=b"credential-one"):
+    credential_ref = bytes_to_base64url(credential_id)
+    return {
+        "id": credential_ref,
+        "rawId": credential_ref,
+        "type": "public-key",
+        "response": {
+            "attestationObject": "AA",
+            "clientDataJSON": "AA",
+            "transports": ["internal"],
+        },
+    }
+
+
+def assertion_payload(credential_id=b"credential-one"):
+    credential_ref = bytes_to_base64url(credential_id)
+    return {
+        "id": credential_ref,
+        "rawId": credential_ref,
+        "type": "public-key",
+        "response": {
+            "authenticatorData": "AA",
+            "clientDataJSON": "AA",
+            "signature": "AA",
+            "userHandle": None,
+        },
+    }
+
+
 def authenticate_session(client, user, credential):
     with client.session_transaction() as sess:
         sess["user_id"] = user.id
@@ -131,6 +165,118 @@ def test_registration_allows_first_passkey_after_password_bootstrap(client):
     assert response.status_code == 200
     assert payload["authenticatorSelection"]["residentKey"] == "required"
     assert payload["authenticatorSelection"]["requireResidentKey"] is True
+
+
+def test_registration_rejects_first_passkey_without_authenticated_session(client):
+    response = client.post(
+        "/auth/webauthn/register/options",
+        json={"label": "Primary passkey"},
+        headers=ORIGIN,
+    )
+
+    assert response.status_code == 401
+    assert response.get_json() == {"error": "Authentication required"}
+
+
+def test_registration_rejects_first_passkey_without_password_bootstrap_context(client):
+    register(client)
+    user = user_by_name()
+    with client.session_transaction() as sess:
+        sess["user_id"] = user.id
+        sess["auth_context"] = "legacy_authenticated"
+
+    response = client.post(
+        "/auth/webauthn/register/options",
+        json={"label": "Primary passkey"},
+        headers=ORIGIN,
+    )
+
+    assert response.status_code == 403
+    assert response.get_json() == {
+        "error": "Recent MFA verification is required before managing security keys"
+    }
+
+
+def test_registration_completes_first_passkey_as_customer_mfa_method(client, monkeypatch):
+    register(client)
+    login(client)
+    user = user_by_name()
+    options_response = client.post(
+        "/auth/webauthn/register/options",
+        json={"label": "Laptop passkey"},
+        headers=ORIGIN,
+    )
+
+    def fake_verify_registration_response(**kwargs):
+        assert kwargs["expected_rp_id"] == "sitbank.duckdns.org"
+        assert kwargs["expected_origin"] == "https://sitbank.duckdns.org"
+        assert kwargs["require_user_verification"] is True
+        return SimpleNamespace(
+            credential_id=b"first-passkey",
+            credential_public_key=b"public-key",
+            sign_count=0,
+            aaguid="",
+            fmt="none",
+            credential_device_type=CredentialDeviceType.MULTI_DEVICE,
+            credential_backed_up=True,
+        )
+
+    monkeypatch.setattr(
+        "app.auth.webauthn_services.verify_registration_response",
+        fake_verify_registration_response,
+    )
+    verify_response = client.post(
+        "/auth/webauthn/register/verify",
+        json={"credential": attestation_payload(b"first-passkey")},
+        headers=ORIGIN,
+    )
+    db.session.refresh(user)
+    dashboard_response = client.get("/dashboard")
+
+    assert options_response.status_code == 200
+    assert verify_response.status_code == 200
+    assert user.mfa_enabled is False
+    assert has_enrolled_mfa_method(user) is True
+    assert webauthn_credential_count(user) == 1
+    assert dashboard_response.status_code == 200
+
+
+def test_registration_requires_fresh_mfa_for_additional_passkey(client):
+    register(client)
+    login(client)
+    user = user_by_name()
+    add_credential(user, credential_id=b"existing-passkey")
+
+    response = client.post(
+        "/auth/webauthn/register/options",
+        json={"label": "Second passkey"},
+        headers=ORIGIN,
+    )
+
+    assert response.status_code == 403
+    assert response.get_json() == {
+        "error": "Recent MFA verification is required before managing security keys"
+    }
+
+
+def test_mfa_policy_counts_totp_or_passkey_as_customer_enrollment(client):
+    register(client)
+    user = user_by_name()
+
+    assert has_enrolled_mfa_method(user) is False
+
+    enable_totp(user)
+    db.session.refresh(user)
+    assert has_enrolled_mfa_method(user) is True
+
+    user.mfa_enabled = False
+    user.mfa_secret_nonce = None
+    user.mfa_secret_ciphertext = None
+    db.session.commit()
+    add_credential(user, credential_id=b"only-passkey")
+    db.session.refresh(user)
+
+    assert has_enrolled_mfa_method(user) is True
 
 
 def test_webauthn_options_fail_closed_without_exact_origin(client):
@@ -416,6 +562,51 @@ def test_password_totp_login_allowed_after_security_key_enrollment(client):
     assert password_response.get_json()["mfa_required"] is True
     assert mfa_response.status_code == 200
     assert mfa_response.get_json()["message"] == "Login successful"
+
+
+def test_public_passkey_options_ignore_identifiers_and_do_not_query_users(client, monkeypatch):
+    register(client)
+    user = user_by_name()
+    add_credential(user, credential_id=b"alice-passkey")
+    client.post("/logout")
+
+    def fail_execute(*_args, **_kwargs):
+        raise AssertionError("public passkey options must not look up users or credentials")
+
+    monkeypatch.setattr("app.auth.webauthn_services.db.session.execute", fail_execute)
+    anonymous_response = client.post("/auth/webauthn/authenticate/options", json={}, headers=ORIGIN)
+    identifier_response = client.post(
+        "/auth/webauthn/authenticate/options",
+        json={
+            "identifier": "alice01",
+            "email": "alice@sit.singaporetech.edu.sg",
+            "account_number": user.account_number,
+        },
+        headers=ORIGIN,
+    )
+
+    assert anonymous_response.status_code == 200
+    assert identifier_response.status_code == 200
+    for payload in (anonymous_response.get_json(), identifier_response.get_json()):
+        assert payload["rpId"] == "sitbank.duckdns.org"
+        assert payload["userVerification"] == "required"
+        assert payload["timeout"] > 0
+        assert "challenge" in payload
+        assert "allowCredentials" not in payload
+
+
+def test_unknown_public_passkey_assertion_fails_generically(client):
+    register(client)
+    client.post("/auth/webauthn/authenticate/options", json={}, headers=ORIGIN)
+
+    response = client.post(
+        "/auth/webauthn/authenticate/verify",
+        json={"credential": assertion_payload(b"unknown-passkey")},
+        headers=ORIGIN,
+    )
+
+    assert response.status_code == 401
+    assert response.get_json() == {"error": "Security key verification failed"}
 
 
 def test_fully_enrolled_user_can_still_use_password_totp_login(client):


### PR DESCRIPTION
## Summary

Add regression coverage for passkey-first customer MFA onboarding and public WebAuthn credential-enumeration protections.

## Why

Customer MFA onboarding must allow either TOTP or a passkey/security key as the first MFA method without opening unauthenticated passkey registration. Public passkey login must remain username-less and must not expose account or credential existence through `allowCredentials` or identifier-based lookup.

## What changed

* Added WebAuthn lifecycle tests for first-passkey registration, password-bootstrap requirements, and fresh-MFA requirements for additional passkeys.
* Added public passkey login tests proving identifiers are ignored, user/credential lookup is not performed before options, and `allowCredentials` is not returned.
* Added password-reset WebAuthn coverage proving `allowCredentials` is only available after a valid reset transaction identifies the user.

## Security impact

Strengthens regression coverage around MFA onboarding, WebAuthn registration, username-less passkey login, and credential-enumeration prevention. This does not weaken auth, MFA, CSRF, session, recovery-code, or rate-limit behavior.

## Deployment impact

No deployment action.

No EC2 bootstrap, staging deployment, production deployment, database migration, or secret changes are required. This is test coverage only.

## Verification

* `git diff --check`
* `pytest tests/test_webauthn_lifecycle.py::test_registration_rejects_first_passkey_without_authenticated_session tests/test_webauthn_lifecycle.py::test_registration_rejects_first_passkey_without_password_bootstrap_context tests/test_webauthn_lifecycle.py::test_registration_completes_first_passkey_as_customer_mfa_method tests/test_webauthn_lifecycle.py::test_registration_requires_fresh_mfa_for_additional_passkey tests/test_webauthn_lifecycle.py::test_mfa_policy_counts_totp_or_passkey_as_customer_enrollment tests/test_webauthn_lifecycle.py::test_public_passkey_options_ignore_identifiers_and_do_not_query_users tests/test_webauthn_lifecycle.py::test_unknown_public_passkey_assertion_fails_generically tests/test_password_reset.py::test_password_reset_webauthn_options_require_transaction_before_allow_credentials tests/test_mfa_lifecycle.py::test_api_onboarding_requires_enrolled_mfa_before_authenticated_endpoints tests/test_authenticated_portal_ui.py::test_security_key_page_redirects_unenrolled_users_to_mfa_setup -q`
* `pytest tests/test_webauthn_lifecycle.py tests/test_password_reset.py tests/test_mfa_lifecycle.py tests/test_authenticated_portal_ui.py -q -n auto`

## Notes

The implementation already enforced the intended controls; this PR turns those requirements into focused regression tests.