### PR TITLE
Add password reset MFA method selection

### DIFF
--- a/app/auth/password_reset.py
+++ b/app/auth/password_reset.py
@@ -41,6 +41,19 @@ GENERIC_RESET_ERROR = "Password reset link is invalid or expired"
 RESET_TRANSACTION_SESSION_KEY = "password_reset_transaction_id"
 RESET_TRANSACTION_PREFIX = "ospbank:password_reset_transaction:"
 GENERIC_AUTHENTICATION_CODE_ERROR = "Invalid authentication code."
+GENERIC_VERIFICATION_METHOD_ERROR = "Invalid verification method."
+RESET_MFA_TOTP = "totp"
+RESET_MFA_WEBAUTHN = "webauthn"
+RESET_MFA_NONE = "none"
+RESET_MFA_METHODS = frozenset({RESET_MFA_TOTP, RESET_MFA_WEBAUTHN})
+RESET_MFA_METHOD_ALIASES = {
+    "authenticator": RESET_MFA_TOTP,
+    "passkey": RESET_MFA_WEBAUTHN,
+    "security-key": RESET_MFA_WEBAUTHN,
+    "security_key": RESET_MFA_WEBAUTHN,
+    RESET_MFA_TOTP: RESET_MFA_TOTP,
+    RESET_MFA_WEBAUTHN: RESET_MFA_WEBAUTHN,
+}
 MANUAL_RECOVERY_STATUS_PENDING = "pending"
 MANUAL_RECOVERY_STATUS_UNDER_REVIEW = "under_review"
 MANUAL_RECOVERY_STATUS_APPROVED = "approved"
@@ -200,21 +213,52 @@ def verify_reset_totp(code: str) -> dict[str, Any]:
     return _verify_reset_authentication_code(code, submitted_factor="authentication_code")
 
 
-def _verify_reset_authentication_code(code: str, *, submitted_factor: str) -> dict[str, Any]:
+def select_reset_mfa_method(method: str) -> dict[str, Any]:
     transaction = _load_current_transaction()
     user = _transaction_user(transaction)
-    if transaction["mfa_required"] != "totp":
+    selected = _normalize_reset_mfa_method(method)
+    available_methods = _available_reset_mfa_methods_for_user(user)
+    if selected not in available_methods:
+        transaction["available_mfa_methods"] = available_methods
+        _store_transaction(transaction)
         audit_event(
             "password_reset_mfa_failed",
             "failure",
             user=user,
-            metadata={
-                "reason": "wrong_factor",
-                "submitted_factor": submitted_factor,
-                "required_factor": transaction["mfa_required"],
-            },
+            metadata={"reason": "unavailable_factor", "requested_factor": selected},
         )
-        raise AuthError(GENERIC_AUTHENTICATION_CODE_ERROR, 400)
+        raise AuthError(GENERIC_VERIFICATION_METHOD_ERROR, 400)
+
+    current_method = str(transaction.get("mfa_required") or RESET_MFA_NONE)
+    if transaction.get("mfa_verified") and current_method != selected:
+        audit_event(
+            "password_reset_mfa_failed",
+            "failure",
+            user=user,
+            metadata={"reason": "already_verified", "requested_factor": selected},
+        )
+        raise AuthError(GENERIC_VERIFICATION_METHOD_ERROR, 400)
+
+    transaction["available_mfa_methods"] = available_methods
+    transaction["mfa_required"] = selected
+    if current_method != selected:
+        transaction["mfa_verified"] = False
+        transaction["recovery_code_verified"] = False
+    _store_transaction(transaction)
+    audit_event("password_reset_mfa_method_selected", "success", user=user, metadata={"factor": selected})
+    return _public_transaction(transaction)
+
+
+def _verify_reset_authentication_code(code: str, *, submitted_factor: str) -> dict[str, Any]:
+    transaction = _load_current_transaction()
+    user = _transaction_user(transaction)
+    _require_selected_reset_mfa_method(
+        transaction,
+        user,
+        RESET_MFA_TOTP,
+        submitted_factor=submitted_factor,
+        error_message=GENERIC_AUTHENTICATION_CODE_ERROR,
+    )
 
     if _is_totp_code(code):
         if not _verify_totp_for_user(user, code, "password_reset_mfa"):
@@ -245,7 +289,19 @@ def _verify_reset_authentication_code(code: str, *, submitted_factor: str) -> di
 
 def mark_reset_webauthn_verified(transaction_id: str, user_id: int) -> dict[str, Any]:
     transaction = _load_transaction(transaction_id)
-    if int(transaction["user_id"]) != int(user_id) or transaction["mfa_required"] != "webauthn":
+    user = db.session.get(User, int(user_id))
+    if user is None or int(transaction["user_id"]) != int(user_id):
+        audit_event("password_reset_webauthn_failed", "failure", user_id=user_id, metadata={"reason": "transaction_mismatch"})
+        raise AuthError("Security key verification failed", 401)
+    try:
+        _require_selected_reset_mfa_method(
+            transaction,
+            user,
+            RESET_MFA_WEBAUTHN,
+            submitted_factor=RESET_MFA_WEBAUTHN,
+            error_message="Security key verification failed",
+        )
+    except AuthError:
         audit_event("password_reset_webauthn_failed", "failure", user_id=user_id, metadata={"reason": "transaction_mismatch"})
         raise AuthError("Security key verification failed", 401)
     transaction["mfa_verified"] = True
@@ -527,9 +583,18 @@ def expire_manual_recovery_requests(
     return len(expired_records)
 
 
-def reset_transaction_user_and_id() -> tuple[User, str]:
+def reset_transaction_user_and_id(*, required_method: str | None = None) -> tuple[User, str]:
     transaction = _load_current_transaction()
-    return _transaction_user(transaction), transaction["transaction_id"]
+    user = _transaction_user(transaction)
+    if required_method is not None:
+        _require_selected_reset_mfa_method(
+            transaction,
+            user,
+            required_method,
+            submitted_factor=required_method,
+            error_message="Security key verification failed",
+        )
+    return user, transaction["transaction_id"]
 
 
 def reset_transaction_id() -> str:
@@ -697,16 +762,20 @@ def _audit_manual_recovery_transition(
 
 
 def _create_reset_transaction(user: User, token: PasswordResetToken) -> dict[str, Any]:
-    mfa_required = _mfa_requirement(user)
+    mfa_policy = _reset_mfa_policy(user)
+    mfa_required = mfa_policy["default_method"]
     transaction = {
         "transaction_id": secrets.token_urlsafe(32),
         "token_id": token.id,
         "user_id": user.id,
         "purpose": "password_reset",
         "mfa_required": mfa_required,
-        "mfa_verified": mfa_required == "none",
+        "available_mfa_methods": mfa_policy["available_methods"],
+        "preferred_mfa_method": mfa_policy["preferred_method"],
+        "default_mfa_method": mfa_policy["default_method"],
+        "mfa_verified": mfa_required == RESET_MFA_NONE,
         "recovery_code_verified": False,
-        "no_mfa_user": mfa_required == "none",
+        "no_mfa_user": mfa_required == RESET_MFA_NONE,
         "created_at": _now_timestamp(),
         "failure_count": 0,
     }
@@ -776,9 +845,13 @@ def _transaction_user(transaction: dict[str, Any]) -> User:
 
 
 def _public_transaction(transaction: dict[str, Any]) -> dict[str, Any]:
+    available_methods = _available_reset_mfa_methods_from_transaction(transaction)
     return {
         "message": "Password reset transaction active",
         "mfa_required": transaction["mfa_required"],
+        "available_mfa_methods": available_methods,
+        "preferred_mfa_method": _public_reset_mfa_method(transaction.get("preferred_mfa_method")),
+        "default_mfa_method": _public_reset_mfa_method(transaction.get("default_mfa_method")),
         "mfa_verified": bool(transaction.get("mfa_verified")),
         "recovery_code_verified": bool(transaction.get("recovery_code_verified")),
         "no_mfa_user": bool(transaction.get("no_mfa_user")),
@@ -787,13 +860,96 @@ def _public_transaction(transaction: dict[str, Any]) -> dict[str, Any]:
 
 
 def _mfa_requirement(user: User) -> str:
+    return _reset_mfa_policy(user)["default_method"]
+
+
+def _reset_mfa_policy(user: User) -> dict[str, Any]:
+    available_methods = _available_reset_mfa_methods_for_user(user)
+    preferred_method = _profile_preference_to_reset_method(user.mfa_step_up_preference)
+    if preferred_method not in available_methods:
+        preferred_method = None
+    default_method = preferred_method or _fallback_reset_mfa_method(available_methods)
+    return {
+        "available_methods": available_methods,
+        "preferred_method": preferred_method,
+        "default_method": default_method,
+    }
+
+
+def _available_reset_mfa_methods_for_user(user: User) -> list[str]:
+    methods: list[str] = []
     if user.mfa_enabled:
-        return "totp"
+        methods.append(RESET_MFA_TOTP)
     from app.auth.webauthn_services import webauthn_credential_count
 
     if webauthn_credential_count(user) > 0:
-        return "webauthn"
-    return "none"
+        methods.append(RESET_MFA_WEBAUTHN)
+    return methods
+
+
+def _available_reset_mfa_methods_from_transaction(transaction: dict[str, Any]) -> list[str]:
+    raw_methods = transaction.get("available_mfa_methods")
+    if isinstance(raw_methods, list):
+        methods: list[str] = []
+        for raw_method in raw_methods:
+            method = _public_reset_mfa_method(raw_method)
+            if method in RESET_MFA_METHODS and method not in methods:
+                methods.append(method)
+        return methods
+    required = _public_reset_mfa_method(transaction.get("mfa_required"))
+    return [required] if required in RESET_MFA_METHODS else []
+
+
+def _fallback_reset_mfa_method(available_methods: list[str]) -> str:
+    if RESET_MFA_WEBAUTHN in available_methods:
+        return RESET_MFA_WEBAUTHN
+    if RESET_MFA_TOTP in available_methods:
+        return RESET_MFA_TOTP
+    return RESET_MFA_NONE
+
+
+def _profile_preference_to_reset_method(value: str | None) -> str | None:
+    normalized = str(value or "").strip().casefold()
+    return RESET_MFA_METHOD_ALIASES.get(normalized)
+
+
+def _normalize_reset_mfa_method(value: str | None) -> str:
+    normalized = str(value or "").strip().casefold()
+    method = RESET_MFA_METHOD_ALIASES.get(normalized)
+    if method not in RESET_MFA_METHODS:
+        raise AuthError(GENERIC_VERIFICATION_METHOD_ERROR, 400)
+    return method
+
+
+def _public_reset_mfa_method(value: Any) -> str | None:
+    method = _profile_preference_to_reset_method(str(value or ""))
+    return method if method in RESET_MFA_METHODS else None
+
+
+def _require_selected_reset_mfa_method(
+    transaction: dict[str, Any],
+    user: User,
+    required_method: str,
+    *,
+    submitted_factor: str,
+    error_message: str,
+) -> None:
+    selected = _normalize_reset_mfa_method(required_method)
+    available_methods = _available_reset_mfa_methods_for_user(user)
+    transaction["available_mfa_methods"] = available_methods
+    if selected not in available_methods or transaction.get("mfa_required") != selected:
+        _store_transaction(transaction)
+        audit_event(
+            "password_reset_mfa_failed",
+            "failure",
+            user=user,
+            metadata={
+                "reason": "wrong_factor",
+                "submitted_factor": submitted_factor,
+                "required_factor": transaction.get("mfa_required"),
+            },
+        )
+        raise AuthError(error_message, 400)
 
 
 def _find_customer_user(identifier: str) -> User | None:

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -30,6 +30,7 @@ from .password_reset import (
     request_manual_recovery,
     request_password_reset,
     reset_transaction_user_and_id,
+    select_reset_mfa_method,
     verify_reset_totp,
     exchange_reset_token,
 )
@@ -40,6 +41,7 @@ from .schemas import (
     LoginSchema,
     ManualRecoverySchema,
     PasswordChangeSchema,
+    PasswordResetMfaMethodSchema,
     PasswordResetSchema,
     RegisterSchema,
     RegistrationOtpRequestSchema,
@@ -105,6 +107,7 @@ AUTH_MFA_ONBOARDING_ALLOWED_ENDPOINTS = {
     "auth.password_reset_request",
     "auth.password_reset_exchange",
     "auth.password_reset_transaction",
+    "auth.password_reset_mfa_method",
     "auth.password_reset_totp",
     "auth.password_reset_webauthn_options",
     "auth.password_reset_webauthn_verify",
@@ -242,6 +245,14 @@ def password_reset_transaction():
     return jsonify(current_reset_transaction())
 
 
+@auth_bp.post("/password-reset/mfa/method")
+@limiter.limit("5 per 5 minutes", key_func=get_remote_address)
+@limiter.limit("5 per 5 minutes", key_func=mfa_principal)
+def password_reset_mfa_method():
+    data = PasswordResetMfaMethodSchema().load(request.get_json(silent=False) or {})
+    return jsonify(select_reset_mfa_method(data["method"]))
+
+
 @auth_bp.post("/password-reset/mfa/totp")
 @limiter.limit("5 per 5 minutes", key_func=get_remote_address)
 @limiter.limit("5 per 5 minutes", key_func=mfa_principal)
@@ -254,7 +265,7 @@ def password_reset_totp():
 @limiter.limit("5 per 5 minutes", key_func=get_remote_address)
 @limiter.limit("5 per 5 minutes", key_func=mfa_principal)
 def password_reset_webauthn_options():
-    user, transaction_id = reset_transaction_user_and_id()
+    user, transaction_id = reset_transaction_user_and_id(required_method="webauthn")
     return jsonify(begin_password_reset_options(user, transaction_id))
 
 
@@ -262,7 +273,7 @@ def password_reset_webauthn_options():
 @limiter.limit("5 per 5 minutes", key_func=get_remote_address)
 @limiter.limit("5 per 5 minutes", key_func=mfa_principal)
 def password_reset_webauthn_verify():
-    user, transaction_id = reset_transaction_user_and_id()
+    user, transaction_id = reset_transaction_user_and_id(required_method="webauthn")
     data = WebAuthnAuthenticationVerifySchema().load(request.get_json(silent=False) or {})
     return jsonify(verify_password_reset_assertion(user, transaction_id, data["credential"]))
 

--- a/app/auth/schemas.py
+++ b/app/auth/schemas.py
@@ -107,6 +107,13 @@ class AuthenticationCodeSchema(Schema):
     totp_code = fields.Str(required=True, load_only=True, validate=validate.Length(min=1, max=80))
 
 
+class PasswordResetMfaMethodSchema(Schema):
+    method = fields.Str(
+        required=True,
+        validate=validate.OneOf(["totp", "authenticator", "webauthn", "passkey", "security-key", "security_key"]),
+    )
+
+
 class TerminateSessionSchema(Schema):
     session_id = fields.Str(
         required=True,

--- a/app/auth/services.py
+++ b/app/auth/services.py
@@ -106,6 +106,15 @@ def _normalize_step_up_preference(value: str | None) -> str:
     return normalized
 
 
+def _ensure_step_up_preference_enrolled(user: User, preference: str) -> None:
+    if preference == "totp" and not user.mfa_enabled:
+        audit_event("profile_update", "failure", user=user, metadata={"reason": "preferred_mfa_unavailable"})
+        raise AuthError("Choose an enrolled verification method", 400)
+    if preference == "passkey" and enrolled_webauthn_credential_count(user) <= 0:
+        audit_event("profile_update", "failure", user=user, metadata={"reason": "preferred_mfa_unavailable"})
+        raise AuthError("Choose an enrolled verification method", 400)
+
+
 def _client_ip() -> str:
     return request.remote_addr or "unknown"
 
@@ -557,6 +566,7 @@ def update_profile_details(
         return False
 
     ensure_account_not_frozen(user, "profile update")
+    _ensure_step_up_preference_enrolled(user, normalized_preference)
 
     duplicate_user = db.session.execute(
         db.select(User).where(

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1423,6 +1423,32 @@ select:focus {
   width: min(420px, 100%);
 }
 
+.reset-method-list {
+  display: grid;
+  gap: var(--space-4);
+  margin-top: var(--space-5);
+}
+
+.reset-method-option {
+  display: grid;
+  gap: var(--space-4);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: var(--space-4);
+  background: var(--surface-raised);
+}
+
+.reset-method-option.is-selected {
+  border-color: color-mix(in srgb, var(--primary) 45%, var(--line));
+}
+
+.reset-method-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
 .mfa-grid {
   display: grid;
   grid-template-columns: minmax(240px, 1fr) minmax(280px, 390px);

--- a/app/templates/reset_password.html
+++ b/app/templates/reset_password.html
@@ -16,23 +16,78 @@
       <h2>Reset transaction</h2>
     </div>
 
-    {% if transaction.mfa_required == "webauthn" and not transaction.mfa_verified %}
-      <form method="post" action="{{ url_for('auth.password_reset_webauthn_options') }}" data-webauthn-reset-form novalidate>
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-        <button class="button secondary full" type="submit">Verify Security Key</button>
-        <p class="field-error" data-webauthn-reset-error hidden></p>
-      </form>
-    {% elif transaction.mfa_required == "totp" and not transaction.mfa_verified %}
-      <form method="post" action="{{ url_for('web.reset_password_continue_submit') }}" novalidate>
-        {{ totp_form.hidden_tag() }}
-        <input type="hidden" name="action" value="verify_totp">
-        <div class="form-group">
-          <label for="{{ totp_form.totp_code.id }}">Authentication code</label>
-          {{ totp_form.totp_code(autocomplete="one-time-code", maxlength="80") }}
-          {% for error in totp_form.totp_code.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
-        </div>
-        <button class="button full" type="submit">Verify Code</button>
-      </form>
+    {% set available_methods = transaction.available_mfa_methods or [] %}
+    {% set selected_method = transaction.mfa_required %}
+    {% set preferred_method = transaction.preferred_mfa_method %}
+    {% set default_method = transaction.default_mfa_method %}
+
+    {% if not transaction.mfa_verified and selected_method != "none" %}
+      <div class="reset-method-list">
+        {% if "webauthn" in available_methods %}
+          <section class="reset-method-option{% if selected_method == 'webauthn' %} is-selected{% endif %}">
+            <div class="reset-method-heading">
+              <div>
+                <p class="eyebrow">Passkey or security key</p>
+                <h3>Use passkey or security key</h3>
+              </div>
+              {% if preferred_method == "webauthn" %}
+                <span class="badge">Your preferred method</span>
+              {% elif default_method == "webauthn" %}
+                <span class="badge neutral">Default</span>
+              {% endif %}
+            </div>
+            {% if selected_method == "webauthn" %}
+              <form method="post" action="{{ url_for('auth.password_reset_webauthn_options') }}" data-webauthn-reset-form novalidate>
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <button class="button secondary full" type="submit">Verify with passkey</button>
+                <p class="field-error" data-webauthn-reset-error hidden></p>
+              </form>
+            {% else %}
+              <form method="post" action="{{ url_for('web.reset_password_continue_submit') }}" novalidate>
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <input type="hidden" name="action" value="select_mfa_method">
+                <input type="hidden" name="mfa_method" value="webauthn">
+                <button class="button secondary full" type="submit">Use passkey or security key</button>
+              </form>
+            {% endif %}
+          </section>
+        {% endif %}
+
+        {% if "totp" in available_methods %}
+          <section class="reset-method-option{% if selected_method == 'totp' %} is-selected{% endif %}">
+            <div class="reset-method-heading">
+              <div>
+                <p class="eyebrow">Authenticator app</p>
+                <h3>Use authenticator app or recovery code</h3>
+              </div>
+              {% if preferred_method == "totp" %}
+                <span class="badge">Your preferred method</span>
+              {% elif default_method == "totp" %}
+                <span class="badge neutral">Default</span>
+              {% endif %}
+            </div>
+            {% if selected_method == "totp" %}
+              <form method="post" action="{{ url_for('web.reset_password_continue_submit') }}" novalidate>
+                {{ totp_form.hidden_tag() }}
+                <input type="hidden" name="action" value="verify_totp">
+                <div class="form-group">
+                  <label for="{{ totp_form.totp_code.id }}">Authenticator code or recovery code</label>
+                  {{ totp_form.totp_code(autocomplete="one-time-code", maxlength="80") }}
+                  {% for error in totp_form.totp_code.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
+                </div>
+                <button class="button full" type="submit">Verify code</button>
+              </form>
+            {% else %}
+              <form method="post" action="{{ url_for('web.reset_password_continue_submit') }}" novalidate>
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <input type="hidden" name="action" value="select_mfa_method">
+                <input type="hidden" name="mfa_method" value="totp">
+                <button class="button secondary full" type="submit">Use authenticator app</button>
+              </form>
+            {% endif %}
+          </section>
+        {% endif %}
+      </div>
     {% endif %}
 
     {% if transaction.mfa_verified %}

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -36,6 +36,7 @@ from app.auth.password_reset import (
     exchange_reset_token,
     request_manual_recovery,
     request_password_reset,
+    select_reset_mfa_method,
     verify_reset_totp,
 )
 from app.auth.mfa_policy import enrolled_webauthn_credential_count, has_enrolled_mfa_method
@@ -358,6 +359,18 @@ def reset_password_continue_submit():
             flash(exc.message, "error")
             return _render_reset_continue(transaction, status_code=exc.status_code)
         flash("Authentication code verified.", "success")
+        return _render_reset_continue(transaction)
+
+    if action == "select_mfa_method":
+        form = CsrfOnlyForm()
+        if not form.validate_on_submit():
+            return _render_reset_continue(transaction, status_code=400)
+        try:
+            transaction = select_reset_mfa_method(request.form.get("mfa_method", ""))
+        except AuthError as exc:
+            flash(exc.message, "error")
+            return _render_reset_continue(transaction, status_code=exc.status_code)
+        flash("Verification method selected.", "success")
         return _render_reset_continue(transaction)
 
     if action == "complete":

--- a/tests/test_account_security_actions.py
+++ b/tests/test_account_security_actions.py
@@ -335,6 +335,54 @@ def test_profile_email_update_accepts_totp_stepup_without_passkey(client):
     assert response.status_code == 302
     assert user.email == "alice.mfa@example.com"
 
+
+def test_profile_preference_rejects_passkey_when_not_enrolled(client):
+    register(client)
+    login(client)
+    user, secret = enable_mfa_for_user()
+    mark_recent_mfa(client, user)
+
+    response = client.post(
+        "/profile",
+        data={
+            "username": "alice01",
+            "email": "alice@sit.singaporetech.edu.sg",
+            "mfa_step_up_preference": "passkey",
+            "totp_code": pyotp.TOTP(secret, digits=6, interval=30).now(),
+        },
+    )
+    db.session.refresh(user)
+
+    assert response.status_code == 400
+    assert user.mfa_step_up_preference == "totp"
+    assert b"Choose an enrolled verification method" in response.data
+
+
+def test_profile_preference_rejects_totp_when_not_enrolled(client):
+    register(client)
+    login(client)
+    user = db.session.execute(db.select(User).where(User.username == "alice01")).scalar_one()
+    add_security_keys_for_user(user)
+    user.mfa_step_up_preference = "passkey"
+    db.session.commit()
+
+    response = client.post(
+        "/profile",
+        data={
+            "username": "alice01",
+            "email": "alice.passkey@example.com",
+            "mfa_step_up_preference": "totp",
+            "stepup_token": mint_stepup_token(client, user, "profile_update"),
+        },
+    )
+    db.session.refresh(user)
+
+    assert response.status_code == 400
+    assert user.email == "alice@sit.singaporetech.edu.sg"
+    assert user.mfa_step_up_preference == "passkey"
+    assert b"Choose an enrolled verification method" in response.data
+
+
 def test_profile_update_rejects_invalid_email(client):
     register(client)
     login(client)

--- a/tests/test_password_reset.py
+++ b/tests/test_password_reset.py
@@ -452,6 +452,155 @@ def test_totp_recovery_code_still_works_when_passkey_is_registered(app, client):
         assert codes[0] not in audit_text
 
 
+def test_password_reset_totp_only_ui_shows_authenticator_recovery_code_method(app, client):
+    with app.app_context():
+        _user, _secret = _create_totp_user("resettotponly", "resettotponly@example.com")
+
+    _request_reset(client, "resettotponly@example.com")
+    token = _reset_token(app)
+    exchanged = _exchange(client, token)
+    page = client.get("/reset-password/continue")
+    markup = page.get_data(as_text=True)
+
+    assert exchanged.status_code == 200
+    assert exchanged.get_json()["mfa_required"] == "totp"
+    assert exchanged.get_json()["available_mfa_methods"] == ["totp"]
+    assert "Authenticator code or recovery code" in markup
+    assert "Verify with passkey" not in markup
+    assert "Use passkey or security key" not in markup
+
+
+def test_password_reset_passkey_only_ui_shows_passkey_method(app, client):
+    with app.app_context():
+        user = _create_user("resetpasskeyonly", "resetpasskeyonly@example.com")
+        _add_webauthn_credential(user)
+
+    _request_reset(client, "resetpasskeyonly@example.com")
+    token = _reset_token(app)
+    exchanged = _exchange(client, token)
+    page = client.get("/reset-password/continue")
+    markup = page.get_data(as_text=True)
+
+    assert exchanged.status_code == 200
+    assert exchanged.get_json()["mfa_required"] == "webauthn"
+    assert exchanged.get_json()["available_mfa_methods"] == ["webauthn"]
+    assert "Verify with passkey" in markup
+    assert "Authenticator code or recovery code" not in markup
+
+
+@pytest.mark.parametrize(
+    ("preference", "expected_method", "expected_button"),
+    [
+        ("totp", "totp", "Use passkey or security key"),
+        ("passkey", "webauthn", "Use authenticator app"),
+    ],
+)
+def test_password_reset_defaults_to_profile_preferred_method_for_dual_mfa_user(
+    app,
+    client,
+    preference,
+    expected_method,
+    expected_button,
+):
+    with app.app_context():
+        user, _secret = _create_totp_user(f"resetpref{preference}", f"resetpref{preference}@example.com")
+        user.mfa_step_up_preference = preference
+        _add_webauthn_credential(user)
+        db.session.commit()
+
+    _request_reset(client, f"resetpref{preference}@example.com")
+    token = _reset_token(app)
+    exchanged = _exchange(client, token)
+    page = client.get("/reset-password/continue")
+    markup = page.get_data(as_text=True)
+
+    payload = exchanged.get_json()
+    assert payload["mfa_required"] == expected_method
+    assert payload["available_mfa_methods"] == ["totp", "webauthn"]
+    assert payload["preferred_mfa_method"] == expected_method
+    assert payload["default_mfa_method"] == expected_method
+    assert "Your preferred method" in markup
+    assert expected_button in markup
+
+
+def test_password_reset_dual_mfa_user_can_switch_to_totp_before_verifying(app, client):
+    with app.app_context():
+        user, secret = _create_totp_user("resetswitch", "resetswitch@example.com")
+        user.mfa_step_up_preference = "passkey"
+        _add_webauthn_credential(user)
+        db.session.commit()
+
+    _request_reset(client, "resetswitch@example.com")
+    token = _reset_token(app)
+    exchanged = _exchange(client, token)
+    blocked_totp = client.post(
+        "/auth/password-reset/mfa/totp",
+        json={"totp_code": pyotp.TOTP(secret).now()},
+    )
+    selected = client.post("/auth/password-reset/mfa/method", json={"method": "totp"})
+    verified = client.post(
+        "/auth/password-reset/mfa/totp",
+        json={"totp_code": pyotp.TOTP(secret).now()},
+    )
+
+    assert exchanged.get_json()["mfa_required"] == "webauthn"
+    assert blocked_totp.status_code == 400
+    assert blocked_totp.get_json() == {"error": "Invalid authentication code."}
+    assert selected.status_code == 200
+    assert selected.get_json()["mfa_required"] == "totp"
+    assert verified.status_code == 200
+    assert verified.get_json()["mfa_verified"] is True
+
+
+def test_recovery_code_cannot_satisfy_passkey_selected_password_reset(app, client):
+    with app.app_context():
+        user, _secret = _create_totp_user("resetwrongfactor", "resetwrongfactor@example.com")
+        user.mfa_step_up_preference = "passkey"
+        _add_webauthn_credential(user)
+        with app.test_request_context("/"):
+            codes = generate_recovery_codes_for_user(user, count=1)
+        db.session.commit()
+
+    _request_reset(client, "resetwrongfactor@example.com")
+    token = _reset_token(app)
+    exchanged = _exchange(client, token)
+    recovery_attempt = client.post("/auth/password-reset/mfa/totp", json={"totp_code": codes[0]})
+    transaction = client.get("/auth/password-reset/transaction")
+
+    assert exchanged.get_json()["mfa_required"] == "webauthn"
+    assert recovery_attempt.status_code == 400
+    assert recovery_attempt.get_json() == {"error": "Invalid authentication code."}
+    assert transaction.get_json()["mfa_verified"] is False
+    with app.app_context():
+        recovery_record = db.session.execute(db.select(RecoveryCode)).scalar_one()
+        assert recovery_record.used_at is None
+
+
+def test_webauthn_options_cannot_satisfy_totp_selected_password_reset(app, client):
+    with app.app_context():
+        user, _secret = _create_totp_user("resetwebauthnblocked", "resetwebauthnblocked@example.com")
+        user.mfa_step_up_preference = "totp"
+        _add_webauthn_credential(user, credential_id=b"blocked-default-passkey")
+        db.session.commit()
+
+    _request_reset(client, "resetwebauthnblocked@example.com")
+    token = _reset_token(app)
+    exchanged = _exchange(client, token)
+    blocked_options = client.post("/auth/password-reset/mfa/webauthn/options", json={}, headers=ORIGIN)
+    selected = client.post("/auth/password-reset/mfa/method", json={"method": "passkey"})
+    allowed_options = client.post("/auth/password-reset/mfa/webauthn/options", json={}, headers=ORIGIN)
+
+    assert exchanged.get_json()["mfa_required"] == "totp"
+    assert blocked_options.status_code == 400
+    assert blocked_options.get_json() == {"error": "Security key verification failed"}
+    assert selected.status_code == 200
+    assert selected.get_json()["mfa_required"] == "webauthn"
+    assert allowed_options.status_code == 200
+    assert {item["id"] for item in allowed_options.get_json()["allowCredentials"]} == {
+        bytes_to_base64url(b"blocked-default-passkey")
+    }
+
+
 def test_admin_like_customer_domain_reset_fails_closed(app, client):
     with app.app_context():
         _create_user("admin", "admin@example.com")

--- a/tests/test_route_inventory_security.py
+++ b/tests/test_route_inventory_security.py
@@ -168,6 +168,17 @@ ROUTE_SECURITY_INVENTORY = {
         "step_up": "reset_mfa",
         "public_justification": "Reset transaction status is scoped to the tokenless reset cookie state.",
     },
+    "auth.password_reset_mfa_method": {
+        "endpoint": "auth.password_reset_mfa_method",
+        "rule": "/auth/password-reset/mfa/method",
+        "methods": {"POST"},
+        "access": "public",
+        "classification": "mfa",
+        "csrf": "required",
+        "rate_limit": "per_route",
+        "step_up": "reset_mfa",
+        "public_justification": "Reset MFA method selection is bound to the tokenless reset transaction before login.",
+    },
     "auth.password_reset_totp": {
         "endpoint": "auth.password_reset_totp",
         "rule": "/auth/password-reset/mfa/totp",


### PR DESCRIPTION
## Summary

Respect the user's preferred MFA method during password-reset verification and replace the old single-factor reset screen with explicit enrolled-method selection.

## Why

Users with both authenticator MFA and passkeys/security keys were forced into the TOTP-first reset flow, even when their profile preference was passkey-first. This made the reset UX confusing and risked wrong-factor handling around recovery codes and WebAuthn.

## What changed

* Added password-reset MFA method policy that derives enrolled methods, honors valid profile preference, and falls back deterministically.
* Added server-side reset MFA method selection and WebAuthn/TOTP wrong-factor enforcement.
* Updated the reset UI to show only enrolled methods with separate passkey and authenticator/recovery-code sections.
* Added profile preference validation so users cannot prefer an unenrolled method.
* Added regression tests for method defaults, switching, wrong-factor rejection, and route inventory.

## Security impact

This strengthens password-reset MFA enforcement. Recovery codes remain TOTP fallback only and cannot satisfy passkey-selected reset verification. WebAuthn reset options are only available when passkey/security-key reset mode is selected. The change does not add secrets, weaken admin reset behavior, or introduce new external dependencies.

## Deployment impact

This PR requires:

* no EC2 bootstrap
* staging deployment after merge for runtime rollout
* production deployment after staging verification
* no database migration
* no secret changes

## Verification

* `python -m pytest tests/test_password_reset.py -q` -> 30 passed
* `python -m pytest tests/test_account_security_actions.py -q` -> 29 passed
* `python -m pytest tests/test_account_security_actions.py::test_profile_preference_rejects_passkey_when_not_enrolled tests/test_account_security_actions.py::test_profile_preference_rejects_totp_when_not_enrolled tests/test_route_inventory_security.py -q` -> 5 passed
* `git diff --check` -> clean

## Notes

No operator action is required beyond the normal application deployment path. The first combined focused pytest command hit the local 120s timeout, so the same coverage was rerun in split commands and passed.