### PR TITLE
Add secure two-step registration flow

### DIFF
--- a/app/auth/forms.py
+++ b/app/auth/forms.py
@@ -6,7 +6,7 @@ from wtforms.validators import Email, EqualTo, InputRequired, Length, Optional, 
 
 from app.security.passwords import PASSWORD_MIN_LENGTH, password_max_chars
 
-from .schemas import PHONE_RE, REGISTRATION_OTP_RE, STEP_UP_TOKEN_RE, TOTP_RE, USERNAME_RE
+from .schemas import FULL_NAME_RE, PHONE_RE, REGISTRATION_OTP_RE, STEP_UP_TOKEN_RE, TOTP_RE, USERNAME_RE
 
 
 def password_length(*, minimum: int | None = None):
@@ -30,7 +30,14 @@ class RegisterForm(FlaskForm):
             Regexp(USERNAME_RE, message="Username contains invalid characters"),
         ],
     )
-    full_name = StringField("Full name", validators=[InputRequired(), Length(min=1, max=120)])
+    full_name = StringField(
+        "Full name",
+        validators=[
+            InputRequired(),
+            Length(min=1, max=120),
+            Regexp(FULL_NAME_RE, message="Full name contains invalid characters"),
+        ],
+    )
     phone_number = StringField(
         "Phone number",
         validators=[
@@ -50,8 +57,53 @@ class RegisterForm(FlaskForm):
     )
 
 
+class RegisterDetailsForm(FlaskForm):
+    username = StringField(
+        "Username",
+        validators=[
+            InputRequired(),
+            Length(min=3, max=64),
+            Regexp(USERNAME_RE, message="Username contains invalid characters"),
+        ],
+    )
+    full_name = StringField(
+        "Full name",
+        validators=[
+            InputRequired(),
+            Length(min=1, max=120),
+            Regexp(FULL_NAME_RE, message="Full name contains invalid characters"),
+        ],
+    )
+    phone_number = StringField(
+        "Phone number",
+        validators=[
+            InputRequired(),
+            Regexp(PHONE_RE, message="Enter a valid Singapore phone number (8 digits starting with 8 or 9)"),
+        ],
+    )
+    password = PasswordField("Password", validators=[InputRequired(), password_length(minimum=PASSWORD_MIN_LENGTH)])
+    confirm_password = PasswordField(
+        "Confirm password",
+        validators=[
+            InputRequired(),
+            password_length(),
+            EqualTo("password", message="Passwords must match"),
+        ],
+    )
+
+
 class RegistrationOtpRequestForm(FlaskForm):
     email = StringField("SIT email", validators=[InputRequired(), Email(), Length(max=255)])
+
+
+class RegistrationOtpCodeForm(FlaskForm):
+    otp_code = StringField(
+        "Verification code",
+        validators=[
+            InputRequired(),
+            Regexp(REGISTRATION_OTP_RE, message="Verification code must be exactly 6 digits"),
+        ],
+    )
 
 
 class RegistrationOtpVerifyForm(FlaskForm):

--- a/app/auth/registration_otp.py
+++ b/app/auth/registration_otp.py
@@ -28,6 +28,7 @@ REGISTRATION_OTP_TTL_SECONDS = 5 * 60
 REGISTRATION_OTP_RESEND_COOLDOWN_SECONDS = 60
 REGISTRATION_OTP_MAX_ATTEMPTS = 5
 REGISTRATION_OTP_SESSION_BINDING_KEY = "registration_otp_session_ref"
+REGISTRATION_OTP_PENDING_EMAIL_KEY = "registration_otp_pending_email"
 REGISTRATION_OTP_VERIFIED_EMAIL_KEY = "registration_otp_verified_email"
 REGISTRATION_OTP_VERIFIED_AT_KEY = "registration_otp_verified_at"
 
@@ -69,7 +70,6 @@ def request_registration_otp(email: str) -> dict[str, str]:
             user=existing_user,
             metadata={"email_ref": email_ref, "eligible": False},
         )
-        _clear_verified_email(normalized_email)
         return {"message": GENERIC_OTP_SENT_MESSAGE}
 
     key = _otp_cache_key(normalized_email, create_session_binding=True)
@@ -91,6 +91,7 @@ def request_registration_otp(email: str) -> dict[str, str]:
             )
 
     otp_code = f"{secrets.randbelow(1_000_000):06d}"
+    _clear_registration_progress_state()
     payload = {
         "email": normalized_email,
         "otp_hmac": _otp_hmac(normalized_email, otp_code),
@@ -98,7 +99,6 @@ def request_registration_otp(email: str) -> dict[str, str]:
         "issued_at": now,
     }
     _redis().set(key, json.dumps(payload, separators=(",", ":"), sort_keys=True), ex=REGISTRATION_OTP_TTL_SECONDS)
-    _clear_verified_email(normalized_email)
     try:
         send_security_email(
             normalized_email,
@@ -111,6 +111,7 @@ def request_registration_otp(email: str) -> dict[str, str]:
         )
     except Exception as exc:
         _redis().delete(key)
+        _clear_registration_progress_state()
         audit_event(
             "registration_otp",
             "failed",
@@ -119,6 +120,7 @@ def request_registration_otp(email: str) -> dict[str, str]:
         raise RegistrationOtpError("Could not send verification code. Please try again later.", 503) from exc
 
     audit_event("registration_otp", "requested", metadata={"email_ref": email_ref, "eligible": True})
+    session[REGISTRATION_OTP_PENDING_EMAIL_KEY] = normalized_email
     return {"message": GENERIC_OTP_SENT_MESSAGE}
 
 
@@ -164,19 +166,38 @@ def verify_registration_otp(email: str, otp_code: str) -> dict[str, str]:
     _redis().delete(key)
     session[REGISTRATION_OTP_VERIFIED_EMAIL_KEY] = normalized_email
     session[REGISTRATION_OTP_VERIFIED_AT_KEY] = int(time.time())
+    session.pop(REGISTRATION_OTP_PENDING_EMAIL_KEY, None)
     audit_event("registration_otp", "verified", metadata={"email_ref": email_ref})
     return {"message": "Email verified. Complete registration to create your account."}
 
 
-def require_verified_registration_email(email: str) -> str:
-    normalized_email = normalize_registration_email(email)
+def pending_registration_email() -> str | None:
+    pending_email = normalize_registration_email(str(session.get(REGISTRATION_OTP_PENDING_EMAIL_KEY) or ""))
+    return pending_email or None
+
+
+def current_verified_registration_email() -> str | None:
     verified_email = normalize_registration_email(str(session.get(REGISTRATION_OTP_VERIFIED_EMAIL_KEY) or ""))
     verified_at = int(session.get(REGISTRATION_OTP_VERIFIED_AT_KEY) or 0)
-    if (
-        not verified_email
-        or verified_email != normalized_email
-        or int(time.time()) - verified_at > REGISTRATION_OTP_TTL_SECONDS
-    ):
+    if not verified_email or int(time.time()) - verified_at > REGISTRATION_OTP_TTL_SECONDS:
+        if verified_email:
+            _clear_registration_session_state()
+        return None
+    return verified_email
+
+
+def require_current_verified_registration_email() -> str:
+    verified_email = current_verified_registration_email()
+    if not verified_email:
+        audit_event("registration", "failure", metadata={"reason": "email_otp_required"})
+        raise RegistrationOtpError("Verify your SIT email before creating an account.", 400)
+    return verified_email
+
+
+def require_verified_registration_email(email: str) -> str:
+    normalized_email = normalize_registration_email(email)
+    verified_email = current_verified_registration_email()
+    if not verified_email or verified_email != normalized_email:
         audit_event(
             "registration",
             "failure",
@@ -192,9 +213,7 @@ def require_verified_registration_email(email: str) -> str:
 def consume_verified_registration_email(email: str) -> None:
     normalized_email = normalize_registration_email(email)
     if normalize_registration_email(str(session.get(REGISTRATION_OTP_VERIFIED_EMAIL_KEY) or "")) == normalized_email:
-        session.pop(REGISTRATION_OTP_VERIFIED_EMAIL_KEY, None)
-        session.pop(REGISTRATION_OTP_VERIFIED_AT_KEY, None)
-        session.pop(REGISTRATION_OTP_SESSION_BINDING_KEY, None)
+        _clear_registration_session_state()
 
 
 def _redis():
@@ -243,10 +262,15 @@ def _remaining_ttl(key: str) -> int:
     return ttl if ttl > 0 else REGISTRATION_OTP_TTL_SECONDS
 
 
-def _clear_verified_email(email: str) -> None:
-    if normalize_registration_email(str(session.get(REGISTRATION_OTP_VERIFIED_EMAIL_KEY) or "")) == normalize_registration_email(email):
-        session.pop(REGISTRATION_OTP_VERIFIED_EMAIL_KEY, None)
-        session.pop(REGISTRATION_OTP_VERIFIED_AT_KEY, None)
+def _clear_registration_session_state() -> None:
+    _clear_registration_progress_state()
+    session.pop(REGISTRATION_OTP_SESSION_BINDING_KEY, None)
+
+
+def _clear_registration_progress_state() -> None:
+    session.pop(REGISTRATION_OTP_PENDING_EMAIL_KEY, None)
+    session.pop(REGISTRATION_OTP_VERIFIED_EMAIL_KEY, None)
+    session.pop(REGISTRATION_OTP_VERIFIED_AT_KEY, None)
 
 
 def _user_by_email(email: str) -> User | None:

--- a/app/auth/schemas.py
+++ b/app/auth/schemas.py
@@ -6,6 +6,7 @@ from app.security.passwords import PASSWORD_MIN_LENGTH, password_max_chars
 
 
 USERNAME_RE = r"^[A-Za-z0-9_.-]{3,64}$"
+FULL_NAME_RE = r"^[^\x00-\x1f\x7f<>]+$"
 PHONE_RE = r"^[89][0-9]{7}$"
 TOTP_RE = r"^[0-9]{6}$"
 SESSION_REFERENCE_RE = r"^[A-Fa-f0-9]{32}$"
@@ -38,7 +39,13 @@ class RegisterSchema(Schema):
             validate.Regexp(USERNAME_RE, error="Username contains invalid characters"),
         ],
     )
-    full_name = fields.Str(required=True, validate=validate.Length(min=1, max=120))
+    full_name = fields.Str(
+        required=True,
+        validate=[
+            validate.Length(min=1, max=120),
+            validate.Regexp(FULL_NAME_RE, error="Full name contains invalid characters"),
+        ],
+    )
     phone_number = fields.Str(
         required=True,
         validate=validate.Regexp(PHONE_RE, error="Enter a valid Singapore phone number (8 digits starting with 8 or 9)"),

--- a/app/auth/services.py
+++ b/app/auth/services.py
@@ -23,6 +23,7 @@ from app.models import User
 from app.auth.registration_otp import (
     RegistrationOtpError,
     consume_verified_registration_email,
+    require_current_verified_registration_email,
     require_verified_registration_email,
 )
 from app.auth.mfa_policy import (
@@ -203,7 +204,11 @@ def _generate_account_number() -> str:
 
 def register_user(data: dict[str, Any]) -> tuple[User, list[str]]:
     try:
-        normalized_email = require_verified_registration_email(data["email"])
+        normalized_email = (
+            require_verified_registration_email(data["email"])
+            if data.get("email")
+            else require_current_verified_registration_email()
+        )
     except RegistrationOtpError as exc:
         raise AuthError(str(exc), exc.status_code) from exc
 

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -22,36 +22,18 @@
       <h2>Create account</h2>
     </div>
 
+    {% if step == "details" %}
     <div class="stacked-panel">
       <div class="page-heading compact">
-        <p class="eyebrow">Email verification</p>
-        <h3>Verify your SIT email</h3>
+        <p class="eyebrow">Step 2 of 2</p>
+        <h3>Complete your account</h3>
       </div>
-      <form method="post" action="{{ url_for('web.register_otp_request') }}" novalidate>
-        {{ otp_request_form.hidden_tag() }}
-        <div class="form-group">
-          <label for="otp_request_email">SIT email</label>
-          {{ otp_request_form.email(id="otp_request_email", autocomplete="email", maxlength="255", placeholder="name@sit.singaporetech.edu.sg") }}
-          {% for error in otp_request_form.email.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
+      <dl class="detail-list">
+        <div>
+          <dt>Verified email</dt>
+          <dd>{{ verified_email }}</dd>
         </div>
-        <button class="button secondary full" type="submit">Send verification code</button>
-      </form>
-
-      <form method="post" action="{{ url_for('web.register_otp_verify') }}" novalidate>
-        {{ otp_verify_form.hidden_tag() }}
-        <div class="form-group">
-          <label for="otp_verify_email">SIT email</label>
-          {{ otp_verify_form.email(id="otp_verify_email", autocomplete="email", maxlength="255", placeholder="name@sit.singaporetech.edu.sg") }}
-          {% for error in otp_verify_form.email.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
-        </div>
-        <div class="form-group">
-          <label for="otp_code">Verification code</label>
-          {{ otp_verify_form.otp_code(id="otp_code", inputmode="numeric", autocomplete="one-time-code", maxlength="6") }}
-          {% for error in otp_verify_form.otp_code.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
-          <p class="hint">Codes expire after 5 minutes. Requesting a new code invalidates the previous one.</p>
-        </div>
-        <button class="button secondary full" type="submit">Verify email</button>
-      </form>
+      </dl>
     </div>
 
     <form method="post" action="{{ url_for('web.register_submit') }}" novalidate>
@@ -77,12 +59,6 @@
       </div>
 
       <div class="form-group">
-        <label for="{{ form.email.id }}">Email</label>
-        {{ form.email(autocomplete="email", maxlength="255", placeholder="name@sit.singaporetech.edu.sg") }}
-        {% for error in form.email.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
-      </div>
-
-      <div class="form-group">
         <label for="{{ form.password.id }}">Password</label>
         <div class="password-input-wrap">
           {{ form.password(autocomplete="new-password", minlength=config["PASSWORD_MIN_LENGTH"], data_password_strength_input="registration-password") }}
@@ -105,6 +81,34 @@
       <p class="hint">Common passwords are rejected server-side.</p>
       <button class="button full" type="submit">Register account</button>
     </form>
+    {% else %}
+    <div class="stacked-panel">
+      <div class="page-heading compact">
+        <p class="eyebrow">Step 1 of 2</p>
+        <h3>Verify your SIT email</h3>
+      </div>
+      <form method="post" action="{{ url_for('web.register_otp_request') }}" novalidate>
+        {{ otp_request_form.hidden_tag() }}
+        <div class="form-group">
+          <label for="otp_request_email">SIT email</label>
+          {{ otp_request_form.email(id="otp_request_email", autocomplete="email", maxlength="255", placeholder="name@sit.singaporetech.edu.sg") }}
+          {% for error in otp_request_form.email.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
+        </div>
+        <button class="button secondary full" type="submit">Send verification code</button>
+      </form>
+
+      <form method="post" action="{{ url_for('web.register_otp_verify') }}" novalidate>
+        {{ otp_verify_form.hidden_tag() }}
+        <div class="form-group">
+          <label for="otp_code">Verification code</label>
+          {{ otp_verify_form.otp_code(id="otp_code", inputmode="numeric", autocomplete="one-time-code", maxlength="6") }}
+          {% for error in otp_verify_form.otp_code.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
+          <p class="hint">Codes expire after 5 minutes. Requesting a new code invalidates the previous one.</p>
+        </div>
+        <button class="button secondary full" type="submit">Verify email</button>
+      </form>
+    </div>
+    {% endif %}
     <p class="switch-link">Already registered? <a href="{{ url_for('web.login') }}">Login</a>.</p>
   </div>
 </section>

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -25,9 +25,9 @@ from app.auth.forms import (
     PasswordChangeForm,
     PasswordResetForm,
     ProfileForm,
-    RegisterForm,
+    RegisterDetailsForm,
+    RegistrationOtpCodeForm,
     RegistrationOtpRequestForm,
-    RegistrationOtpVerifyForm,
     TotpForm,
 )
 from app.auth.password_reset import (
@@ -41,7 +41,10 @@ from app.auth.password_reset import (
 )
 from app.auth.mfa_policy import enrolled_webauthn_credential_count, has_enrolled_mfa_method
 from app.auth.registration_otp import (
+    GENERIC_OTP_ERROR,
     RegistrationOtpError,
+    current_verified_registration_email,
+    pending_registration_email,
     request_registration_otp,
     verify_registration_otp,
 )
@@ -161,7 +164,10 @@ def prevent_sensitive_page_caching(response):
 def register_form():
     if getattr(g, "current_user", None) is not None:
         return redirect(url_for("web.dashboard"))
-    return _render_register_form(RegisterForm())
+    verified_email = current_verified_registration_email()
+    if verified_email:
+        return _render_register_details_form(RegisterDetailsForm(), verified_email=verified_email)
+    return _render_register_email_form()
 
 
 @web_bp.post("/register/otp/request")
@@ -171,17 +177,15 @@ def register_otp_request():
     if getattr(g, "current_user", None) is not None:
         return redirect(url_for("web.dashboard"))
     form = RegistrationOtpRequestForm()
-    register_form = RegisterForm()
     if not form.validate_on_submit():
-        return _render_register_form(register_form, otp_request_form=form), 400
+        return _render_register_email_form(otp_request_form=form), 400
     try:
         result = request_registration_otp(form.email.data)
     except RegistrationOtpError as exc:
         flash(exc.message, "error")
-        return _render_register_form(register_form, otp_request_form=form), exc.status_code
-    register_form.email.data = form.email.data
+        return _render_register_email_form(otp_request_form=form), exc.status_code
     flash(result["message"], "info")
-    return _render_register_form(register_form, otp_request_form=form)
+    return _render_register_email_form(otp_request_form=form)
 
 
 @web_bp.post("/register/otp/verify")
@@ -190,18 +194,23 @@ def register_otp_request():
 def register_otp_verify():
     if getattr(g, "current_user", None) is not None:
         return redirect(url_for("web.dashboard"))
-    form = RegistrationOtpVerifyForm()
-    register_form = RegisterForm()
+    form = RegistrationOtpCodeForm()
+    request_form = RegistrationOtpRequestForm()
+    pending_email = pending_registration_email()
+    if pending_email:
+        request_form.email.data = pending_email
     if not form.validate_on_submit():
-        return _render_register_form(register_form, otp_verify_form=form), 400
+        return _render_register_email_form(otp_request_form=request_form, otp_verify_form=form), 400
+    if not pending_email:
+        flash(GENERIC_OTP_ERROR, "error")
+        return _render_register_email_form(otp_verify_form=form), 400
     try:
-        result = verify_registration_otp(form.email.data, form.otp_code.data)
+        result = verify_registration_otp(pending_email, form.otp_code.data)
     except RegistrationOtpError as exc:
         flash(exc.message, "error")
-        return _render_register_form(register_form, otp_verify_form=form), exc.status_code
-    register_form.email.data = form.email.data
+        return _render_register_email_form(otp_request_form=request_form, otp_verify_form=form), exc.status_code
     flash(result["message"], "success")
-    return _render_register_form(register_form, otp_verify_form=form)
+    return redirect(url_for("web.register_form"))
 
 
 @web_bp.post("/register")
@@ -211,9 +220,14 @@ def register_submit():
     if getattr(g, "current_user", None) is not None:
         return redirect(url_for("web.dashboard"))
 
-    form = RegisterForm()
+    verified_email = current_verified_registration_email()
+    if not verified_email:
+        flash("Verify your SIT email before creating an account.", "error")
+        return _render_register_email_form(), 400
+
+    form = RegisterDetailsForm()
     if not form.validate_on_submit():
-        return _render_register_form(form), 400
+        return _render_register_details_form(form, verified_email=verified_email), 400
 
     try:
         _user, warnings = register_user(
@@ -221,14 +235,16 @@ def register_submit():
                 "username": form.username.data,
                 "full_name": form.full_name.data,
                 "phone_number": form.phone_number.data,
-                "email": form.email.data,
                 "password": form.password.data,
                 "confirm_password": form.confirm_password.data,
             }
         )
     except AuthError as exc:
         flash(exc.message, "error")
-        return _render_register_form(form), exc.status_code
+        verified_email = current_verified_registration_email()
+        if verified_email:
+            return _render_register_details_form(form, verified_email=verified_email), exc.status_code
+        return _render_register_email_form(), exc.status_code
 
     for warning in warnings:
         flash(warning, "warning")
@@ -236,17 +252,36 @@ def register_submit():
     return redirect(url_for("web.login"))
 
 
-def _render_register_form(
-    form: RegisterForm,
+def _render_register_email_form(
     *,
     otp_request_form: RegistrationOtpRequestForm | None = None,
-    otp_verify_form: RegistrationOtpVerifyForm | None = None,
+    otp_verify_form: RegistrationOtpCodeForm | None = None,
+):
+    request_form = otp_request_form or RegistrationOtpRequestForm()
+    if not request_form.email.data:
+        request_form.email.data = pending_registration_email()
+    return render_template(
+        "register.html",
+        step="email",
+        form=None,
+        verified_email=None,
+        otp_request_form=request_form,
+        otp_verify_form=otp_verify_form or RegistrationOtpCodeForm(),
+    )
+
+
+def _render_register_details_form(
+    form: RegisterDetailsForm,
+    *,
+    verified_email: str,
 ):
     return render_template(
         "register.html",
+        step="details",
         form=form,
-        otp_request_form=otp_request_form or RegistrationOtpRequestForm(),
-        otp_verify_form=otp_verify_form or RegistrationOtpVerifyForm(),
+        verified_email=verified_email,
+        otp_request_form=None,
+        otp_verify_form=None,
     )
 
 

--- a/tests/test_auth_registration_login.py
+++ b/tests/test_auth_registration_login.py
@@ -54,6 +54,82 @@ def test_register_requires_verified_sit_email(client):
     assert db.session.query(User).count() == 0
 
 
+def test_registration_step_one_has_single_email_input(client):
+    response = client.get("/register")
+    html = response.data.decode("utf-8")
+
+    assert response.status_code == 200
+    assert "Step 1 of 2" in html
+    assert html.count('name="email"') == 1
+    assert "Step 2 of 2" not in html
+    assert "data-password-strength" not in html
+
+
+def test_registration_step_two_uses_verified_email_text_not_input(client):
+    verify_registration_email(client, "verified@sit.singaporetech.edu.sg")
+
+    response = client.get("/register")
+    html = response.data.decode("utf-8")
+
+    assert response.status_code == 200
+    assert "Step 2 of 2" in html
+    assert "Verified email" in html
+    assert "verified@sit.singaporetech.edu.sg" in html
+    assert 'name="email"' not in html
+    assert "data-password-strength" in html
+
+
+def test_registration_ignores_forged_step_two_email_field(client):
+    verify_registration_email(client, "verified@sit.singaporetech.edu.sg")
+
+    response = client.post(
+        "/register",
+        data={
+            "username": "verified01",
+            "email": "attacker@sit.singaporetech.edu.sg",
+            "email_verified": "true",
+            "full_name": "Verified User",
+            "phone_number": "91234567",
+            "password": "correct horse battery staple",
+            "confirm_password": "correct horse battery staple",
+        },
+    )
+    user = db.session.execute(db.select(User).where(User.username == "verified01")).scalar_one()
+
+    assert response.status_code == 302
+    assert user.email == "verified@sit.singaporetech.edu.sg"
+
+
+def test_registration_consumes_verified_email_after_success(client):
+    verify_registration_email(client, "consume@sit.singaporetech.edu.sg")
+
+    created = client.post(
+        "/register",
+        data={
+            "username": "consume01",
+            "full_name": "Consume User",
+            "phone_number": "91234567",
+            "password": "correct horse battery staple",
+            "confirm_password": "correct horse battery staple",
+        },
+    )
+    reused = client.post(
+        "/register",
+        data={
+            "username": "consume02",
+            "full_name": "Consume User Two",
+            "phone_number": "91234568",
+            "password": "correct horse battery staple",
+            "confirm_password": "correct horse battery staple",
+        },
+    )
+
+    assert created.status_code == 302
+    assert reused.status_code == 400
+    assert b"Verify your SIT email before creating an account" in reused.data
+    assert db.session.query(User).count() == 1
+
+
 def test_registration_otp_rejects_non_sit_email_domain(client):
     response = client.post("/auth/register/otp/request", json={"email": "alice@example.com"})
 
@@ -248,6 +324,7 @@ def test_long_unicode_password_can_register_login_and_change(client, monkeypatch
     assert verify_password(new_password, user.password_hash)
 
 def test_password_templates_do_not_truncate_and_show_max_length_guidance(client):
+    verify_registration_email(client, "template@sit.singaporetech.edu.sg")
     register_response = client.get("/register")
     login_response = client.get("/login")
     register(client)
@@ -379,6 +456,7 @@ def test_oversized_api_login_password_fails_generically(client):
     assert response.get_json() == {"error": "Invalid username or password"}
 
 def test_registration_requires_matching_confirm_password(client):
+    verify_registration_email(client)
     response = client.post(
         "/register",
         data={
@@ -395,6 +473,7 @@ def test_registration_requires_matching_confirm_password(client):
     assert db.session.query(User).count() == 0
 
 def test_registration_requires_full_name_and_valid_phone_number(client):
+    verify_registration_email(client)
     missing_name = client.post(
         "/register",
         data={
@@ -421,6 +500,26 @@ def test_registration_requires_full_name_and_valid_phone_number(client):
     assert invalid_phone.status_code == 400
     assert b"Enter a valid Singapore phone number" in invalid_phone.data
     assert db.session.query(User).count() == 0
+
+
+def test_registration_rejects_unsafe_full_name(client):
+    verify_registration_email(client)
+
+    response = client.post(
+        "/register",
+        data={
+            "username": "alice01",
+            "full_name": "<script>alert(1)</script>",
+            "phone_number": "91234567",
+            "password": "correct horse battery staple",
+            "confirm_password": "correct horse battery staple",
+        },
+    )
+
+    assert response.status_code == 400
+    assert b"Full name contains invalid characters" in response.data
+    assert db.session.query(User).count() == 0
+
 
 def test_registration_rejects_duplicate_phone_with_generic_error(client):
     created = register(client)

--- a/tests/test_authenticated_portal_ui.py
+++ b/tests/test_authenticated_portal_ui.py
@@ -182,6 +182,7 @@ def test_public_layout_does_not_expose_authenticated_account_actions(client):
     assert 'action="/logout"' not in markup
 
 def test_authentication_pages_have_password_helpers_and_mfa_back_link(client):
+    verify_registration_email(client, "helpers@sit.singaporetech.edu.sg")
     register_page = client.get("/register")
     login_page = client.get("/login")
     register(client)


### PR DESCRIPTION
## Summary

Redesigns browser registration into a secure two-step flow where users verify their SIT email first, then complete account details using the server-side verified email.

## Why

The previous registration page showed duplicate SIT email inputs for OTP request, OTP verification, and final account creation. That was confusing for users and meant the final browser registration submit still depended on client-supplied email data.

## What changed

* Split browser registration into Step 1 email verification and Step 2 account details.
* Removed editable email input from the account details step and display the verified email as read-only text.
* Added server-side handling so account creation uses the verified registration session email and ignores forged client email fields.
* Added regression tests for duplicate email inputs, forged email fields, verification-state consumption, and unsafe full-name input.

## Security impact

Strengthens registration by keeping email verification as a server-side state boundary. The account creation step no longer trusts hidden, forged, or editable client email fields. Existing OTP HMAC storage, 5-minute expiry, rate limits, CSRF, audit logging, and generic error behavior are preserved.

## Deployment impact

This PR requires:

* no EC2 bootstrap
* staging deployment
* production deployment
* no database migration
* no secret changes

## Verification

* `python -m compileall app tests`
* `python -m pytest tests/test_auth_registration_login.py tests/test_authenticated_portal_ui.py::test_authentication_pages_have_password_helpers_and_mfa_back_link tests/test_route_inventory_security.py tests/test_pentest_auth_bypass.py::TestRegistrationBypass -q`
* `git diff --check`

## Notes

Focused tests passed: `55 passed`. The full test suite was not run.