### PR TITLE
Validate PR descriptions and relax message policy

### DIFF
--- a/.github/workflows/commit-message-policy.yml
+++ b/.github/workflows/commit-message-policy.yml
@@ -7,9 +7,15 @@ on:
       - synchronize
       - reopened
       - edited
+      - ready_for_review
 
 permissions:
   contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   commit-message-policy:
@@ -30,7 +36,6 @@ jobs:
         run: |
           set -Eeuo pipefail
 
-          allowed_verbs='Add|Fix|Update|Remove|Refactor|Document|Improve|Secure|Configure|Align|Restore|Prevent|Validate|Enforce|Implement|Rename|Replace|Move|Create|Delete|Test'
           failed=0
 
           annotation_escape() {
@@ -39,6 +44,31 @@ jobs:
             value="${value//$'\r'/'%0D'}"
             value="${value//$'\n'/'%0A'}"
             printf '%s' "$value"
+          }
+
+          print_examples() {
+            cat <<'EXAMPLES'
+          Good examples:
+            Fix: staging admin secret wiring
+            Feat: add admin deployment boundary
+            Chore(deps): bump msgpack to 1.2.1
+            Docs: update deployment notes
+            Security: harden admin session validation
+            Fix staging admin secret wiring
+            Add commit subject validation
+            Harden admin session validation
+            Production deployment is manual only
+
+          Bad examples:
+            fix: staging admin secret wiring
+            feat: add admin deployment boundary
+            chore(deps): bump msgpack to 1.2.1
+            fix staging admin secret wiring
+            wip
+            update stuff
+            Fix bug.
+            minor changes
+          EXAMPLES
           }
 
           report_error() {
@@ -51,45 +81,64 @@ jobs:
             failed=1
           }
 
-          while IFS= read -r line; do
-            sha="${line%% *}"
-            subject="${line#* }"
+          validate_message() {
+            local sha="$1"
+            local value="$2"
+            local lower_value
 
-            if [[ "${subject}" =~ ^Merge[[:space:]] ]] || [[ "${subject}" =~ ^Revert[[:space:]] ]]; then
-              continue
+            if [[ "${value}" =~ ^Merge[[:space:]] ]] || [[ "${value}" =~ ^Revert[[:space:]] ]]; then
+              return 0
             fi
 
-            lower_subject="${subject,,}"
-
-            if (( ${#subject} < 12 )); then
-              report_error "${sha}" "${subject}" "Commit subject must be at least 12 characters."
-              continue
+            if [[ -z "${value}" ]]; then
+              report_error "${sha}" "${value}" "Commit subject must not be empty."
+              return 1
             fi
 
-            if (( ${#subject} > 72 )); then
-              report_error "${sha}" "${subject}" "Commit subject must be at most 72 characters."
-              continue
+            if [[ "${value}" =~ ^[[:space:]] || "${value}" =~ [[:space:]]$ ]]; then
+              report_error "${sha}" "${value}" "Commit subject must not have leading or trailing whitespace."
+              return 1
             fi
 
-            if [[ "${subject}" == *. ]]; then
-              report_error "${sha}" "${subject}" "Commit subject must not end with a full stop."
-              continue
+            if (( ${#value} < 12 )); then
+              report_error "${sha}" "${value}" "Commit subject must be at least 12 characters."
+              return 1
             fi
 
-            case "${lower_subject}" in
-              fix|update|changes|change|wip|test|misc|stuff|done|bug|final|commit)
-                report_error "${sha}" "${subject}" "Commit subject is too generic."
-                continue
+            if (( ${#value} > 72 )); then
+              report_error "${sha}" "${value}" "Commit subject must be at most 72 characters."
+              return 1
+            fi
+
+            if [[ ! "${value}" =~ ^[A-Z] ]]; then
+              report_error "${sha}" "${value}" "Commit subject must start with a capital letter."
+              return 1
+            fi
+
+            if [[ "${value}" == *. ]]; then
+              report_error "${sha}" "${value}" "Commit subject must not end with a full stop."
+              return 1
+            fi
+
+            lower_value="${value,,}"
+            case "${lower_value}" in
+              fix|update|updates|changes|change|wip|test|tests|misc|stuff|done|bug|bugs|final|commit|temp|tmp|work|progress)
+                report_error "${sha}" "${value}" "Commit subject is too generic."
+                return 1
+                ;;
+              "fix bug"|"fix bugs"|"fix issue"|"fix issues"|"update stuff"|"update things"|"make changes"|"minor changes")
+                report_error "${sha}" "${value}" "Commit subject is too vague."
+                return 1
                 ;;
             esac
+          }
 
-            if [[ ! "${subject}" =~ ^(${allowed_verbs})[[:space:]] ]]; then
-              report_error "${sha}" "${subject}" "Commit subject must start with an approved capitalized imperative verb."
-              continue
-            fi
-          done < <(git log --format='%H %s' "${BASE_SHA}..${HEAD_SHA}")
+          while IFS= read -r -d '' sha && IFS= read -r -d '' subject; do
+            validate_message "${sha}" "${subject}" || true
+          done < <(git log --format='%H%x00%s%x00' "${BASE_SHA}..${HEAD_SHA}")
 
           if (( failed != 0 )); then
+            print_examples
             exit 1
           fi
 

--- a/.github/workflows/pr-title-policy.yml
+++ b/.github/workflows/pr-title-policy.yml
@@ -9,21 +9,30 @@ on:
       - reopened
       - ready_for_review
 
-permissions: {}
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   pr-title-policy:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Check out validator
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+
       - name: Validate PR title
         shell: bash
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           set -Eeuo pipefail
-
-          allowed_verbs='Add|Fix|Update|Remove|Refactor|Document|Improve|Secure|Configure|Align|Restore|Prevent|Validate|Enforce|Implement|Rename|Replace|Move|Create|Delete|Test'
 
           annotation_escape() {
             local value="$1"
@@ -33,37 +42,97 @@ jobs:
             printf '%s' "$value"
           }
 
-          fail() {
-            local message="$1"
-            local escaped_title
-            escaped_title="$(annotation_escape "${PR_TITLE}")"
-            echo "::error title=Invalid PR title::${message} Current title: ${escaped_title}"
-            exit 1
+          print_examples() {
+            cat <<'EXAMPLES'
+          Good examples:
+            Fix: staging admin secret wiring
+            Feat: add admin deployment boundary
+            Chore(deps): bump msgpack to 1.2.1
+            Docs: update deployment notes
+            Security: harden admin session validation
+            Fix staging admin secret wiring
+            Add commit subject validation
+            Harden admin session validation
+            Production deployment is manual only
+
+          Bad examples:
+            fix: staging admin secret wiring
+            feat: add admin deployment boundary
+            chore(deps): bump msgpack to 1.2.1
+            fix staging admin secret wiring
+            wip
+            update stuff
+            Fix bug.
+            minor changes
+          EXAMPLES
           }
 
-          title="${PR_TITLE}"
-          lower_title="${title,,}"
+          report_error() {
+            local message="$1"
+            local value="$2"
+            local escaped_value
+            escaped_value="$(annotation_escape "${value}")"
+            echo "::error title=Invalid PR title::${message} Value: ${escaped_value}"
+          }
 
-          if (( ${#title} < 12 )); then
-            fail "PR title must be at least 12 characters."
-          fi
+          validate_message() {
+            local value="$1"
+            local lower_value
 
-          if (( ${#title} > 72 )); then
-            fail "PR title must be at most 72 characters."
-          fi
+            if [[ -z "${value}" ]]; then
+              report_error "PR title must not be empty." "${value}"
+              return 1
+            fi
 
-          if [[ "${title}" == *. ]]; then
-            fail "PR title must not end with a full stop."
-          fi
+            if [[ "${value}" =~ ^[[:space:]] || "${value}" =~ [[:space:]]$ ]]; then
+              report_error "PR title must not have leading or trailing whitespace." "${value}"
+              return 1
+            fi
 
-          case "${lower_title}" in
-            fix|update|changes|change|wip|test|misc|stuff|done|bug|final|commit)
-              fail "PR title is too generic."
-              ;;
-          esac
+            if (( ${#value} < 12 )); then
+              report_error "PR title must be at least 12 characters." "${value}"
+              return 1
+            fi
 
-          if [[ ! "${title}" =~ ^(${allowed_verbs})[[:space:]] ]]; then
-            fail "PR title must start with an approved capitalized imperative verb."
+            if (( ${#value} > 72 )); then
+              report_error "PR title must be at most 72 characters." "${value}"
+              return 1
+            fi
+
+            if [[ ! "${value}" =~ ^[A-Z] ]]; then
+              report_error "PR title must start with a capital letter." "${value}"
+              return 1
+            fi
+
+            if [[ "${value}" == *. ]]; then
+              report_error "PR title must not end with a full stop." "${value}"
+              return 1
+            fi
+
+            lower_value="${value,,}"
+            case "${lower_value}" in
+              fix|update|updates|changes|change|wip|test|tests|misc|stuff|done|bug|bugs|final|commit|temp|tmp|work|progress)
+                report_error "PR title is too generic." "${value}"
+                return 1
+                ;;
+              "fix bug"|"fix bugs"|"fix issue"|"fix issues"|"update stuff"|"update things"|"make changes"|"minor changes")
+                report_error "PR title is too vague." "${value}"
+                return 1
+                ;;
+            esac
+          }
+
+          if ! validate_message "${PR_TITLE}"; then
+            print_examples
+            exit 1
           fi
 
           echo "PR title policy passed."
+
+      - name: Validate PR description
+        shell: bash
+        env:
+          EVENT_PATH: ${{ github.event_path }}
+        run: |
+          set -Eeuo pipefail
+          python ops/security/validate_pr_body.py --event-path "${EVENT_PATH}"

--- a/docs/CONTRIBUTION_MESSAGE_POLICY.md
+++ b/docs/CONTRIBUTION_MESSAGE_POLICY.md
@@ -1,24 +1,38 @@
 # Contribution Message Policy
 
-SITBank pull request titles and pull request commit subjects must use concise
-sentence-style imperative wording.
+SITBank pull request titles and pull request commit subjects must use concise,
+capitalized wording. Sentence-style titles and capitalized Conventional Commit
+style are both allowed.
 
 ## Required Format
 
 Each PR title and commit subject must:
 
-- Start with one approved capitalized imperative verb:
-  `Add`, `Fix`, `Update`, `Remove`, `Refactor`, `Document`, `Improve`,
-  `Secure`, `Configure`, `Align`, `Restore`, `Prevent`, `Validate`, `Enforce`,
-  `Implement`, `Rename`, `Replace`, `Move`, `Create`, `Delete`, or `Test`
+- Start with a capital letter.
 - Be at least 12 characters.
 - Be at most 72 characters.
 - Not end with a full stop.
-- Not be a lazy or generic message such as `fix`, `update`, `changes`, `change`,
-  `wip`, `test`, `misc`, `stuff`, `done`, `bug`, `final`, or `commit`.
+- Not have leading or trailing whitespace.
+- Not be a lazy or generic message such as `fix`, `update`, `updates`,
+  `changes`, `change`, `wip`, `test`, `tests`, `misc`, `stuff`, `done`, `bug`,
+  `bugs`, `final`, `commit`, `temp`, `tmp`, `work`, or `progress`.
+- Not use vague phrases such as `fix bug`, `fix issue`, `update stuff`,
+  `make changes`, or `minor changes`.
 
 Git-generated `Merge ...` and `Revert ...` commit subjects are allowed for the
 commit-message check.
+
+Capitalized Conventional Commit prefixes are allowed, including scopes:
+
+- `Fix: staging admin secret wiring`
+- `Feat: add admin deployment boundary`
+- `Chore(deps): bump msgpack to 1.2.1`
+
+Lowercase Conventional Commit prefixes are rejected:
+
+- `fix: staging admin secret wiring`
+- `feat: add admin deployment boundary`
+- `chore(deps): bump msgpack to 1.2.1`
 
 ## Good Examples
 
@@ -26,6 +40,8 @@ commit-message check.
 - `Add dashboard security regression tests`
 - `Remove inline styles blocked by CSP`
 - `Update production deployment gating`
+- `Security: harden admin session validation`
+- `Production deployment is manual only`
 
 ## Bad Examples
 
@@ -34,8 +50,36 @@ commit-message check.
 - `WIP`
 - `changes`
 - `Fixed bug.`
+- `update stuff`
+- `minor changes`
 
 ## Why This Exists
 
 Clear PR titles and commit subjects make audit trails easier to review, improve
 release notes, and reduce ambiguity during incident response or rollback.
+
+## PR Description Requirements
+
+Pull requests must also fill in the repository PR template. The description
+must include these sections, either as plain headings or Markdown headings:
+
+- `Summary`
+- `Why`
+- `What changed`
+- `Security impact`
+- `Deployment impact`
+- `Verification`
+- `Notes`
+
+Every section except `Notes` must contain meaningful content. `Notes` may use
+`None`, `N/A`, or `No follow-up required` when there is nothing to add.
+
+Do not leave template placeholder text in the PR description. A custom paragraph
+above an unchanged template still fails validation.
+
+`Deployment impact` must state at least one concrete impact, such as
+`staging deployment`, `production deployment`, `database migration`,
+`secret changes`, or `No deployment action required`.
+
+`Verification` must include at least one test command, manual verification step,
+CI check, or a short explanation of why verification was not run.

--- a/ops/security/validate_pr_body.py
+++ b/ops/security/validate_pr_body.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REQUIRED_SECTIONS = (
+    "Summary",
+    "Why",
+    "What changed",
+    "Security impact",
+    "Deployment impact",
+    "Verification",
+    "Notes",
+)
+
+PLACEHOLDERS = (
+    "Briefly describe what this PR improves or fixes.",
+    "Explain the problem, risk, or reason this change is needed.",
+    "Explain how this affects security controls, secrets, permissions, auth, CI/CD, deployment safety, or runtime behavior.",
+    "Explain whether this PR requires:",
+    "Add any follow-up work, limitations, or operator instructions.",
+)
+
+DEPLOYMENT_IMPACT_PATTERNS = (
+    r"\bec2 bootstrap\b",
+    r"\bstaging deployment\b",
+    r"\bproduction deployment\b",
+    r"\bdatabase migration\b",
+    r"\bsecret changes?\b",
+    r"\bno deployment action\b",
+    r"\bno deployment action required\b",
+    r"\bno deployment required\b",
+)
+
+HEADING_RE = re.compile(
+    r"^\s{0,3}(?:#{1,6}\s*)?"
+    r"(summary|why|what changed|security impact|deployment impact|verification|notes)"
+    r"\s*:?\s*$",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class ValidationError:
+    message: str
+    value: str
+
+
+def annotation_escape(value: str) -> str:
+    return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def load_body_from_event(path: Path) -> str:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    body = (payload.get("pull_request") or {}).get("body") or ""
+    return str(body)
+
+
+def parse_sections(body: str) -> dict[str, str]:
+    sections: dict[str, list[str]] = {}
+    current: str | None = None
+    for line in body.splitlines():
+        heading = HEADING_RE.match(line)
+        if heading:
+            current = _canonical_section_name(heading.group(1))
+            sections.setdefault(current, [])
+            continue
+        if current is not None:
+            sections[current].append(line)
+    return {name: "\n".join(lines).strip() for name, lines in sections.items()}
+
+
+def validate_body(body: str) -> list[ValidationError]:
+    errors: list[ValidationError] = []
+    if not body.strip():
+        return [ValidationError("PR description must not be empty.", body)]
+
+    for placeholder in PLACEHOLDERS:
+        if placeholder in body:
+            errors.append(
+                ValidationError(
+                    "PR description still contains unchanged template placeholder text.",
+                    placeholder,
+                )
+            )
+
+    sections = parse_sections(body)
+    for section in REQUIRED_SECTIONS:
+        if section not in sections:
+            errors.append(ValidationError(f"Missing required PR description section: {section}.", body[:240]))
+            continue
+        if section != "Notes" and not _has_meaningful_content(sections[section]):
+            errors.append(
+                ValidationError(
+                    f"PR description section '{section}' must contain meaningful content.",
+                    sections[section],
+                )
+            )
+
+    deployment_impact = sections.get("Deployment impact", "")
+    if "Deployment impact" in sections and not _has_deployment_impact(deployment_impact):
+        errors.append(
+            ValidationError(
+                "Deployment impact must state at least one concrete deployment impact.",
+                deployment_impact,
+            )
+        )
+
+    verification = sections.get("Verification", "")
+    if "Verification" in sections and not _has_meaningful_content(verification):
+        errors.append(
+            ValidationError(
+                "Verification must include at least one test command, manual check, CI check, or explanation.",
+                verification,
+            )
+        )
+
+    return errors
+
+
+def print_examples() -> None:
+    print(
+        """Valid PR description example:
+Summary
+Adds server-side Payee management required for Local Transfer.
+
+Why
+Local Transfer needs trusted recipient records before transfer creation.
+
+What changed
+* Added Payee model and routes
+* Added server-side validation
+* Added tests for invalid recipient input
+
+Security impact
+Recipient names are loaded from the database and are not accepted from client input.
+
+Deployment impact
+No deployment action required.
+
+Verification
+* python -m pytest tests/test_payees.py
+
+Notes
+No follow-up required.
+""".rstrip()
+    )
+
+
+def report_errors(errors: list[ValidationError]) -> None:
+    for error in errors:
+        print(
+            "::error title=Invalid PR description::"
+            f"{error.message} Value: {annotation_escape(error.value[:500])}"
+        )
+    print_examples()
+
+
+def _canonical_section_name(name: str) -> str:
+    lowered = " ".join(name.casefold().split())
+    return {section.casefold(): section for section in REQUIRED_SECTIONS}[lowered]
+
+
+def _has_deployment_impact(content: str) -> bool:
+    normalized = _normalize_text(content)
+    return any(re.search(pattern, normalized, flags=re.IGNORECASE) for pattern in DEPLOYMENT_IMPACT_PATTERNS)
+
+
+def _has_meaningful_content(content: str) -> bool:
+    for line in content.splitlines():
+        normalized = _normalize_line(line)
+        if not normalized:
+            continue
+        if normalized in {"*", "-", "n/a", "na", "none"}:
+            continue
+        if any(normalized == placeholder.casefold() for placeholder in PLACEHOLDERS):
+            continue
+        return True
+    return False
+
+
+def _normalize_line(line: str) -> str:
+    return re.sub(r"\s+", " ", re.sub(r"^\s*[*-]\s*", "", line).strip()).casefold()
+
+
+def _normalize_text(content: str) -> str:
+    return re.sub(r"\s+", " ", content.strip()).casefold()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate a GitHub pull request description.")
+    parser.add_argument("--event-path", type=Path, help="Path to a GitHub pull_request event JSON payload.")
+    parser.add_argument("--body-file", type=Path, help="Path to a text file containing a PR body.")
+    args = parser.parse_args(argv)
+
+    if args.body_file:
+        body = args.body_file.read_text(encoding="utf-8")
+    elif args.event_path:
+        body = load_body_from_event(args.event_path)
+    else:
+        parser.error("Provide --event-path or --body-file.")
+
+    errors = validate_body(body)
+    if errors:
+        report_errors(errors)
+        return 1
+    print("PR description policy passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_pr_body_policy.py
+++ b/tests/test_pr_body_policy.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+
+from ops.security.validate_pr_body import load_body_from_event, validate_body
+
+
+VALID_BODY = """Summary
+Adds server-side Payee management required for Local Transfer.
+
+Why
+Local Transfer needs trusted recipient records before transfer creation.
+
+What changed
+* Added Payee model and routes
+* Added server-side validation
+* Added tests for invalid recipient input
+
+Security impact
+Recipient names are loaded from the database and are not accepted from client input.
+
+Deployment impact
+No deployment action required.
+
+Verification
+* python -m pytest tests/test_payees.py
+
+Notes
+No follow-up required.
+"""
+
+
+def _messages(body: str) -> list[str]:
+    return [error.message for error in validate_body(body)]
+
+
+def test_valid_pr_body_passes_with_plain_headings():
+    assert validate_body(VALID_BODY) == []
+
+
+def test_valid_pr_body_passes_with_markdown_headings_and_notes_none():
+    body = VALID_BODY.replace("Summary", "## Summary", 1).replace("Notes\nNo follow-up required.", "### Notes\nN/A")
+
+    assert validate_body(body) == []
+
+
+def test_empty_pr_body_fails():
+    assert _messages(" \n\t ") == ["PR description must not be empty."]
+
+
+def test_missing_required_section_fails():
+    body = VALID_BODY.replace("Why\nLocal Transfer needs trusted recipient records before transfer creation.\n\n", "")
+
+    assert "Missing required PR description section: Why." in _messages(body)
+
+
+def test_placeholder_template_left_below_custom_paragraph_fails():
+    body = """Introduces the Payee feature as a prerequisite for Local Transfer.
+
+Summary
+Briefly describe what this PR improves or fixes.
+
+Why
+Explain the problem, risk, or reason this change is needed.
+
+What changed
+
+Security impact
+Explain how this affects security controls, secrets, permissions, auth, CI/CD, deployment safety, or runtime behavior.
+
+Deployment impact
+Explain whether this PR requires:
+
+EC2 bootstrap
+staging deployment
+production deployment
+database migration
+secret changes
+no deployment action
+
+Verification
+
+Notes
+Add any follow-up work, limitations, or operator instructions.
+"""
+
+    messages = _messages(body)
+
+    assert "PR description still contains unchanged template placeholder text." in messages
+    assert "PR description section 'What changed' must contain meaningful content." in messages
+    assert "PR description section 'Verification' must contain meaningful content." in messages
+
+
+def test_deployment_impact_requires_concrete_impact():
+    body = VALID_BODY.replace("No deployment action required.", "Reviewed by operator.")
+
+    assert "Deployment impact must state at least one concrete deployment impact." in _messages(body)
+
+
+def test_verification_requires_meaningful_content():
+    body = VALID_BODY.replace("* python -m pytest tests/test_payees.py", "*\n*\n*")
+
+    assert "PR description section 'Verification' must contain meaningful content." in _messages(body)
+
+
+def test_event_payload_body_is_loaded(tmp_path):
+    event_path = tmp_path / "event.json"
+    event_path.write_text(json.dumps({"pull_request": {"body": VALID_BODY}}), encoding="utf-8")
+
+    assert load_body_from_event(event_path) == VALID_BODY


### PR DESCRIPTION
## Summary

Updates the repository contribution-message policy and adds PR description/template validation.

The PR title and commit-subject checks remain in place, but the policy is now less rigid. It accepts capitalized sentence-style messages and capitalized Conventional Commit messages, while still rejecting lowercase Conventional Commit prefixes and vague subjects.

This also adds validation for the PR description so contributors must complete the required template sections instead of leaving placeholders, empty sections, or weak deployment/verification content.

## Why

The previous approved-verb requirement was too restrictive and blocked otherwise clear PR titles and commit messages.

At the same time, PR descriptions still needed stronger validation because contributors could add text above the template while leaving required sections unchanged or empty. That makes reviews harder and can hide missing security, deployment, or verification details.

## What changed

* Removed the approved-verb list requirement.
* Allowed capitalized sentence-style PR titles and commit subjects.
* Allowed capitalized Conventional Commit PR titles and commit subjects.
* Rejected lowercase Conventional Commit prefixes such as `fix:`, `feat:`, and `chore:`.
* Rejected vague messages such as `wip`, `update stuff`, and `minor changes`.
* Added `ready_for_review` to commit-message policy triggers.
* Added minimal workflow permissions:

  * `contents: read`
  * `pull-requests: read`
* Added PR-scoped concurrency cancellation.
* Kept the existing pinned `actions/checkout` SHA.
* Kept `fetch-depth: 0`.
* Kept `persist-credentials: false`.
* Added `ops/security/validate_pr_body.py`.
* Added PR description validation that reads the PR body from `GITHUB_EVENT_PATH`.
* Required all PR template sections to be present and completed.
* Rejected empty PR bodies, missing sections, empty sections, unchanged placeholders, weak deployment impact, and empty verification content.
* Added escaped GitHub Actions `::error::` annotations for PR body validation failures.
* Added `tests/test_pr_body_policy.py` with 8 focused tests.
* Updated `.github/workflows/pr-title-policy.yml` to keep title validation and add PR description validation.
* Updated `docs/CONTRIBUTION_MESSAGE_POLICY.md` with the relaxed message rules and PR description requirements.

## Security impact

This is a CI/repository policy change only.

It does not change application authentication, authorization, secrets, runtime behavior, deployment logic, or customer-facing code.

It improves review safety by requiring PR descriptions to include completed security impact, deployment impact, and verification sections before the PR policy check can pass.

The workflow uses minimal read-only permissions and keeps the existing pinned checkout action, full fetch depth, disabled credential persistence, and PR-scoped concurrency cancellation.

## Deployment impact

No deployment action.

This PR does not require:

* EC2 bootstrap
* staging deployment
* production deployment
* database migration
* secret changes

## Verification

* Run PR title policy workflow.
* Run commit-message policy workflow.
* Run PR body policy tests:

  * `python -m pytest -q tests/test_pr_body_policy.py`
* Confirm invalid PR descriptions fail with GitHub `::error::` annotations.
* Confirm valid PR descriptions pass without replacing the existing title or commit-subject checks.

## Notes

The PR description validation is intended to catch incomplete template usage, including cases where contributors write a summary above the template but leave the required sections empty or unchanged.

Capitalized Conventional Commit messages are allowed, but lowercase prefixes such as `fix:` remain rejected by policy.
