### PR TITLE
Fix deployment migration order

### DIFF
--- a/ops/deploy/sitbank-container-deploy
+++ b/ops/deploy/sitbank-container-deploy
@@ -695,12 +695,6 @@ validate_staging_isolation
 validate_production_admin_isolation
 prepare_dependencies
 
-compose "${image}" run --rm --no-deps app \
-    python -m flask --app wsgi:app production-check
-if [[ "${target}" == "production" ]]; then
-    compose "${image}" run --rm --no-deps admin \
-        python -m flask --app admin_wsgi:app production-check
-fi
 migration_run \
     python -m flask --app wsgi:app db upgrade
 migration_run \
@@ -708,6 +702,12 @@ migration_run \
 apply_staging_admin_runtime_db_privileges
 migration_run \
     python -m flask --app wsgi:app verify-runtime-db-privileges
+compose "${image}" run --rm --no-deps app \
+    python -m flask --app wsgi:app production-check
+if [[ "${target}" == "production" ]]; then
+    compose "${image}" run --rm --no-deps admin \
+        python -m flask --app admin_wsgi:app production-check
+fi
 if [[ "${target}" == "staging" ]]; then
     compose "${image}" run --rm --no-deps admin \
         python -m flask --app admin_wsgi:app production-check

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1123,6 +1123,7 @@ def test_dockerfile_and_compose_enforce_hardened_runtime():
     assert deploy_db_sequence_text.index("db upgrade") < deploy_db_sequence_text.index("apply-runtime-db-privileges")
     assert deploy_db_sequence_text.index("apply-runtime-db-privileges") < deploy_db_sequence_text.index("apply_staging_admin_runtime_db_privileges")
     assert deploy_db_sequence_text.index("apply_staging_admin_runtime_db_privileges") < deploy_db_sequence_text.index("verify-runtime-db-privileges")
+    assert deploy_db_sequence_text.index("verify-runtime-db-privileges") < deploy_db_sequence_text.index("production-check")
     assert "staging_migration_run" not in deploy_script
     assert deploy_script.count("migration_run \\") == 3
     assert (


### PR DESCRIPTION
## Summary

Fix the EC2 deployment wrapper so Alembic migrations and runtime DB privilege checks run before `production-check`.

## Why

After DB-backed security state was added, `production-check` validates tables such as `server_side_sessions`. The wrapper was running `production-check` before `db upgrade`, so staging failed with `relation "server_side_sessions" does not exist`.

## What changed

* Moved customer/admin `production-check` after `db upgrade`, `apply-runtime-db-privileges`, and `verify-runtime-db-privileges`.
* Kept deployment fail-closed if migrations, privilege checks, or readiness checks fail.
* Added a deployment regression assertion for the required command order.

## Security impact

This preserves the DB-backed security-state guard while ensuring it runs after the schema exists. No new secrets, permissions, auth behavior, or runtime state model changes are introduced.

## Deployment impact

This PR requires:

* EC2 bootstrap, because `ops/deploy/sitbank-container-deploy` changed
* staging deployment
* production deployment if promoting the fix
* no new database migration
* no new secret changes

## Verification

* `python -m pytest -q tests/test_deployment.py` -> `43 passed`
* `git diff --check` -> clean

## Notes

After merge, rerun trusted staging bootstrap from `main`, then rerun staging deployment. Do the same production bootstrap before production deployment.