### PR TITLE
Fix deployment migration order

### DIFF
--- a/ops/deploy/sitbank-container-deploy
+++ b/ops/deploy/sitbank-container-deploy
@@ -695,12 +695,6 @@ validate_staging_isolation
 validate_production_admin_isolation
 prepare_dependencies
 
-compose "${image}" run --rm --no-deps app \
-    python -m flask --app wsgi:app production-check
-if [[ "${target}" == "production" ]]; then
-    compose "${image}" run --rm --no-deps admin \
-        python -m flask --app admin_wsgi:app production-check
-fi
 migration_run \
     python -m flask --app wsgi:app db upgrade
 migration_run \
@@ -708,6 +702,12 @@ migration_run \
 apply_staging_admin_runtime_db_privileges
 migration_run \
     python -m flask --app wsgi:app verify-runtime-db-privileges
+compose "${image}" run --rm --no-deps app \
+    python -m flask --app wsgi:app production-check
+if [[ "${target}" == "production" ]]; then
+    compose "${image}" run --rm --no-deps admin \
+        python -m flask --app admin_wsgi:app production-check
+fi
 if [[ "${target}" == "staging" ]]; then
     compose "${image}" run --rm --no-deps admin \
         python -m flask --app admin_wsgi:app production-check

--- a/ops/deploy/sitbank-container-deploy
+++ b/ops/deploy/sitbank-container-deploy
@@ -351,10 +351,7 @@ migration_run() {
         app "$@"
 }
 
-apply_staging_admin_runtime_db_privileges() {
-    if [[ "${target}" != "staging" ]]; then
-        return
-    fi
+apply_admin_runtime_db_privileges() {
     compose "${image}" run --rm --no-deps \
         --env DATABASE_MIGRATION_URL_FILE=/run/secrets/database_migration_url \
         --env ADMIN_DATABASE_URL_FILE=/run/secrets/admin_database_url \
@@ -699,7 +696,7 @@ migration_run \
     python -m flask --app wsgi:app db upgrade
 migration_run \
     python -m flask --app wsgi:app apply-runtime-db-privileges
-apply_staging_admin_runtime_db_privileges
+apply_admin_runtime_db_privileges
 migration_run \
     python -m flask --app wsgi:app verify-runtime-db-privileges
 compose "${image}" run --rm --no-deps app \

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1102,7 +1102,7 @@ def test_dockerfile_and_compose_enforce_hardened_runtime():
     assert "admin_session_lookup_hmac_key" in deploy_script
     assert "apply-runtime-db-privileges" in deploy_script
     assert "apply-admin-runtime-db-privileges" in deploy_script
-    assert "apply_staging_admin_runtime_db_privileges" in deploy_script
+    assert "apply_admin_runtime_db_privileges" in deploy_script
     assert "verify-runtime-db-privileges" in deploy_script
     assert "validate_production_admin_isolation" in deploy_script
     assert "ADMIN_APP_BIND_PORT='5002'" in deploy_script
@@ -1121,8 +1121,8 @@ def test_dockerfile_and_compose_enforce_hardened_runtime():
     assert deploy_db_sequence is not None
     deploy_db_sequence_text = deploy_db_sequence.group(0)
     assert deploy_db_sequence_text.index("db upgrade") < deploy_db_sequence_text.index("apply-runtime-db-privileges")
-    assert deploy_db_sequence_text.index("apply-runtime-db-privileges") < deploy_db_sequence_text.index("apply_staging_admin_runtime_db_privileges")
-    assert deploy_db_sequence_text.index("apply_staging_admin_runtime_db_privileges") < deploy_db_sequence_text.index("verify-runtime-db-privileges")
+    assert deploy_db_sequence_text.index("apply-runtime-db-privileges") < deploy_db_sequence_text.index("apply_admin_runtime_db_privileges")
+    assert deploy_db_sequence_text.index("apply_admin_runtime_db_privileges") < deploy_db_sequence_text.index("verify-runtime-db-privileges")
     assert deploy_db_sequence_text.index("verify-runtime-db-privileges") < deploy_db_sequence_text.index("production-check")
     assert "staging_migration_run" not in deploy_script
     assert deploy_script.count("migration_run \\") == 3

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1123,6 +1123,7 @@ def test_dockerfile_and_compose_enforce_hardened_runtime():
     assert deploy_db_sequence_text.index("db upgrade") < deploy_db_sequence_text.index("apply-runtime-db-privileges")
     assert deploy_db_sequence_text.index("apply-runtime-db-privileges") < deploy_db_sequence_text.index("apply_staging_admin_runtime_db_privileges")
     assert deploy_db_sequence_text.index("apply_staging_admin_runtime_db_privileges") < deploy_db_sequence_text.index("verify-runtime-db-privileges")
+    assert deploy_db_sequence_text.index("verify-runtime-db-privileges") < deploy_db_sequence_text.index("production-check")
     assert "staging_migration_run" not in deploy_script
     assert deploy_script.count("migration_run \\") == 3
     assert (


### PR DESCRIPTION
## Summary

Fix EC2 deployment ordering and admin runtime database grants for DB-backed security-state tables.

## Why

Deployment failed after DB-backed security state was added because `production-check` validated `server_side_sessions`.

First, the wrapper ran `production-check` before `db upgrade`. After that was fixed, production admin still failed because the admin runtime role did not receive privileges on the new security-state tables.

## What changed

* Run `db upgrade`, runtime privilege application, and privilege verification before `production-check`.
* Apply admin runtime DB privileges during both staging and production deployments.
* Extend deployment regression tests for the required command order and admin privilege step.

## Security impact

This preserves fail-closed production checks while ensuring they run after schema and privilege setup. Admin remains on a distinct runtime DB role, and the role receives the intended least-privilege access needed for DB-backed security-state checks.

## Deployment impact

This PR requires:

* EC2 bootstrap
* staging deployment
* production deployment if promoting the fix
* no new database migration
* no new secret changes

## Verification

* `python -m pytest -q tests/test_deployment.py` -> `43 passed`
* `git diff --check` -> clean

## Notes

After merge, rerun trusted staging bootstrap from `main`, then rerun staging deployment. Rerun trusted production bootstrap before production deployment.