### PR TITLE
Fix admin runtime role grants

### DIFF
--- a/app/ops/db_privileges.py
+++ b/app/ops/db_privileges.py
@@ -97,15 +97,10 @@ def apply_admin_runtime_database_privileges(
                     {"role": admin_role},
                 ).scalar_one()
             )
-            if role_exists:
-                connection.execute(
-                    text(f"ALTER ROLE {quoted_admin_role} LOGIN PASSWORD :password"),
-                    {"password": admin_password},
-                )
-            else:
-                connection.execute(
-                    text(f"CREATE ROLE {quoted_admin_role} LOGIN PASSWORD :password"),
-                    {"password": admin_password},
+            if not role_exists:
+                raise RuntimeError(
+                    "ADMIN_DATABASE_URL role must already exist; create or rotate it "
+                    "with a PostgreSQL administrator before deployment"
                 )
 
             connection.execute(
@@ -142,6 +137,26 @@ def apply_admin_runtime_database_privileges(
             )
     finally:
         migration_engine.dispose()
+
+    admin_engine = create_engine(admin_url)
+    try:
+        with admin_engine.connect() as admin_connection:
+            connected_admin_role = str(
+                admin_connection.execute(text("SELECT current_user")).scalar_one()
+            )
+            if connected_admin_role != admin_role:
+                raise RuntimeError(
+                    "ADMIN_DATABASE_URL did not authenticate as the configured role"
+                )
+            connected_database = str(
+                admin_connection.execute(text("SELECT current_database()")).scalar_one()
+            )
+            if connected_database != database:
+                raise RuntimeError(
+                    "ADMIN_DATABASE_URL did not authenticate to the configured database"
+                )
+    finally:
+        admin_engine.dispose()
 
     return AdminRuntimePrivilegeApplication(
         admin_role=admin_role,

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -62,7 +62,11 @@ secret files under `/etc/sitbank/secrets`: `admin_secret_key`,
 `admin_session_lookup_hmac_key`, `admin_database_url`, and
 `admin_password_pepper_b64`.
 `admin_database_url` must use a dedicated admin runtime database role and must
-not reuse either `database_url` or `database_migration_url`.
+not reuse either `database_url` or `database_migration_url`. Provision that
+database role, and rotate its password, with a PostgreSQL administrator or
+other approved role-management account before deployment; the deployment
+wrapper only grants schema, table, sequence, and default privileges to the
+existing role after migrations run.
 `admin_session_lookup_hmac_key` must not reuse the customer
 `session_lookup_hmac_key`.
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -11,7 +11,11 @@ Production admin uses separate root-managed secret files in
 customer Flask signing, CSRF, session-HMAC, session-lookup HMAC,
 password-pepper, or database runtime material.
 `admin_database_url` must use a dedicated admin runtime role, distinct from
-both the customer runtime role and the migration/schema-owner role.
+both the customer runtime role and the migration/schema-owner role. Create that
+role, and rotate its password, with a PostgreSQL administrator or other
+approved role-management account; routine application deployments do not grant
+the migration/schema-owner role permission to create, alter, or rotate database
+roles.
 
 MFA/TOTP seed encryption uses envelope encryption. Keep old KEKs in `mfa_kek_keys_json` until `rewrap-mfa-deks` has moved stored records to the new active KEK. Then update `MFA_KEK_ACTIVE_ID` and the root-managed keyring together.
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -299,8 +299,11 @@ def test_runtime_privilege_verifier_quotes_create_probe_table_name():
     assert "apply_runtime_audit_table_privileges" in source
     assert "apply_admin_runtime_database_privileges" in source
     assert "ADMIN_DATABASE_URL is required for admin privilege application" in source
-    assert "CREATE ROLE" in source
-    assert "ALTER ROLE" in source
+    assert "ADMIN_DATABASE_URL role must already exist" in source
+    assert "CREATE ROLE" not in source
+    assert "ALTER ROLE" not in source
+    assert "create_engine(admin_url)" in source
+    assert "ADMIN_DATABASE_URL did not authenticate as the configured role" in source
     assert "GRANT SELECT, INSERT ON ALL TABLES" in source
     assert "ALTER DEFAULT PRIVILEGES FOR ROLE" in source
     assert "REVOKE UPDATE, DELETE, TRUNCATE ON TABLE" in source


### PR DESCRIPTION
## Summary

Fix production admin runtime DB privilege setup so deployment no longer requires the migration/schema-owner role to create or alter PostgreSQL roles.

## Why

Production deployment failed when `apply-admin-runtime-db-privileges` attempted to `ALTER ROLE sitbank_admin`, because the migration role correctly does not have PostgreSQL role-management privileges.

## What changed

* Require the admin runtime DB role to be pre-provisioned instead of created/rotated during app deployment.
* Keep deployment-time grants for schema, table, sequence, and default privileges.
* Validate that `ADMIN_DATABASE_URL` can authenticate after grants are applied.
* Update deployment and operations docs.

## Security impact

Improves least privilege by avoiding `CREATEROLE` or admin-option grants for the migration/schema-owner role. Admin role creation and password rotation remain a PostgreSQL administrator responsibility.

## Deployment impact

* no EC2 bootstrap
* staging deployment recommended
* production deployment required to fix the failed release
* no database migration
* no secret changes unless the existing `admin_database_url` password does not match the `sitbank_admin` role password

## Verification

* `.\.venv\Scripts\python.exe -m pytest -q tests/test_deployment.py`
* `git diff --check`

## Notes

If deployment later fails authenticating `ADMIN_DATABASE_URL`, sync the `sitbank_admin` password with the root-managed `admin_database_url` secret using a PostgreSQL administrator. Do not grant `CREATEROLE` to `sitbank_owner`.