### PR TITLE
Implement root-admin staff invite onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SITBank is a student cybersecurity project and demonstration site. Do not enter 
 
 ## Overview
 
-SITBank is a Flask/Gunicorn application deployed as hardened Docker containers behind host-managed Nginx, TLS, and PostgreSQL. Production customer traffic runs at `https://sitbank.duckdns.org`; the isolated production admin boundary is reserved at `https://admin-sitbank.duckdns.org` and is fail-closed until a reviewed admin MFA design and network allowlist controls are implemented. Staging runs separately at `https://staging-sitbank.duckdns.org` and does not include an admin service in this phase.
+SITBank is a Flask/Gunicorn application deployed as hardened Docker containers behind host-managed Nginx, TLS, and PostgreSQL. Production customer traffic runs at `https://sitbank.duckdns.org`; the isolated production admin boundary at `https://admin-sitbank.duckdns.org` uses a separate admin app, cookie, session keys, database role, root-admin-controlled staff invites, and mandatory TOTP. Staging runs separately at `https://staging-sitbank.duckdns.org`.
 
 Security-critical state is application-owned PostgreSQL data, not Redis data. Server-side sessions, authentication failure counters, TOTP replay markers, registration OTP challenges, password-reset transactions, security-alert dedupe windows, and breached-password circuit-breaker state are stored in dedicated tables. Browser cookies keep only opaque identifiers; lookup hashes are HMAC-derived with `SESSION_LOOKUP_HMAC_KEY` or `ADMIN_SESSION_LOOKUP_HMAC_KEY`, and stored session payloads remain signed with the session HMAC keyring.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -55,8 +55,10 @@ runtime role. The admin role must be distinct from both `sitbank_app` and
 `sitbank_owner`; it must not use migration/schema-owner credentials. Admin MFA,
 administrator step-up, VPN, Tailscale, WireGuard, and administrator IP allowlist
 setup are Phase 2 items pending an approved design. Until those controls exist,
-`admin-sitbank.duckdns.org` is fail-closed at Nginx with `deny all` and the
-Flask admin login route returns failure without creating a session.
+`admin-sitbank.duckdns.org` remains isolated at the edge and should be protected
+with an explicit network allowlist. The Flask admin app uses a separate cookie,
+session HMAC keyring, database role, root-admin-controlled staff invites, and
+mandatory TOTP; WebAuthn/passkeys are not offered for staff/admin onboarding.
 
 Staging secrets must never be copied from production. The staging deployment
 wrapper rejects identical application secret files when production secrets are

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -1,35 +1,116 @@
 from __future__ import annotations
 
-from flask import Blueprint, current_app, jsonify, request, session
+from flask import Blueprint, current_app, jsonify, request
+from flask_limiter.util import get_remote_address
+from flask_wtf.csrf import generate_csrf
+from marshmallow import Schema, ValidationError, fields, validate, validates_schema
 from sqlalchemy import text
 
-from app.extensions import csrf, db
-from app.security.audit import audit_event
+from app.extensions import db, limiter
+from app.security.rate_limits import request_principal
+
+from .services import (
+    AuthError,
+    authenticate_admin_primary,
+    complete_admin_mfa_login,
+    create_staff_invite,
+    invite_info,
+    logout_admin_session,
+    public_invites_for_root_admin,
+    require_root_admin_session,
+    require_staff_session,
+    revoke_staff_invite,
+    start_invite_acceptance,
+    verify_invite_acceptance,
+)
 
 
 admin_bp = Blueprint("admin", __name__)
 
 
-def _request_payload_keys() -> list[str]:
-    payload = request.get_json(silent=True)
-    if isinstance(payload, dict):
-        return sorted(str(key)[:64] for key in payload)
-    return sorted(str(key)[:64] for key in request.form.keys())
+class AdminLoginSchema(Schema):
+    workplace_email = fields.Email(required=True, validate=validate.Length(max=255))
+    password = fields.Str(required=True, load_only=True, validate=validate.Length(min=1))
 
 
-def _audit_admin_denial(event_type: str, outcome: str) -> None:
-    audit_event(
-        event_type,
-        outcome,
-        metadata={
-            "app_mode": "admin",
-            "path": request.path,
-            "payload_keys": _request_payload_keys(),
-            "password": (request.get_json(silent=True) or request.form or {}).get("password"),
-            "token": (request.get_json(silent=True) or request.form or {}).get("token"),
-            "phase": "phase_1a_fail_closed",
-        },
+class AdminTotpSchema(Schema):
+    totp_code = fields.Str(
+        required=True,
+        load_only=True,
+        validate=validate.Regexp(r"^[0-9]{6}$", error="MFA code must be exactly 6 digits"),
     )
+
+
+class StaffInviteCreateSchema(Schema):
+    personal_email = fields.Email(required=True, validate=validate.Length(max=255))
+    workplace_email = fields.Email(required=True, validate=validate.Length(max=255))
+    role = fields.Str(required=True, validate=validate.OneOf(["staff", "admin"]))
+    totp_code = fields.Str(
+        required=True,
+        load_only=True,
+        validate=validate.Regexp(r"^[0-9]{6}$", error="MFA code must be exactly 6 digits"),
+    )
+
+
+class StaffInviteRevokeSchema(Schema):
+    totp_code = fields.Str(
+        required=True,
+        load_only=True,
+        validate=validate.Regexp(r"^[0-9]{6}$", error="MFA code must be exactly 6 digits"),
+    )
+
+
+class StaffInviteStartSchema(Schema):
+    full_name = fields.Str(required=True, validate=validate.Length(min=1, max=120))
+    phone_number = fields.Str(required=True, validate=validate.Regexp(r"^[89][0-9]{7}$"))
+    password = fields.Str(required=True, load_only=True)
+    confirm_password = fields.Str(required=True, load_only=True)
+    turnstile_token = fields.Str(required=False, load_only=True, allow_none=True)
+
+    @validates_schema
+    def validate_password_match(self, data, **_kwargs):
+        if data.get("password") != data.get("confirm_password"):
+            raise ValidationError("Passwords must match")
+
+
+class StaffInviteVerifySchema(Schema):
+    totp_code = fields.Str(
+        required=True,
+        load_only=True,
+        validate=validate.Regexp(r"^[0-9]{6}$", error="MFA code must be exactly 6 digits"),
+    )
+    workplace_verification_code = fields.Str(
+        required=True,
+        load_only=True,
+        validate=validate.Regexp(r"^[0-9]{6}$", error="Verification code must be exactly 6 digits"),
+    )
+
+
+@admin_bp.errorhandler(AuthError)
+def handle_auth_error(error: AuthError):
+    response = jsonify({"error": error.message})
+    if error.retry_after is not None:
+        response.headers["Retry-After"] = str(error.retry_after)
+        response.headers["X-Auth-Retry-After"] = str(error.retry_after)
+    return response, error.status_code
+
+
+@admin_bp.errorhandler(ValidationError)
+def handle_validation_error(_error: ValidationError):
+    return jsonify({"error": "Invalid request"}), 400
+
+
+def _payload(schema: Schema) -> dict:
+    if request.is_json:
+        return schema.load(request.get_json(silent=False) or {})
+    return schema.load(dict(request.form))
+
+
+def _request_fields() -> set[str]:
+    if request.is_json:
+        payload = request.get_json(silent=False) or {}
+        return {str(key) for key in payload} if isinstance(payload, dict) else set()
+    return {str(key) for key in request.form.keys()}
 
 
 @admin_bp.get("/health/live")
@@ -48,24 +129,106 @@ def health_ready():
     return jsonify({"status": "ready", "app_mode": "admin"})
 
 
-@admin_bp.route("/", methods=["GET", "POST"])
-def index_disabled():
-    session.clear()
-    _audit_admin_denial("admin_access_denied", "fail_closed")
-    return jsonify({"error": "Admin access is disabled pending strong authentication"}), 403
+@admin_bp.get("/csrf-token")
+def csrf_token():
+    return jsonify({"csrf_token": generate_csrf()})
 
 
-@admin_bp.route("/login", methods=["GET", "POST"])
-@csrf.exempt
-def login_disabled():
-    session.clear()
-    _audit_admin_denial("admin_login_disabled", "fail_closed")
-    return jsonify({"error": "Admin login is disabled"}), 403
+@admin_bp.get("/")
+def index():
+    user = require_staff_session()
+    return jsonify({"message": "Admin access granted", "user": {"id": user.id, "role": user.account_type}})
 
 
-@admin_bp.route("/step-up", methods=["GET", "POST"])
-@csrf.exempt
-def step_up_disabled():
-    session.clear()
-    _audit_admin_denial("admin_step_up_disabled", "fail_closed")
-    return jsonify({"error": "Admin step-up is disabled"}), 403
+@admin_bp.post("/login")
+@limiter.limit("50 per day", key_func=get_remote_address)
+@limiter.limit("50 per day", key_func=request_principal)
+@limiter.limit("5 per minute", key_func=get_remote_address)
+@limiter.limit("5 per minute", key_func=request_principal)
+def login():
+    data = _payload(AdminLoginSchema())
+    return jsonify(authenticate_admin_primary(data["workplace_email"], data["password"]))
+
+
+@admin_bp.post("/mfa/verify")
+@limiter.limit("5 per 5 minutes", key_func=get_remote_address)
+@limiter.limit("5 per 5 minutes", key_func=request_principal)
+def mfa_verify():
+    data = _payload(AdminTotpSchema())
+    return jsonify(complete_admin_mfa_login(data["totp_code"]))
+
+
+@admin_bp.post("/logout")
+def logout():
+    logout_admin_session()
+    return jsonify({"message": "Logged out"})
+
+
+@admin_bp.get("/invites")
+def invites():
+    require_root_admin_session()
+    return jsonify({"invites": public_invites_for_root_admin()})
+
+
+@admin_bp.post("/invites")
+@limiter.limit("10 per hour", key_func=get_remote_address)
+@limiter.limit("5 per 5 minutes", key_func=request_principal)
+def invite_create():
+    actor = require_root_admin_session()
+    data = _payload(StaffInviteCreateSchema())
+    return jsonify(
+        create_staff_invite(
+            actor,
+            personal_email=data["personal_email"],
+            workplace_email=data["workplace_email"],
+            role=data["role"],
+            totp_code=data["totp_code"],
+        )
+    ), 201
+
+
+@admin_bp.post("/invites/<int:invite_id>/revoke")
+@limiter.limit("10 per hour", key_func=get_remote_address)
+def invite_revoke(invite_id: int):
+    actor = require_root_admin_session()
+    data = _payload(StaffInviteRevokeSchema())
+    return jsonify(revoke_staff_invite(actor, invite_id, data["totp_code"]))
+
+
+@admin_bp.get("/invites/accept/<token>")
+@limiter.limit("20 per hour", key_func=get_remote_address)
+def invite_accept_info(token: str):
+    return jsonify(invite_info(token))
+
+
+@admin_bp.post("/invites/accept/<token>/start")
+@limiter.limit("20 per hour", key_func=get_remote_address)
+@limiter.limit("10 per 15 minutes", key_func=request_principal)
+def invite_accept_start(token: str):
+    data = _payload(StaffInviteStartSchema())
+    return jsonify(
+        start_invite_acceptance(
+            token,
+            full_name=data["full_name"],
+            phone_number=data["phone_number"],
+            password=data["password"],
+            confirm_password=data["confirm_password"],
+            turnstile_token=data.get("turnstile_token"),
+            request_fields=_request_fields(),
+        )
+    )
+
+
+@admin_bp.post("/invites/accept/<token>/verify")
+@limiter.limit("10 per 15 minutes", key_func=get_remote_address)
+@limiter.limit("10 per 15 minutes", key_func=request_principal)
+def invite_accept_verify(token: str):
+    data = _payload(StaffInviteVerifySchema())
+    return jsonify(
+        verify_invite_acceptance(
+            token,
+            totp_code=data["totp_code"],
+            workplace_verification_code=data["workplace_verification_code"],
+            request_fields=_request_fields(),
+        )
+    )

--- a/app/admin/separation.py
+++ b/app/admin/separation.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from flask import has_request_context
+
+from app.auth.services import AuthError
+from app.extensions import db
+from app.models import PersonIdentityLink, User
+from app.security.audit import audit_event, audit_reference, audit_system_event
+
+from .services import ACCOUNT_CUSTOMER, STAFF_ACCOUNT_TYPES
+
+
+def assert_not_self_customer_action(
+    actor_staff_user: User,
+    target_customer_user: User,
+    action_type: str,
+) -> None:
+    if actor_staff_user is None or target_customer_user is None:
+        _block(actor_staff_user, target_customer_user, action_type, "missing_identity")
+    if actor_staff_user.account_type not in STAFF_ACCOUNT_TYPES:
+        _block(actor_staff_user, target_customer_user, action_type, "actor_not_staff")
+    if target_customer_user.account_type != ACCOUNT_CUSTOMER:
+        _block(actor_staff_user, target_customer_user, action_type, "target_not_customer")
+
+    if _has_active_identity_link(actor_staff_user.id, target_customer_user.id):
+        _block(actor_staff_user, target_customer_user, action_type, "explicit_identity_link")
+
+    actor_emails = {
+        _normalized_email(actor_staff_user.email),
+        _normalized_email(actor_staff_user.staff_personal_email),
+    }
+    target_email = _normalized_email(target_customer_user.email)
+    if target_email and target_email in actor_emails:
+        _block(actor_staff_user, target_customer_user, action_type, "verified_email_overlap")
+
+
+def _has_active_identity_link(staff_user_id: int, customer_user_id: int) -> bool:
+    return bool(
+        db.session.execute(
+            db.select(PersonIdentityLink.id).where(
+                PersonIdentityLink.staff_user_id == staff_user_id,
+                PersonIdentityLink.customer_user_id == customer_user_id,
+                PersonIdentityLink.revoked_at.is_(None),
+            )
+        ).scalar_one_or_none()
+    )
+
+
+def _block(
+    actor_staff_user: User | None,
+    target_customer_user: User | None,
+    action_type: str,
+    reason: str,
+) -> None:
+    metadata = {
+        "action_type": str(action_type or "privileged_customer_action")[:80],
+        "reason": reason,
+        "target_customer_ref": audit_reference(
+            "customer_user",
+            getattr(target_customer_user, "id", None),
+        ),
+    }
+    if has_request_context():
+        audit_event(
+            "staff_self_customer_action_blocked",
+            "blocked",
+            user=actor_staff_user,
+            metadata=metadata,
+        )
+    else:
+        audit_system_event(
+            "staff_self_customer_action_blocked",
+            "blocked",
+            user_id=getattr(actor_staff_user, "id", None),
+            metadata=metadata,
+        )
+    raise AuthError("This privileged action is not permitted for that customer account", 403)
+
+
+def _normalized_email(value: str | None) -> str:
+    return str(value or "").strip().casefold()

--- a/app/admin/services.py
+++ b/app/admin/services.py
@@ -1,0 +1,761 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import re
+import secrets
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pyotp
+from flask import current_app, request, session, url_for
+from sqlalchemy import func, or_
+from sqlalchemy.exc import IntegrityError
+
+from app.auth.services import (
+    AuthError,
+    _dummy_password_hash,
+    _verify_totp_for_user,
+)
+from app.extensions import db
+from app.models import StaffInvite, User
+from app.security.audit import audit_event, audit_event_required, audit_reference, principal_reference
+from app.security.crypto import encrypt_mfa_secret
+from app.security.email import send_security_email
+from app.security.passwords import (
+    PasswordPolicyError,
+    hash_password,
+    is_password_raw_length_safe,
+    password_hash_needs_rehash,
+    validate_password_policy,
+    verify_password,
+)
+from app.security.rate_limits import AuthBackoffRequired, apply_exponential_backoff, clear_failures, record_failure
+from app.security.session_hmac import active_hmac_hex
+from app.security.sessions import (
+    begin_password_authenticated_session,
+    establish_authenticated_session,
+    public_session_reference,
+    revoke_current_session,
+)
+from app.security.turnstile import TurnstileError, verify_turnstile_token
+
+
+ACCOUNT_CUSTOMER = "customer"
+ACCOUNT_STAFF = "staff"
+ACCOUNT_ADMIN = "admin"
+ACCOUNT_ROOT_ADMIN = "root_admin"
+STAFF_ACCOUNT_TYPES = frozenset({ACCOUNT_STAFF, ACCOUNT_ADMIN, ACCOUNT_ROOT_ADMIN})
+INVITABLE_ROLES = frozenset({ACCOUNT_STAFF, ACCOUNT_ADMIN})
+ACTIVE_INVITE_STATUSES = frozenset({"pending", "totp_pending"})
+GENERIC_ADMIN_LOGIN_ERROR = "Invalid workplace email, password, or authentication code"
+GENERIC_INVITE_ERROR = "Invite link is invalid or expired"
+GENERIC_WORKPLACE_VERIFICATION_ERROR = "Workplace verification failed"
+ADMIN_AUTH_BACKOFF_ERROR = "Too many attempts. Please try again later."
+STAFF_USERNAME_RE = re.compile(r"^[A-Za-z0-9_.-]{3,64}$")
+FULL_NAME_RE = re.compile(r"^[^\x00-\x1f\x7f<>]{1,120}$")
+PHONE_RE = re.compile(r"^[89][0-9]{7}$")
+EMAIL_RE = re.compile(r"^[^@\s\x00-\x1f\x7f]{1,128}@[^@\s\x00-\x1f\x7f]{1,253}$")
+TOTP_RE = re.compile(r"^[0-9]{6}$")
+WORKPLACE_CODE_RE = re.compile(r"^[0-9]{6}$")
+
+
+def is_customer_user(user: User | None) -> bool:
+    return bool(user is not None and (user.account_type or ACCOUNT_CUSTOMER) == ACCOUNT_CUSTOMER)
+
+
+def is_staff_user(user: User | None) -> bool:
+    return bool(user is not None and (user.account_type or ACCOUNT_CUSTOMER) in STAFF_ACCOUNT_TYPES)
+
+
+def is_active_staff_user(user: User | None) -> bool:
+    return bool(is_staff_user(user) and user.account_status == "active" and user.mfa_enabled)
+
+
+def is_root_admin(user: User | None) -> bool:
+    if user is None or user.account_type != ACCOUNT_ROOT_ADMIN:
+        return False
+    return _normalize_email(user.email).casefold() in _root_admin_emails()
+
+
+def require_staff_session() -> User:
+    user_id = session.get("user_id")
+    if not user_id:
+        raise AuthError("Authentication required", 401)
+    user = db.session.get(User, int(user_id))
+    if not is_active_staff_user(user):
+        audit_event("admin_access_denied", "blocked", user=user, metadata={"reason": "not_active_staff"})
+        raise AuthError("Forbidden", 403)
+    return user
+
+
+def require_root_admin_session() -> User:
+    user = require_staff_session()
+    if not is_root_admin(user):
+        audit_event("staff_invite_authorization", "blocked", user=user, metadata={"reason": "not_root_admin"})
+        raise AuthError("Forbidden", 403)
+    return user
+
+
+def authenticate_admin_primary(workplace_email: str, password: str) -> dict[str, Any]:
+    normalized_email = normalize_workplace_email(workplace_email)
+    principal = _auth_principal(normalized_email)
+    try:
+        _enforce_auth_backoff("admin_login", principal)
+    except AuthError:
+        raise
+
+    user = _staff_user_by_workplace_email(normalized_email)
+    password_ok = False
+    if is_password_raw_length_safe(password):
+        candidate_hash = user.password_hash if user else _dummy_password_hash()
+        password_ok = verify_password(password, candidate_hash)
+
+    if (
+        user is None
+        or not password_ok
+        or not is_active_staff_user(user)
+        or not user.workplace_email_verified_at
+    ):
+        audit_event(
+            "admin_login",
+            "failure",
+            user=user,
+            metadata={
+                "known_user": user is not None,
+                "principal_ref": principal_reference(normalized_email),
+            },
+        )
+        record_failure("admin_login", principal)
+        raise AuthError(GENERIC_ADMIN_LOGIN_ERROR, 401)
+
+    if user.is_frozen or user.security_locked_at is not None:
+        audit_event("admin_login", "blocked", user=user, metadata={"reason": user.security_lock_reason or "locked"})
+        raise AuthError(GENERIC_ADMIN_LOGIN_ERROR, 401)
+
+    user.failed_login_count = 0
+    user.last_login_at = _utcnow()
+    if password_hash_needs_rehash(user.password_hash):
+        user.password_hash = hash_password(password)
+    db.session.commit()
+    clear_failures("admin_login", principal)
+    begin_password_authenticated_session(user.id)
+    audit_event("admin_login_password", "success", user=user, metadata={"mfa_required": True})
+    return {"message": "MFA verification required", "mfa_required": True}
+
+
+def complete_admin_mfa_login(totp_code: str) -> dict[str, Any]:
+    user_id = session.get("pending_mfa_user_id")
+    if not user_id:
+        raise AuthError("No pending MFA challenge", 401)
+    user = db.session.get(User, int(user_id))
+    if not is_active_staff_user(user):
+        audit_event("admin_mfa_login", "failure", user_id=int(user_id), metadata={"reason": "not_active_staff"})
+        raise AuthError("No pending MFA challenge", 401)
+    if not _verify_totp_for_user(user, totp_code, "admin_mfa_login"):
+        audit_event("admin_mfa_login", "failure", user=user)
+        raise AuthError(GENERIC_ADMIN_LOGIN_ERROR, 401)
+    session_id = establish_authenticated_session(
+        user_id=user.id,
+        mfa_verified=True,
+        auth_context="admin_password+totp",
+    )
+    audit_event("admin_mfa_login", "success", user=user, session_id=session_id)
+    return {
+        "message": "Login successful",
+        "session_ref": public_session_reference(session_id),
+        "user": public_admin_user(user),
+    }
+
+
+def logout_admin_session() -> None:
+    user_id = session.get("user_id") or session.get("pending_mfa_user_id")
+    revoke_current_session(ended_reason="logout")
+    audit_event("admin_logout", "success", user_id=int(user_id) if user_id else None)
+
+
+def create_staff_invite(
+    actor: User,
+    *,
+    personal_email: str,
+    workplace_email: str,
+    role: str,
+    totp_code: str | None,
+) -> dict[str, Any]:
+    if not is_root_admin(actor):
+        audit_event("staff_invite_create", "blocked", user=actor, metadata={"reason": "not_root_admin"})
+        raise AuthError("Forbidden", 403)
+    if not totp_code:
+        audit_event("staff_invite_create", "failure", user=actor, metadata={"reason": "missing_totp_step_up"})
+        raise AuthError("Fresh MFA verification is required", 403)
+
+    normalized_personal = normalize_personal_email(personal_email)
+    normalized_workplace = normalize_workplace_email(workplace_email)
+    normalized_role = str(role or "").strip().casefold()
+    if normalized_role not in INVITABLE_ROLES:
+        audit_event("staff_invite_create", "failure", user=actor, metadata={"reason": "invalid_role"})
+        raise AuthError("Invalid invite role", 400)
+    if normalized_role == ACCOUNT_ROOT_ADMIN:
+        raise AuthError("Invalid invite role", 400)
+    _reject_existing_staff_identity(normalized_workplace)
+    _reject_active_invite(normalized_workplace, normalized_personal)
+    if not _verify_totp_for_user(actor, totp_code, "staff_invite_create"):
+        audit_event("staff_invite_create", "failure", user=actor, metadata={"reason": "invalid_totp_step_up"})
+        raise AuthError("Fresh MFA verification is required", 403)
+
+    token = secrets.token_urlsafe(32)
+    now = _utcnow()
+    invite = StaffInvite(
+        token_hash=invite_token_hash(token),
+        personal_email_normalized=normalized_personal,
+        workplace_email_normalized=normalized_workplace,
+        role=normalized_role,
+        status="pending",
+        created_by_user_id=actor.id,
+        created_at=now,
+        expires_at=now + timedelta(seconds=int(current_app.config["STAFF_INVITE_TTL_SECONDS"])),
+    )
+    db.session.add(invite)
+    try:
+        db.session.flush()
+        audit_event_required(
+            "staff_invite_created",
+            "success",
+            user=actor,
+            metadata=_invite_audit_metadata(invite),
+        )
+        db.session.commit()
+    except IntegrityError as exc:
+        db.session.rollback()
+        audit_event("staff_invite_create", "failure", user=actor, metadata={"reason": "integrity_error"})
+        raise AuthError("Invite could not be created", 400) from exc
+
+    invite_url = url_for("admin.invite_accept_info", token=token, _external=True)
+    try:
+        _send_invite_email(invite, invite_url)
+    except Exception as exc:
+        current_app.logger.warning("staff_invite_email_failed error=%s", type(exc).__name__)
+        audit_event(
+            "staff_invite_email",
+            "failure",
+            user=actor,
+            metadata={**_invite_audit_metadata(invite), "reason": "email_delivery_failed"},
+        )
+        raise AuthError("Invite could not be sent", 503) from exc
+    audit_event("staff_invite_email", "queued", user=actor, metadata=_invite_audit_metadata(invite))
+    return {
+        "message": "Invite created",
+        "invite": public_invite(invite),
+    }
+
+
+def public_invites_for_root_admin() -> list[dict[str, Any]]:
+    invites = list(
+        db.session.execute(
+            db.select(StaffInvite).order_by(StaffInvite.created_at.desc(), StaffInvite.id.desc())
+        ).scalars()
+    )
+    return [public_invite(invite) for invite in invites]
+
+
+def revoke_staff_invite(actor: User, invite_id: int, totp_code: str | None) -> dict[str, Any]:
+    if not is_root_admin(actor):
+        raise AuthError("Forbidden", 403)
+    if not totp_code or not _verify_totp_for_user(actor, totp_code, "staff_invite_revoke"):
+        audit_event("staff_invite_revoked", "failure", user=actor, metadata={"reason": "invalid_totp_step_up"})
+        raise AuthError("Fresh MFA verification is required", 403)
+    invite = db.session.get(StaffInvite, int(invite_id))
+    if invite is None or invite.status not in ACTIVE_INVITE_STATUSES:
+        raise AuthError("Invite not found", 404)
+    invite.status = "revoked"
+    invite.revoked_at = _utcnow()
+    invite.revoked_by_user_id = actor.id
+    audit_event_required("staff_invite_revoked", "success", user=actor, metadata=_invite_audit_metadata(invite))
+    db.session.commit()
+    return {"message": "Invite revoked", "invite": public_invite(invite)}
+
+
+def invite_info(token: str) -> dict[str, Any]:
+    invite = _active_invite_by_token(token, audit_failures=True)
+    return {
+        "message": "Invite found",
+        "invite": {
+            "workplace_email": invite.workplace_email_normalized,
+            "role": invite.role,
+            "expires_at": _utc_iso(invite.expires_at),
+            "status": invite.status,
+        },
+    }
+
+
+def start_invite_acceptance(
+    token: str,
+    *,
+    full_name: str,
+    phone_number: str,
+    password: str,
+    confirm_password: str,
+    turnstile_token: str | None,
+    request_fields: set[str],
+) -> dict[str, Any]:
+    _reject_forged_invite_fields(request_fields)
+    try:
+        verify_turnstile_token(turnstile_token)
+    except TurnstileError as exc:
+        audit_event("staff_invite_accept", "failure", metadata={"reason": "turnstile_failed"})
+        raise AuthError("Invite acceptance failed", 400) from exc
+
+    invite = _active_invite_by_token(token, lock=True, audit_failures=True)
+    name = validate_full_name(full_name)
+    phone = validate_phone_number(phone_number)
+    if password != confirm_password:
+        audit_event("staff_invite_accept", "failure", metadata={"reason": "password_mismatch"})
+        raise AuthError("Passwords must match", 400)
+    try:
+        validate_password_policy(password)
+    except PasswordPolicyError as exc:
+        audit_event("staff_invite_accept", "failure", metadata={"reason": "password_policy"})
+        raise AuthError(str(exc), 400) from exc
+
+    user = db.session.get(User, invite.setup_user_id) if invite.setup_user_id else None
+    if user is None:
+        _reject_duplicate_staff_signup(invite.workplace_email_normalized, phone)
+        user = User(
+            username=_staff_username(invite.workplace_email_normalized),
+            email=invite.workplace_email_normalized,
+            password_hash=hash_password(password),
+            account_type=invite.role,
+            account_status="setup_pending",
+            full_name=name,
+            phone_number=phone,
+            account_number=None,
+            staff_personal_email=invite.personal_email_normalized,
+            mfa_enabled=False,
+        )
+        db.session.add(user)
+        db.session.flush()
+        invite.setup_user_id = user.id
+    else:
+        if user.account_status != "setup_pending" or user.account_type != invite.role:
+            raise AuthError(GENERIC_INVITE_ERROR, 401)
+        user.full_name = name
+        user.phone_number = phone
+        user.password_hash = hash_password(password)
+        user.staff_personal_email = invite.personal_email_normalized
+
+    secret = pyotp.random_base32(length=32)
+    user.mfa_secret_nonce, user.mfa_secret_ciphertext = encrypt_mfa_secret(secret, user.id)
+    user.mfa_enabled = False
+    invite.status = "totp_pending"
+    invite.last_attempt_at = _utcnow()
+    try:
+        _send_workplace_verification(invite)
+        audit_event_required(
+            "staff_workplace_verification_sent",
+            "queued",
+            user=user,
+            metadata=_invite_audit_metadata(invite),
+        )
+        audit_event_required(
+            "staff_invite_accept_started",
+            "success",
+            user=user,
+            metadata=_invite_audit_metadata(invite),
+        )
+        db.session.commit()
+    except Exception as exc:
+        db.session.rollback()
+        current_app.logger.warning("staff_workplace_verification_email_failed error=%s", type(exc).__name__)
+        audit_event("staff_workplace_verification_sent", "failure", metadata={"reason": "email_delivery_failed"})
+        raise AuthError("Invite acceptance failed", 503) from exc
+    return {
+        "message": "TOTP setup required",
+        "invite": {
+            "workplace_email": invite.workplace_email_normalized,
+            "role": invite.role,
+        },
+        "totp_setup": _mfa_setup_payload(user, secret),
+        "workplace_verification_required": True,
+    }
+
+
+def verify_invite_acceptance(
+    token: str,
+    *,
+    totp_code: str,
+    workplace_verification_code: str,
+    request_fields: set[str],
+) -> dict[str, Any]:
+    _reject_forged_invite_fields(request_fields)
+    invite = _active_invite_by_token(token, lock=True, audit_failures=True)
+    user = db.session.get(User, invite.setup_user_id) if invite.setup_user_id else None
+    if user is None or user.account_status != "setup_pending" or user.account_type != invite.role:
+        audit_event("staff_invite_accept", "failure", metadata={"reason": "setup_missing"})
+        raise AuthError(GENERIC_INVITE_ERROR, 401)
+    if not TOTP_RE.fullmatch(str(totp_code or "")):
+        audit_event("staff_totp_setup", "failure", user=user, metadata={"reason": "invalid_format"})
+        raise AuthError("Invalid authentication code.", 401)
+    if not _verify_totp_for_user(user, totp_code, "staff_totp_setup"):
+        audit_event("staff_totp_setup", "failure", user=user)
+        raise AuthError("Invalid authentication code.", 401)
+    if not _verify_workplace_code(invite, workplace_verification_code):
+        audit_event(
+            "staff_workplace_verification",
+            "failure",
+            user=user,
+            metadata=_invite_audit_metadata(invite),
+        )
+        raise AuthError(GENERIC_WORKPLACE_VERIFICATION_ERROR, 401)
+
+    now = _utcnow()
+    user.mfa_enabled = True
+    user.account_status = "active"
+    user.workplace_email_verified_at = now
+    invite.status = "accepted"
+    invite.used_at = now
+    invite.used_by_user_id = user.id
+    invite.workplace_verified_at = now
+    audit_event_required("staff_totp_setup", "success", user=user, metadata={"method": "totp"})
+    audit_event_required("staff_workplace_verification", "success", user=user, metadata=_invite_audit_metadata(invite))
+    audit_event_required("staff_account_activated", "success", user=user, metadata=_invite_audit_metadata(invite))
+    db.session.commit()
+    return {
+        "message": "Staff account activated",
+        "user": public_admin_user(user),
+    }
+
+
+def public_admin_user(user: User) -> dict[str, Any]:
+    return {
+        "id": user.id,
+        "email": user.email,
+        "account_type": user.account_type,
+        "account_status": user.account_status,
+        "mfa_enabled": user.mfa_enabled,
+        "workplace_email_verified": bool(user.workplace_email_verified_at),
+    }
+
+
+def public_invite(invite: StaffInvite) -> dict[str, Any]:
+    return {
+        "id": invite.id,
+        "personal_email_ref": audit_reference("staff_personal_email", invite.personal_email_normalized),
+        "workplace_email": invite.workplace_email_normalized,
+        "role": invite.role,
+        "status": invite.status,
+        "created_at": _utc_iso(invite.created_at),
+        "expires_at": _utc_iso(invite.expires_at),
+        "used_at": _utc_iso(invite.used_at) if invite.used_at else None,
+        "revoked_at": _utc_iso(invite.revoked_at) if invite.revoked_at else None,
+    }
+
+
+def normalize_workplace_email(email: str) -> str:
+    normalized = _normalize_email(email)
+    local, separator, domain = normalized.partition("@")
+    if not _valid_email_parts(local, separator, domain):
+        raise AuthError("Invalid workplace email", 400)
+    if domain.casefold() not in _workplace_domains():
+        raise AuthError("Invalid workplace email", 400)
+    if _contains_alias_separator(local):
+        raise AuthError("Invalid workplace email", 400)
+    return f"{local}@{domain.casefold()}"
+
+
+def normalize_personal_email(email: str) -> str:
+    normalized = _normalize_email(email)
+    local, separator, domain = normalized.partition("@")
+    if not _valid_email_parts(local, separator, domain):
+        raise AuthError("Invalid personal email", 400)
+    domain_lower = domain.casefold()
+    if domain_lower in _workplace_domains() or domain_lower not in _personal_domains():
+        raise AuthError("Invalid personal email", 400)
+    if _contains_alias_separator(local):
+        raise AuthError("Invalid personal email", 400)
+    return f"{local}@{domain_lower}"
+
+
+def validate_full_name(full_name: str) -> str:
+    text = str(full_name or "").strip()
+    if not FULL_NAME_RE.fullmatch(text):
+        raise AuthError("Invalid full name", 400)
+    return text
+
+
+def validate_phone_number(phone_number: str) -> str:
+    text = str(phone_number or "").strip()
+    if not PHONE_RE.fullmatch(text):
+        raise AuthError("Invalid phone number", 400)
+    return text
+
+
+def invite_token_hash(token: str) -> str:
+    token_text = str(token or "").strip()
+    if len(token_text) < 32 or not re.fullmatch(r"[A-Za-z0-9_-]{32,256}", token_text):
+        raise AuthError(GENERIC_INVITE_ERROR, 401)
+    return active_hmac_hex(f"staff-invite-token:{token_text}", length=64)
+
+
+def _active_invite_by_token(
+    token: str,
+    *,
+    lock: bool = False,
+    audit_failures: bool = False,
+) -> StaffInvite:
+    try:
+        token_hash = invite_token_hash(token)
+    except AuthError:
+        if audit_failures:
+            audit_event("staff_invite_invalid_attempt", "failure", metadata={"reason": "malformed_token"})
+        raise
+    statement = db.select(StaffInvite).where(StaffInvite.token_hash == token_hash)
+    if lock and db.engine.dialect.name == "postgresql":
+        statement = statement.with_for_update()
+    invite = db.session.execute(statement).scalar_one_or_none()
+    now = _utcnow()
+    if invite is None:
+        if audit_failures:
+            audit_event("staff_invite_invalid_attempt", "failure", metadata={"reason": "missing"})
+        raise AuthError(GENERIC_INVITE_ERROR, 401)
+    invite.last_attempt_at = now
+    if _as_utc(invite.expires_at) <= now:
+        invite.status = "expired"
+        db.session.commit()
+        audit_event("staff_invite_expired", "expired", metadata=_invite_audit_metadata(invite))
+        raise AuthError(GENERIC_INVITE_ERROR, 401)
+    if invite.revoked_at is not None or invite.status == "revoked":
+        if audit_failures:
+            audit_event("staff_invite_invalid_attempt", "failure", metadata={"reason": "revoked"})
+        raise AuthError(GENERIC_INVITE_ERROR, 401)
+    if invite.used_at is not None or invite.status == "accepted":
+        if audit_failures:
+            audit_event("staff_invite_invalid_attempt", "failure", metadata={"reason": "used"})
+        raise AuthError(GENERIC_INVITE_ERROR, 401)
+    if invite.status not in ACTIVE_INVITE_STATUSES:
+        raise AuthError(GENERIC_INVITE_ERROR, 401)
+    return invite
+
+
+def _send_invite_email(invite: StaffInvite, invite_url: str) -> None:
+    send_security_email(
+        invite.personal_email_normalized,
+        "SITBank staff access invite",
+        (
+            "You have been invited to set up separate SITBank staff access.\n\n"
+            f"Open this link to continue: {invite_url}\n\n"
+            "This invite expires in 24 hours. You will set your own password and "
+            "must enroll an authenticator app before staff access is activated. "
+            "This staff identity is separate from any customer banking account."
+        ),
+    )
+
+
+def _send_workplace_verification(invite: StaffInvite) -> None:
+    code = f"{secrets.randbelow(1_000_000):06d}"
+    now = _utcnow()
+    invite.workplace_verification_code_hmac = _workplace_code_hmac(invite, code)
+    invite.workplace_verification_sent_at = now
+    invite.workplace_verification_expires_at = now + timedelta(
+        seconds=int(current_app.config["STAFF_WORKPLACE_VERIFICATION_TTL_SECONDS"])
+    )
+    send_security_email(
+        invite.workplace_email_normalized,
+        "SITBank workplace email verification code",
+        (
+            "Use this code to verify your SITBank workplace email for staff access:\n\n"
+            f"{code}\n\n"
+            "This code expires shortly. Staff access is separate from customer banking access."
+        ),
+    )
+
+
+def _verify_workplace_code(invite: StaffInvite, code: str) -> bool:
+    code_text = str(code or "").strip()
+    if not WORKPLACE_CODE_RE.fullmatch(code_text):
+        return False
+    if not invite.workplace_verification_code_hmac or not invite.workplace_verification_expires_at:
+        return False
+    if _as_utc(invite.workplace_verification_expires_at) <= _utcnow():
+        return False
+    expected = invite.workplace_verification_code_hmac
+    submitted = _workplace_code_hmac(invite, code_text)
+    return hmac.compare_digest(expected, submitted)
+
+
+def _workplace_code_hmac(invite: StaffInvite, code: str) -> str:
+    return active_hmac_hex(
+        f"staff-workplace-verification:{invite.token_hash}:{invite.workplace_email_normalized}:{code}",
+        length=64,
+    )
+
+
+def _reject_forged_invite_fields(request_fields: set[str]) -> None:
+    forbidden = {"role", "workplace_email", "email", "account_type", "customer_user_id", "is_admin"}
+    forged = sorted(forbidden & {field.strip() for field in request_fields})
+    if forged:
+        audit_event("staff_invite_accept", "failure", metadata={"reason": "forged_fields", "fields": forged})
+        raise AuthError("Invalid request", 400)
+
+
+def _reject_existing_staff_identity(workplace_email: str) -> None:
+    existing = db.session.execute(
+        db.select(User).where(
+            func.lower(User.email) == workplace_email.casefold(),
+            User.account_type.in_(tuple(STAFF_ACCOUNT_TYPES)),
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        raise AuthError("Invite could not be created", 400)
+
+
+def _reject_duplicate_staff_signup(workplace_email: str, phone_number: str) -> None:
+    existing = db.session.execute(
+        db.select(User).where(
+            or_(
+                func.lower(User.email) == workplace_email.casefold(),
+                User.phone_number == phone_number,
+            )
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        raise AuthError("Invite acceptance failed", 400)
+
+
+def _reject_active_invite(workplace_email: str, personal_email: str) -> None:
+    now = _utcnow()
+    existing = db.session.execute(
+        db.select(StaffInvite).where(
+            StaffInvite.status.in_(tuple(ACTIVE_INVITE_STATUSES)),
+            StaffInvite.revoked_at.is_(None),
+            StaffInvite.used_at.is_(None),
+            StaffInvite.expires_at > now,
+            or_(
+                func.lower(StaffInvite.workplace_email_normalized) == workplace_email.casefold(),
+                func.lower(StaffInvite.personal_email_normalized) == personal_email.casefold(),
+            ),
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        raise AuthError("Invite could not be created", 400)
+
+
+def _staff_user_by_workplace_email(email: str) -> User | None:
+    return db.session.execute(
+        db.select(User).where(
+            func.lower(User.email) == email.casefold(),
+            User.account_type.in_(tuple(STAFF_ACCOUNT_TYPES)),
+        )
+    ).scalar_one_or_none()
+
+
+def _staff_username(workplace_email: str) -> str:
+    local = workplace_email.partition("@")[0]
+    normalized = re.sub(r"[^A-Za-z0-9_.-]", ".", local).strip(".")[:48] or "staff"
+    base = f"staff.{normalized}"
+    if len(base) < 3:
+        base = "staff.user"
+    candidate = base[:64]
+    suffix = 0
+    while db.session.execute(db.select(User.id).where(func.lower(User.username) == candidate.casefold())).scalar_one_or_none():
+        suffix += 1
+        candidate = f"{base[:56]}.{suffix:02d}"
+    if not STAFF_USERNAME_RE.fullmatch(candidate):
+        return f"staff.{secrets.token_hex(8)}"
+    return candidate
+
+
+def _mfa_setup_payload(user: User, secret: str) -> dict[str, str]:
+    provisioning_uri = pyotp.TOTP(secret, digits=6, interval=30, digest=hashlib.sha1).provisioning_uri(
+        name=user.email,
+        issuer_name=current_app.config["MFA_ISSUER_NAME"],
+    )
+    return {
+        "issuer": current_app.config["MFA_ISSUER_NAME"],
+        "manual_entry_secret": secret,
+        "otpauth_uri": provisioning_uri,
+        "qr_code_data_uri": _qr_data_uri(provisioning_uri),
+    }
+
+
+def _qr_data_uri(provisioning_uri: str) -> str:
+    import base64
+    import io
+
+    import qrcode
+
+    image = qrcode.make(provisioning_uri)
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    encoded = base64.b64encode(buffer.getvalue()).decode("ascii")
+    return f"data:image/png;base64,{encoded}"
+
+
+def _invite_audit_metadata(invite: StaffInvite) -> dict[str, Any]:
+    return {
+        "invite_ref": audit_reference("staff_invite", invite.id),
+        "workplace_email_ref": audit_reference("staff_workplace_email", invite.workplace_email_normalized),
+        "personal_email_ref": audit_reference("staff_personal_email", invite.personal_email_normalized),
+        "target_role": invite.role,
+        "status": invite.status,
+    }
+
+
+def _auth_principal(identifier: str) -> str:
+    return f"{request.remote_addr or 'unknown'}:{_normalize_email(identifier).casefold()}"
+
+
+def _enforce_auth_backoff(scope: str, principal: str) -> None:
+    try:
+        apply_exponential_backoff(scope, principal)
+    except AuthBackoffRequired as exc:
+        audit_event("auth_backoff", "blocked", metadata={"scope": scope, "retry_after": exc.retry_after})
+        raise AuthError(ADMIN_AUTH_BACKOFF_ERROR, 429, retry_after=exc.retry_after) from exc
+
+
+def _normalize_email(email: str) -> str:
+    text = str(email or "").strip()
+    if "\x00" in text or "\r" in text or "\n" in text or len(text) > 255:
+        raise AuthError("Invalid email", 400)
+    local, separator, domain = text.partition("@")
+    return f"{local}@{domain.strip().casefold()}" if separator else text
+
+
+def _valid_email_parts(local: str, separator: str, domain: str) -> bool:
+    if separator != "@" or not local or not domain:
+        return False
+    if not EMAIL_RE.fullmatch(f"{local}@{domain}"):
+        return False
+    labels = domain.split(".")
+    return all(label and not label.startswith("-") and not label.endswith("-") for label in labels)
+
+
+def _contains_alias_separator(local: str) -> bool:
+    separators = tuple(current_app.config.get("STAFF_INVITE_ALIAS_SEPARATORS") or ("+",))
+    return any(separator and separator in local for separator in separators)
+
+
+def _workplace_domains() -> frozenset[str]:
+    return frozenset(str(item).casefold() for item in current_app.config["SIT_WORKPLACE_EMAIL_DOMAINS"])
+
+
+def _personal_domains() -> frozenset[str]:
+    return frozenset(str(item).casefold() for item in current_app.config["STAFF_INVITE_PERSONAL_EMAIL_DOMAINS"])
+
+
+def _root_admin_emails() -> frozenset[str]:
+    return frozenset(str(item).casefold() for item in current_app.config["ROOT_ADMIN_EMAILS"])
+
+
+def _utcnow() -> datetime:
+    return datetime.fromtimestamp(time.time(), timezone.utc)
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _utc_iso(value: datetime) -> str:
+    return _as_utc(value).isoformat()

--- a/app/auth/decorators.py
+++ b/app/auth/decorators.py
@@ -5,12 +5,16 @@ from time import time
 
 from flask import current_app, g, jsonify, session
 
+from app.admin.services import is_customer_user
+
 
 def login_required(view):
     @wraps(view)
     def wrapped(*args, **kwargs):
         if not session.get("user_id") or getattr(g, "current_user", None) is None:
             return jsonify({"error": "Authentication required"}), 401
+        if current_app.config.get("APP_MODE") == "customer" and not is_customer_user(g.current_user):
+            return jsonify({"error": "Forbidden"}), 403
         return view(*args, **kwargs)
 
     return wrapped

--- a/app/auth/password_reset.py
+++ b/app/auth/password_reset.py
@@ -976,7 +976,8 @@ def _find_customer_user(identifier: str) -> User | None:
             or_(
                 func.lower(User.username) == normalized,
                 func.lower(User.email) == normalized,
-            )
+            ),
+            User.account_type == "customer",
         )
     ).scalar_one_or_none()
 
@@ -1020,6 +1021,8 @@ def _account_reset_blocked(user: User) -> bool:
 
 
 def _is_admin_like_user(user: User) -> bool:
+    if getattr(user, "account_type", "customer") != "customer":
+        return True
     username = str(user.username or "").strip().casefold()
     email = str(user.email or "").strip().casefold()
     local, _separator, domain = email.partition("@")

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -7,6 +7,7 @@ from marshmallow import Schema, ValidationError
 
 from app.extensions import limiter
 from app.auth.mfa_policy import has_enrolled_mfa_method
+from app.admin.services import is_customer_user
 from app.security.rate_limits import mfa_principal, request_principal
 
 from .decorators import login_required, not_frozen_required
@@ -99,6 +100,8 @@ AUTH_MFA_ONBOARDING_ALLOWED_ENDPOINTS = {
 @auth_bp.before_request
 def enforce_api_mfa_onboarding():
     user = getattr(g, "current_user", None)
+    if user is not None and not is_customer_user(user):
+        return jsonify({"error": "Forbidden"}), 403
     if user is None or has_enrolled_mfa_method(user):
         return None
     if request.endpoint in AUTH_MFA_ONBOARDING_ALLOWED_ENDPOINTS:

--- a/app/auth/services.py
+++ b/app/auth/services.py
@@ -226,6 +226,8 @@ def register_user(data: dict[str, Any]) -> tuple[User, list[str]]:
         username=data["username"].strip(),
         email=normalized_email,
         password_hash=hash_password(data["password"]),
+        account_type="customer",
+        account_status="active",
         full_name=data["full_name"].strip(),
         phone_number=data["phone_number"].strip(),
         account_number=_generate_account_number(),
@@ -264,6 +266,9 @@ def authenticate_primary(identifier: str, password: str) -> dict[str, Any]:
     if is_password_raw_length_safe(password):
         candidate_hash = user.password_hash if user else _dummy_password_hash()
         password_ok = verify_password(password, candidate_hash)
+
+    if user is not None and getattr(user, "account_type", "customer") != "customer":
+        password_ok = False
 
     if user is None or not password_ok:
         audit_event(
@@ -1021,6 +1026,7 @@ def _public_user(user: User) -> dict[str, Any]:
         "id": user.id,
         "username": user.username,
         "email": user.email,
+        "account_type": user.account_type,
         "mfa_enabled": user.mfa_enabled,
         "mfa_step_up_preference": user.mfa_step_up_preference,
         "is_frozen": user.is_frozen,

--- a/app/models.py
+++ b/app/models.py
@@ -14,9 +14,13 @@ class User(db.Model):
     username = db.Column(db.String(64), nullable=False)
     email = db.Column(db.String(255), nullable=False)
     password_hash = db.Column(db.String(255), nullable=False)
+    account_type = db.Column(db.String(32), nullable=False, default="customer", index=True)
+    account_status = db.Column(db.String(32), nullable=False, default="active", index=True)
     full_name = db.Column(db.String(128), nullable=False)
     phone_number = db.Column(db.String(8), nullable=False, unique=True)
-    account_number = db.Column(db.String(9), nullable=False, unique=True)
+    account_number = db.Column(db.String(9), nullable=True, unique=True)
+    staff_personal_email = db.Column(db.String(255), nullable=True)
+    workplace_email_verified_at = db.Column(db.DateTime(timezone=True), nullable=True)
 
     mfa_secret_ciphertext = db.Column(db.LargeBinary, nullable=True)
     mfa_secret_nonce = db.Column(db.LargeBinary(12), nullable=True)
@@ -44,6 +48,14 @@ class User(db.Model):
     __table_args__ = (
         Index("ix_users_username_lower", func.lower(username), unique=True),
         Index("ix_users_email_lower", func.lower(email), unique=True),
+        db.CheckConstraint(
+            "account_type IN ('customer', 'staff', 'admin', 'root_admin')",
+            name="ck_users_account_type",
+        ),
+        db.CheckConstraint(
+            "account_status IN ('active', 'setup_pending', 'revoked', 'locked')",
+            name="ck_users_account_status",
+        ),
     )
 
     def __repr__(self) -> str:
@@ -305,6 +317,77 @@ class RegistrationOtpChallenge(db.Model):
             "session_binding_hash",
             "email_hash",
             name="uq_registration_otp_challenges_session_email",
+        ),
+    )
+
+
+class StaffInvite(db.Model):
+    __tablename__ = "staff_invites"
+
+    id = db.Column(db.Integer, primary_key=True)
+    token_hash = db.Column(db.String(64), nullable=False, unique=True, index=True)
+    personal_email_normalized = db.Column(db.String(255), nullable=False, index=True)
+    workplace_email_normalized = db.Column(db.String(255), nullable=False, index=True)
+    role = db.Column(db.String(32), nullable=False)
+    status = db.Column(db.String(32), nullable=False, default="pending", index=True)
+    created_by_user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False, index=True)
+    setup_user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True, index=True)
+    used_by_user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True, index=True)
+    revoked_by_user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True, index=True)
+    created_at = db.Column(
+        db.DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        index=True,
+    )
+    expires_at = db.Column(db.DateTime(timezone=True), nullable=False, index=True)
+    used_at = db.Column(db.DateTime(timezone=True), nullable=True)
+    revoked_at = db.Column(db.DateTime(timezone=True), nullable=True)
+    last_attempt_at = db.Column(db.DateTime(timezone=True), nullable=True)
+    workplace_verification_code_hmac = db.Column(db.String(64), nullable=True)
+    workplace_verification_sent_at = db.Column(db.DateTime(timezone=True), nullable=True)
+    workplace_verification_expires_at = db.Column(db.DateTime(timezone=True), nullable=True)
+    workplace_verified_at = db.Column(db.DateTime(timezone=True), nullable=True)
+
+    created_by = db.relationship("User", foreign_keys=[created_by_user_id], backref="created_staff_invites")
+    setup_user = db.relationship("User", foreign_keys=[setup_user_id], backref="pending_staff_invites")
+    used_by = db.relationship("User", foreign_keys=[used_by_user_id], backref="accepted_staff_invites")
+    revoked_by = db.relationship("User", foreign_keys=[revoked_by_user_id], backref="revoked_staff_invites")
+
+    __table_args__ = (
+        db.CheckConstraint("role IN ('staff', 'admin')", name="ck_staff_invites_role"),
+        db.CheckConstraint(
+            "status IN ('pending', 'totp_pending', 'accepted', 'revoked', 'expired')",
+            name="ck_staff_invites_status",
+        ),
+    )
+
+
+class PersonIdentityLink(db.Model):
+    __tablename__ = "person_identity_links"
+
+    id = db.Column(db.Integer, primary_key=True)
+    staff_user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False, index=True)
+    customer_user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False, index=True)
+    created_by_user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True, index=True)
+    created_at = db.Column(
+        db.DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+    verified_at = db.Column(db.DateTime(timezone=True), nullable=True)
+    revoked_at = db.Column(db.DateTime(timezone=True), nullable=True, index=True)
+    notes = db.Column(db.String(512), nullable=False, default="")
+
+    staff_user = db.relationship("User", foreign_keys=[staff_user_id], backref="linked_customer_identities")
+    customer_user = db.relationship("User", foreign_keys=[customer_user_id], backref="linked_staff_identities")
+    created_by = db.relationship("User", foreign_keys=[created_by_user_id])
+
+    __table_args__ = (
+        db.UniqueConstraint(
+            "staff_user_id",
+            "customer_user_id",
+            name="uq_person_identity_links_staff_customer",
         ),
     )
 

--- a/app/ops/commands.py
+++ b/app/ops/commands.py
@@ -12,7 +12,7 @@ from flask import Flask
 from sqlalchemy import text
 
 from app.extensions import db
-from app.models import AuthAttemptCounter, ServerSideSession, User
+from app.models import AuthAttemptCounter, ServerSideSession, StaffInvite, User
 from app.security.alerts import (
     build_security_alert_report,
     deliver_security_alerts,
@@ -111,15 +111,14 @@ def register_ops_commands(app: Flask) -> None:
         except Exception as exc:
             failures.append(f"DB-backed security-state table check failed: {exc}")
 
-        if app_mode == "customer":
-            mfa_kek_keys = app.config.get("MFA_KEK_KEYS")
-            mfa_kek_active_id = app.config.get("MFA_KEK_ACTIVE_ID")
-            if not isinstance(mfa_kek_keys, dict) or not mfa_kek_keys:
-                failures.append("MFA_KEK_KEYS_JSON must configure at least one MFA KEK")
-            elif mfa_kek_active_id not in mfa_kek_keys:
-                failures.append("MFA_KEK_ACTIVE_ID must identify a configured MFA KEK")
-            else:
-                click.echo(f"Configured MFA KEKs: {len(mfa_kek_keys)}")
+        mfa_kek_keys = app.config.get("MFA_KEK_KEYS")
+        mfa_kek_active_id = app.config.get("MFA_KEK_ACTIVE_ID")
+        if not isinstance(mfa_kek_keys, dict) or not mfa_kek_keys:
+            failures.append("MFA_KEK_KEYS_JSON must configure at least one MFA KEK")
+        elif mfa_kek_active_id not in mfa_kek_keys:
+            failures.append("MFA_KEK_ACTIVE_ID must identify a configured MFA KEK")
+        else:
+            click.echo(f"Configured MFA KEKs: {len(mfa_kek_keys)}")
 
         try:
             alert_config = validate_security_alert_config(require_delivery=True)
@@ -166,13 +165,20 @@ def register_ops_commands(app: Flask) -> None:
         if app_mode == "admin":
             if app.config.get("SESSION_COOKIE_NAME") != "__Host-sitbank_admin_session":
                 failures.append("Admin session cookie name must be isolated")
-            if app.config.get("ADMIN_AUTH_ENABLED") is not False:
-                failures.append("Admin authentication must remain disabled in Phase 1A")
+            if app.config.get("ADMIN_AUTH_ENABLED") is not True:
+                failures.append("Admin authentication must be enabled for invite-only staff onboarding")
+            root_admin_emails = app.config.get("ROOT_ADMIN_EMAILS") or set()
+            if len(root_admin_emails) != 7:
+                failures.append("ROOT_ADMIN_EMAILS must configure exactly 7 root administrators")
             if not str(app.config.get("RATELIMIT_KEY_PREFIX", "")).startswith("ospbank:admin:"):
                 failures.append("Admin rate-limit key prefix must be isolated")
             if not str(app.config.get("SESSION_KEY_PREFIX", "")).startswith("admin-"):
                 failures.append("Admin session key prefix must be isolated")
-            click.echo("Admin auth is fail-closed; admin login and step-up remain disabled")
+            try:
+                db.session.execute(db.select(StaffInvite.id).limit(1))
+            except Exception as exc:
+                failures.append(f"Staff invite table check failed: {exc}")
+            click.echo("Admin auth enabled for root-admin invite-only TOTP onboarding")
         if int(app.config.get("TOTP_LOGIN_VALID_WINDOW", -1)) > 1:
             failures.append("TOTP_LOGIN_VALID_WINDOW must be 0 or 1")
         if int(app.config.get("TOTP_HIGH_RISK_VALID_WINDOW", -1)) != 0:

--- a/app/security/rate_limits.py
+++ b/app/security/rate_limits.py
@@ -31,6 +31,8 @@ def request_principal() -> str:
     value = (
         payload.get("username")
         or payload.get("email")
+        or payload.get("workplace_email")
+        or payload.get("personal_email")
         or payload.get("identifier")
         or session.get("pending_mfa_user_id")
         or getattr(getattr(g, "current_user", None), "id", None)

--- a/app/security/turnstile.py
+++ b/app/security/turnstile.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from urllib import parse, request as urlrequest
+
+from flask import current_app, request
+
+
+class TurnstileError(ValueError):
+    pass
+
+
+def verify_turnstile_token(token: str | None) -> None:
+    if not current_app.config.get("TURNSTILE_ENABLED", False):
+        return
+    token_text = str(token or "").strip()
+    secret_key = str(current_app.config.get("TURNSTILE_SECRET_KEY") or "").strip()
+    if not token_text or not secret_key:
+        raise TurnstileError("Challenge verification failed")
+
+    payload = parse.urlencode(
+        {
+            "secret": secret_key,
+            "response": token_text,
+            "remoteip": request.remote_addr or "",
+        }
+    ).encode("utf-8")
+    verifier = urlrequest.Request(
+        str(current_app.config["TURNSTILE_VERIFY_URL"]),
+        data=payload,
+        method="POST",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    try:
+        with urlrequest.urlopen(verifier, timeout=5) as response:
+            body = response.read(16 * 1024)
+        result = json.loads(body.decode("utf-8"))
+    except Exception as exc:
+        raise TurnstileError("Challenge verification failed") from exc
+    if not isinstance(result, dict) or result.get("success") is not True:
+        raise TurnstileError("Challenge verification failed")

--- a/app/security/turnstile.py
+++ b/app/security/turnstile.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import json
-from urllib import parse, request as urlrequest
+import http.client
+from urllib import parse
 
 from flask import current_app, request
 
@@ -25,17 +26,33 @@ def verify_turnstile_token(token: str | None) -> None:
             "remoteip": request.remote_addr or "",
         }
     ).encode("utf-8")
-    verifier = urlrequest.Request(
-        str(current_app.config["TURNSTILE_VERIFY_URL"]),
-        data=payload,
-        method="POST",
-        headers={"Content-Type": "application/x-www-form-urlencoded"},
-    )
     try:
-        with urlrequest.urlopen(verifier, timeout=5) as response:
+        host, port, target = _turnstile_verify_target()
+        connection = http.client.HTTPSConnection(host, port=port, timeout=5)
+        try:
+            connection.request(
+                "POST",
+                target,
+                body=payload,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+            response = connection.getresponse()
             body = response.read(16 * 1024)
+        finally:
+            connection.close()
         result = json.loads(body.decode("utf-8"))
     except Exception as exc:
         raise TurnstileError("Challenge verification failed") from exc
     if not isinstance(result, dict) or result.get("success") is not True:
         raise TurnstileError("Challenge verification failed")
+
+
+def _turnstile_verify_target() -> tuple[str, int | None, str]:
+    raw_url = str(current_app.config["TURNSTILE_VERIFY_URL"])
+    parsed = parse.urlsplit(raw_url)
+    if parsed.scheme != "https" or not parsed.hostname:
+        raise TurnstileError("Challenge verification failed")
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise TurnstileError("Challenge verification failed")
+    path = parsed.path or "/"
+    return parsed.hostname, parsed.port, path

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -29,6 +29,7 @@ from app.auth.forms import (
     RegistrationOtpRequestForm,
     TotpForm,
 )
+from app.admin.services import is_customer_user
 from app.auth.password_reset import (
     complete_password_reset,
     current_reset_transaction,
@@ -98,6 +99,10 @@ WEB_MFA_ONBOARDING_ALLOWED_ENDPOINTS = {
 @web_bp.before_request
 def enforce_mfa_onboarding():
     user = getattr(g, "current_user", None)
+    if user is not None and not is_customer_user(user):
+        session.clear()
+        flash("Please log in with a customer account.", "warning")
+        return redirect(url_for("web.login"))
     if user is None or has_enrolled_mfa_method(user):
         return None
     if request.endpoint in WEB_MFA_ONBOARDING_ALLOWED_ENDPOINTS:
@@ -111,6 +116,10 @@ def web_login_required(view):
     def wrapped(*args, **kwargs):
         if not session.get("user_id") or getattr(g, "current_user", None) is None:
             flash("Please log in to continue.", "warning")
+            return redirect(url_for("web.login"))
+        if not is_customer_user(g.current_user):
+            session.clear()
+            flash("Please log in with a customer account.", "warning")
             return redirect(url_for("web.login"))
         return view(*args, **kwargs)
 

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -149,6 +149,7 @@ services:
       ADMIN_SESSION_HMAC_KEYS_JSON_FILE: /run/secrets/admin_session_hmac_keys_json
       ADMIN_SESSION_LOOKUP_HMAC_KEY_FILE: /run/secrets/admin_session_lookup_hmac_key
       ADMIN_DATABASE_URL_FILE: /run/secrets/admin_database_url
+      MFA_KEK_KEYS_JSON_FILE: /run/secrets/mfa_kek_keys_json
       ADMIN_PASSWORD_PEPPER_B64_FILE: /run/secrets/admin_password_pepper_b64
       SECURITY_AUDIT_HMAC_KEY_FILE: /run/secrets/security_audit_hmac_key
       SECURITY_ALERT_WEBHOOK_URL_FILE: /run/secrets/security_alert_webhook_url
@@ -165,6 +166,8 @@ services:
         target: admin_session_lookup_hmac_key
       - source: admin_database_url
         target: admin_database_url
+      - source: mfa_kek_keys_json
+        target: mfa_kek_keys_json
       - source: admin_password_pepper_b64
         target: admin_password_pepper_b64
       - source: security_audit_hmac_key

--- a/compose.staging.yml
+++ b/compose.staging.yml
@@ -201,6 +201,7 @@ services:
       ADMIN_SESSION_HMAC_KEYS_JSON_FILE: /run/secrets/admin_session_hmac_keys_json
       ADMIN_SESSION_LOOKUP_HMAC_KEY_FILE: /run/secrets/admin_session_lookup_hmac_key
       ADMIN_DATABASE_URL_FILE: /run/secrets/admin_database_url
+      MFA_KEK_KEYS_JSON_FILE: /run/secrets/mfa_kek_keys_json
       ADMIN_PASSWORD_PEPPER_B64_FILE: /run/secrets/admin_password_pepper_b64
       SECURITY_AUDIT_HMAC_KEY_FILE: /run/secrets/security_audit_hmac_key
       SECURITY_ALERT_WEBHOOK_URL_FILE: /run/secrets/security_alert_webhook_url
@@ -217,6 +218,8 @@ services:
         target: admin_session_lookup_hmac_key
       - source: admin_database_url
         target: admin_database_url
+      - source: mfa_kek_keys_json
+        target: mfa_kek_keys_json
       - source: admin_password_pepper_b64
         target: admin_password_pepper_b64
       - source: security_audit_hmac_key

--- a/config.py
+++ b/config.py
@@ -44,6 +44,7 @@ ADMIN_RUNTIME_SECRET_ENV_NAMES = {
     "SESSION_HMAC_KEYS": "ADMIN_SESSION_HMAC_KEYS_JSON",
     "SESSION_LOOKUP_HMAC_KEY": "ADMIN_SESSION_LOOKUP_HMAC_KEY",
     "SQLALCHEMY_DATABASE_URI": "ADMIN_DATABASE_URL",
+    "MFA_KEK_KEYS": "MFA_KEK_KEYS_JSON",
     "PASSWORD_PEPPER_B64": "ADMIN_PASSWORD_PEPPER_B64",
     "SECURITY_AUDIT_HMAC_KEY": "SECURITY_AUDIT_HMAC_KEY",
 }
@@ -289,6 +290,32 @@ def _choice_env(name: str, *, default: str, choices: set[str]) -> str:
         allowed = ", ".join(sorted(choices))
         raise RuntimeError(f"{name} must be one of: {allowed}")
     return value
+
+
+def _csv_env_set(name: str, *, default: str) -> frozenset[str]:
+    raw_value = os.getenv(name, default)
+    values = frozenset(
+        item.strip().casefold()
+        for item in raw_value.split(",")
+        if item.strip()
+    )
+    if not values:
+        raise RuntimeError(f"{name} must contain at least one value")
+    return values
+
+
+def _optional_turnstile_secret() -> str | None:
+    direct_value = os.getenv("TURNSTILE_SECRET_KEY")
+    file_value = os.getenv("TURNSTILE_SECRET_KEY_FILE")
+    if direct_value and file_value:
+        raise RuntimeError("Configure either TURNSTILE_SECRET_KEY or TURNSTILE_SECRET_KEY_FILE, not both")
+    if file_value:
+        return _read_secret_file("TURNSTILE_SECRET_KEY", file_value)
+    if not direct_value:
+        return None
+    if _looks_placeholder(direct_value):
+        raise RuntimeError("TURNSTILE_SECRET_KEY contains a placeholder value")
+    return direct_value
 
 
 def _validate_password_reset_email_config(
@@ -537,6 +564,13 @@ def _admin_runtime_overrides(config: dict) -> dict[str, object]:
             lambda: _required_env("ADMIN_SESSION_HMAC_ACTIVE_KEY_ID"),
         )
     )
+    mfa_kek_active_id = str(
+        _configured_value(
+            config,
+            "MFA_KEK_ACTIVE_ID",
+            lambda: _required_env("MFA_KEK_ACTIVE_ID"),
+        )
+    )
     return {
         "APP_MODE": "admin",
         "SECRET_ENV_NAMES": ADMIN_RUNTIME_SECRET_ENV_NAMES,
@@ -574,6 +608,16 @@ def _admin_runtime_overrides(config: dict) -> dict[str, object]:
             ),
         ),
         "SQLALCHEMY_MIGRATION_DATABASE_URI": None,
+        "MFA_KEK_ACTIVE_ID": mfa_kek_active_id,
+        "MFA_KEK_KEYS": _configured_value(
+            config,
+            "MFA_KEK_KEYS",
+            lambda: _required_keyring(
+                "MFA_KEK_KEYS_JSON",
+                active_key_id=mfa_kek_active_id,
+                active_label="MFA_KEK_ACTIVE_ID",
+            ),
+        ),
         "PASSWORD_PEPPER_B64": _configured_value(
             config,
             "ADMIN_PASSWORD_PEPPER_B64",
@@ -589,9 +633,9 @@ def _admin_runtime_overrides(config: dict) -> dict[str, object]:
         "RATELIMIT_STORAGE_URI": config.get("ADMIN_RATELIMIT_STORAGE_URI") or "memory://",
         "RATELIMIT_KEY_PREFIX": config.get("ADMIN_RATELIMIT_KEY_PREFIX")
         or os.getenv("ADMIN_RATELIMIT_KEY_PREFIX", "ospbank:admin:ratelimit:"),
-        "ADMIN_AUTH_ENABLED": False,
-        "ADMIN_WEBAUTHN_PHASE": "phase_2",
-        "ADMIN_STEP_UP_PHASE": "phase_2",
+        "ADMIN_AUTH_ENABLED": True,
+        "ADMIN_WEBAUTHN_PHASE": "disabled",
+        "ADMIN_STEP_UP_PHASE": "totp",
     }
 
 
@@ -829,6 +873,52 @@ class Config:
 
     # 60 seconds (1 min) for testing — change to 43200 for 12h in production
     PAYEE_COOLDOWN_SECONDS = int(os.getenv("PAYEE_COOLDOWN_SECONDS", "60"))
+
+    SIT_WORKPLACE_EMAIL_DOMAINS = _csv_env_set(
+        "SIT_WORKPLACE_EMAIL_DOMAINS",
+        default="sit.singaporetech.edu.sg,singaporetech.edu.sg",
+    )
+    STAFF_INVITE_PERSONAL_EMAIL_DOMAINS = _csv_env_set(
+        "STAFF_INVITE_PERSONAL_EMAIL_DOMAINS",
+        default="gmail.com,outlook.com,hotmail.com,yahoo.com,icloud.com,proton.me,protonmail.com",
+    )
+    STAFF_INVITE_ALIAS_SEPARATORS = tuple(
+        item
+        for item in os.getenv("STAFF_INVITE_ALIAS_SEPARATORS", "+").split(",")
+        if item
+    )
+    ROOT_ADMIN_EMAILS = _csv_env_set(
+        "ROOT_ADMIN_EMAILS",
+        default=(
+            "root1@sit.singaporetech.edu.sg,"
+            "root2@sit.singaporetech.edu.sg,"
+            "root3@sit.singaporetech.edu.sg,"
+            "root4@sit.singaporetech.edu.sg,"
+            "root5@sit.singaporetech.edu.sg,"
+            "root6@sit.singaporetech.edu.sg,"
+            "root7@sit.singaporetech.edu.sg"
+        ),
+    )
+    if len(ROOT_ADMIN_EMAILS) != 7:
+        raise RuntimeError("ROOT_ADMIN_EMAILS must contain exactly 7 workplace email addresses")
+    STAFF_INVITE_TTL_SECONDS = _int_env(
+        "STAFF_INVITE_TTL_SECONDS",
+        default=str(24 * 60 * 60),
+        minimum=15 * 60,
+        maximum=48 * 60 * 60,
+    )
+    STAFF_WORKPLACE_VERIFICATION_TTL_SECONDS = _int_env(
+        "STAFF_WORKPLACE_VERIFICATION_TTL_SECONDS",
+        default="900",
+        minimum=300,
+        maximum=3600,
+    )
+    TURNSTILE_ENABLED = _optional_bool("TURNSTILE_ENABLED", default=False)
+    TURNSTILE_SECRET_KEY = _optional_turnstile_secret()
+    TURNSTILE_VERIFY_URL = os.getenv(
+        "TURNSTILE_VERIFY_URL",
+        "https://challenges.cloudflare.com/turnstile/v0/siteverify",
+    ).strip()
 
 
 class TestingConfig(Config):

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -112,14 +112,14 @@ The reviewed production bootstrap installs and enables the production edge from 
 - `compose.prod.yml` publishes no app ports.
 - `/health/ready` is for local deployment and load-balancer checks and should deny public traffic.
 - Admin `/` serves only a static Google verification and restricted-access
-  notice. Admin `/health/ready`, `/login`, and all other admin routes remain
-  denied by default until a future VPN, explicit IP allowlist, or equivalent
-  network control is configured.
+  notice at the public edge. Admin `/health/ready`, `/login`, and all other
+  admin routes should remain denied by default at Nginx until a VPN, explicit
+  IP allowlist, or equivalent network control is configured.
 - Cloudflare or AWS WAF should sit in front of Nginx for managed common, SQL injection, XSS, bot, and protocol anomaly rules.
 - Cloudflare or AWS WAF rules and security-group allowlists are still infrastructure state and must be checked manually.
-- Admin auth remains fail-closed pending an approved MFA design and is not
-  implemented in this PR. The current admin app is not publicly usable and must
-  not expose password-only administrator login.
+- Flask admin auth is implemented only for root-admin-controlled invite
+  onboarding with mandatory TOTP, separate admin sessions, and no WebAuthn or
+  password-only administrator login.
 
 Verification:
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -90,11 +90,11 @@ TOTP-backed transaction authorization checks. There is no final ledger movement
 endpoint in this codebase, so final transfer execution is intentionally out of
 scope until such an endpoint exists.
 
-The Phase 1A admin boundary audits disabled/fail-closed admin login and access
-denied attempts with `admin_*` event types. Full admin audit coverage, including
-admin login success/failure, admin step-up, admin data access, and admin
-configuration changes, is Phase 2 after an approved admin MFA design and
-network controls exist.
+The admin boundary audits root-admin-controlled staff invite onboarding,
+admin login success/failure, TOTP verification, admin step-up, admin data
+access, and admin configuration changes with safe `admin_*` and
+`staff_*` event metadata. Admin sessions, credentials, cookies, and session
+HMAC keys remain separate from customer sessions.
 
 Useful checks:
 

--- a/migrations/versions/20260626_0014_staff_invite_onboarding.py
+++ b/migrations/versions/20260626_0014_staff_invite_onboarding.py
@@ -1,0 +1,156 @@
+"""Add staff invite onboarding and identity separation tables.
+
+Revision ID: 20260626_0014
+Revises: 20260625_0013
+Create Date: 2026-06-26 00:14:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import text
+
+
+revision = "20260626_0014"
+down_revision = "20260625_0013"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    dialect = op.get_context().dialect.name
+
+    op.add_column(
+        "users",
+        sa.Column("account_type", sa.String(length=32), nullable=True),
+    )
+    op.add_column(
+        "users",
+        sa.Column("account_status", sa.String(length=32), nullable=True),
+    )
+    op.add_column(
+        "users",
+        sa.Column("staff_personal_email", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "users",
+        sa.Column("workplace_email_verified_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.execute(text("UPDATE users SET account_type = 'customer' WHERE account_type IS NULL"))
+    op.execute(text("UPDATE users SET account_status = 'active' WHERE account_status IS NULL"))
+    if dialect != "sqlite":
+        op.alter_column("users", "account_type", existing_type=sa.String(32), nullable=False)
+        op.alter_column("users", "account_status", existing_type=sa.String(32), nullable=False)
+        op.alter_column("users", "account_number", existing_type=sa.String(9), nullable=True)
+        op.create_check_constraint(
+            "ck_users_account_type",
+            "users",
+            "account_type IN ('customer', 'staff', 'admin', 'root_admin')",
+        )
+        op.create_check_constraint(
+            "ck_users_account_status",
+            "users",
+            "account_status IN ('active', 'setup_pending', 'revoked', 'locked')",
+        )
+    op.create_index("ix_users_account_type", "users", ["account_type"])
+    op.create_index("ix_users_account_status", "users", ["account_status"])
+
+    op.create_table(
+        "staff_invites",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("token_hash", sa.String(length=64), nullable=False),
+        sa.Column("personal_email_normalized", sa.String(length=255), nullable=False),
+        sa.Column("workplace_email_normalized", sa.String(length=255), nullable=False),
+        sa.Column("role", sa.String(length=32), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("created_by_user_id", sa.Integer(), nullable=False),
+        sa.Column("setup_user_id", sa.Integer(), nullable=True),
+        sa.Column("used_by_user_id", sa.Integer(), nullable=True),
+        sa.Column("revoked_by_user_id", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_attempt_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("workplace_verification_code_hmac", sa.String(length=64), nullable=True),
+        sa.Column("workplace_verification_sent_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("workplace_verification_expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("workplace_verified_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["created_by_user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["revoked_by_user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["setup_user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["used_by_user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("token_hash"),
+        sa.CheckConstraint("role IN ('staff', 'admin')", name="ck_staff_invites_role"),
+        sa.CheckConstraint(
+            "status IN ('pending', 'totp_pending', 'accepted', 'revoked', 'expired')",
+            name="ck_staff_invites_status",
+        ),
+    )
+    op.create_index("ix_staff_invites_created_at", "staff_invites", ["created_at"])
+    op.create_index("ix_staff_invites_created_by_user_id", "staff_invites", ["created_by_user_id"])
+    op.create_index("ix_staff_invites_expires_at", "staff_invites", ["expires_at"])
+    op.create_index("ix_staff_invites_personal_email_normalized", "staff_invites", ["personal_email_normalized"])
+    op.create_index("ix_staff_invites_revoked_by_user_id", "staff_invites", ["revoked_by_user_id"])
+    op.create_index("ix_staff_invites_setup_user_id", "staff_invites", ["setup_user_id"])
+    op.create_index("ix_staff_invites_status", "staff_invites", ["status"])
+    op.create_index("ix_staff_invites_token_hash", "staff_invites", ["token_hash"], unique=True)
+    op.create_index("ix_staff_invites_used_by_user_id", "staff_invites", ["used_by_user_id"])
+    op.create_index("ix_staff_invites_workplace_email_normalized", "staff_invites", ["workplace_email_normalized"])
+
+    op.create_table(
+        "person_identity_links",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("staff_user_id", sa.Integer(), nullable=False),
+        sa.Column("customer_user_id", sa.Integer(), nullable=False),
+        sa.Column("created_by_user_id", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("verified_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("notes", sa.String(length=512), nullable=False),
+        sa.ForeignKeyConstraint(["created_by_user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["customer_user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["staff_user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "staff_user_id",
+            "customer_user_id",
+            name="uq_person_identity_links_staff_customer",
+        ),
+    )
+    op.create_index("ix_person_identity_links_created_by_user_id", "person_identity_links", ["created_by_user_id"])
+    op.create_index("ix_person_identity_links_customer_user_id", "person_identity_links", ["customer_user_id"])
+    op.create_index("ix_person_identity_links_revoked_at", "person_identity_links", ["revoked_at"])
+    op.create_index("ix_person_identity_links_staff_user_id", "person_identity_links", ["staff_user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_person_identity_links_staff_user_id", table_name="person_identity_links")
+    op.drop_index("ix_person_identity_links_revoked_at", table_name="person_identity_links")
+    op.drop_index("ix_person_identity_links_customer_user_id", table_name="person_identity_links")
+    op.drop_index("ix_person_identity_links_created_by_user_id", table_name="person_identity_links")
+    op.drop_table("person_identity_links")
+
+    op.drop_index("ix_staff_invites_workplace_email_normalized", table_name="staff_invites")
+    op.drop_index("ix_staff_invites_used_by_user_id", table_name="staff_invites")
+    op.drop_index("ix_staff_invites_token_hash", table_name="staff_invites")
+    op.drop_index("ix_staff_invites_status", table_name="staff_invites")
+    op.drop_index("ix_staff_invites_setup_user_id", table_name="staff_invites")
+    op.drop_index("ix_staff_invites_revoked_by_user_id", table_name="staff_invites")
+    op.drop_index("ix_staff_invites_personal_email_normalized", table_name="staff_invites")
+    op.drop_index("ix_staff_invites_expires_at", table_name="staff_invites")
+    op.drop_index("ix_staff_invites_created_by_user_id", table_name="staff_invites")
+    op.drop_index("ix_staff_invites_created_at", table_name="staff_invites")
+    op.drop_table("staff_invites")
+
+    op.drop_index("ix_users_account_status", table_name="users")
+    op.drop_index("ix_users_account_type", table_name="users")
+    dialect = op.get_context().dialect.name
+    if dialect != "sqlite":
+        op.drop_constraint("ck_users_account_status", "users", type_="check")
+        op.drop_constraint("ck_users_account_type", "users", type_="check")
+        op.alter_column("users", "account_number", existing_type=sa.String(9), nullable=False)
+    op.drop_column("users", "workplace_email_verified_at")
+    op.drop_column("users", "staff_personal_email")
+    op.drop_column("users", "account_status")
+    op.drop_column("users", "account_type")

--- a/ops/runtime_contract.py
+++ b/ops/runtime_contract.py
@@ -20,6 +20,7 @@ ADMIN_APP_SECRET_INPUTS = {
     "ADMIN_SESSION_HMAC_KEYS_JSON": "admin_session_hmac_keys_json",
     "ADMIN_SESSION_LOOKUP_HMAC_KEY": "admin_session_lookup_hmac_key",
     "ADMIN_DATABASE_URL": "admin_database_url",
+    "MFA_KEK_KEYS_JSON": "mfa_kek_keys_json",
     "ADMIN_PASSWORD_PEPPER_B64": "admin_password_pepper_b64",
 }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,6 +166,29 @@ class TestConfig:
     FRESH_MFA_SECONDS = 5 * 60
     TOTP_LOGIN_VALID_WINDOW = 1
     TOTP_HIGH_RISK_VALID_WINDOW = 0
+    SIT_WORKPLACE_EMAIL_DOMAINS = frozenset(
+        {"sit.singaporetech.edu.sg", "singaporetech.edu.sg"}
+    )
+    STAFF_INVITE_PERSONAL_EMAIL_DOMAINS = frozenset(
+        {"gmail.com", "outlook.com", "hotmail.com", "yahoo.com", "icloud.com", "proton.me", "protonmail.com"}
+    )
+    STAFF_INVITE_ALIAS_SEPARATORS = ("+",)
+    ROOT_ADMIN_EMAILS = frozenset(
+        {
+            "root1@sit.singaporetech.edu.sg",
+            "root2@sit.singaporetech.edu.sg",
+            "root3@sit.singaporetech.edu.sg",
+            "root4@sit.singaporetech.edu.sg",
+            "root5@sit.singaporetech.edu.sg",
+            "root6@sit.singaporetech.edu.sg",
+            "root7@sit.singaporetech.edu.sg",
+        }
+    )
+    STAFF_INVITE_TTL_SECONDS = 24 * 60 * 60
+    STAFF_WORKPLACE_VERIFICATION_TTL_SECONDS = 15 * 60
+    TURNSTILE_ENABLED = False
+    TURNSTILE_SECRET_KEY = None
+    TURNSTILE_VERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
     TALISMAN_FORCE_HTTPS = False
     TALISMAN_CONTENT_SECURITY_POLICY = {
         "default-src": "'self'",
@@ -179,6 +202,7 @@ class TestConfig:
 SECURITY_TEST_FILES = frozenset(
     {
         "tests/test_account_security_actions.py",
+        "tests/test_admin_staff_invites.py",
         "tests/test_audit_alerting.py",
         "tests/test_auth_registration_login.py",
         "tests/test_authenticated_portal_ui.py",
@@ -202,6 +226,7 @@ DEPLOYMENT_TEST_FILES = frozenset({"tests/test_deployment.py"})
 SLOW_TEST_FILES = frozenset(
     {
         "tests/test_account_security_actions.py",
+        "tests/test_admin_staff_invites.py",
         "tests/test_audit_alerting.py",
         "tests/test_auth_registration_login.py",
         "tests/test_authenticated_portal_ui.py",

--- a/tests/test_admin_isolation.py
+++ b/tests/test_admin_isolation.py
@@ -5,8 +5,9 @@ import logging
 from datetime import timedelta
 
 from app.extensions import db
-from app.models import SecurityAuditEvent, ServerSideSession
+from app.models import SecurityAuditEvent, ServerSideSession, User
 from app.security.audit import verify_audit_hash_chain
+from app.security.passwords import hash_password
 from conftest import TestConfig
 
 
@@ -37,7 +38,10 @@ def test_customer_and_admin_apps_have_isolated_route_surfaces(monkeypatch):
     assert "/dashboard" in customer_rules
     assert "/dashboard" not in admin_rules
     assert not any(rule.startswith("/banking") for rule in admin_rules)
-    assert admin_rules["/login"] == "admin.login_disabled"
+    assert admin_rules["/login"] == "admin.login"
+    assert admin_rules["/mfa/verify"] == "admin.mfa_verify"
+    assert "/invites" in admin_rules
+    assert "admin.invite_create" in set(admin_rules.values())
 
 
 def test_entrypoints_select_explicit_factory_modes(monkeypatch):
@@ -91,11 +95,13 @@ def test_admin_runtime_config_is_separate_and_stricter(monkeypatch):
     assert customer_app.config["AUTH_FAILURE_KEY_PREFIX"] != admin_app.config["AUTH_FAILURE_KEY_PREFIX"]
     assert customer_app.config["SQLALCHEMY_DATABASE_URI"] != admin_app.config["SQLALCHEMY_DATABASE_URI"]
     assert admin_app.config["SQLALCHEMY_MIGRATION_DATABASE_URI"] is None
+    assert admin_app.config["ADMIN_AUTH_ENABLED"] is True
+    assert admin_app.config["ADMIN_WEBAUTHN_PHASE"] == "disabled"
     assert admin_app.config["PERMANENT_SESSION_LIFETIME"] == timedelta(minutes=5)
     assert admin_app.config["PERMANENT_SESSION_LIFETIME"] < customer_app.config["PERMANENT_SESSION_LIFETIME"]
 
 
-def test_admin_auth_fails_closed_without_creating_sessions(monkeypatch):
+def test_admin_auth_rejects_bad_requests_without_creating_privileged_sessions(monkeypatch):
     from app import create_app
 
     admin_app = create_app(TestConfig, app_mode="admin")
@@ -108,10 +114,10 @@ def test_admin_auth_fails_closed_without_creating_sessions(monkeypatch):
         register = client.get("/register")
         customer_cookie = client.get("/", headers={"Cookie": "__Host-sitbank_session=customer"}).status_code
 
-        assert password_only.status_code == 403
-        assert username_only.status_code == 403
+        assert password_only.status_code == 400
+        assert username_only.status_code == 400
         assert register.status_code == 404
-        assert customer_cookie == 403
+        assert customer_cookie == 401
         assert db.session.query(ServerSideSession).count() == 0
         for response in (password_only, username_only, register):
             assert not any(
@@ -124,29 +130,40 @@ def test_admin_auth_fails_closed_without_creating_sessions(monkeypatch):
         db.drop_all()
 
 
-def test_disabled_admin_login_is_audited_and_redacted(monkeypatch):
+def test_admin_login_failures_are_audited_and_redacted(monkeypatch):
     from app import create_app
 
     admin_app = create_app(TestConfig, app_mode="admin")
     with admin_app.app_context():
         db.create_all()
+        db.session.add(
+            User(
+                username="root-admin",
+                email="root1@sit.singaporetech.edu.sg",
+                password_hash=hash_password("correct horse battery staple"),
+                account_type="root_admin",
+                account_status="active",
+                full_name="Root Admin",
+                phone_number="91234567",
+                account_number=None,
+                mfa_enabled=False,
+            )
+        )
+        db.session.commit()
         response = admin_app.test_client().post(
             "/login",
             json={
-                "username": "admin",
+                "workplace_email": "root1@sit.singaporetech.edu.sg",
                 "password": "plaintext-password",
-                "token": "bearer sensitive",
             },
         )
 
-        assert response.status_code == 403
+        assert response.status_code == 401
         event = db.session.query(SecurityAuditEvent).one()
-        assert event.event_type == "admin_login_disabled"
-        assert event.outcome == "fail_closed"
-        assert event.event_metadata["app_mode"] == "admin"
-        assert event.event_metadata["password"] == "[redacted]"
-        assert event.event_metadata["token"] == "[redacted]"
-        assert event.event_metadata["phase"] == "phase_1a_fail_closed"
+        assert event.event_type == "admin_login"
+        assert event.outcome == "failure"
+        assert event.event_metadata["principal_ref"]
+        assert "plaintext-password" not in str(event.event_metadata)
         assert verify_audit_hash_chain()["valid"] is True
 
         db.session.remove()

--- a/tests/test_admin_staff_invites.py
+++ b/tests/test_admin_staff_invites.py
@@ -1,0 +1,382 @@
+from __future__ import annotations
+
+import json
+import re
+import time
+from datetime import datetime, timezone
+
+import pyotp
+import pytest
+
+from app.extensions import db
+from app.models import PersonIdentityLink, SecurityAuditEvent, StaffInvite, User
+from app.security.crypto import encrypt_mfa_secret
+from app.security.email import password_reset_outbox
+from app.security.passwords import hash_password
+from conftest import TestConfig
+
+
+ROOT_EMAIL = "root1@sit.singaporetech.edu.sg"
+ROOT_PASSWORD = "correct horse battery staple"
+STAFF_PASSWORD = "another correct horse battery staple"
+
+
+@pytest.fixture()
+def admin_app(monkeypatch):
+    from app import create_app
+    from app.security import passwords
+
+    monkeypatch.setattr(passwords, "_is_password_pwned_by_hibp", lambda _password: False)
+    flask_app = create_app(TestConfig, app_mode="admin")
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture()
+def admin_client(admin_app):
+    return admin_app.test_client()
+
+
+def _create_staff_identity(
+    *,
+    username: str,
+    email: str,
+    account_type: str,
+    phone_number: str,
+    password: str = ROOT_PASSWORD,
+    active: bool = True,
+    personal_email: str | None = None,
+) -> tuple[User, str]:
+    user = User(
+        username=username,
+        email=email,
+        password_hash=hash_password(password),
+        account_type=account_type,
+        account_status="active" if active else "setup_pending",
+        full_name=username.replace("-", " ").title(),
+        phone_number=phone_number,
+        account_number=None,
+        staff_personal_email=personal_email,
+        workplace_email_verified_at=datetime.now(timezone.utc) if active else None,
+    )
+    db.session.add(user)
+    db.session.flush()
+    secret = pyotp.random_base32(length=32)
+    user.mfa_secret_nonce, user.mfa_secret_ciphertext = encrypt_mfa_secret(secret, user.id)
+    user.mfa_enabled = active
+    db.session.commit()
+    return user, secret
+
+
+def _login_admin(client, secret: str, email: str = ROOT_EMAIL, password: str = ROOT_PASSWORD):
+    password_response = client.post(
+        "/login",
+        json={"workplace_email": email, "password": password},
+    )
+    assert password_response.status_code == 200
+    verify_response = client.post(
+        "/mfa/verify",
+        json={"totp_code": pyotp.TOTP(secret, digits=6, interval=30).now()},
+    )
+    assert verify_response.status_code == 200
+    return verify_response
+
+
+def _create_invite(client, secret: str, **overrides):
+    payload = {
+        "personal_email": "staff.person@gmail.com",
+        "workplace_email": "staff.person@sit.singaporetech.edu.sg",
+        "role": "staff",
+        "totp_code": pyotp.TOTP(secret, digits=6, interval=30).now(),
+    }
+    payload.update(overrides)
+    return client.post("/invites", json=payload)
+
+
+def _latest_invite_token() -> str:
+    body = password_reset_outbox()[-1]["body"]
+    match = re.search(r"/invites/accept/([A-Za-z0-9_-]{32,256})", body)
+    assert match, body
+    return match.group(1)
+
+
+def _latest_workplace_code() -> str:
+    body = password_reset_outbox()[-1]["body"]
+    match = re.search(r"\b([0-9]{6})\b", body)
+    assert match, body
+    return match.group(1)
+
+
+def test_root_admin_can_create_hashed_staff_invite(admin_client):
+    _root, secret = _create_staff_identity(
+        username="root-admin",
+        email=ROOT_EMAIL,
+        account_type="root_admin",
+        phone_number="91234567",
+    )
+    _login_admin(admin_client, secret)
+
+    response = _create_invite(admin_client, secret)
+    token = _latest_invite_token()
+    invite = db.session.execute(db.select(StaffInvite)).scalar_one()
+    events = db.session.query(SecurityAuditEvent).filter_by(event_type="staff_invite_created").all()
+
+    assert response.status_code == 201
+    assert response.get_json()["invite"]["workplace_email"] == "staff.person@sit.singaporetech.edu.sg"
+    assert invite.token_hash != token
+    assert token not in json.dumps(invite.__dict__, default=str)
+    assert invite.expires_at.replace(tzinfo=timezone.utc) > datetime.now(timezone.utc)
+    assert password_reset_outbox()[-1]["to"] == "staff.person@gmail.com"
+    assert "temporary password" not in password_reset_outbox()[-1]["body"].casefold()
+    assert events and "token" not in json.dumps(events[0].event_metadata).casefold()
+
+
+def test_only_root_admin_with_totp_stepup_can_create_invites(admin_client):
+    _staff, staff_secret = _create_staff_identity(
+        username="staff-admin",
+        email="staff.admin@sit.singaporetech.edu.sg",
+        account_type="admin",
+        phone_number="91234567",
+    )
+    _login_admin(admin_client, staff_secret, email="staff.admin@sit.singaporetech.edu.sg")
+
+    non_root = _create_invite(admin_client, staff_secret)
+    assert non_root.status_code == 403
+
+    admin_client.post("/logout")
+    _root, root_secret = _create_staff_identity(
+        username="root-admin",
+        email=ROOT_EMAIL,
+        account_type="root_admin",
+        phone_number="91234568",
+    )
+    _login_admin(admin_client, root_secret)
+    missing_stepup = admin_client.post(
+        "/invites",
+        json={
+            "personal_email": "person@gmail.com",
+            "workplace_email": "person@sit.singaporetech.edu.sg",
+            "role": "staff",
+        },
+    )
+
+    assert missing_stepup.status_code == 400
+    assert db.session.query(StaffInvite).count() == 0
+
+
+def test_invite_creation_validates_server_side_email_and_role_policy(admin_client):
+    _root, secret = _create_staff_identity(
+        username="root-admin",
+        email=ROOT_EMAIL,
+        account_type="root_admin",
+        phone_number="91234567",
+    )
+    _login_admin(admin_client, secret)
+
+    cases = [
+        {"workplace_email": "staff@sit.singaporetech.edu.sg.evil.com"},
+        {"workplace_email": "staff@gmail.com"},
+        {"personal_email": "staff+tag@gmail.com"},
+        {"personal_email": "staff@sit.singaporetech.edu.sg"},
+        {"role": "root_admin"},
+    ]
+    responses = [_create_invite(admin_client, secret, **case) for case in cases]
+
+    assert [response.status_code for response in responses] == [400, 400, 400, 400, 400]
+    assert db.session.query(StaffInvite).count() == 0
+
+
+def test_invite_acceptance_requires_turnstile_when_enabled(admin_app, admin_client, monkeypatch):
+    admin_app.config["TURNSTILE_ENABLED"] = True
+    admin_app.config["TURNSTILE_SECRET_KEY"] = "turnstile-secret"
+    _root, secret = _create_staff_identity(
+        username="root-admin",
+        email=ROOT_EMAIL,
+        account_type="root_admin",
+        phone_number="91234567",
+    )
+    _login_admin(admin_client, secret)
+    assert _create_invite(admin_client, secret).status_code == 201
+    token = _latest_invite_token()
+
+    missing = admin_client.post(
+        f"/invites/accept/{token}/start",
+        json={
+            "full_name": "Staff Person",
+            "phone_number": "91234568",
+            "password": STAFF_PASSWORD,
+            "confirm_password": STAFF_PASSWORD,
+        },
+    )
+
+    calls = []
+
+    def fake_verify(token_value):
+        calls.append(token_value)
+
+    monkeypatch.setattr("app.admin.services.verify_turnstile_token", fake_verify)
+    valid = admin_client.post(
+        f"/invites/accept/{token}/start",
+        json={
+            "full_name": "Staff Person",
+            "phone_number": "91234568",
+            "password": STAFF_PASSWORD,
+            "confirm_password": STAFF_PASSWORD,
+            "turnstile_token": "browser-token",
+        },
+    )
+
+    assert missing.status_code == 400
+    assert valid.status_code == 200
+    assert calls == ["browser-token"]
+
+
+def test_staff_invite_acceptance_activates_only_after_workplace_code_and_totp(admin_client):
+    _root, root_secret = _create_staff_identity(
+        username="root-admin",
+        email=ROOT_EMAIL,
+        account_type="root_admin",
+        phone_number="91234567",
+    )
+    _login_admin(admin_client, root_secret)
+    assert _create_invite(admin_client, root_secret).status_code == 201
+    token = _latest_invite_token()
+
+    info = admin_client.get(f"/invites/accept/{token}")
+    forged_start = admin_client.post(
+        f"/invites/accept/{token}/start",
+        json={
+            "full_name": "Staff Person",
+            "phone_number": "91234568",
+            "password": STAFF_PASSWORD,
+            "confirm_password": STAFF_PASSWORD,
+            "role": "admin",
+        },
+    )
+    start = admin_client.post(
+        f"/invites/accept/{token}/start",
+        json={
+            "full_name": "Staff Person",
+            "phone_number": "91234568",
+            "password": STAFF_PASSWORD,
+            "confirm_password": STAFF_PASSWORD,
+        },
+    )
+    setup = start.get_json()["totp_setup"]
+    staff_user = db.session.execute(
+        db.select(User).where(User.email == "staff.person@sit.singaporetech.edu.sg")
+    ).scalar_one()
+    login_before_activation = admin_client.post(
+        "/login",
+        json={"workplace_email": staff_user.email, "password": STAFF_PASSWORD},
+    )
+    workplace_code = _latest_workplace_code()
+    totp_code = pyotp.TOTP(setup["manual_entry_secret"], digits=6, interval=30).now()
+    verify = admin_client.post(
+        f"/invites/accept/{token}/verify",
+        json={"totp_code": totp_code, "workplace_verification_code": workplace_code},
+    )
+    reuse = admin_client.get(f"/invites/accept/{token}")
+    db.session.refresh(staff_user)
+
+    assert info.status_code == 200
+    assert info.get_json()["invite"]["role"] == "staff"
+    assert forged_start.status_code == 400
+    assert start.status_code == 200
+    assert staff_user.account_type == "staff"
+    assert staff_user.account_status == "active"
+    assert staff_user.account_number is None
+    assert staff_user.workplace_email_verified_at is not None
+    assert login_before_activation.status_code == 401
+    assert verify.status_code == 200
+    assert reuse.status_code == 401
+    assert db.session.query(User).filter_by(account_type="customer").count() == 0
+
+
+def test_customer_registration_cannot_create_staff_or_admin_roles(client):
+    from _auth_flow_helpers import register
+
+    response = register(client)
+    forged = client.post(
+        "/auth/register",
+        json={
+            "username": "staff01",
+            "email": "staff@sit.singaporetech.edu.sg",
+            "full_name": "Staff User",
+            "phone_number": "91234568",
+            "password": STAFF_PASSWORD,
+            "confirm_password": STAFF_PASSWORD,
+            "account_type": "admin",
+            "role": "admin",
+        },
+    )
+    user = db.session.execute(db.select(User).where(User.username == "alice01")).scalar_one()
+
+    assert response.status_code == 302
+    assert forged.status_code == 400
+    assert user.account_type == "customer"
+    assert user.account_status == "active"
+
+
+def test_admin_login_creates_only_admin_session_cookie(admin_app, admin_client):
+    _root, secret = _create_staff_identity(
+        username="root-admin",
+        email=ROOT_EMAIL,
+        account_type="root_admin",
+        phone_number="91234567",
+    )
+
+    response = _login_admin(admin_client, secret)
+    cookies = "\n".join(response.headers.getlist("Set-Cookie"))
+
+    assert "__Host-sitbank_admin_session=" in cookies
+    assert "__Host-sitbank_session=" not in cookies
+    assert admin_client.get("/").status_code == 200
+
+
+def test_separation_guard_blocks_linked_staff_acting_on_own_customer(admin_app):
+    from app.admin.separation import assert_not_self_customer_action
+    from app.auth.services import AuthError
+
+    staff, _secret = _create_staff_identity(
+        username="staff-user",
+        email="staff.user@sit.singaporetech.edu.sg",
+        account_type="staff",
+        phone_number="91234567",
+        personal_email="same.person@gmail.com",
+    )
+    customer = User(
+        username="customer-user",
+        email="same.person@gmail.com",
+        password_hash=hash_password(STAFF_PASSWORD),
+        account_type="customer",
+        account_status="active",
+        full_name="Same Person",
+        phone_number="91234568",
+        account_number="012123456",
+    )
+    db.session.add(customer)
+    db.session.flush()
+    db.session.add(
+        PersonIdentityLink(
+            staff_user_id=staff.id,
+            customer_user_id=customer.id,
+            created_by_user_id=staff.id,
+            verified_at=datetime.now(timezone.utc),
+        )
+    )
+    db.session.commit()
+
+    with pytest.raises(AuthError):
+        assert_not_self_customer_action(staff, customer, "balance_edit")
+
+    event = db.session.query(SecurityAuditEvent).filter_by(
+        event_type="staff_self_customer_action_blocked",
+        outcome="blocked",
+    ).one()
+    assert event.user_id == staff.id
+    assert event.event_metadata["action_type"] == "balance_edit"
+    assert "012123456" not in json.dumps(event.event_metadata)

--- a/tests/test_admin_staff_invites.py
+++ b/tests/test_admin_staff_invites.py
@@ -234,6 +234,18 @@ def test_invite_acceptance_requires_turnstile_when_enabled(admin_app, admin_clie
     assert calls == ["browser-token"]
 
 
+def test_turnstile_verifier_rejects_non_https_verify_url(admin_app):
+    from app.security.turnstile import TurnstileError, verify_turnstile_token
+
+    admin_app.config["TURNSTILE_ENABLED"] = True
+    admin_app.config["TURNSTILE_SECRET_KEY"] = "turnstile-secret"
+    admin_app.config["TURNSTILE_VERIFY_URL"] = "file:///tmp/not-a-verifier"
+
+    with admin_app.test_request_context("/invites/accept/token/start", method="POST"):
+        with pytest.raises(TurnstileError):
+            verify_turnstile_token("browser-token")
+
+
 def test_staff_invite_acceptance_activates_only_after_workplace_code_and_totp(admin_client):
     _root, root_secret = _create_staff_identity(
         username="root-admin",

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -2346,7 +2346,7 @@ def test_production_edge_runbook_documents_network_waf_and_verification_steps():
         "Nginx terminates TLS, redirects HTTP to HTTPS",
         "Gunicorn binds only to `127.0.0.1:5000`",
         "Admin Gunicorn binds only to `127.0.0.1:5002`",
-        "Admin auth remains fail-closed pending an approved MFA design",
+        "Flask admin auth is implemented only for root-admin-controlled invite",
         "compose.prod.yml` publishes no",
         "`/health/ready` is for local deployment and load-balancer checks",
         "Cloudflare or AWS WAF should sit in front of Nginx",


### PR DESCRIPTION
## Summary

Implements the secure root-admin staff invite onboarding flow for the admin boundary.

Root admins can now create and revoke staff invites, invited staff can accept onboarding, complete workplace verification, and activate an admin identity using TOTP-only admin authentication.

This also adds explicit account typing/status, staff invite records, identity-link records, Turnstile server verification support, stricter customer/admin separation, and a Bandit-safe Turnstile verifier implementation.

## Why

The previous admin authentication path was disabled and did not provide a complete controlled onboarding flow for staff accounts.

This change creates a safer admin onboarding model where staff identities are invited by a root admin, verified before activation, and kept separate from customer identities and banking account records.

It also reduces privilege-boundary risk by ensuring customer authentication rejects staff identities, customer registration always creates customer accounts, and staff rows do not receive banking account numbers.

The Turnstile verifier was also updated to avoid Bandit concerns around generic URL opening by requiring HTTPS-only verifier URLs and using `http.client.HTTPSConnection`.

## What changed

* Added explicit `account_type` and `account_status` fields.
* Added staff invite records.
* Added identity-link records.
* Replaced disabled admin auth with TOTP-only admin login.
* Added root-admin staff invite creation.
* Added root-admin staff invite revocation.
* Added staff invite acceptance.
* Added workplace verification and activation flow.
* Added Turnstile server verification support.
* Added HTTPS-only Turnstile verifier URL validation.
* Replaced `urllib.request.urlopen` with `http.client.HTTPSConnection` for Turnstile verification.
* Added regression coverage rejecting `file://` verifier URLs.
* Added a reusable self-customer action guard.
* Kept customer/admin separation strict:

  * Customer auth rejects staff identities.
  * Customer registration always creates customer accounts.
  * Staff rows do not get banking account numbers.
* Added migration:

  * `20260626_0014_staff_invite_onboarding.py`
* Updated compose/runtime/docs for the active admin TOTP onboarding boundary.

## Security impact

This strengthens the admin boundary and onboarding model.

Admin access is now explicitly invite-based, activated only after workplace verification, and protected by TOTP-only admin login. Root-admin invite creation and revocation provide a controlled staff onboarding path.

Customer and staff identities remain separated. Customer registration cannot create staff accounts, customer authentication rejects staff identities, and staff records are prevented from receiving banking account numbers.

Turnstile server verification adds bot-abuse resistance for protected onboarding actions, depending on deployment configuration. The verifier now rejects non-HTTPS verifier URLs and no longer uses generic URL opening, addressing the Bandit finding and preventing unsafe verifier targets such as `file://`.

## Deployment impact

This PR requires:

* staging deployment
* production deployment
* database migration

Run the migration after deploying this branch:

```bash
flask --app wsgi:app db upgrade
```

This PR may also require runtime configuration/secret updates if Turnstile verification or the active admin onboarding boundary is enabled in the target environment.

This PR does not appear to require EC2 bootstrap unless the deployment environment needs new runtime files, secrets, or admin boundary configuration applied outside the normal deployment path.

## Verification

* `python -m pytest`

  * `400 passed, 2 skipped`
* `python -m compileall app tests`
* `python -m bandit -q -ll -r app ops config.py wsgi.py`
* `python -m pytest tests/test_admin_staff_invites.py`
* `git diff --check`

## Notes

Follow the updated runtime/deployment documentation for the active admin TOTP onboarding boundary.

Confirm the root-admin account and staff invite workflow are configured in staging before relying on this path in production.
