### PR TITLE
Update deployment verification to include compose file checks

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -747,25 +747,40 @@ jobs:
             exit 1
           fi
 
-      - name: Verify trusted staging deployment wrapper
+      - name: Verify trusted staging deployment files
         run: |
-          expected_hash="$(
+          expected_wrapper_hash="$(
             sha256sum ops/deploy/sitbank-container-deploy | awk '{print $1}'
+          )"
+          expected_compose_hash="$(
+            sha256sum compose.staging.yml | awk '{print $1}'
           )"
           if ! remote_output="$(
               ssh -p "${REMOTE_PORT}" -i ~/.ssh/deploy_key \
               -o BatchMode=yes -o IdentitiesOnly=yes \
               -o StrictHostKeyChecking=yes -o ConnectTimeout=15 \
               "${REMOTE_USER}@${REMOTE_HOST}" \
-              "sha256sum /usr/local/sbin/sitbank-container-deploy"
+              "sha256sum /usr/local/sbin/sitbank-container-deploy /opt/sitbank-staging/compose.yml"
             )"; then
-            echo "::error::The EC2 staging deployment wrapper is unavailable. Rerun the trusted staging bootstrap before deployment."
+            echo "::error::The EC2 staging deployment files are unavailable. Rerun the trusted staging bootstrap before deployment."
             exit 1
           fi
-          remote_hash="${remote_output%% *}"
-          if [[ ! "${remote_hash}" =~ ^[0-9a-f]{64}$ \
-              || "${remote_hash}" != "${expected_hash}" ]]; then
+          remote_wrapper_hash="$(
+            printf '%s\n' "${remote_output}" \
+              | awk '$2 == "/usr/local/sbin/sitbank-container-deploy" { print $1 }'
+          )"
+          remote_compose_hash="$(
+            printf '%s\n' "${remote_output}" \
+              | awk '$2 == "/opt/sitbank-staging/compose.yml" { print $1 }'
+          )"
+          if [[ ! "${remote_wrapper_hash}" =~ ^[0-9a-f]{64}$ \
+              || "${remote_wrapper_hash}" != "${expected_wrapper_hash}" ]]; then
             echo "::error::The EC2 staging deployment wrapper is missing or stale. Rerun the trusted staging bootstrap before deployment."
+            exit 1
+          fi
+          if [[ ! "${remote_compose_hash}" =~ ^[0-9a-f]{64}$ \
+              || "${remote_compose_hash}" != "${expected_compose_hash}" ]]; then
+            echo "::error::The EC2 staging compose file is missing or stale. Rerun the trusted staging bootstrap before deployment."
             exit 1
           fi
 
@@ -930,25 +945,40 @@ jobs:
             exit 1
           fi
 
-      - name: Verify trusted production deployment wrapper
+      - name: Verify trusted production deployment files
         run: |
-          expected_hash="$(
+          expected_wrapper_hash="$(
             sha256sum ops/deploy/sitbank-container-deploy | awk '{print $1}'
+          )"
+          expected_compose_hash="$(
+            sha256sum compose.prod.yml | awk '{print $1}'
           )"
           if ! remote_output="$(
               ssh -p "${REMOTE_PORT}" -i ~/.ssh/deploy_key \
               -o BatchMode=yes -o IdentitiesOnly=yes \
               -o StrictHostKeyChecking=yes -o ConnectTimeout=15 \
               "${REMOTE_USER}@${REMOTE_HOST}" \
-              "sha256sum /usr/local/sbin/sitbank-container-deploy"
+              "sha256sum /usr/local/sbin/sitbank-container-deploy /opt/sitbank/compose.yml"
             )"; then
-            echo "::error::The EC2 production deployment wrapper is unavailable. Rerun the trusted production bootstrap before deployment."
+            echo "::error::The EC2 production deployment files are unavailable. Rerun the trusted production bootstrap before deployment."
             exit 1
           fi
-          remote_hash="${remote_output%% *}"
-          if [[ ! "${remote_hash}" =~ ^[0-9a-f]{64}$ \
-              || "${remote_hash}" != "${expected_hash}" ]]; then
+          remote_wrapper_hash="$(
+            printf '%s\n' "${remote_output}" \
+              | awk '$2 == "/usr/local/sbin/sitbank-container-deploy" { print $1 }'
+          )"
+          remote_compose_hash="$(
+            printf '%s\n' "${remote_output}" \
+              | awk '$2 == "/opt/sitbank/compose.yml" { print $1 }'
+          )"
+          if [[ ! "${remote_wrapper_hash}" =~ ^[0-9a-f]{64}$ \
+              || "${remote_wrapper_hash}" != "${expected_wrapper_hash}" ]]; then
             echo "::error::The EC2 production deployment wrapper is missing or stale. Rerun the trusted production bootstrap before deployment."
+            exit 1
+          fi
+          if [[ ! "${remote_compose_hash}" =~ ^[0-9a-f]{64}$ \
+              || "${remote_compose_hash}" != "${expected_compose_hash}" ]]; then
+            echo "::error::The EC2 production compose file is missing or stale. Rerun the trusted production bootstrap before deployment."
             exit 1
           fi
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1462,20 +1462,26 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     assert workflow_text.count(
         "sha256sum ops/deploy/sitbank-container-deploy"
     ) == 2
+    assert workflow_text.count("sha256sum compose.staging.yml") == 1
+    assert workflow_text.count("sha256sum compose.prod.yml") == 1
     assert workflow_text.count(
         "sha256sum /usr/local/sbin/sitbank-container-deploy"
     ) == 2
+    assert workflow_text.count("/opt/sitbank-staging/compose.yml") >= 2
+    assert workflow_text.count("/opt/sitbank/compose.yml") >= 2
     assert "EC2 staging deployment wrapper is missing or stale" in workflow_text
     assert "EC2 production deployment wrapper is missing or stale" in workflow_text
+    assert "EC2 staging compose file is missing or stale" in workflow_text
+    assert "EC2 production compose file is missing or stale" in workflow_text
     for job_name, wrapper_step_name, upload_step_name in (
         (
             "deploy-staging",
-            "Verify trusted staging deployment wrapper",
+            "Verify trusted staging deployment files",
             "Upload authenticated deployment inputs",
         ),
         (
             "deploy-production",
-            "Verify trusted production deployment wrapper",
+            "Verify trusted production deployment files",
             "Upload authenticated deployment inputs",
         ),
     ):


### PR DESCRIPTION
## Summary

Adds an additional deploy CI guard that verifies the remote compose hash before deployment.

The deployment workflow already verified the trusted deploy wrapper. This change extends that protection so CI also checks that the remote compose file matches the expected hash before continuing with deployment.

## Why

Deployment safety depends on both the trusted deploy wrapper and the remote compose configuration being the expected versions.

Without checking the remote compose hash, deployment could proceed even if the compose file on the server was stale, manually modified, or inconsistent with the expected deployment state.

## What changed

* Updated `.github/workflows/ci-deploy.yml` to verify the remote compose hash before deployment.
* Kept the existing deploy wrapper verification.
* Added deployment regression coverage in `tests/test_deployment.py`.
* Ensured deployment is blocked when the remote compose hash does not match the expected value.

## Security impact

This improves deployment integrity.

CI now verifies both required remote deployment trust anchors before deploying:

* trusted deploy wrapper
* expected remote compose hash

This reduces the risk of deploying with stale or tampered remote compose configuration.

## Deployment impact

No deployment action.

This PR does not require:

* EC2 bootstrap
* staging deployment
* production deployment
* database migration
* secret changes

## Verification

* Run deployment test coverage:

  * `python -m pytest -q tests/test_deployment.py`
* Run diff hygiene check:

  * `git diff --check`

## Notes

This is a CI/deployment safety guard only. It does not change application runtime behavior.
