### PR TITLE
Add assessor-facing security documentation

### DIFF
--- a/docs/security/access-control.md
+++ b/docs/security/access-control.md
@@ -1,0 +1,153 @@
+# Access Control
+
+This document records the access-control model implemented in the SITBank
+repository. It distinguishes implemented runtime enforcement from test gaps and
+service-only flows.
+
+## 3.1 Access-Control Model
+
+SITBank uses role, account-state, MFA-state, and ownership checks. The primary
+role field is `User.account_type` in `app/models.py`, constrained to:
+
+```text
+customer, staff, admin, root_admin
+```
+
+Customer and admin functionality are separated at application-factory level:
+
+| Runtime | Entry point | Registered surface | Evidence |
+| --- | --- | --- | --- |
+| Customer app | `wsgi.py` / `create_app(app_mode="customer")` | Auth, banking, web, main routes | `app/__init__.py`, `app/auth/routes.py`, `app/banking/routes.py`, `app/web/routes.py` |
+| Admin app | `admin_wsgi.py` / `create_app(app_mode="admin")` | Admin routes only | `app/__init__.py`, `app/admin/routes.py` |
+
+The customer app rejects staff/admin account types during customer login in
+`app/auth/services.py`. The admin app accepts only staff account types with
+active status, verified workplace email, password authentication, and TOTP in
+`app/admin/services.py`.
+
+Tests:
+
+| Test | Coverage |
+| --- | --- |
+| `tests/test_admin_isolation.py::test_customer_and_admin_apps_have_isolated_route_surfaces` | Customer/admin application route separation |
+| `tests/test_admin_staff_invites.py::test_customer_registration_cannot_create_staff_or_admin_roles` | Customer self-registration cannot create privileged roles |
+| `tests/test_admin_isolation.py::test_admin_auth_rejects_bad_requests_without_creating_privileged_sessions` | Admin malformed requests do not create privileged sessions |
+| `tests/test_pentest_auth_bypass.py` | Negative authentication and authorization bypass cases |
+
+## 3.2 Customer Access Controls
+
+Customer authenticated pages use request hooks and decorators to require a
+valid authenticated customer session, MFA readiness where needed, and non-frozen
+account state.
+
+| Area | Enforcement | Evidence |
+| --- | --- | --- |
+| Dashboard and authenticated web pages | Web `before_request` gates require login and MFA onboarding completion | `app/web/routes.py`, `tests/test_dashboard.py::test_dashboard_requires_login`, `tests/test_dashboard.py::test_dashboard_requires_mfa` |
+| JSON auth/account routes | Auth blueprint request hooks enforce login/MFA for protected endpoints | `app/auth/routes.py`, `tests/test_mfa_lifecycle.py::test_api_onboarding_requires_enrolled_mfa_before_authenticated_endpoints` |
+| Frozen accounts | Sensitive actions call `ensure_account_not_frozen()` or are blocked by route gates | `app/auth/services.py`, `app/web/routes.py`, `tests/test_account_security_actions.py::test_account_freeze_is_durable_and_blocks_group_a_sensitive_actions` |
+| Pending MFA sessions | Pending sessions cannot access authenticated resources | `tests/test_pentest_auth_bypass.py::test_pending_mfa_session_cannot_access_dashboard`, `tests/test_pentest_auth_bypass.py::test_pending_mfa_session_cannot_freeze_account` |
+| Session management | Public session refs are scoped to the current user | `app/auth/services.py::terminate_session_for_user()`, `tests/test_session_management.py::test_past_sessions_are_scoped_to_current_user` |
+
+The route inventory in `tests/test_route_inventory_security.py` records each
+customer-app route's security classification, authentication requirement, CSRF
+requirement, rate-limit decision, and step-up source. The inventory is tested
+against registered Flask routes by:
+
+| Test | Coverage |
+| --- | --- |
+| `tests/test_route_inventory_security.py::test_route_inventory_matches_registered_flask_routes` | Inventory must match registered customer routes |
+| `tests/test_route_inventory_security.py::test_route_inventory_has_complete_security_decisions` | Each route has explicit auth, CSRF, rate-limit, and step-up metadata |
+| `tests/test_route_inventory_security.py::test_login_and_registration_have_method_level_security_decisions` | Method-level decisions for login and registration |
+
+Current gap: this route inventory is for the customer app surface. Admin routes
+have separate isolation and invite-flow tests, but no equivalent admin
+route-inventory matrix was found.
+
+## 3.3 Banking And Payee Authorization
+
+Payee management lives in `app/banking/routes.py` and is registered only in the
+customer app. Routes use authenticated web decorators and high-risk TOTP step-up
+for payee creation confirmation and removal.
+
+| Action | Authorization control | Evidence |
+| --- | --- | --- |
+| List payees | Query filters by `Payee.user_id == g.current_user.id` | `app/banking/routes.py::payees()` |
+| Add payee step 1 | Form validation, own-account rejection, duplicate payee check scoped to current user | `app/banking/forms.py`, `app/banking/routes.py::payees_add_submit()` |
+| Add payee confirmation | Pending payee state is consumed before MFA, recipient is reloaded from the database, duplicate check is repeated, and TOTP step-up is required | `app/banking/routes.py::payees_confirm_submit()` |
+| Remove payee | Payee is loaded with `id` and current `user_id`; TOTP step-up is required | `app/banking/routes.py::payees_remove_submit()` |
+
+Transfer payload validation and future transaction-risk primitives are in
+`app/banking/services.py` and `app/banking/schemas.py`, covered by
+`tests/test_banking_transaction_security.py`.
+
+Current test gap: no dedicated payee IDOR test file was found. The code uses
+current-user ownership filters, and payee routes are included in the route
+inventory, but there is no focused test that attempts to remove or view another
+user's payee.
+
+## 3.4 Admin And Staff Controls
+
+Admin/staff access is invite-only and uses the admin runtime.
+
+| Control | Implementation evidence | Test evidence |
+| --- | --- | --- |
+| Staff/admin login requires workplace email, password, active account, verified workplace email, and TOTP | `app/admin/services.py::authenticate_staff_primary()` and `complete_staff_mfa()` | `tests/test_admin_staff_invites.py::test_admin_login_creates_only_admin_session_cookie` |
+| Root admin is configured by role and email allowlist | `app/admin/services.py::is_root_admin()` and `config.py` `ROOT_ADMIN_EMAILS` | `tests/test_admin_staff_invites.py::test_only_root_admin_with_totp_stepup_can_create_invites` |
+| Root admin can invite only `staff` or `admin`, not `root_admin` | `StaffInvite` role constraint in `app/models.py`; role validation in `app/admin/services.py` | `tests/test_admin_staff_invites.py::test_invite_creation_validates_server_side_email_and_role_policy` |
+| Invite acceptance rejects forged privileged fields | `_reject_forged_invite_fields()` in `app/admin/services.py` | `tests/test_admin_staff_invites.py` |
+| Staff invite acceptance activates only after workplace verification and TOTP setup | `start_invite_acceptance()` and `verify_invite_acceptance()` | `tests/test_admin_staff_invites.py::test_staff_invite_acceptance_activates_only_after_workplace_code_and_totp` |
+| Staff/customer self-action guard | `app/admin/separation.py::assert_not_self_customer_action()` | `tests/test_admin_staff_invites.py::test_separation_guard_blocks_linked_staff_acting_on_own_customer` |
+
+Production Nginx currently defines an admin hostname in
+`ops/nginx/sitbank-production.conf` but denies public access to the primary
+admin paths with `deny all`. This keeps the admin app available for deployment
+health and future controlled exposure while preventing public browser access
+unless the edge policy is deliberately changed.
+
+Current gap: no active admin route was found for operator review or completion
+of manual recovery requests. `app/auth/password_reset.py` implements
+`transition_manual_recovery_request()` and `complete_manual_recovery_request()`,
+and `tests/test_password_reset.py` covers the service behavior, but
+`app/admin/routes.py` does not expose those functions.
+
+## 3.5 High-Risk Actions And Step-Up
+
+High-risk customer actions use `verify_high_risk_authorization()` in
+`app/auth/services.py`. The current active control is TOTP. Passkey step-up
+tokens are explicitly rejected because active WebAuthn ceremonies are disabled.
+
+| Action | Step-up and access control | Evidence |
+| --- | --- | --- |
+| Password change | Authenticated user, MFA setup, current password, TOTP step-up, revoke other sessions | `app/auth/services.py::change_password()`, `tests/test_account_security_actions.py::test_password_change_succeeds_with_recent_mfa_and_revokes_other_sessions` |
+| Profile update | Authenticated user and TOTP step-up when email, phone, or other sensitive profile fields change | `app/auth/services.py::update_profile_details()`, `tests/test_account_security_actions.py::test_profile_update_requires_mfa_when_enabled` |
+| MFA replacement start | Fresh TOTP step-up before replacing an existing authenticator secret | `app/auth/services.py`, `tests/test_mfa_lifecycle.py::test_mfa_replacement_start_requires_fresh_mfa_stepup` |
+| Account freeze | Authenticated user, non-frozen state, TOTP step-up, revoke other sessions | `app/auth/services.py::freeze_own_account()`, `tests/test_account_security_actions.py::test_account_freeze_is_durable_and_blocks_group_a_sensitive_actions` |
+| Revoke other sessions | Authenticated user and TOTP step-up | `app/auth/routes.py::revoke_other_sessions()`, `tests/test_pentest_auth_bypass.py::test_revoke_others_requires_valid_mfa_code` |
+| Terminate one session | Authenticated user, current-user ownership, public reference | `app/auth/services.py::terminate_session_for_user()`, `tests/test_pentest_auth_bypass.py::test_cannot_terminate_other_users_session` |
+| Payee add confirmation | Authenticated user, pending payee state, recipient revalidation, TOTP step-up | `app/banking/routes.py::payees_confirm_submit()` |
+| Payee removal | Authenticated user, payee ownership check, TOTP step-up | `app/banking/routes.py::payees_remove_submit()` |
+| Staff invite create/revoke | Root admin session and TOTP code | `app/admin/services.py::create_staff_invite()`, `app/admin/services.py::revoke_staff_invite()` |
+| Manual recovery public request | No step-up because the caller is unauthenticated; it creates only a pending request and does not unlock or mutate the account | `app/auth/password_reset.py::request_manual_recovery()`, `tests/test_password_reset.py::test_manual_recovery_request_does_not_freeze_or_unlock_account` |
+
+Current gap: recovery-code regeneration requires an authenticated MFA-ready
+session and CSRF, but the service path `regenerate_totp_recovery_codes()` does
+not require a fresh TOTP step-up. If recovery-code regeneration is classified
+as high risk for assessment purposes, add explicit step-up before generating
+new codes.
+
+## 3.6 Broken Access Control Mitigations
+
+| OWASP broken-access-control risk | Repository control |
+| --- | --- |
+| Relying on hidden UI controls only | Sensitive operations are enforced in routes/services, not only templates |
+| Missing authentication on new routes | Customer route inventory must match registered routes and include decisions |
+| CSRF on state-changing routes | Global Flask-WTF CSRF plus route inventory checks |
+| IDOR on session management | Public session references are scoped to current user and raw internal ids are rejected |
+| Staff/admin privilege creation through customer registration | Customer registration sets `account_type="customer"` and tests reject forged account-number and privileged fields |
+| Staff acting on their own linked customer identity | `app/admin/separation.py` guard and test coverage |
+| Pending MFA bypass | Pending sessions cannot access dashboard, profile, session list, MFA setup, or freeze actions |
+| Frozen account bypass | Frozen accounts cannot create new login sessions or perform sensitive actions |
+
+Current gap: route-level authorization is well covered for the customer app,
+but admin route authorization relies on targeted admin tests and service tests
+rather than a generated admin route-inventory policy.

--- a/docs/security/cryptography-and-authentication.md
+++ b/docs/security/cryptography-and-authentication.md
@@ -1,0 +1,308 @@
+# Cryptography And Authentication
+
+This document records the cryptography and authentication controls found in the
+SITBank repository. It cites repository evidence and calls out gaps where the
+repo delegates a control to deployment state or does not implement it.
+
+## 1.1 Server Authentication
+
+The repository implements HTTPS termination at Nginx, not inside Flask or
+Gunicorn. The Flask apps run behind loopback Gunicorn listeners; Nginx is the
+public TLS endpoint and forwards to the customer and admin apps with explicit
+proxy headers.
+
+| Environment | Hostname | TLS termination | Upstream |
+| --- | --- | --- | --- |
+| Production customer | `sitbank.duckdns.org` | Nginx in `ops/nginx/sitbank-production.conf` | `http://127.0.0.1:5000` |
+| Production admin | `admin-sitbank.duckdns.org` | Nginx in `ops/nginx/sitbank-production.conf` | `http://127.0.0.1:5002` |
+| Staging customer | `staging-sitbank.duckdns.org` | Nginx in `ops/nginx/sitbank-staging.conf` | `http://127.0.0.1:5001` |
+
+The client authenticates the server through the normal browser TLS certificate
+chain for the relevant hostname. The repository expects Certbot/Let's Encrypt
+files on the host:
+
+```nginx
+ssl_certificate /etc/letsencrypt/live/sitbank.duckdns.org/fullchain.pem;
+ssl_certificate_key /etc/letsencrypt/live/sitbank.duckdns.org/privkey.pem;
+ssl_protocols TLSv1.2 TLSv1.3;
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+```
+
+Evidence:
+
+| Control | Evidence |
+| --- | --- |
+| TLS server block and certificate path | `ops/nginx/sitbank-production.conf`; `ops/nginx/sitbank-staging.conf` |
+| HTTP to HTTPS redirect | `return 301 https://sitbank.duckdns.org$request_uri;` and `return 301 https://admin-sitbank.duckdns.org$request_uri;` in `ops/nginx/sitbank-production.conf` |
+| Unknown host rejection | `ops/nginx/sitbank-default.conf` returns `444` for the default HTTP server and uses `ssl_reject_handshake on` for the default HTTPS server |
+| HSTS | Production uses `Strict-Transport-Security "max-age=31536000; includeSubDomains"`; staging uses `max-age=300` |
+| Proxy trust boundary | `ops/nginx-proxy-headers.conf` overwrites `Host`, `X-Real-IP`, `X-Forwarded-For`, and `X-Forwarded-Proto`; `app/__init__.py` applies `ProxyFix` using `TRUSTED_PROXY_COUNT` |
+| Deployment validation | `ops/deploy/bootstrap-container-ec2` requires the Certbot files before installing the production or staging Nginx site and runs `nginx -t` before reload |
+| Tests | `tests/test_deployment.py::test_nginx_default_server_is_shared_for_same_host_production_and_staging`, `tests/test_deployment.py::test_production_nginx_edge_config_enforces_network_boundary_and_limits`, `tests/test_deployment.py::test_staging_nginx_enforces_https_auth_health_and_rate_limits`, `tests/test_deployment.py::test_proxyfix_trusts_exactly_the_configured_nginx_hop` |
+
+Short evidence for unknown-host rejection:
+
+```nginx
+server {
+    listen 443 ssl http2 default_server;
+    server_name _;
+    ssl_reject_handshake on;
+    return 444;
+}
+```
+
+Current gap: certificate issuance and renewal are deployment operations. The
+repo checks that expected certificate files exist before bootstrap, but it does
+not contain ACME account state, private keys, or a certbot renewal timer.
+
+## 1.2 HTTPS Cipher Suites
+
+Production and staging Nginx explicitly enable only TLS 1.2 and TLS 1.3:
+
+```nginx
+ssl_protocols TLSv1.2 TLSv1.3;
+ssl_prefer_server_ciphers off;
+ssl_session_tickets off;
+```
+
+This disables SSLv2, SSLv3, TLS 1.0, and TLS 1.1 by omission. TLS 1.2 and TLS
+1.3 are the only protocol versions configured in the repository. Session
+tickets are disabled to reduce long-lived ticket-key exposure.
+
+Current gap: the repo does not explicitly configure `ssl_ciphers` or
+`ssl_ecdh_curve`. Cipher suite selection therefore depends on the installed
+Nginx/OpenSSL defaults on the host. The deployment documentation should verify
+the live host's cipher suites before release.
+
+## 1.3 Server Private Key Storage
+
+The TLS private key is expected to exist only on the deployment host under
+Certbot-managed paths, for example:
+
+| Hostname | Expected private key path |
+| --- | --- |
+| `sitbank.duckdns.org` | `/etc/letsencrypt/live/sitbank.duckdns.org/privkey.pem` |
+| `admin-sitbank.duckdns.org` | `/etc/letsencrypt/live/admin-sitbank.duckdns.org/privkey.pem` |
+| `staging-sitbank.duckdns.org` | `/etc/letsencrypt/live/staging-sitbank.duckdns.org/privkey.pem` |
+
+The private key is not committed to Git. `ops/deploy/bootstrap-container-ec2`
+checks that the expected key files are readable before installing the Nginx
+site. The application containers in `compose.prod.yml` and `compose.staging.yml`
+mount application secrets from `/run/secrets`, but they do not mount
+`/etc/letsencrypt`; only host Nginx needs the TLS private key.
+
+Current gap: the repo does not set or verify the final filesystem mode or owner
+of `/etc/letsencrypt/.../privkey.pem`. That remains a Certbot/host hardening
+responsibility.
+
+## 1.4 Key Establishment And Secret Key Derivation
+
+Communication keys are established by TLS during the HTTPS handshake. The
+Flask application does not derive transport encryption keys and does not
+implement custom transport encryption. With TLS 1.3, modern Nginx/OpenSSL
+stacks use ephemeral key exchange for forward secrecy; the exact negotiated
+groups and ciphers are deployment-stack behavior because cipher suites are not
+explicitly pinned in this repo.
+
+Application-level secrets are loaded from environment variables or Docker
+secret files. In production, `_read_secret_file()` in `config.py` requires
+secret files to resolve under `/run/secrets`, rejects symlinks, rejects empty
+or multiline values, and rejects placeholder values. The Compose files map
+host files from `/etc/sitbank/secrets` or `/etc/sitbank-staging/secrets` into
+`/run/secrets`.
+
+| Secret or key | Purpose | Configuration evidence | Validation or rotation evidence |
+| --- | --- | --- | --- |
+| `SECRET_KEY` / `ADMIN_SECRET_KEY` | Flask application secret and registration OTP HMAC key | `config.py`, `compose.prod.yml`, `compose.staging.yml` | Minimum 32 characters in production; direct value and `_FILE` are mutually exclusive |
+| `WTF_CSRF_SECRET_KEY` / admin variant | Flask-WTF CSRF signing | `config.py`, `app/extensions.py`, `app/__init__.py` | Minimum 32 characters; `production-check` fails if too short or CSRF is disabled |
+| `SESSION_HMAC_KEYS_JSON` / admin variant | Keyring for database session payload signatures and public references | `config.py`, `app/security/session_hmac.py` | 32-byte base64 values, active key id must exist; old keys can remain during rotation |
+| `SESSION_LOOKUP_HMAC_KEY` / admin variant | HMAC of browser session IDs before database lookup | `config.py`, `app/security/sessions.py` | Must decode to exactly 32 bytes; customer and admin keys are separate |
+| `MFA_KEK_KEYS_JSON` | Key-encryption keys for MFA secret envelope encryption | `config.py`, `app/security/crypto.py` | Keyring supports active id and `flask rewrap-mfa-deks` for rewrapping stored DEKs |
+| `PASSWORD_PEPPER_B64` / admin variant | 32-byte pepper before PBKDF2 password hashing | `config.py`, `app/security/passwords.py` | Must decode to exactly 32 bytes |
+| `SECURITY_AUDIT_HMAC_KEY` | HMAC key for audit hash-chain integrity | `config.py`, `app/security/audit.py` | Required and at least 32 characters in production; verified by `production-check` |
+| SMTP credentials | Password reset and staff invite email delivery | `config.py`, `app/security/email.py`, Compose files | Production requires SMTP host, credentials, and `SMTP_USE_TLS=true` |
+
+Tests covering key validation include
+`tests/test_config.py::test_required_configuration_accepts_direct_or_file_exclusively`,
+`tests/test_config.py::test_secret_file_rejects_empty_multiline_and_symlink`,
+`tests/test_config.py::test_session_lookup_hmac_key_decodes_to_32_bytes`,
+`tests/test_config.py::test_session_hmac_keyring_requires_active_32_byte_key`,
+`tests/test_mfa_envelope_crypto.py::test_mfa_keyring_config_fails_closed`, and
+`tests/test_deployment.py::test_container_bundle_keyring_validation_normalizes_ids_and_rejects_duplicates`.
+
+## 1.5 Cryptographic Algorithms
+
+Communication encryption is provided by HTTPS/TLS at Nginx. The Flask app does
+not implement custom transport encryption. Internal cryptographic controls are
+listed below.
+
+| Purpose | Algorithm / primitive | File path | Why used |
+| --- | --- | --- | --- |
+| External transport | TLS 1.2 and TLS 1.3 through Nginx/OpenSSL | `ops/nginx/sitbank-production.conf`, `ops/nginx/sitbank-staging.conf` | Encrypts client/server communications and authenticates the server certificate |
+| MFA secret storage | AES-256-GCM envelope encryption; random 32-byte DEK; random 12-byte nonces; KEK-wrapped DEK | `app/security/crypto.py` | Keeps stored TOTP seeds encrypted and bound to user-specific associated data |
+| Session payload integrity | HMAC-SHA256 over canonical envelope including key id, payload, and binding context | `app/security/session_hmac.py`, `app/security/sessions.py` | Rejects tampered or copied database session payloads |
+| Session lookup hashing | HMAC-SHA256 over opaque browser session id | `app/security/sessions.py` | Stores only lookup hashes, not raw browser session IDs |
+| Password hashing | HMAC-SHA256 pepper followed by PBKDF2-HMAC-SHA256 with 600,000+ iterations, 32-byte salt, 32-byte derived key | `app/security/passwords.py` | Password storage with per-password salt and server-side pepper |
+| Recovery codes | HMAC-SHA256 using the active session HMAC keyring | `app/auth/recovery_codes.py` | Stores one-time recovery-code verifiers without storing raw codes |
+| Password reset verifier | HMAC-SHA256 using the active session HMAC keyring | `app/auth/password_reset.py` | Stores reset verifier HMACs; raw verifier appears only in the emailed URL |
+| Staff invite and workplace verification | HMAC-SHA256 using the active session HMAC keyring | `app/admin/services.py` | Stores invite tokens and workplace verification codes without raw values |
+| Audit log chain | HMAC-SHA256 over canonical audit event JSON | `app/security/audit.py` | Makes audit event ordering and contents tamper-evident |
+| TOTP MFA | RFC 6238-style TOTP with SHA-1, 6 digits, 30-second steps | `app/auth/services.py`, `app/admin/services.py` | Standard authenticator-app compatibility |
+| HIBP password screening | SHA-1 k-anonymity prefix lookup | `app/security/passwords.py` | Sends only the first five SHA-1 hex characters to Have I Been Pwned; SHA-1 is not used for password storage |
+| Random tokens | `secrets.token_urlsafe`, `secrets.token_hex`, `os.urandom`, `uuid.uuid4` | `app/auth/password_reset.py`, `app/admin/services.py`, `app/security/crypto.py`, `app/security/sessions.py` | Generates reset links, invites, recovery codes, envelope keys, nonces, and session IDs |
+
+Tests include `tests/test_mfa_envelope_crypto.py`, `tests/test_db_session_integrity.py`,
+`tests/test_passwords.py`, `tests/test_audit_alerting.py::test_audit_hash_chain_uses_hmac_key_and_reads_legacy_sha_rows`,
+and `tests/test_password_reset.py::test_recovery_codes_are_hashed_single_use_reset_factors`.
+
+## 1.6 User Authentication
+
+### Customer Authentication
+
+Customer registration requires a verified SIT email OTP before `register_user`
+creates a customer account. Evidence: `app/auth/registration_otp.py`,
+`app/auth/services.py`, `app/auth/routes.py`, and `app/web/routes.py`.
+
+Customer login uses username or email plus password. `authenticate_primary()`
+uses a dummy password hash for unknown users to reduce user-enumeration timing
+differences, returns the generic message `Invalid username or password`, and
+rejects non-customer account types on the customer app. If TOTP is enabled,
+password login creates a pending MFA session and the customer must complete
+`/auth/mfa/verify` or `/mfa/verify`.
+
+After first password login for a no-MFA customer, the code creates a limited
+password-bootstrap session and the web/API `before_request` gates require MFA
+setup before normal account access. Evidence: `app/auth/mfa_policy.py`,
+`app/auth/routes.py::enforce_api_mfa_onboarding`, and
+`app/web/routes.py::enforce_mfa_onboarding`.
+
+### TOTP MFA And Recovery Codes
+
+The repository implements authenticator-app TOTP. TOTP secrets are generated
+with `pyotp.random_base32(length=32)` and stored through AES-GCM envelope
+encryption. Verification records a replay digest in `totp_replay_records`, so
+the same accepted TOTP step and code cannot be replayed for the same scope.
+
+Recovery codes are generated as random 16-byte values encoded as grouped hex,
+stored as HMACs, consumed once, and used only as TOTP recovery factors.
+
+### WebAuthn / Passkeys
+
+WebAuthn/passkey active ceremonies are not implemented in the current runtime.
+The compatibility routes return `410` with a disabled message. Legacy passkey
+records can be listed as inactive inventory, but they do not satisfy the MFA
+policy. Evidence: `app/auth/routes.py`, `app/auth/webauthn_services.py`, and
+`app/auth/mfa_policy.py`.
+
+Tests: `tests/test_webauthn_lifecycle.py::test_public_passkey_endpoints_fail_closed`,
+`tests/test_webauthn_lifecycle.py::test_authenticated_passkey_endpoints_fail_closed`,
+and `tests/test_webauthn_lifecycle.py::test_legacy_passkey_rows_do_not_satisfy_mfa_policy`.
+
+### Password Reset
+
+Customer password reset uses a one-time `selector.verifier` URL. The selector
+is stored for lookup; the verifier is stored only as an HMAC. Exchanging the
+URL token creates a short-lived server-side reset transaction and clears the
+raw URL token from continued browser flow. TOTP users must verify TOTP or a
+TOTP recovery code before completing reset; no-MFA users can reset but remain
+in MFA-onboarding state on next login. Admin-like accounts are blocked from
+the customer reset flow.
+
+Evidence: `app/auth/password_reset.py`, `app/auth/routes.py`,
+`app/web/routes.py`, and `app/models.py` (`PasswordResetToken` and
+`PasswordResetTransaction`).
+
+Tests: `tests/test_password_reset.py::test_forgot_password_response_is_generic_and_token_is_hashed`,
+`tests/test_password_reset.py::test_reset_token_exchanges_once_into_tokenless_transaction`,
+`tests/test_password_reset.py::test_totp_user_must_verify_totp_before_password_reset`,
+`tests/test_password_reset.py::test_passkey_only_user_cannot_fall_back_to_email_only_reset`,
+and `tests/test_password_reset.py::test_admin_like_customer_domain_reset_fails_closed`.
+
+### Admin And Staff Authentication
+
+The admin runtime is a separate Flask app mode selected by `admin_wsgi.py` and
+`create_app(app_mode="admin")`. Admin/staff users use workplace email,
+password, and mandatory TOTP. Active staff users must have `account_status`
+`active`, an allowed staff account type, `mfa_enabled`, and
+`workplace_email_verified_at`.
+
+Staff onboarding is invite-based. Root admins create invites for `staff` or
+`admin` roles only; root-admin self-service invite creation is not allowed.
+Invite acceptance validates the token, personal and workplace email policies,
+password policy, optional Turnstile, workplace verification code, and TOTP
+setup before activating the account.
+
+Evidence: `app/admin/routes.py`, `app/admin/services.py`,
+`app/admin/separation.py`, `admin_wsgi.py`, `config.py`, and
+`compose.prod.yml`.
+
+Tests: `tests/test_admin_staff_invites.py::test_root_admin_can_create_hashed_staff_invite`,
+`tests/test_admin_staff_invites.py::test_only_root_admin_with_totp_stepup_can_create_invites`,
+`tests/test_admin_staff_invites.py::test_staff_invite_acceptance_activates_only_after_workplace_code_and_totp`,
+`tests/test_admin_staff_invites.py::test_customer_registration_cannot_create_staff_or_admin_roles`,
+and `tests/test_admin_isolation.py::test_customer_and_admin_apps_have_isolated_route_surfaces`.
+
+## 1.7 Password Storage
+
+Passwords are stored as custom PBKDF2-HMAC-SHA256 hashes in `User.password_hash`.
+The format includes algorithm, version, iteration count, salt, and derived hash:
+
+```text
+osp-pbkdf2-sha256$v1$i=<iterations>$s=<salt>$h=<hash>
+```
+
+Implementation evidence:
+
+| Control | Evidence |
+| --- | --- |
+| Per-password random salt | `hash_password()` uses `os.urandom(PBKDF2_SALT_BYTES)` in `app/security/passwords.py` |
+| Minimum iteration count | `PASSWORD_PBKDF2_ITERATIONS` must be at least `600000` in `config.py` and `app/security/passwords.py` |
+| Server-side pepper | `_pbkdf2_digest()` HMACs the normalized password with `PASSWORD_PEPPER_B64` before PBKDF2 |
+| Constant-time comparison | `verify_password()` uses `hmac.compare_digest()` |
+| Algorithm and cost metadata | Hash string contains prefix, version, `i=`, `s=`, and `h=` fields |
+| Rehash support | `password_hash_needs_rehash()` triggers rehash when stored iterations are below the current config |
+| Common-password checks | Local blocklist plus HIBP range API in `validate_password_policy()` |
+| Maximum length checks | `PASSWORD_MAX_CHARS` and schema/form validators reject oversized passwords before hashing |
+
+Tests: `tests/test_auth_registration_login.py::test_registration_hashes_password_with_pbkdf2`,
+`tests/test_auth_registration_login.py::test_hash_password_uses_configured_pbkdf2_iterations`,
+`tests/test_passwords.py::test_hashes_long_unicode_passwords_with_pbkdf2_and_rejects_unknown_hashes`,
+`tests/test_passwords.py::test_password_hashing_normalizes_unicode_with_nfc`,
+`tests/test_passwords.py::test_rejects_password_found_in_local_blocklist_without_remote_call`,
+and `tests/test_passwords.py::test_sends_only_hash_prefix_with_padding_and_short_timeout`.
+
+Passwords are not logged in plaintext by the code paths inspected. Audit
+metadata sanitization redacts keys and values containing password, token,
+secret, session, credential URL, webhook URL, and private-key patterns.
+
+Current gap: full password history is not implemented. The code prevents reuse
+of the current password during change/reset, but no previous-password history
+table or retention policy was found.
+
+## 1.8 Protection Against Unauthorized Access To Stored Passwords
+
+The repository protects password hashes through application and deployment
+controls:
+
+| Control | Evidence |
+| --- | --- |
+| Runtime/migration role separation | `ops/postgres/init-sitbank-staging-roles.sh`, `app/ops/db_privileges.py`, `ops/container/smoke-test.sh` |
+| Admin runtime role separation | `compose.prod.yml` and `compose.staging.yml` use `ADMIN_DATABASE_URL_FILE`; `app/ops/db_privileges.py::apply_admin_runtime_database_privileges` grants admin runtime access separately |
+| Runtime app uses Docker secrets, not committed env files | `compose.prod.yml`, `compose.staging.yml`, `config.py`, `ops/runtime_contract.py` |
+| No plaintext password logging | `app/security/audit.py` redacts sensitive metadata and log output |
+| Customer/admin separation | `admin_wsgi.py`, `wsgi.py`, `app/__init__.py`, `app/admin/services.py`, `app/web/routes.py` |
+| Secret scanning | `ops/security/scan_repository_secrets.py`, `tests/test_secret_scanner.py`, and CI in `.github/workflows/ci-deploy.yml` |
+| Audit append-only controls | `migrations/versions/20260618_0003_audit_append_only_triggers.py`, `migrations/versions/20260618_0004_audit_truncate_trigger.py`, `app/ops/db_privileges.py` |
+
+Tests include
+`tests/test_deployment.py::test_smoke_fixture_and_deployment_wrapper_match_runtime_contract`,
+`tests/test_deployment.py::test_compose_secret_mounts_match_runtime_contract`,
+`tests/test_deployment.py::test_runtime_secret_inventory_matches_config_and_renderer`,
+`tests/test_deployment.py::test_deployment_profiles_keep_production_and_staging_isolated`,
+`tests/test_audit_metadata_sanitization.py::test_audit_event_storage_and_logs_do_not_leak_sensitive_metadata`,
+and `tests/test_audit_alerting.py::test_audit_hash_chain_records_verifies_and_exports_anchor`.
+
+Current gap: backup and database dump encryption/access handling is described
+only at an operational level in `SECURITY.md`; the repo does not include an
+automated backup encryption implementation or backup restore access-control
+test.

--- a/docs/security/secure-coding.md
+++ b/docs/security/secure-coding.md
@@ -1,0 +1,174 @@
+# Secure Coding
+
+This document maps SITBank's secure-coding practices to the implementation
+found in the repository, with emphasis on OWASP Proactive Controls and OWASP
+Top 10 risks.
+
+## 4.1 Input Validation
+
+The application validates input at the edge of each feature using WTForms,
+Marshmallow schemas, and service-level allowlists. Sensitive server-controlled
+fields are ignored or rejected rather than trusted from client payloads.
+
+| Area | Validation evidence | Test evidence |
+| --- | --- | --- |
+| Customer registration and login | `app/auth/forms.py`, `app/auth/schemas.py`, `app/auth/services.py` | `tests/test_auth_registration_login.py` |
+| Password policy and length limits | `app/security/passwords.py` | `tests/test_passwords.py`, `tests/test_auth_registration_login.py::test_oversized_registration_password_rejected_before_policy_processing` |
+| SIT email OTP registration | `app/auth/registration_otp.py` | `tests/test_auth_registration_login.py::test_registration_otp_rejects_non_sit_email_domain`, `tests/test_auth_registration_login.py::test_registration_otp_rejects_suffix_lookalike_domain` |
+| Admin invite acceptance | `app/admin/routes.py`, `app/admin/services.py` | `tests/test_admin_staff_invites.py` |
+| Banking and transaction payloads | `app/banking/forms.py`, `app/banking/schemas.py`, `app/banking/services.py` | `tests/test_banking_transaction_security.py` |
+| Open redirect and URL-like mass assignment | `app/auth/routes.py`, `app/web/routes.py` | `tests/test_owasp_regressions.py::test_external_next_parameter_cannot_create_an_open_redirect`, `tests/test_owasp_regressions.py::test_url_like_mass_assignment_field_is_rejected` |
+
+Examples of server-side validation:
+
+| Control | Evidence |
+| --- | --- |
+| Client-supplied account numbers are rejected during registration | `tests/test_auth_registration_login.py::test_api_registration_rejects_client_supplied_account_number` |
+| Staff invite acceptance rejects privileged forged fields such as `role`, `workplace_email`, `email`, `account_type`, `customer_user_id`, and `is_admin` | `app/admin/services.py::_reject_forged_invite_fields()` |
+| Transaction payloads reject server-controlled fields and unsafe business values | `tests/test_banking_transaction_security.py::test_future_transaction_payload_guardrails_reject_server_controlled_fields`, `tests/test_banking_transaction_security.py::test_public_transaction_payload_business_rules_reject_unsafe_values` |
+| Route inventory records method-level auth, CSRF, rate-limit, and step-up decisions | `tests/test_route_inventory_security.py` |
+
+## 4.2 Output Encoding
+
+The app uses Jinja templates, which autoescape HTML by default. The repository
+also contains a regression test that checks templates do not mark
+user-controlled values safe.
+
+| Control | Evidence |
+| --- | --- |
+| Template autoescaping by framework convention | `app/templates/` |
+| No user-controlled `|safe` usage in templates | `tests/test_authenticated_portal_ui.py::test_templates_do_not_mark_user_controlled_data_safe` |
+| Account details are masked in authenticated UI | `tests/test_authenticated_portal_ui.py::test_dashboard_bank_card_masks_account_details_and_loads_toggle_script` |
+| Server errors do not disclose stack traces | `tests/test_owasp_regressions.py::test_server_errors_do_not_disclose_tracebacks` |
+
+Audit and application logs sanitize sensitive metadata before storage or output.
+Evidence: `app/security/audit.py`,
+`tests/test_audit_metadata_sanitization.py`, and
+`tests/test_audit_alerting.py::test_structured_audit_log_output_is_sanitized`.
+
+## 4.3 Authentication And Password Coding Practices
+
+Authentication code avoids common implementation failures:
+
+| Practice | Evidence |
+| --- | --- |
+| Generic login errors | `app/auth/services.py`; `tests/test_auth_registration_login.py::test_login_errors_are_generic_for_unknown_and_wrong_password` |
+| Dummy password hash for unknown users | `app/auth/services.py`; `tests/test_auth_registration_login.py::test_dummy_password_hash_tracks_current_pbkdf2_configuration` |
+| Password hashing with PBKDF2-HMAC-SHA256, salt, pepper, and cost metadata | `app/security/passwords.py`; `tests/test_auth_registration_login.py::test_registration_hashes_password_with_pbkdf2` |
+| Oversized passwords rejected before expensive hashing | `tests/test_auth_registration_login.py::test_oversized_login_password_uses_generic_failure_without_hashing` |
+| TOTP replay prevention | `app/auth/services.py`, `app/models.py::TotpReplayRecord`; `tests/test_mfa_lifecycle.py::test_mfa_setup_stores_encrypted_secret_and_rejects_replay` |
+| Recovery codes are one-time HMAC verifiers | `app/auth/recovery_codes.py`; `tests/test_password_reset.py::test_recovery_codes_are_hashed_single_use_reset_factors` |
+| Active passkey flows fail closed | `app/auth/webauthn_services.py`; `tests/test_webauthn_lifecycle.py` |
+
+Current gap: full password history is not implemented. The app rejects reuse of
+the current password during change/reset but does not store previous password
+hashes for history checks.
+
+## 4.4 Session And CSRF Coding Practices
+
+Session state is server-side, signed, and bound to a database row context.
+State-changing routes use global Flask-WTF CSRF protection plus route inventory
+tests.
+
+| Practice | Evidence |
+| --- | --- |
+| Opaque browser session id; server-side payload | `app/security/sessions.py`, `app/models.py::ServerSideSession` |
+| HMAC-signed payloads with key rotation | `app/security/session_hmac.py`, `tests/test_db_session_integrity.py` |
+| Secure, HttpOnly, SameSite Strict cookies | `config.py`, `tests/test_session_management.py::test_login_sets_secure_session_cookie_and_hides_raw_session_id` |
+| CSRF on unsafe customer routes | `app/extensions.py`, `app/__init__.py`, `tests/test_route_inventory_security.py::test_route_inventory_has_complete_security_decisions` |
+| Explicit CSRF regression tests | `tests/test_account_security_actions.py::test_profile_post_requires_csrf_when_enabled`, `tests/test_account_security_actions.py::test_json_auth_post_requires_global_csrf_header_when_enabled` |
+
+Current gap: there is no hard absolute maximum lifetime for fully
+authenticated sessions independent of activity. Pending MFA sessions do have an
+absolute age check.
+
+## 4.5 Access-Control Coding Practices
+
+Access control is implemented in decorators, request hooks, and services. The
+customer route inventory prevents silent addition of unclassified routes.
+
+| Practice | Evidence |
+| --- | --- |
+| Customer/admin app surfaces are isolated | `app/__init__.py`, `tests/test_admin_isolation.py::test_customer_and_admin_apps_have_isolated_route_surfaces` |
+| Customer login rejects non-customer roles | `app/auth/services.py` |
+| Admin/staff login requires active staff role, workplace email verification, and TOTP | `app/admin/services.py` |
+| High-risk customer actions use TOTP step-up | `app/auth/services.py::verify_high_risk_authorization()` |
+| Payee routes filter by current user id | `app/banking/routes.py` |
+| Session management uses public references and ownership checks | `app/auth/services.py::terminate_session_for_user()` |
+
+Current gap: the route-inventory matrix covers the customer app, but no
+equivalent generated matrix for admin routes was found.
+
+## 4.6 Secure Configuration
+
+Production configuration fails closed when critical secrets or deployment
+settings are missing.
+
+| Configuration control | Evidence |
+| --- | --- |
+| Production secrets must come from direct env or `_FILE`, not both | `config.py::_required_env_or_file()` |
+| Production secret files must resolve beneath `/run/secrets`, not symlinks | `config.py::_read_secret_file()`, `tests/test_config.py::test_production_secret_file_must_resolve_beneath_run_secrets` |
+| SMTP password-reset backend requires TLS and credentials in production | `config.py`, `app/security/email.py`, `tests/test_config.py::test_production_smtp_email_requires_host_and_credentials_without_secret_leakage` |
+| Password reset base URL must be HTTPS in production | `tests/test_config.py::test_password_reset_base_url_must_be_https_in_production` |
+| Nginx rejects unknown hosts and redirects HTTP to HTTPS | `ops/nginx/sitbank-default.conf`, `ops/nginx/sitbank-production.conf` |
+| Docker runtime drops capabilities and runs read-only as UID/GID `10001:10001` | `Dockerfile`, `compose.prod.yml`, `tests/test_deployment.py::test_dockerfile_and_compose_enforce_hardened_runtime` |
+| Deployment contract keeps production and staging isolated | `compose.prod.yml`, `compose.staging.yml`, `tests/test_deployment.py::test_deployment_profiles_keep_production_and_staging_isolated` |
+
+Current gap: Nginx does not pin an explicit `ssl_ciphers` list. The repo pins
+protocols to TLS 1.2 and TLS 1.3, but cipher selection depends on deployed
+Nginx/OpenSSL defaults.
+
+## 4.7 Logging, Auditing, And Error Handling
+
+SITBank records security-relevant events while redacting sensitive values.
+Audit integrity uses an HMAC-SHA256 hash chain.
+
+| Control | Evidence |
+| --- | --- |
+| Audit metadata redaction | `app/security/audit.py`, `tests/test_audit_metadata_sanitization.py` |
+| Structured logs are sanitized | `tests/test_audit_alerting.py::test_structured_audit_log_output_is_sanitized` |
+| Required audit writes can fail closed for critical actions | `app/security/audit.py::audit_event_required()`, `tests/test_audit_alerting.py` |
+| Audit chain records, verifies, and exports anchors | `tests/test_audit_alerting.py::test_audit_hash_chain_records_verifies_and_exports_anchor` |
+| Runtime database privilege verifier checks append-only audit behavior | `app/ops/db_privileges.py`, `tests/test_deployment.py::test_audit_operations_runbook_and_append_only_privileges_are_present` |
+| 500 handler logs sanitized context | `tests/test_audit_alerting.py::test_500_handler_logs_sanitized_context` |
+
+## 4.8 Dependency And Build Integrity
+
+Dependency and build controls are implemented in scripts, lockfiles, and GitHub
+Actions.
+
+| Control | Evidence |
+| --- | --- |
+| Hashed Python lockfiles | `requirements.lock`, `requirements-dev.lock` |
+| Lockfile policy check | `ops/security/check_dependency_locks.py`, `tests/test_deployment.py::test_dependency_manifests_have_one_hashed_lockfile_source_of_truth` |
+| Vulnerability scans | `pip-audit` in `scripts/ci-local` and `.github/workflows/ci-deploy.yml`; Trivy image scans in CI |
+| Static analysis | Bandit, CodeQL, actionlint, zizmor in CI/local workflows |
+| Secret scanning | `ops/security/scan_repository_secrets.py`, `tests/test_secret_scanner.py` |
+| Pinned GitHub Actions and images | `.github/workflows/ci-deploy.yml`, `Dockerfile`, tests in `tests/test_deployment.py` |
+| Image signing and digest deployment | `.github/workflows/ci-deploy.yml`, `tests/test_deployment.py::test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest` |
+
+## 4.9 OWASP Top 10 Mapping
+
+| OWASP risk | SITBank controls | Gaps or notes |
+| --- | --- | --- |
+| A01 Broken Access Control | Customer route inventory, decorators/hooks, high-risk step-up, ownership filters, admin/customer runtime separation | Admin routes do not have an equivalent generated route-inventory matrix; payee IDOR has code-level owner filters but no dedicated IDOR test |
+| A02 Cryptographic Failures | HTTPS, HSTS, AES-256-GCM MFA envelopes, HMAC session/audit integrity, PBKDF2 password storage, Docker secrets validation | No explicit Nginx cipher list; backup encryption is operationally documented but not automated in repo |
+| A03 Injection | SQLAlchemy query construction, WTForms/Marshmallow validation, payload allowlists, no arbitrary URL-like mass assignment | Continue adding focused injection tests as new query surfaces are added |
+| A04 Insecure Design | MFA onboarding gates, password-reset token exchange, manual recovery pending-only public request, staff invite workflow, frozen-account behavior | Manual recovery completion exists as service code but no active admin route was found |
+| A05 Security Misconfiguration | Production config validation, Nginx default host rejection, Docker hardening, CSRF/Talisman defaults, deployment tests | Live host TLS cipher and certificate-renewal state must be verified outside the repo |
+| A06 Vulnerable And Outdated Components | Dependabot, pip-audit, Trivy, CodeQL, hashed lockfiles, pinned Docker base image | No JavaScript package manifest was found, so npm/yarn scanning is not applicable |
+| A07 Identification And Authentication Failures | Generic errors, dummy hash, rate/backoff counters, TOTP, recovery codes, reset verifier HMACs, disabled passkeys fail closed | No full password history |
+| A08 Software And Data Integrity Failures | Hash-locked dependencies, pinned actions, pinned images, cosign signing, audit hash chain, migration/DB privilege tests | Verify external runner and registry trust at deployment time |
+| A09 Security Logging And Monitoring Failures | Structured audit events, sanitization, alerts, append-only audit DB triggers, 500 handler logging | Alert delivery endpoint configuration is deployment-specific |
+| A10 Server-Side Request Forgery | No user-supplied arbitrary URL fetch flow found; fixed HIBP range endpoint sends only SHA-1 prefixes; Turnstile verification uses configured endpoint and redacts token data | New outbound integrations should add allowlists and SSRF tests |
+
+## 4.10 Current Secure-Coding Gaps
+
+| Gap | Impact | Suggested remediation |
+| --- | --- | --- |
+| No full password history | Users can change back to an older password if it is not the current password | Add a password-history table with pepper-aware hash metadata and retention policy |
+| No independent absolute lifetime for fully authenticated sessions | Long active sessions can continue as sliding sessions | Add a created-at maximum age check for authenticated sessions |
+| No explicit Nginx cipher list | Cipher selection depends on host defaults | Pin approved TLS 1.2 cipher suites and verify with a live TLS scan |
+| No generated admin route inventory | Admin route authorization coverage is less systematic than customer routes | Add admin-app inventory tests with auth, CSRF, rate-limit, and step-up decisions |
+| Recovery-code regeneration lacks fresh step-up | An already authenticated session can regenerate backup codes without re-entering TOTP | Require `verify_high_risk_authorization()` before regeneration |
+| Backup encryption not automated in repo | Database dump protection is operational rather than testable here | Add backup encryption scripts and restore/access tests if backups are in assessment scope |

--- a/docs/security/session-management.md
+++ b/docs/security/session-management.md
@@ -1,0 +1,165 @@
+# Session Management
+
+This document describes the session management controls implemented in the
+SITBank repository. The implementation uses database-backed server-side
+sessions with an opaque browser cookie, not Redis or client-side session
+payloads.
+
+## 2.1 Session Storage
+
+SITBank installs a custom `DatabaseSessionInterface` from
+`app/security/sessions.py` during application startup in `app/__init__.py`.
+Although `config.py` sets `SESSION_TYPE = "database"`, the repository does not
+use Flask-Session or Redis for production session storage. Browser cookies hold
+only an opaque session id. Session state is stored in the `server_side_sessions`
+table represented by `ServerSideSession` in `app/models.py`.
+
+| Stored value | Implementation evidence | Protection |
+| --- | --- | --- |
+| Browser session id | `app/security/sessions.py::_generate_sid()` | Opaque id generated with `uuid.uuid4()`; not stored raw in the database |
+| Database lookup key | `app/security/sessions.py::session_lookup_hash()` | HMAC-SHA256 with `SESSION_LOOKUP_HMAC_KEY` |
+| Serialized session payload | `ServerSideSession.data` in `app/models.py` | Signed by `app/security/session_hmac.py` with a binding context that includes the component and lookup hash |
+| User/session metadata | `user_id`, `auth_level`, `created_at`, `last_seen_at`, `expires_at`, `revoked_at`, `ended_reason`, `risk_fingerprint` | Used for revocation, session inventory, inactivity timeout, and risk reauthentication |
+| Public session reference | `session_ref` and `_public_reference_from_lookup_hash()` | HMAC-derived public id for session-management actions; raw internal ids are rejected |
+
+The session payload signature is versioned and key-id aware. The active HMAC
+key signs new payloads, and old keys can remain configured so existing
+sessions survive key rotation. Evidence: `app/security/session_hmac.py` and
+`tests/test_db_session_integrity.py::test_db_session_payload_survives_active_hmac_key_rotation`.
+
+Current gap: Redis-backed session storage is not implemented. Any control that
+specifically requires Redis session persistence or Redis payload HMACs is not
+applicable to the current codebase unless the storage layer is changed.
+
+## 2.2 Cookie Structure
+
+Customer and admin runtimes use different cookie names and separate secret
+material:
+
+| Runtime | Cookie name | Evidence |
+| --- | --- | --- |
+| Customer app | `__Host-sitbank_session` | `config.py` customer runtime config |
+| Admin app | `__Host-sitbank_admin_session` | `config.py` admin runtime config |
+
+Both cookies are configured with:
+
+| Attribute | Value | Evidence |
+| --- | --- | --- |
+| `Secure` | Enabled | `SESSION_COOKIE_SECURE = True` in `config.py`; `app/__init__.py` passes it to Flask-Talisman |
+| `HttpOnly` | Enabled | `SESSION_COOKIE_HTTPONLY = True` in `config.py` |
+| `SameSite` | `Strict` | `SESSION_COOKIE_SAMESITE = "Strict"` in `config.py` |
+| Cookie name prefix | `__Host-` | Customer and admin cookie names in `config.py` |
+| Domain | Not configured in the repo | Required by the `__Host-` browser prefix semantics |
+| Path | Flask default path `/` | No narrower path override was found in config |
+
+The cookie value is an opaque session id. It does not contain the user id, role,
+MFA state, CSRF token, or serialized account data. The server uses the opaque
+id to compute a lookup HMAC and retrieve the signed payload from the database.
+
+Tests:
+
+| Test | Coverage |
+| --- | --- |
+| `tests/test_session_management.py::test_login_sets_secure_session_cookie_and_hides_raw_session_id` | Checks secure cookie behavior and that the raw session id is not exposed in session management UI |
+| `tests/test_admin_staff_invites.py::test_admin_login_creates_only_admin_session_cookie` | Confirms admin login creates only the admin cookie |
+| `tests/test_config.py::test_runtime_secret_maps_use_session_lookup_key_not_redis_url` | Confirms runtime secret maps use the session lookup HMAC key and not Redis URL configuration |
+
+## 2.3 Cookie Transmission
+
+Cookies are transmitted by the browser on HTTPS requests to the configured
+hostname. Production and staging Nginx terminate HTTPS and forward to loopback
+Gunicorn listeners. Nginx overwrites proxy headers in
+`ops/nginx-proxy-headers.conf`, and `app/__init__.py` applies `ProxyFix` with
+`TRUSTED_PROXY_COUNT`.
+
+Transport protections:
+
+| Control | Evidence |
+| --- | --- |
+| HTTPS edge | `ops/nginx/sitbank-production.conf`, `ops/nginx/sitbank-staging.conf` |
+| HTTP to HTTPS redirect | Production Nginx redirects customer and admin HTTP hostnames to HTTPS |
+| HSTS | Production Nginx sets `Strict-Transport-Security "max-age=31536000; includeSubDomains"` |
+| Flask secure cookie enforcement | `SESSION_COOKIE_SECURE`, `SESSION_COOKIE_HTTPONLY`, and `SESSION_COOKIE_SAMESITE` in `config.py` |
+| Proxy trust boundary | `ops/nginx-proxy-headers.conf` and `tests/test_deployment.py::test_proxyfix_trusts_exactly_the_configured_nginx_hop` |
+
+Current gap: TLS cipher suite pinning is not explicit in Nginx. Session cookie
+transport depends on the deployed host's Nginx/OpenSSL cipher defaults in
+addition to the repository's `ssl_protocols TLSv1.2 TLSv1.3` setting.
+
+## 2.4 Session Modification And Tamper Resistance
+
+The browser cannot directly modify authenticated session state because the
+cookie contains only an opaque session id. The database payload is signed with
+HMAC-SHA256 and bound to the session row context. A copied signed payload from
+one session row is rejected when placed in another row.
+
+Tamper handling in `app/security/sessions.py`:
+
+| Condition | Behavior | Evidence |
+| --- | --- | --- |
+| Unknown or expired session | Returns a fresh anonymous session | `DatabaseSessionInterface.open_session()` |
+| Revoked session | Treated as ended and not authenticated | `ServerSideSession.revoked_at` checks |
+| Missing or invalid payload signature | Logs `session_integrity` with a safe reference and starts a new anonymous session | `_handle_integrity_failure()` |
+| Unsupported payload format | Rejected rather than interpreted | `tests/test_db_session_integrity.py::test_unsupported_db_session_payload_format_is_rejected` |
+| Copied payload between rows | Rejected because the binding context changes | `tests/test_db_session_integrity.py::test_signed_db_session_payload_copied_to_another_row_is_rejected` |
+
+Relevant integrity tests:
+
+| Test | Coverage |
+| --- | --- |
+| `tests/test_db_session_integrity.py::test_valid_db_session_payload_continues_to_authenticate` | Baseline valid database session payload |
+| `tests/test_db_session_integrity.py::test_modified_db_session_user_id_is_rejected` | User id tampering |
+| `tests/test_db_session_integrity.py::test_modified_db_session_privilege_flags_are_rejected` | Privilege flag tampering |
+| `tests/test_db_session_integrity.py::test_invalid_db_session_signature_is_rejected` | Invalid HMAC |
+| `tests/test_db_session_integrity.py::test_tampered_db_session_payload_logs_only_safe_reference` | Logging does not expose raw session material |
+| `tests/test_db_session_integrity.py::test_session_payload_binding_context_is_required_and_checked` | Binding context enforcement |
+
+## 2.5 Session Lifecycle
+
+Session creation and rotation are implemented in `app/security/sessions.py` and
+called from authentication services in `app/auth/services.py` and
+`app/admin/services.py`.
+
+| Lifecycle event | Control | Evidence |
+| --- | --- | --- |
+| Password login that requires MFA | Creates a pending MFA session instead of a fully authenticated session | `app/auth/services.py::authenticate_primary()`; `tests/test_pentest_auth_bypass.py::test_pending_mfa_session_cannot_access_dashboard` |
+| Successful customer MFA | Rotates the session id and records authenticated session metadata | `app/auth/services.py::complete_pending_mfa()` and `app/security/sessions.py` |
+| Successful admin MFA | Uses the admin session cookie and staff account checks | `app/admin/services.py`; `tests/test_admin_staff_invites.py::test_admin_login_creates_only_admin_session_cookie` |
+| Password change | Requires TOTP step-up, rotates current session, revokes other sessions | `app/auth/services.py::change_password()`; `tests/test_account_security_actions.py::test_password_change_succeeds_with_recent_mfa_and_revokes_other_sessions` |
+| Logout | Revokes current server-side session | `tests/test_session_management.py::test_logout_invalidates_current_session` |
+| Revoke other sessions | Requires high-risk TOTP authorization and keeps the current session after rotation | `tests/test_session_management.py::test_revoke_other_sessions_accepts_totp_stepup_and_rotates_session` |
+| Terminate one listed session | Uses public session references and ownership checks | `tests/test_session_management.py::test_terminate_other_session_by_public_reference_revokes_it` |
+| Inactivity expiry | Rejects sessions after `SESSION_INACTIVITY_SECONDS` | `tests/test_session_management.py::test_session_inactivity_expiry_revokes_session` |
+
+The customer and admin runtimes default to five minutes for
+`SESSION_INACTIVITY_SECONDS` and `PERMANENT_SESSION_LIFETIME` in `config.py`.
+The database record's `expires_at` is renewed on active requests and revoked
+when inactivity is detected.
+
+Current gap: the active authenticated session lifetime is sliding. No
+independent hard absolute maximum lifetime for a fully authenticated session
+was found. Pending MFA sessions do have an absolute age check covered by
+`tests/test_mfa_lifecycle.py::test_pending_mfa_session_expires_by_absolute_age`.
+
+## 2.6 Session Attack Coverage
+
+| Attack or risk | Implemented control | Evidence |
+| --- | --- | --- |
+| Session fixation | Session id is rotated after authentication milestones and high-risk changes | `rotate_session_id()` in `app/security/sessions.py`; password-change and revoke-other-session tests |
+| Client-side privilege tampering | Authenticated state is server-side and HMAC-signed | `tests/test_db_session_integrity.py` |
+| Raw session id exposure in management UI | UI uses public HMAC-derived references | `tests/test_session_management.py::test_session_termination_rejects_raw_internal_session_id` |
+| Terminating another user's session | Ownership and public-reference checks | `tests/test_pentest_auth_bypass.py::test_cannot_terminate_other_users_session` |
+| Public reference brute force | Invalid references are rejected | `tests/test_pentest_auth_bypass.py::test_session_ref_bruteforce_rejected` |
+| Pending MFA bypass | Pending sessions cannot access authenticated pages or sensitive APIs | `tests/test_pentest_auth_bypass.py::test_pending_mfa_session_cannot_access_dashboard`, `tests/test_pentest_auth_bypass.py::test_pending_mfa_session_cannot_freeze_account` |
+| CSRF on session-changing routes | Global Flask-WTF CSRF plus route inventory checks | `tests/test_route_inventory_security.py::test_route_inventory_has_complete_security_decisions` |
+| Insecure transport | HTTPS-only Nginx and secure cookie flag | `ops/nginx/sitbank-production.conf`, `config.py`, `tests/test_deployment.py` |
+| Risk drift after login | IP/UA-derived risk fingerprint requires reauthentication before sensitive actions | `app/security/sessions.py`; `tests/test_account_security_actions.py::test_session_risk_drift_requires_reauth_before_sensitive_action` |
+| Stolen active cookie | Inactivity timeout, revocation, session inventory, and risk step-up reduce impact | `app/security/sessions.py`, `tests/test_session_management.py` |
+
+Current gap: there is no concurrent-session count limit. Users can view and
+revoke sessions, but the repository does not cap the number of active sessions
+per user.
+
+Current gap: a stolen active cookie may remain usable until inactivity expiry,
+revocation, or risk-based reauthentication triggers. There is no cryptographic
+binding to a device key or client certificate.

--- a/docs/security/test-automation-and-dependencies.md
+++ b/docs/security/test-automation-and-dependencies.md
@@ -1,0 +1,187 @@
+# Test Automation And Dependencies
+
+This document records the SITBank dependency inventory, security automation,
+and test evidence found in the repository.
+
+## 5.1 Dependency Inventory
+
+| Manifest or file | Purpose | Notes |
+| --- | --- | --- |
+| `requirements.in` | Top-level runtime Python dependencies | Flask, SQLAlchemy, Flask-WTF, Flask-Limiter, Flask-Talisman, PyOTP, Marshmallow, Cryptography, and related runtime packages |
+| `requirements.lock` | Runtime Python lockfile | Generated with hashes and consumed by `pip-audit --require-hashes` |
+| `requirements-dev.in` | Development/test dependencies | Includes `-r requirements.in`, `pytest`, `pytest-xdist`, `pip-audit`, `bandit`, and `pip-tools` |
+| `requirements-dev.lock` | Development/test lockfile | Generated with hashes and audited separately |
+| `Dockerfile` | Runtime image | Uses pinned Python base image digest and creates non-root UID/GID `10001:10001` |
+| `compose.prod.yml` | Production deployment model | Uses Docker secrets, read-only app containers, loopback bindings, and separate customer/admin secret sets |
+| `compose.staging.yml` | Staging deployment model | Uses separate staging secrets and database roles |
+| `docker-compose.test.yml` | Test/CI compose model | Used by container smoke and validation flows |
+| `ops/container/compose-validation.override.yml` | Compose validation override | Used by `ops/container/validate-compose.sh` |
+| `.github/dependabot.yml` | Dependency update automation | Weekly Docker, GitHub Actions, and pip updates with limits and labels |
+| `.github/workflows/ci-deploy.yml` | Main CI, image, smoke, scan, sign, and deploy workflow | Runs tests, audits, scans, DAST paths, Trivy, and cosign |
+| `.github/workflows/codeql.yml` | CodeQL static analysis | Python `security-extended` queries on pull requests, main pushes, and schedule when repository is public |
+| `.github/workflows/bootstrap-ec2.yml` | Bootstrap artifact workflow | Uses pinned actions and cosign blob signing |
+
+Current gap / not applicable: no `package.json`, `package-lock.json`,
+`yarn.lock`, `pnpm-lock.yaml`, `pyproject.toml`, `poetry.lock`, or Pipenv files
+were found in the repository snapshot inspected. JavaScript package auditing is
+therefore not applicable unless a frontend package manager is added.
+
+## 5.2 Dependency And Vulnerability Checks
+
+| Check | Location | What it verifies |
+| --- | --- | --- |
+| Runtime `pip-audit` | `scripts/ci-local`, `.github/workflows/ci-deploy.yml` | Audits `requirements.lock` with `--disable-pip --require-hashes` |
+| Dev `pip-audit` | `scripts/ci-local`, `.github/workflows/ci-deploy.yml` | Audits `requirements-dev.lock` separately |
+| `pip check` | `scripts/ci-local`, `.github/workflows/ci-deploy.yml` | Verifies installed package metadata compatibility |
+| Dependency lock validation | `ops/security/check_dependency_locks.py` | Enforces the hashed lockfile source of truth and rejects legacy dependency manifests |
+| Dependabot | `.github/dependabot.yml` | Opens controlled weekly updates for Docker, GitHub Actions, and pip dependencies |
+| GitHub dependency review | `.github/workflows/ci-deploy.yml` | Reviews dependency changes in pull requests |
+| Trivy image scans | `.github/workflows/ci-deploy.yml` | Scans built images and repository filesystem paths; `.trivyignore` exceptions are tested |
+| CodeQL | `.github/workflows/codeql.yml` | Runs Python security-extended static analysis when the repository is public |
+| Bandit | `scripts/ci-local`, `.github/workflows/ci-deploy.yml` | Runs a high-confidence Python security scan |
+| Secret scanner | `ops/security/scan_repository_secrets.py` | Scans tracked files and, in CI/local CI, git history for private keys and common token formats |
+| Action hygiene | `.github/workflows/ci-deploy.yml` | Runs actionlint and zizmor; tests require actions to be SHA-pinned |
+| Image and artifact signing | `.github/workflows/ci-deploy.yml`, `.github/workflows/bootstrap-ec2.yml`, `ops/deploy/sitbank-container-deploy` | Uses cosign to sign/verify images and deployment artifacts |
+
+Tests for this automation include:
+
+| Test | Coverage |
+| --- | --- |
+| `tests/test_pytest_optimization.py::test_ci_keeps_full_parallel_pytest_and_locked_dependency_checks` | CI keeps full unscoped pytest, pip check, Bandit, pip-audit, lock validation, and secret scan |
+| `tests/test_pytest_optimization.py::test_local_ci_keeps_full_parallel_pytest_and_security_gates` | Local CI wrapper keeps the same security gates |
+| `tests/test_deployment.py::test_dependency_manifests_have_one_hashed_lockfile_source_of_truth` | Dependency manifest policy |
+| `tests/test_deployment.py::test_dependabot_tracks_docker_base_images_without_automerge` | Dependabot policy |
+| `tests/test_deployment.py::test_every_github_action_is_pinned_to_a_full_commit_sha` | GitHub Actions pinning |
+| `tests/test_deployment.py::test_trivy_exception_is_narrow_documented_and_temporary` | Trivy ignore policy |
+| `tests/test_secret_scanner.py` | Secret scanner behavior |
+
+## 5.3 Test Automation Coverage
+
+The main Python test command is intentionally unscoped:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q -n auto --durations=30 --durations-min=0.5
+```
+
+This command is represented in `scripts/ci-local` and
+`.github/workflows/ci-deploy.yml`. The tests cover security controls across
+configuration, authentication, session integrity, access control, audit, and
+deployment.
+
+| Test area | Representative files |
+| --- | --- |
+| Configuration and secret validation | `tests/test_config.py`, `tests/test_deployment.py` |
+| Registration, login, password policy, and rate limits | `tests/test_auth_registration_login.py`, `tests/test_passwords.py` |
+| MFA lifecycle and envelope encryption | `tests/test_mfa_lifecycle.py`, `tests/test_mfa_envelope_crypto.py` |
+| Password reset and manual recovery services | `tests/test_password_reset.py` |
+| Database session integrity | `tests/test_db_session_integrity.py` |
+| Session management UI/API | `tests/test_session_management.py` |
+| Auth bypass and pentest regressions | `tests/test_pentest_auth_bypass.py`, `tests/test_owasp_regressions.py` |
+| Route inventory | `tests/test_route_inventory_security.py` |
+| Admin isolation and staff invites | `tests/test_admin_isolation.py`, `tests/test_admin_staff_invites.py` |
+| Banking payload and transaction guardrails | `tests/test_banking_transaction_security.py` |
+| Audit, alerts, and redaction | `tests/test_audit_alerting.py`, `tests/test_audit_metadata_sanitization.py` |
+| Deployment, Nginx, Docker, workflows, and runtime contracts | `tests/test_deployment.py` |
+| UI security regressions | `tests/test_authenticated_portal_ui.py`, `tests/test_dashboard.py` |
+
+Current test gap: payee ownership is enforced in `app/banking/routes.py`, and
+payee routes are in `tests/test_route_inventory_security.py`, but no dedicated
+payee IDOR regression test was found.
+
+Current test gap: admin route authorization has targeted tests, but no
+generated route-inventory matrix equivalent to the customer app inventory was
+found.
+
+## 5.4 Local Security Commands
+
+The preferred local wrapper is:
+
+```powershell
+.\.venv\Scripts\python.exe scripts\ci-local
+```
+
+That wrapper runs the Python checks below, then Bash syntax checks, then
+Compose validation if Docker is available.
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q -n auto --durations=30 --durations-min=0.5
+.\.venv\Scripts\python.exe -m compileall app config.py wsgi.py admin_wsgi.py
+.\.venv\Scripts\python.exe -m pip check
+.\.venv\Scripts\python.exe -m bandit -q -ll -r app ops config.py wsgi.py admin_wsgi.py
+.\.venv\Scripts\python.exe -m pip_audit --disable-pip --require-hashes -r requirements.lock
+.\.venv\Scripts\python.exe -m pip_audit --disable-pip --require-hashes -r requirements-dev.lock
+.\.venv\Scripts\python.exe ops\security\check_dependency_locks.py
+.\.venv\Scripts\python.exe ops\security\scan_repository_secrets.py --history
+git diff --check
+```
+
+The GitHub workflow command block in `.github/workflows/ci-deploy.yml` runs the
+same core checks. Its Bandit command currently scans `app`, `ops`, `config.py`,
+and `wsgi.py`; the local wrapper additionally includes `admin_wsgi.py`.
+
+Current gap: `scripts/ci-local` skips Docker/Compose-only checks when Docker is
+unavailable. In that case, the skipped Docker result is explicit, but local CI
+does not prove the Compose model on that machine.
+
+## 5.5 CI/CD Security Automation
+
+The main workflow in `.github/workflows/ci-deploy.yml` includes these security
+stages:
+
+| Stage | Evidence |
+| --- | --- |
+| Workflow hygiene | actionlint installation plus zizmor action |
+| Dependency review | `actions/dependency-review-action` |
+| Python tests and checks | pytest, compileall, pip check, Bandit, pip-audit, lock validation, secret scan |
+| Container smoke and DAST path | `ops/container/smoke-test.sh` |
+| Trivy scans | Multiple Trivy action invocations for filesystem/image scan paths |
+| Immutable image deployment | Image digest promotion and deployment tests |
+| Cosign signing and verification | Image and deployment artifact signing/verification |
+| Manual release DAST option | `workflow_dispatch` input `run_dast` controls authenticated DAST during release verification |
+
+The separate `.github/workflows/codeql.yml` runs CodeQL Python
+`security-extended` queries for public repository events. The separate
+`.github/workflows/bootstrap-ec2.yml` signs bootstrap artifacts with cosign and
+is covered by deployment tests.
+
+Tests in `tests/test_deployment.py` assert that these workflow controls remain
+present, including dependency review, action pinning, Trivy policy, cosign, and
+DAST policy.
+
+## 5.6 Authenticated DAST And Smoke Tests
+
+Container smoke tests live in `ops/container/smoke-test.sh`. The script pins the
+ZAP image as `zaproxy/zap-stable:2.17.0@sha256:...` and runs authenticated DAST
+only when `RUN_ZAP_DAST=true`.
+
+Authenticated DAST session creation is handled by
+`ops/container/create_dast_session.py`:
+
+| Control | Evidence |
+| --- | --- |
+| Target host restricted to loopback or explicit smoke host | `tests/test_deployment.py::test_dast_session_creator_requires_loopback_or_explicit_smoke_host` |
+| Synthetic account registration follows the real registration contract | `tests/test_deployment.py::test_dast_session_creator_matches_registration_contract` |
+| Generated credentials are synthetic and random | `ops/container/create_dast_session.py` |
+| The script emits an authenticated session cookie for ZAP rather than real user credentials | `ops/container/smoke-test.sh` |
+
+`ops/container/dast-smoke.sh` provides a local smoke-oriented DAST path using
+synthetic secrets and a synthetic local test user. No real customer, admin, or
+staff credentials are required by the DAST scripts in the repository.
+
+Current gap: authenticated DAST is conditional. Ordinary pull requests skip the
+full authenticated crawl; scheduled runs and release verification paths enable
+it according to workflow policy.
+
+## 5.7 Dependency Update Workflow
+
+Dependabot is configured in `.github/dependabot.yml`:
+
+| Ecosystem | Schedule | Limits |
+| --- | --- | --- |
+| Docker | Weekly Monday, Asia/Singapore timezone | Pull request limit 3; Python 3.13+ base images ignored |
+| GitHub Actions | Weekly Monday | Pull request limit 5 |
+| pip | Weekly Monday | Pull request limit 8; patch/minor grouping; cooldowns for major/minor/patch changes |
+
+Dependabot does not auto-merge updates in the repository configuration
+inspected. Updates must still pass the lockfile policy, tests, audits, scans,
+and review workflow.


### PR DESCRIPTION
## Summary

Adds five assessor-facing security documentation pages under `docs/security/`.

The new docs explain SITBank security controls across cryptography/authentication, session management, access control, secure coding, and test automation/dependency management. They cite actual implementation paths and tests, and clearly mark partial or missing coverage as `Current gap` or `Current test gap`.

## Why

Security assessors need a clear, evidence-based map of the project’s implemented controls, supporting tests, and known gaps.

These documents make the security posture easier to review without overstating incomplete controls. They also help future contributors understand where key security behavior is implemented and which tests protect it.

## What changed

* Added `docs/security/cryptography-and-authentication.md`.
* Added `docs/security/session-management.md`.
* Added `docs/security/access-control.md`.
* Added `docs/security/secure-coding.md`.
* Added `docs/security/test-automation-and-dependencies.md`.
* Documented security controls with references to actual implementation paths.
* Documented supporting regression/security tests.
* Marked partial or missing controls as `Current gap`.
* Marked missing or incomplete test coverage as `Current test gap`.
* Verified the new docs do not contain non-ASCII text.
* Verified the new docs do not contain secret-like patterns.

## Security impact

This is a documentation-only change.

It does not change application authentication, authorization, cryptography, secrets, CI/CD behavior, deployment behavior, runtime behavior, or customer/admin functionality.

It improves review transparency by documenting implemented controls, evidence paths, and known security/test gaps without claiming that incomplete controls are fully implemented.

## Deployment impact

No deployment action.

This PR does not require:

* EC2 bootstrap
* staging deployment
* production deployment
* database migration
* secret changes

## Verification

* `git diff --check`
* Non-ASCII scan for `docs/security`
* Secret-like pattern scan for the new docs
* `.\.venv\Scripts\python.exe -m pytest -q`

  * `401 passed, 2 skipped, 6 warnings in 3m13s`

## Notes

These documents are assessor-facing and intentionally cite current implementation/test paths.

Known partial or missing controls are labelled as `Current gap` or `Current test gap` instead of being presented as complete.
