### PR TITLE
Clean active security documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ SITBank is a student cybersecurity project and demonstration site. Do not enter 
 
 SITBank is a Flask/Gunicorn application deployed as hardened Docker containers behind host-managed Nginx, TLS, and PostgreSQL. Production customer traffic runs at `https://sitbank.duckdns.org`; the isolated production admin boundary at `https://admin-sitbank.duckdns.org` uses a separate admin app, cookie, session keys, database role, root-admin-controlled staff invites, and mandatory TOTP. Staging runs separately at `https://staging-sitbank.duckdns.org`.
 
-Security-critical state is application-owned PostgreSQL data, not Redis data. Server-side sessions, authentication failure counters, TOTP replay markers, registration OTP challenges, password-reset transactions, security-alert dedupe windows, and breached-password circuit-breaker state are stored in dedicated tables. Browser cookies keep only opaque identifiers; lookup hashes are HMAC-derived with `SESSION_LOOKUP_HMAC_KEY` or `ADMIN_SESSION_LOOKUP_HMAC_KEY`, and stored session payloads remain signed with the session HMAC keyring.
+Security-critical state is stored in application-owned PostgreSQL tables. Server-side sessions, authentication failure counters, TOTP replay markers, registration OTP challenges, password-reset transactions, security-alert dedupe windows, and breached-password circuit-breaker state are stored in dedicated tables. Browser cookies keep only opaque identifiers; lookup hashes are HMAC-derived with `SESSION_LOOKUP_HMAC_KEY` or `ADMIN_SESSION_LOOKUP_HMAC_KEY`, and stored session payloads remain signed with the session HMAC keyring.
 
-The app keeps password hashing PBKDF2+pepper only and MFA/TOTP seed encryption envelope-only using `MFA_KEK_ACTIVE_ID` plus `MFA_KEK_KEYS_JSON`. Authenticator TOTP is the supported MFA and step-up method, with recovery codes only where the reset flow already allows TOTP recovery. WebAuthn/passkeys are decommissioned because instructor review disallowed the high-level `webauthn` library; legacy credential rows are retained only for audit and manual-recovery decisions. Legacy one-key MFA AES compatibility and direct non-PBKDF2 password hash compatibility are intentionally removed because current users are test-only and environments must be reset before this change is deployed.
+The app keeps password hashing PBKDF2+pepper only and MFA/TOTP seed encryption envelope-only using `MFA_KEK_ACTIVE_ID` plus `MFA_KEK_KEYS_JSON`. The current MFA baseline is authenticator TOTP with recovery-code support for reset flows. Legacy one-key MFA AES compatibility and direct non-PBKDF2 password hash compatibility are intentionally removed because current users are test-only and environments must be reset before this change is deployed.
 
 ## Local Development
 
@@ -42,7 +42,7 @@ Common local test commands:
 .\.venv\Scripts\python.exe -m pytest -q -m "not slow"
 ```
 
-The `not slow` and focused marker commands are for local iteration only. Pull requests and protected CI still run the full pytest suite, including security, deployment, database session integrity, CSRF, MFA, legacy passkey decommission checks, route inventory, production guard, dependency lock, and secret-scanning checks.
+The `not slow` and focused marker commands are for local iteration only. Pull requests and protected CI still run the full pytest suite, including security, deployment, database session integrity, CSRF, MFA, compatibility-route regression checks, route inventory, production guard, dependency lock, and secret-scanning checks.
 
 For a fuller local check, run `scripts/ci-local`. It runs the full pytest suite in parallel with timing output, then Python/package/security checks, Git Bash syntax checks, Docker/Compose checks when Docker is available, and contract checks around `ops/runtime_contract.py`.
 
@@ -98,8 +98,6 @@ Current required settings include:
 
 See `ops/production-env.required` for the machine-readable checklist.
 
-WebAuthn RP and FIDO metadata settings are not part of the runtime contract because active passkey registration, login, reset, and step-up are retired.
-
 ## Customer Password Reset
 
 Customer forgot-password requests use generic responses and do not reveal
@@ -110,12 +108,11 @@ token.
 
 Password reset changes only the password. It does not disable MFA, does not
 create a login session, and revokes active sessions after completion. Customers
-with TOTP must verify TOTP or a recovery code; passkeys do not replace TOTP
-recovery. Customers with only legacy passkey records must use manual account
-recovery before resetting the password, so passkey retirement does not create
-an email-link-only fallback. Customers without MFA can reset but are sent
-through the existing MFA onboarding gate on next login. Admin-account reset is
-not implemented in the customer domain.
+with TOTP must verify TOTP or a recovery code. Accounts that cannot complete
+the supported reset verification flow must use manual account recovery before
+password reset or MFA re-enrollment. Customers without MFA can reset but are
+sent through the existing MFA onboarding gate on next login. Admin-account
+reset is not implemented in the customer domain.
 
 ## Documentation
 
@@ -123,6 +120,7 @@ not implemented in the customer domain.
 - [GitHub Actions](docs/GITHUB_ACTIONS.md)
 - [Operations](docs/OPERATIONS.md)
 - [Security](SECURITY.md)
+- [Legacy and out-of-scope technology notes](docs/security/legacy-and-out-of-scope-technology.md)
 - [Archived EC2 transition notes](docs/archive/EC2_TRANSITION.md)
 
 ## Deployment Snapshot

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -58,7 +58,7 @@ setup are Phase 2 items pending an approved design. Until those controls exist,
 `admin-sitbank.duckdns.org` remains isolated at the edge and should be protected
 with an explicit network allowlist. The Flask admin app uses a separate cookie,
 session HMAC keyring, database role, root-admin-controlled staff invites, and
-mandatory TOTP; WebAuthn/passkeys are not offered for staff/admin onboarding.
+mandatory TOTP.
 
 Staging secrets must never be copied from production. The staging deployment
 wrapper rejects identical application secret files when production secrets are
@@ -71,7 +71,7 @@ distinct.
 Security audit events are written to `security_audit_events` and emitted as
 sanitized structured application log lines for container and journald
 forwarding. Audit records must capture who, what, where, and when without
-storing plaintext passwords, TOTP codes, CSRF tokens, legacy WebAuthn challenge
+storing plaintext passwords, TOTP codes, CSRF tokens, authentication challenge
 material, private keys, bearer tokens, MFA secrets, ciphertext, nonces, raw
 session payloads, raw session IDs, raw attempted login identifiers, or full
 account numbers.
@@ -219,8 +219,7 @@ checked manually.
 - Enable WAF managed common, SQL injection, XSS, bot, and protocol anomaly
   rules.
 - Add WAF rate-based rules for `/login`, `/register`, `/mfa/verify`,
-  `/auth/`, `/auth/webauthn/`, `/password/`, `/sessions/`, `/security-keys/`,
-  `/profile`, and `/account/`.
+  `/auth/`, `/password/`, `/sessions/`, and account-management routes.
 - Block TRACE at the edge and preserve only the expected proxy headers:
   `Host`, `X-Real-IP`, `X-Forwarded-For`, and `X-Forwarded-Proto`.
 - If a CDN or WAF forwards traffic to Nginx, configure the trusted real-client
@@ -272,8 +271,6 @@ psql "$DATABASE_MIGRATION_URL" --no-psqlrc --command \
 psql "$DATABASE_MIGRATION_URL" --no-psqlrc --command \
   "SELECT created_at, user_id, event_metadata->>'reason' AS reason FROM security_audit_events WHERE event_type = 'account_lock' ORDER BY created_at DESC LIMIT 20;"
 psql "$DATABASE_MIGRATION_URL" --no-psqlrc --command \
-  "SELECT created_at, user_id, event_metadata->>'credential_id' AS credential_ref FROM security_audit_events WHERE event_type = 'webauthn_clone_detected' ORDER BY created_at DESC LIMIT 20;"
-psql "$DATABASE_MIGRATION_URL" --no-psqlrc --command \
   "SELECT created_at, ip_address, session_ref, event_metadata->>'reason' AS reason FROM security_audit_events WHERE event_type = 'session_integrity' AND outcome = 'failure' ORDER BY created_at DESC LIMIT 20;"
 journalctl -u sitbank-container.service --since -15m | grep security_audit_write_failed
 python -m flask --app wsgi:app check-security-alerts --report-only
@@ -295,7 +292,7 @@ request bodies, raw identifiers, passwords, session IDs, or full account
 numbers. Immediately before webhook delivery, both generic JSON payloads and
 Discord-formatted payloads pass through a final sanitizer that redacts
 sensitive keys, bearer/basic credentials, session or cookie values, database URLs with
-credentials, legacy Redis URLs with credentials, webhook URLs, API keys,
+credentials, credentialed service URLs, webhook URLs, API keys,
 private-key-like values, and long token-like strings. Set
 `SECURITY_ALERT_STATE_PATH=/run/state/security-alert-state.json` on the
 host-mounted alert state directory so `check-security-alerts` can compare
@@ -320,10 +317,7 @@ or more `auth_backoff` or `rate_limit` events from the same source in 10
 minutes, 3 or more transaction failures for the same user/ref in 15 minutes, or
 10 transaction failures globally in 15 minutes. Also alert on failed
 deployments, signature or revision mismatches, unexpected image digests, and
-database table regression. Historical WebAuthn/passkey alert names such as
-`webauthn_clone_detected` and `password_reset_webauthn_failed` remain queryable
-for legacy audit context, but active passkey ceremonies are retired because
-instructor review disallowed the high-level `webauthn` library.
+database table regression.
 
 Production installs `sitbank-security-alerts.service` and
 `sitbank-security-alerts.timer` through the EC2 bootstrap path. The timer runs
@@ -356,9 +350,8 @@ Reset MFA policy:
 
 - TOTP customers must verify TOTP after the reset transaction is active.
   Recovery codes are accepted only as TOTP recovery factors.
-- Passkeys do not replace TOTP recovery. A legacy passkey-only account cannot
-  use an email-link-only reset fallback and must complete manual customer
-  recovery before password reset or MFA re-enrollment.
+- Customers who cannot complete TOTP or recovery-code verification must
+  complete manual customer recovery before password reset or MFA re-enrollment.
 - No-MFA customers can set a new password but remain incomplete-security-state
   users and hit MFA onboarding on next login.
 - Recovery codes are stored HMACed, shown only by trusted authenticated

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -2,7 +2,7 @@
 
 ## Current Architecture
 
-Only Flask/Gunicorn runs in the SITBank container. Nginx, TLS, PostgreSQL, and backups remain host-managed on EC2. Redis is not part of the runtime contract; sessions, authentication counters, OTP/reset state, alert dedupe, and breached-password circuit state live in application-owned PostgreSQL tables. WebAuthn/passkeys are decommissioned because instructor review disallowed the high-level `webauthn` library, so production no longer requires WebAuthn RP or FIDO metadata configuration.
+Only Flask/Gunicorn runs in the SITBank container. Nginx, TLS, PostgreSQL, and backups remain host-managed on EC2. Sessions, authentication counters, OTP/reset state, alert dedupe, and breached-password circuit state live in application-owned PostgreSQL tables.
 
 - Production public host: `sitbank.duckdns.org`
 - Production admin host: `admin-sitbank.duckdns.org`
@@ -118,7 +118,7 @@ The reviewed production bootstrap installs and enables the production edge from 
 - Cloudflare or AWS WAF should sit in front of Nginx for managed common, SQL injection, XSS, bot, and protocol anomaly rules.
 - Cloudflare or AWS WAF rules and security-group allowlists are still infrastructure state and must be checked manually.
 - Flask admin auth is implemented only for root-admin-controlled invite
-  onboarding with mandatory TOTP, separate admin sessions, and no WebAuthn or
+  onboarding with mandatory TOTP, separate admin sessions, and no
   password-only administrator login.
 
 Verification:

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -104,7 +104,7 @@ psql "$DATABASE_MIGRATION_URL" --no-psqlrc --command \
 psql "$DATABASE_MIGRATION_URL" --no-psqlrc --command \
   "SELECT created_at, ip_address, event_metadata->>'principal_ref' AS principal_ref FROM security_audit_events WHERE event_type = 'login' AND outcome = 'failure' ORDER BY created_at DESC LIMIT 20;"
 psql "$DATABASE_MIGRATION_URL" --no-psqlrc --command \
-  "SELECT created_at, user_id, event_metadata->>'reason' AS reason FROM security_audit_events WHERE event_type IN ('account_lock', 'webauthn_clone_detected', 'session_integrity') ORDER BY created_at DESC LIMIT 20;"
+  "SELECT created_at, user_id, event_metadata->>'reason' AS reason FROM security_audit_events WHERE event_type IN ('account_lock', 'session_integrity') ORDER BY created_at DESC LIMIT 20;"
 journalctl -u sitbank-container.service --since -15m | grep security_audit_write_failed
 python -m flask --app wsgi:app check-security-alerts --report-only
 ```
@@ -129,7 +129,7 @@ sanitized by exception type and must not print webhook URLs or tokens. A final
 sanitization pass runs immediately before outbound webhook JSON serialization
 for both generic and Discord payloads; it redacts sensitive keys, bearer/basic
 credentials, cookies, session values, MFA/TOTP secrets, API keys,
-private-key-like text, database URLs with credentials, legacy Redis URLs with credentials, webhook URLs,
+private-key-like text, database URLs with credentials, credentialed service URLs, webhook URLs,
 and long token-like strings while preserving harmless severity, event type, summary,
 timestamp, correlation ID, public session reference, and safe user references.
 PostgreSQL alert-dedupe state suppresses repeated delivery of the same alert for
@@ -170,9 +170,7 @@ transaction failures for the same user/ref in 15 minutes; 10 transaction
 failures globally in 15 minutes; audit hash-chain verification failure; audit
 anchor mismatch; database table regression; failed deployments; signature or
 revision mismatches; unexpected image digests; and changes to root-managed
-secret files. Historical `webauthn_clone_detected` audit rows may still be
-reviewed for legacy incident context, but active WebAuthn/passkey ceremonies are
-retired.
+secret files.
 
 ## Password Reset Operations
 

--- a/docs/security/access-control.md
+++ b/docs/security/access-control.md
@@ -113,13 +113,12 @@ and `tests/test_password_reset.py` covers the service behavior, but
 ## 3.5 High-Risk Actions And Step-Up
 
 High-risk customer actions use `verify_high_risk_authorization()` in
-`app/auth/services.py`. The current active control is TOTP. Passkey step-up
-tokens are explicitly rejected because active WebAuthn ceremonies are disabled.
+`app/auth/services.py`. The current active control is TOTP.
 
 | Action | Step-up and access control | Evidence |
 | --- | --- | --- |
 | Password change | Authenticated user, MFA setup, current password, TOTP step-up, revoke other sessions | `app/auth/services.py::change_password()`, `tests/test_account_security_actions.py::test_password_change_succeeds_with_recent_mfa_and_revokes_other_sessions` |
-| Profile update | Authenticated user and TOTP step-up when email, phone, or other sensitive profile fields change | `app/auth/services.py::update_profile_details()`, `tests/test_account_security_actions.py::test_profile_update_requires_mfa_when_enabled` |
+| Account details update | Authenticated user and TOTP step-up when email, phone, or other sensitive account fields change | `app/auth/services.py`, `tests/test_account_security_actions.py` |
 | MFA replacement start | Fresh TOTP step-up before replacing an existing authenticator secret | `app/auth/services.py`, `tests/test_mfa_lifecycle.py::test_mfa_replacement_start_requires_fresh_mfa_stepup` |
 | Account freeze | Authenticated user, non-frozen state, TOTP step-up, revoke other sessions | `app/auth/services.py::freeze_own_account()`, `tests/test_account_security_actions.py::test_account_freeze_is_durable_and_blocks_group_a_sensitive_actions` |
 | Revoke other sessions | Authenticated user and TOTP step-up | `app/auth/routes.py::revoke_other_sessions()`, `tests/test_pentest_auth_bypass.py::test_revoke_others_requires_valid_mfa_code` |
@@ -145,7 +144,7 @@ new codes.
 | IDOR on session management | Public session references are scoped to current user and raw internal ids are rejected |
 | Staff/admin privilege creation through customer registration | Customer registration sets `account_type="customer"` and tests reject forged account-number and privileged fields |
 | Staff acting on their own linked customer identity | `app/admin/separation.py` guard and test coverage |
-| Pending MFA bypass | Pending sessions cannot access dashboard, profile, session list, MFA setup, or freeze actions |
+| Pending MFA bypass | Pending sessions cannot access dashboard, account details, session list, MFA setup, or freeze actions |
 | Frozen account bypass | Frozen accounts cannot create new login sessions or perform sensitive actions |
 
 Current gap: route-level authorization is well covered for the customer app,

--- a/docs/security/cryptography-and-authentication.md
+++ b/docs/security/cryptography-and-authentication.md
@@ -178,6 +178,8 @@ setup before normal account access. Evidence: `app/auth/mfa_policy.py`,
 
 ### TOTP MFA And Recovery Codes
 
+The current MFA baseline is TOTP with recovery-code support.
+
 The repository implements authenticator-app TOTP. TOTP secrets are generated
 with `pyotp.random_base32(length=32)` and stored through AES-GCM envelope
 encryption. Verification records a replay digest in `totp_replay_records`, so
@@ -185,18 +187,6 @@ the same accepted TOTP step and code cannot be replayed for the same scope.
 
 Recovery codes are generated as random 16-byte values encoded as grouped hex,
 stored as HMACs, consumed once, and used only as TOTP recovery factors.
-
-### WebAuthn / Passkeys
-
-WebAuthn/passkey active ceremonies are not implemented in the current runtime.
-The compatibility routes return `410` with a disabled message. Legacy passkey
-records can be listed as inactive inventory, but they do not satisfy the MFA
-policy. Evidence: `app/auth/routes.py`, `app/auth/webauthn_services.py`, and
-`app/auth/mfa_policy.py`.
-
-Tests: `tests/test_webauthn_lifecycle.py::test_public_passkey_endpoints_fail_closed`,
-`tests/test_webauthn_lifecycle.py::test_authenticated_passkey_endpoints_fail_closed`,
-and `tests/test_webauthn_lifecycle.py::test_legacy_passkey_rows_do_not_satisfy_mfa_policy`.
 
 ### Password Reset
 
@@ -215,7 +205,7 @@ Evidence: `app/auth/password_reset.py`, `app/auth/routes.py`,
 Tests: `tests/test_password_reset.py::test_forgot_password_response_is_generic_and_token_is_hashed`,
 `tests/test_password_reset.py::test_reset_token_exchanges_once_into_tokenless_transaction`,
 `tests/test_password_reset.py::test_totp_user_must_verify_totp_before_password_reset`,
-`tests/test_password_reset.py::test_passkey_only_user_cannot_fall_back_to_email_only_reset`,
+`tests/test_password_reset.py::test_recovery_codes_are_hashed_single_use_reset_factors`,
 and `tests/test_password_reset.py::test_admin_like_customer_domain_reset_fails_closed`.
 
 ### Admin And Staff Authentication
@@ -298,7 +288,7 @@ Tests include
 `tests/test_deployment.py::test_smoke_fixture_and_deployment_wrapper_match_runtime_contract`,
 `tests/test_deployment.py::test_compose_secret_mounts_match_runtime_contract`,
 `tests/test_deployment.py::test_runtime_secret_inventory_matches_config_and_renderer`,
-`tests/test_deployment.py::test_deployment_profiles_keep_production_and_staging_isolated`,
+`tests/test_deployment.py`,
 `tests/test_audit_metadata_sanitization.py::test_audit_event_storage_and_logs_do_not_leak_sensitive_metadata`,
 and `tests/test_audit_alerting.py::test_audit_hash_chain_records_verifies_and_exports_anchor`.
 

--- a/docs/security/legacy-and-out-of-scope-technology.md
+++ b/docs/security/legacy-and-out-of-scope-technology.md
@@ -1,0 +1,29 @@
+# Legacy And Out-Of-Scope Technology
+
+This note centralizes historical technology context that should not be repeated
+through active architecture, deployment, or operations documentation.
+
+## Session Storage
+
+Redis session storage was previously considered or documented, but the current
+session source of truth is the application-owned `server_side_sessions`
+PostgreSQL table. Controls tied to Redis session persistence, Redis-specific
+namespaces, Redis connection settings, or payload-signature schemes for that
+storage model apply only if the session storage layer changes.
+
+Regression tests may still mention Redis to prove the runtime contract requires
+the session lookup HMAC key and does not accidentally reintroduce old storage
+configuration.
+
+## Browser Credential Compatibility
+
+WebAuthn, passkey, security-key, and FIDO-related work remains as disabled
+compatibility code, historical database shape, checked-in metadata fixtures, and
+regression coverage. Current user-facing MFA is TOTP with recovery-code support.
+Existing browser-credential rows are retained only for inactive inventory,
+audit, and manual-recovery decisions; they do not satisfy MFA, login, reset, or
+step-up policy.
+
+Regression tests may still mention these technologies to prove compatibility
+endpoints fail closed, inactive credential rows cannot satisfy MFA, and retired
+routes do not regain active behavior without review.

--- a/docs/security/secure-coding.md
+++ b/docs/security/secure-coding.md
@@ -58,7 +58,6 @@ Authentication code avoids common implementation failures:
 | Oversized passwords rejected before expensive hashing | `tests/test_auth_registration_login.py::test_oversized_login_password_uses_generic_failure_without_hashing` |
 | TOTP replay prevention | `app/auth/services.py`, `app/models.py::TotpReplayRecord`; `tests/test_mfa_lifecycle.py::test_mfa_setup_stores_encrypted_secret_and_rejects_replay` |
 | Recovery codes are one-time HMAC verifiers | `app/auth/recovery_codes.py`; `tests/test_password_reset.py::test_recovery_codes_are_hashed_single_use_reset_factors` |
-| Active passkey flows fail closed | `app/auth/webauthn_services.py`; `tests/test_webauthn_lifecycle.py` |
 
 Current gap: full password history is not implemented. The app rejects reuse of
 the current password during change/reset but does not store previous password
@@ -76,7 +75,7 @@ tests.
 | HMAC-signed payloads with key rotation | `app/security/session_hmac.py`, `tests/test_db_session_integrity.py` |
 | Secure, HttpOnly, SameSite Strict cookies | `config.py`, `tests/test_session_management.py::test_login_sets_secure_session_cookie_and_hides_raw_session_id` |
 | CSRF on unsafe customer routes | `app/extensions.py`, `app/__init__.py`, `tests/test_route_inventory_security.py::test_route_inventory_has_complete_security_decisions` |
-| Explicit CSRF regression tests | `tests/test_account_security_actions.py::test_profile_post_requires_csrf_when_enabled`, `tests/test_account_security_actions.py::test_json_auth_post_requires_global_csrf_header_when_enabled` |
+| Explicit CSRF regression tests | `tests/test_account_security_actions.py`, `tests/test_route_inventory_security.py` |
 
 Current gap: there is no hard absolute maximum lifetime for fully
 authenticated sessions independent of activity. Pending MFA sessions do have an
@@ -112,7 +111,7 @@ settings are missing.
 | Password reset base URL must be HTTPS in production | `tests/test_config.py::test_password_reset_base_url_must_be_https_in_production` |
 | Nginx rejects unknown hosts and redirects HTTP to HTTPS | `ops/nginx/sitbank-default.conf`, `ops/nginx/sitbank-production.conf` |
 | Docker runtime drops capabilities and runs read-only as UID/GID `10001:10001` | `Dockerfile`, `compose.prod.yml`, `tests/test_deployment.py::test_dockerfile_and_compose_enforce_hardened_runtime` |
-| Deployment contract keeps production and staging isolated | `compose.prod.yml`, `compose.staging.yml`, `tests/test_deployment.py::test_deployment_profiles_keep_production_and_staging_isolated` |
+| Deployment contract keeps production and staging isolated | `compose.prod.yml`, `compose.staging.yml`, `tests/test_deployment.py` |
 
 Current gap: Nginx does not pin an explicit `ssl_ciphers` list. The repo pins
 protocols to TLS 1.2 and TLS 1.3, but cipher selection depends on deployed
@@ -157,7 +156,7 @@ Actions.
 | A04 Insecure Design | MFA onboarding gates, password-reset token exchange, manual recovery pending-only public request, staff invite workflow, frozen-account behavior | Manual recovery completion exists as service code but no active admin route was found |
 | A05 Security Misconfiguration | Production config validation, Nginx default host rejection, Docker hardening, CSRF/Talisman defaults, deployment tests | Live host TLS cipher and certificate-renewal state must be verified outside the repo |
 | A06 Vulnerable And Outdated Components | Dependabot, pip-audit, Trivy, CodeQL, hashed lockfiles, pinned Docker base image | No JavaScript package manifest was found, so npm/yarn scanning is not applicable |
-| A07 Identification And Authentication Failures | Generic errors, dummy hash, rate/backoff counters, TOTP, recovery codes, reset verifier HMACs, disabled passkeys fail closed | No full password history |
+| A07 Identification And Authentication Failures | Generic errors, dummy hash, rate/backoff counters, TOTP, recovery codes, reset verifier HMACs, and MFA onboarding gates | No full password history |
 | A08 Software And Data Integrity Failures | Hash-locked dependencies, pinned actions, pinned images, cosign signing, audit hash chain, migration/DB privilege tests | Verify external runner and registry trust at deployment time |
 | A09 Security Logging And Monitoring Failures | Structured audit events, sanitization, alerts, append-only audit DB triggers, 500 handler logging | Alert delivery endpoint configuration is deployment-specific |
 | A10 Server-Side Request Forgery | No user-supplied arbitrary URL fetch flow found; fixed HIBP range endpoint sends only SHA-1 prefixes; Turnstile verification uses configured endpoint and redacts token data | New outbound integrations should add allowlists and SSRF tests |

--- a/docs/security/session-management.md
+++ b/docs/security/session-management.md
@@ -2,34 +2,28 @@
 
 This document describes the session management controls implemented in the
 SITBank repository. The implementation uses database-backed server-side
-sessions with an opaque browser cookie, not Redis or client-side session
-payloads.
+sessions identified by an opaque browser cookie.
 
 ## 2.1 Session Storage
 
 SITBank installs a custom `DatabaseSessionInterface` from
 `app/security/sessions.py` during application startup in `app/__init__.py`.
-Although `config.py` sets `SESSION_TYPE = "database"`, the repository does not
-use Flask-Session or Redis for production session storage. Browser cookies hold
-only an opaque session id. Session state is stored in the `server_side_sessions`
-table represented by `ServerSideSession` in `app/models.py`.
+Browser cookies hold only an opaque session id. Session state is stored in the
+`server_side_sessions` table represented by `ServerSideSession` in
+`app/models.py`.
 
 | Stored value | Implementation evidence | Protection |
 | --- | --- | --- |
-| Browser session id | `app/security/sessions.py::_generate_sid()` | Opaque id generated with `uuid.uuid4()`; not stored raw in the database |
+| Browser session id | `app/security/sessions.py::_new_session_id()` | Opaque id generated with `uuid.uuid4()`; not stored raw in the database |
 | Database lookup key | `app/security/sessions.py::session_lookup_hash()` | HMAC-SHA256 with `SESSION_LOOKUP_HMAC_KEY` |
-| Serialized session payload | `ServerSideSession.data` in `app/models.py` | Signed by `app/security/session_hmac.py` with a binding context that includes the component and lookup hash |
-| User/session metadata | `user_id`, `auth_level`, `created_at`, `last_seen_at`, `expires_at`, `revoked_at`, `ended_reason`, `risk_fingerprint` | Used for revocation, session inventory, inactivity timeout, and risk reauthentication |
+| Serialized session payload | `ServerSideSession.payload` in `app/models.py` | Signed by `app/security/session_hmac.py` with a binding context that includes the component and lookup hash |
+| User/session metadata | `user_id`, `created_at`, `last_activity_at`, `expires_at`, `revoked_at`, `ended_reason`, `risk_fingerprint` | Used for revocation, session inventory, inactivity timeout, and risk reauthentication |
 | Public session reference | `session_ref` and `_public_reference_from_lookup_hash()` | HMAC-derived public id for session-management actions; raw internal ids are rejected |
 
 The session payload signature is versioned and key-id aware. The active HMAC
 key signs new payloads, and old keys can remain configured so existing
 sessions survive key rotation. Evidence: `app/security/session_hmac.py` and
 `tests/test_db_session_integrity.py::test_db_session_payload_survives_active_hmac_key_rotation`.
-
-Current gap: Redis-backed session storage is not implemented. Any control that
-specifically requires Redis session persistence or Redis payload HMACs is not
-applicable to the current codebase unless the storage layer is changed.
 
 ## 2.2 Cookie Structure
 
@@ -62,7 +56,7 @@ Tests:
 | --- | --- |
 | `tests/test_session_management.py::test_login_sets_secure_session_cookie_and_hides_raw_session_id` | Checks secure cookie behavior and that the raw session id is not exposed in session management UI |
 | `tests/test_admin_staff_invites.py::test_admin_login_creates_only_admin_session_cookie` | Confirms admin login creates only the admin cookie |
-| `tests/test_config.py::test_runtime_secret_maps_use_session_lookup_key_not_redis_url` | Confirms runtime secret maps use the session lookup HMAC key and not Redis URL configuration |
+| `tests/test_config.py` runtime secret map checks | Confirms runtime secret maps include the required session lookup HMAC key |
 
 ## 2.3 Cookie Transmission
 


### PR DESCRIPTION
## Summary

Cleans up active project documentation so Redis, WebAuthn, passkey, security-key, and FIDO references are removed from current-facing docs and centralized into one legacy/out-of-scope security note.

The cleanup keeps active documentation aligned with the current SITBank implementation while preserving historical context for older tests and removed/disabled compatibility paths.

## Why

Active documentation should describe the current system, not older design decisions or removed runtime technologies.

Some historical references still matter because regression tests intentionally cover removed behavior, disabled compatibility endpoints, sanitizer cases, deployment-contract checks, and UI-removal checks. Centralizing those references avoids confusing assessors while still explaining why legacy terms remain in test files.

## What changed

* Cleaned active documentation in:

  * `README.md`
  * `SECURITY.md`
  * `docs/DEPLOYMENT.md`
  * `docs/OPERATIONS.md`
  * `docs/security/session-management.md`
  * `docs/security/access-control.md`
  * `docs/security/cryptography-and-authentication.md`
  * `docs/security/secure-coding.md`
* Added historical context file:

  * `docs/security/legacy-and-out-of-scope-technology.md`
* Centralized remaining Markdown references to Redis, WebAuthn, passkeys, security keys, and FIDO in the legacy/out-of-scope note.
* Confirmed stricter cleanup searches return no active-doc matches for Redis/WebAuthn/passkey-related wording.
* Kept test references to legacy technologies where they support regression coverage for:

  * Disabled compatibility endpoints
  * Legacy credential rows not satisfying MFA
  * Removed runtime configuration
  * Sanitizer coverage
  * Route inventory checks
  * Deployment contract checks
  * UI removal checks
* Removed tutor/instructor/professor/standalone prof wording from active documentation.

## Security impact

This is a documentation-only cleanup.

It does not change authentication, authorization, cryptography, secrets, CI/CD behavior, deployment behavior, database schema, or runtime behavior.

It improves assessor clarity by separating current security documentation from legacy/out-of-scope technology context, while still preserving explanations for why certain regression tests reference removed or historical controls.

## Deployment impact

No deployment action.

This PR does not require:

* EC2 bootstrap
* staging deployment
* production deployment
* database migration
* secret changes

## Verification

* `git diff --check`

  * Passed
* Cleanup search for active documentation references to Redis/WebAuthn/passkey/security-key/FIDO wording

  * Remaining Markdown mentions are centralized in `docs/security/legacy-and-out-of-scope-technology.md`
* Search for tutor/instructor/professor/standalone prof wording in active documentation

  * No remaining matches
* `.\.venv\Scripts\python.exe -m pytest -q`

  * `401 passed, 2 skipped, 6 existing warnings`

## Notes

Test files still reference Redis, WebAuthn, passkeys, security keys, and FIDO intentionally for regression coverage.

Those references were kept because they validate removed or legacy behavior, compatibility boundaries, sanitizer behavior, deployment expectations, and UI removal checks.
