### PR TITLE
Add GitHub issue and PR labeling automation

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,198 @@
+admin:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'app/admin/**'
+          - 'admin_wsgi.py'
+          - 'ops/**/admin*'
+          - 'ops/**/admin/**'
+          - 'tests/test_admin_*.py'
+
+customer:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'app/web/**'
+          - 'app/main/**'
+          - 'app/templates/index.html'
+          - 'app/templates/dashboard.html'
+          - 'app/templates/profile.html'
+          - 'tests/test_dashboard.py'
+          - 'tests/test_authenticated_portal_ui.py'
+
+banking:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'app/banking/**'
+          - 'app/templates/add_payee.html'
+          - 'app/templates/confirm_payee.html'
+          - 'app/templates/freeze.html'
+          - 'app/templates/payees.html'
+          - 'app/templates/remove_payee.html'
+          - 'app/static/js/account.js'
+          - 'app/static/js/payees.js'
+          - 'tests/test_banking_*.py'
+          - 'tests/test_account_security_actions.py'
+
+auth:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'app/auth/**'
+          - 'app/templates/login.html'
+          - 'app/templates/register.html'
+          - 'app/templates/forgot_password.html'
+          - 'app/templates/reset_password.html'
+          - 'app/templates/password_change.html'
+          - 'tests/test_auth_*.py'
+          - 'tests/test_password*.py'
+
+mfa:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'app/auth/mfa_policy.py'
+          - 'app/auth/recovery_codes.py'
+          - 'app/auth/webauthn_services.py'
+          - 'app/templates/mfa_*.html'
+          - 'app/templates/security_keys.html'
+          - 'migrations/versions/*mfa*'
+          - 'migrations/versions/*passkey*'
+          - 'migrations/versions/*webauthn*'
+          - 'tests/test_mfa_*.py'
+          - 'tests/test_webauthn_*.py'
+          - '**/*mfa*'
+          - '**/*totp*'
+          - '**/*webauthn*'
+          - '**/*passkey*'
+          - '**/*security_key*'
+          - '**/*recovery_code*'
+
+security:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'app/security/**'
+          - 'docs/security/**'
+          - 'SECURITY.md'
+          - '.trivyignore'
+          - 'ops/security/**'
+          - 'ops/fido-*.json'
+          - 'tests/test_*security*.py'
+          - 'tests/test_audit_*.py'
+          - 'tests/test_owasp_regressions.py'
+          - 'tests/test_pentest_auth_bypass.py'
+          - 'tests/test_route_inventory_security.py'
+          - 'tests/test_secret_scanner.py'
+          - 'tests/test_session_management.py'
+          - '**/*csrf*'
+          - '**/*csp*'
+          - '**/*hmac*'
+          - '**/*crypto*'
+          - '**/*secret*'
+          - '**/*rate_limit*'
+  - head-branch:
+      - 'security'
+      - 'auth'
+      - 'mfa'
+      - 'csrf'
+      - 'csp'
+      - 'session'
+      - 'audit'
+      - 'admin-isolation'
+      - 'webauthn'
+      - 'passkey'
+      - 'secret'
+      - 'rate-limit'
+
+session:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'app/security/session_hmac.py'
+          - 'app/security/sessions.py'
+          - 'app/static/js/session-timeout.js'
+          - 'app/templates/sessions.html'
+          - 'tests/test_session_management.py'
+          - '**/*session*'
+          - '**/*cookie*'
+
+audit:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'app/security/audit.py'
+          - 'app/security/alerts.py'
+          - 'migrations/versions/*audit*'
+          - 'tests/test_audit_*.py'
+          - '**/*audit*'
+          - '**/*alert*'
+
+deployment:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'ops/**'
+          - 'compose*.yml'
+          - 'docker-compose*.yml'
+          - 'Dockerfile'
+          - 'config.py'
+          - 'docs/DEPLOYMENT.md'
+          - 'docs/OPERATIONS.md'
+          - 'docs/archive/EC2_TRANSITION.md'
+          - 'tests/test_deployment.py'
+
+database:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'migrations/**'
+          - 'app/models.py'
+          - 'app/ops/db_privileges.py'
+          - 'ops/postgres/**'
+          - 'tests/test_db_session_integrity.py'
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/workflows/**'
+          - '.github/dependabot.yml'
+          - 'scripts/ci-local'
+          - 'ops/security/check_dependency_locks.py'
+          - 'ops/security/validate_pr_body.py'
+          - 'tests/test_pr_body_policy.py'
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'requirements.in'
+          - 'requirements-dev.in'
+          - 'requirements.lock'
+          - 'requirements-dev.lock'
+          - '.github/dependabot.yml'
+          - 'ops/security/check_dependency_locks.py'
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/**'
+          - 'README*'
+          - 'SECURITY.md'
+          - '**/*.md'
+
+frontend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'app/templates/**'
+          - 'app/static/**'
+          - '**/*.css'
+          - '**/*.js'
+          - '**/*.svg'
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'tests/**'
+          - 'pytest.ini'
+
+feature:
+  - head-branch:
+      - '^feature/'
+      - '^feat/'
+
+fix:
+  - head-branch:
+      - '^fix/'
+      - '^bugfix/'
+      - '^hotfix/'

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -7,9 +7,7 @@ on:
       - reopened
       - edited
 
-permissions:
-  contents: read
-  issues: write
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.issue.number }}
@@ -19,6 +17,9 @@ jobs:
   label:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Ensure standard labels exist
         shell: bash

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,153 @@
+name: Issue labeler
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+      - edited
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Ensure standard labels exist
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -Eeuo pipefail
+
+          create_label() {
+            gh label create "$1" --description "$2" --color "$3" --force
+          }
+
+          create_label needs-triage "New issue awaiting maintainer triage." fbca04
+          create_label needs-review "Ready for maintainer review." 0e8a16
+          create_label security "Security controls, vulnerabilities, secrets, authn/authz, audit, sessions, crypto, or hardening." d73a4a
+          create_label admin "Admin portal, staff workflows, admin route isolation, or admin deployment boundary." b60205
+          create_label customer "Customer-facing routes, dashboard, profile, account pages, or portal UX." 1d76db
+          create_label banking "Accounts, transfers, payees, balances, freezes, funds, or transaction safety." 0052cc
+          create_label auth "Login, registration, password reset, OTP, sessions, decorators, or auth schemas." c5def5
+          create_label mfa "MFA, TOTP, WebAuthn, passkeys, security keys, recovery codes, or second factors." 5319e7
+          create_label session "Session state, cookies, HMAC, Redis namespace, logout, or active sessions." 0b7285
+          create_label audit "Audit logs, hash chains, HMAC, metadata, alerting, or audit events." d93f0b
+          create_label deployment "Deployment, Docker, compose, nginx, systemd, EC2, runtime, or operations." 006b75
+          create_label database "Database schema, migrations, Postgres, roles, privileges, or DB integrity." 531dab
+          create_label ci "GitHub Actions, CI policy, CodeQL, dependency audit, build, or pipeline changes." a2eeef
+          create_label dependencies "Dependency updates, lock files, package manager changes, or Dependabot PRs." 0366d6
+          create_label documentation "Docs, README, guides, instructions, or policy documents." 0075ca
+          create_label frontend "Templates, CSS, JavaScript, SVG, UI layout, browser-facing pages, or forms." c2e0c6
+          create_label tests "Tests, pytest, fixtures, coverage, or regression checks." fef2c0
+          create_label feature "Feature branch or feature-oriented change." 84b6eb
+          create_label fix "Fix, bugfix, or hotfix branch." d4c5f9
+          create_label docker "Dockerfile, image, compose, or Docker dependency updates." 0db7ed
+          create_label github-actions "GitHub Actions workflow dependency updates or CI workflow automation." 2088ff
+          create_label python "Python dependency or Python runtime/package updates." 3572a5
+
+      - name: Add computed issue labels
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -Eeuo pipefail
+
+          ISSUE_NUMBER="$(jq -r '.issue.number' "${GITHUB_EVENT_PATH}")"
+          TEXT="$(
+            jq -r '(.issue.title // "") + "\n" + (.issue.body // "")' \
+              "${GITHUB_EVENT_PATH}" \
+              | tr '[:upper:]' '[:lower:]'
+          )"
+
+          labels=(needs-triage)
+
+          add_label() {
+            local label="$1"
+            local existing
+            for existing in "${labels[@]}"; do
+              if [[ "${existing}" == "${label}" ]]; then
+                return 0
+              fi
+            done
+            labels+=("${label}")
+          }
+
+          contains_any() {
+            local term
+            for term in "$@"; do
+              if [[ "${TEXT}" == *"${term}"* ]]; then
+                return 0
+              fi
+            done
+            return 1
+          }
+
+          contains_regex() {
+            local pattern
+            for pattern in "$@"; do
+              if [[ "${TEXT}" =~ ${pattern} ]]; then
+                return 0
+              fi
+            done
+            return 1
+          }
+
+          if contains_any security vulnerability exploit "auth bypass" "authorization bypass" "authentication bypass" "session fixation" "session hijack" cookie csrf csp xss "sql injection" secret encryption hmac audit "rate limit" "admin isolation" "privilege escalation" owasp; then
+            add_label security
+          fi
+          if contains_any admin administrator staff invite "staff invite" "admin portal" "admin route" "admin isolation" "admin session" "admin database" "admin deployment"; then
+            add_label admin
+          fi
+          if contains_any customer "user portal" dashboard profile "account page" "customer route"; then
+            add_label customer
+          fi
+          if contains_any banking account transaction transfer payee balance freeze money funds; then
+            add_label banking
+          fi
+          if contains_any login register registration password "reset password" "forgot password" otp authentication session cookie || contains_regex '(^|[^a-z0-9])auth([^a-z0-9]|$)'; then
+            add_label auth
+          fi
+          if contains_any mfa totp webauthn passkey "security key" "recovery code" authenticator "second factor" 2fa; then
+            add_label mfa
+          fi
+          if contains_any session cookie "session hmac" "active session" logout "remember me" "redis session"; then
+            add_label session
+          fi
+          if contains_any audit alert "security alert" "hash chain" "audit event" "audit log" "audit metadata"; then
+            add_label audit
+          fi
+          if contains_any deploy deployment staging production ec2 nginx docker compose bootstrap systemd runtime "environment variable" "secret file"; then
+            add_label deployment
+          fi
+          if contains_any database postgres migration schema role privilege alembic || contains_regex '(^|[^a-z0-9])db([^a-z0-9]|$)' '(^|[^a-z0-9])sql([^a-z0-9]|$)'; then
+            add_label database
+          fi
+          if contains_any workflow "github actions" dependabot codeql "dependency audit" "pr title" "commit message" "pull request policy" build pipeline || contains_regex '(^|[^a-z0-9])ci([^a-z0-9]|$)'; then
+            add_label ci
+          fi
+          if contains_any dependency dependencies package requirements pip "docker base image" dependabot "lock file" msgpack "library bump"; then
+            add_label dependencies
+          fi
+          if contains_any test tests pytest coverage regression fixture; then
+            add_label tests
+          fi
+          if contains_any docs documentation readme guide instructions "policy document"; then
+            add_label documentation
+          fi
+          if contains_any css javascript template page form button "dashboard layout" browser || contains_regex '(^|[^a-z0-9])ui([^a-z0-9]|$)'; then
+            add_label frontend
+          fi
+
+          IFS=,
+          gh issue edit "${ISSUE_NUMBER}" --add-label "${labels[*]}"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -8,10 +8,7 @@ on:
       - reopened
       - ready_for_review
 
-permissions:
-  contents: read
-  pull-requests: write
-  issues: write
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -21,6 +18,10 @@ jobs:
   label:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     steps:
       - name: Ensure standard labels exist
         shell: bash
@@ -60,9 +61,9 @@ jobs:
       # pull_request_target is privileged and runs from trusted base-branch workflow
       # content. Keep this workflow label-only: do not checkout or execute untrusted
       # pull request code here.
-      # zizmor: ignore[unpinned-uses] actions/labeler@v6 is required by the repository labeling policy.
+      # Pinned to the actions/labeler v6.1.0 commit.
       - name: Label pull request
-        uses: actions/labeler@v6
+        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213
         with:
           configuration-path: .github/labeler.yml
           sync-labels: false

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,7 +1,7 @@
 name: Pull request labeler
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize
@@ -58,9 +58,9 @@ jobs:
           create_label github-actions "GitHub Actions workflow dependency updates or CI workflow automation." 2088ff
           create_label python "Python dependency or Python runtime/package updates." 3572a5
 
-      # pull_request_target is privileged and runs from trusted base-branch workflow
-      # content. Keep this workflow label-only: do not checkout or execute untrusted
-      # pull request code here.
+      # Keep this workflow label-only: do not checkout or execute pull request
+      # code here. The ordinary pull_request trigger avoids privileged PR
+      # trigger execution.
       # Pinned to the actions/labeler v6.1.0 commit.
       - name: Label pull request
         uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,68 @@
+name: Pull request labeler
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Ensure standard labels exist
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -Eeuo pipefail
+
+          create_label() {
+            gh label create "$1" --description "$2" --color "$3" --force
+          }
+
+          create_label needs-triage "New issue awaiting maintainer triage." fbca04
+          create_label needs-review "Ready for maintainer review." 0e8a16
+          create_label security "Security controls, vulnerabilities, secrets, authn/authz, audit, sessions, crypto, or hardening." d73a4a
+          create_label admin "Admin portal, staff workflows, admin route isolation, or admin deployment boundary." b60205
+          create_label customer "Customer-facing routes, dashboard, profile, account pages, or portal UX." 1d76db
+          create_label banking "Accounts, transfers, payees, balances, freezes, funds, or transaction safety." 0052cc
+          create_label auth "Login, registration, password reset, OTP, sessions, decorators, or auth schemas." c5def5
+          create_label mfa "MFA, TOTP, WebAuthn, passkeys, security keys, recovery codes, or second factors." 5319e7
+          create_label session "Session state, cookies, HMAC, Redis namespace, logout, or active sessions." 0b7285
+          create_label audit "Audit logs, hash chains, HMAC, metadata, alerting, or audit events." d93f0b
+          create_label deployment "Deployment, Docker, compose, nginx, systemd, EC2, runtime, or operations." 006b75
+          create_label database "Database schema, migrations, Postgres, roles, privileges, or DB integrity." 531dab
+          create_label ci "GitHub Actions, CI policy, CodeQL, dependency audit, build, or pipeline changes." a2eeef
+          create_label dependencies "Dependency updates, lock files, package manager changes, or Dependabot PRs." 0366d6
+          create_label documentation "Docs, README, guides, instructions, or policy documents." 0075ca
+          create_label frontend "Templates, CSS, JavaScript, SVG, UI layout, browser-facing pages, or forms." c2e0c6
+          create_label tests "Tests, pytest, fixtures, coverage, or regression checks." fef2c0
+          create_label feature "Feature branch or feature-oriented change." 84b6eb
+          create_label fix "Fix, bugfix, or hotfix branch." d4c5f9
+          create_label docker "Dockerfile, image, compose, or Docker dependency updates." 0db7ed
+          create_label github-actions "GitHub Actions workflow dependency updates or CI workflow automation." 2088ff
+          create_label python "Python dependency or Python runtime/package updates." 3572a5
+
+      # pull_request_target is privileged and runs from trusted base-branch workflow
+      # content. Keep this workflow label-only: do not checkout or execute untrusted
+      # pull request code here.
+      # zizmor: ignore[unpinned-uses] actions/labeler@v6 is required by the repository labeling policy.
+      - name: Label pull request
+        uses: actions/labeler@v6
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: false

--- a/.github/workflows/retag-labels.yml
+++ b/.github/workflows/retag-labels.yml
@@ -37,10 +37,7 @@ on:
         description: Type RETAG to allow label removal and retagging
         required: false
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.target }}-${{ inputs.state }}
@@ -50,6 +47,10 @@ jobs:
   retag:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     env:
       GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}
@@ -481,7 +482,7 @@ jobs:
               mapfile -t current < <(jq -r '.labels[].name' <<< "${pr_json}")
 
               if ! mapfile -t computed < <(compute_pr_labels "${number}" "${head}"); then
-                echo "::warning::Could not compute dry-run PR labels for #${number}; actions/labeler@v6 will compute them in apply mode."
+                echo "::warning::Could not compute dry-run PR labels for #${number}; the SHA-pinned actions/labeler v6 action will compute them in apply mode."
                 computed=()
               fi
 
@@ -500,7 +501,7 @@ jobs:
               echo "protected labels preserved: $(join_labels "${preserved[@]}")"
               echo "unprotected labels removed: $(join_labels "${removed[@]}")"
               echo "computed labels added: $(join_labels "${computed[@]}")"
-              echo "actions/labeler@v6 would run for PR #${number} with sync-labels=false."
+              echo "The SHA-pinned actions/labeler v6 action would run for PR #${number} with sync-labels=false."
               echo "final expected labels: $(join_labels "${final_labels[@]}")"
               echo "::endgroup::"
 
@@ -544,10 +545,10 @@ jobs:
       # This privileged manual workflow uses trusted workflow content only. It
       # does not checkout PR branches or execute untrusted PR code; PR labels are
       # reapplied through actions/labeler using GitHub API data and sync-labels=false.
-      # zizmor: ignore[unpinned-uses] actions/labeler@v6 is required by the repository labeling policy.
+      # Pinned to the actions/labeler v6.1.0 commit.
       - name: Reapply pull request labels
         if: ${{ inputs.dry_run == 'false' && (inputs.target == 'prs' || inputs.target == 'both') && steps.retag.outputs.pr_numbers != '' }}
-        uses: actions/labeler@v6
+        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213
         with:
           configuration-path: .github/labeler.yml
           sync-labels: false

--- a/.github/workflows/retag-labels.yml
+++ b/.github/workflows/retag-labels.yml
@@ -1,0 +1,550 @@
+name: Retag issue and pull request labels
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Issues, pull requests, or both.
+        required: true
+        type: choice
+        options:
+          - issues
+          - prs
+          - both
+        default: both
+      state:
+        description: Item state to retag.
+        required: true
+        type: choice
+        options:
+          - open
+          - closed
+          - all
+        default: all
+      limit:
+        description: Maximum issues and/or pull requests to inspect.
+        required: true
+        default: "500"
+      dry_run:
+        description: Print planned changes without editing issue or PR labels.
+        required: true
+        type: choice
+        options:
+          - "true"
+          - "false"
+        default: "true"
+      confirm_retag:
+        description: Type RETAG to allow label removal and retagging
+        required: false
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.target }}-${{ inputs.state }}
+  cancel-in-progress: false
+
+jobs:
+  retag:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      TARGET: ${{ inputs.target }}
+      STATE: ${{ inputs.state }}
+      LIMIT: ${{ inputs.limit }}
+      DRY_RUN: ${{ inputs.dry_run }}
+      CONFIRM_RETAG: ${{ inputs.confirm_retag }}
+      # Protected labels are preserved during retagging because Dependabot or
+      # GitHub Actions may depend on them. They are never removed from individual
+      # issues/PRs by this workflow, and they are not automatically added to
+      # every issue/PR. A scan of the existing workflows before adding this
+      # labeler found no additional issue/PR label dependencies, so only the
+      # current Dependabot labels are protected today.
+      PROTECTED_LABELS: |
+        dependencies
+        docker
+        github-actions
+        python
+    steps:
+      - name: Validate retag request
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          if [[ ! "${LIMIT}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::limit must be a positive integer."
+            exit 1
+          fi
+
+          if [[ "${DRY_RUN}" != "true" && "${CONFIRM_RETAG}" != "RETAG" ]]; then
+            echo "::error::dry_run=false requires confirm_retag to equal RETAG."
+            exit 1
+          fi
+
+          if [[ "${DRY_RUN}" == "true" ]]; then
+            echo "Dry-run mode is active; no issue, pull request, or repository labels will be changed."
+          else
+            echo "Apply mode confirmed; unprotected labels will be removed from matching items before recomputed labels are added."
+          fi
+
+      - name: Ensure standard labels exist
+        if: ${{ inputs.dry_run == 'false' }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          create_label() {
+            gh label create "$1" --description "$2" --color "$3" --force
+          }
+
+          create_label needs-triage "New issue awaiting maintainer triage." fbca04
+          create_label needs-review "Ready for maintainer review." 0e8a16
+          create_label security "Security controls, vulnerabilities, secrets, authn/authz, audit, sessions, crypto, or hardening." d73a4a
+          create_label admin "Admin portal, staff workflows, admin route isolation, or admin deployment boundary." b60205
+          create_label customer "Customer-facing routes, dashboard, profile, account pages, or portal UX." 1d76db
+          create_label banking "Accounts, transfers, payees, balances, freezes, funds, or transaction safety." 0052cc
+          create_label auth "Login, registration, password reset, OTP, sessions, decorators, or auth schemas." c5def5
+          create_label mfa "MFA, TOTP, WebAuthn, passkeys, security keys, recovery codes, or second factors." 5319e7
+          create_label session "Session state, cookies, HMAC, Redis namespace, logout, or active sessions." 0b7285
+          create_label audit "Audit logs, hash chains, HMAC, metadata, alerting, or audit events." d93f0b
+          create_label deployment "Deployment, Docker, compose, nginx, systemd, EC2, runtime, or operations." 006b75
+          create_label database "Database schema, migrations, Postgres, roles, privileges, or DB integrity." 531dab
+          create_label ci "GitHub Actions, CI policy, CodeQL, dependency audit, build, or pipeline changes." a2eeef
+          create_label dependencies "Dependency updates, lock files, package manager changes, or Dependabot PRs." 0366d6
+          create_label documentation "Docs, README, guides, instructions, or policy documents." 0075ca
+          create_label frontend "Templates, CSS, JavaScript, SVG, UI layout, browser-facing pages, or forms." c2e0c6
+          create_label tests "Tests, pytest, fixtures, coverage, or regression checks." fef2c0
+          create_label feature "Feature branch or feature-oriented change." 84b6eb
+          create_label fix "Fix, bugfix, or hotfix branch." d4c5f9
+          create_label docker "Dockerfile, image, compose, or Docker dependency updates." 0db7ed
+          create_label github-actions "GitHub Actions workflow dependency updates or CI workflow automation." 2088ff
+          create_label python "Python dependency or Python runtime/package updates." 3572a5
+
+      - name: Retag issues and prepare pull requests
+        id: retag
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          mapfile -t PROTECTED < <(printf '%s\n' "${PROTECTED_LABELS}" | sed '/^[[:space:]]*$/d')
+          processed_prs=()
+
+          add_unique() {
+            local -n values_ref="$1"
+            local value="$2"
+            local existing
+            for existing in "${values_ref[@]}"; do
+              if [[ "${existing}" == "${value}" ]]; then
+                return 0
+              fi
+            done
+            values_ref+=("${value}")
+          }
+
+          is_protected() {
+            local label="$1"
+            local protected
+            for protected in "${PROTECTED[@]}"; do
+              if [[ "${label}" == "${protected}" ]]; then
+                return 0
+              fi
+            done
+            return 1
+          }
+
+          split_labels() {
+            preserved=()
+            removed=()
+            local label
+            for label in "$@"; do
+              if is_protected "${label}"; then
+                add_unique preserved "${label}"
+              else
+                add_unique removed "${label}"
+              fi
+            done
+          }
+
+          join_labels() {
+            if [[ "$#" -eq 0 ]]; then
+              printf '(none)'
+              return 0
+            fi
+
+            local output=""
+            local label
+            for label in "$@"; do
+              if [[ -z "${output}" ]]; then
+                output="${label}"
+              else
+                output="${output}, ${label}"
+              fi
+            done
+            printf '%s' "${output}"
+          }
+
+          MATCH_TEXT=""
+
+          contains_any() {
+            local term
+            for term in "$@"; do
+              if [[ "${MATCH_TEXT}" == *"${term}"* ]]; then
+                return 0
+              fi
+            done
+            return 1
+          }
+
+          contains_regex() {
+            local pattern
+            for pattern in "$@"; do
+              if [[ "${MATCH_TEXT}" =~ ${pattern} ]]; then
+                return 0
+              fi
+            done
+            return 1
+          }
+
+          compute_issue_labels() {
+            local title="$1"
+            local body="$2"
+            local labels=(needs-triage)
+            MATCH_TEXT="$(printf '%s\n%s\n' "${title}" "${body}" | tr '[:upper:]' '[:lower:]')"
+
+            if contains_any security vulnerability exploit "auth bypass" "authorization bypass" "authentication bypass" "session fixation" "session hijack" cookie csrf csp xss "sql injection" secret encryption hmac audit "rate limit" "admin isolation" "privilege escalation" owasp; then
+              add_unique labels security
+            fi
+            if contains_any admin administrator staff invite "staff invite" "admin portal" "admin route" "admin isolation" "admin session" "admin database" "admin deployment"; then
+              add_unique labels admin
+            fi
+            if contains_any customer "user portal" dashboard profile "account page" "customer route"; then
+              add_unique labels customer
+            fi
+            if contains_any banking account transaction transfer payee balance freeze money funds; then
+              add_unique labels banking
+            fi
+            if contains_any login register registration password "reset password" "forgot password" otp authentication session cookie || contains_regex '(^|[^a-z0-9])auth([^a-z0-9]|$)'; then
+              add_unique labels auth
+            fi
+            if contains_any mfa totp webauthn passkey "security key" "recovery code" authenticator "second factor" 2fa; then
+              add_unique labels mfa
+            fi
+            if contains_any session cookie "session hmac" "active session" logout "remember me" "redis session"; then
+              add_unique labels session
+            fi
+            if contains_any audit alert "security alert" "hash chain" "audit event" "audit log" "audit metadata"; then
+              add_unique labels audit
+            fi
+            if contains_any deploy deployment staging production ec2 nginx docker compose bootstrap systemd runtime "environment variable" "secret file"; then
+              add_unique labels deployment
+            fi
+            if contains_any database postgres migration schema role privilege alembic || contains_regex '(^|[^a-z0-9])db([^a-z0-9]|$)' '(^|[^a-z0-9])sql([^a-z0-9]|$)'; then
+              add_unique labels database
+            fi
+            if contains_any workflow "github actions" dependabot codeql "dependency audit" "pr title" "commit message" "pull request policy" build pipeline || contains_regex '(^|[^a-z0-9])ci([^a-z0-9]|$)'; then
+              add_unique labels ci
+            fi
+            if contains_any dependency dependencies package requirements pip "docker base image" dependabot "lock file" msgpack "library bump"; then
+              add_unique labels dependencies
+            fi
+            if contains_any test tests pytest coverage regression fixture; then
+              add_unique labels tests
+            fi
+            if contains_any docs documentation readme guide instructions "policy document"; then
+              add_unique labels documentation
+            fi
+            if contains_any css javascript template page form button "dashboard layout" browser || contains_regex '(^|[^a-z0-9])ui([^a-z0-9]|$)'; then
+              add_unique labels frontend
+            fi
+
+            printf '%s\n' "${labels[@]}"
+          }
+
+          PR_FILES=()
+          PR_HEAD=""
+
+          path_matches() {
+            local pattern="$1"
+            local file
+            for file in "${PR_FILES[@]}"; do
+              if [[ "${file}" == ${pattern} ]]; then
+                return 0
+              fi
+            done
+            return 1
+          }
+
+          path_contains() {
+            local term
+            local file
+            for term in "$@"; do
+              for file in "${PR_FILES[@]}"; do
+                if [[ "${file}" == *"${term}"* ]]; then
+                  return 0
+                fi
+              done
+            done
+            return 1
+          }
+
+          branch_contains() {
+            local term
+            for term in "$@"; do
+              if [[ "${PR_HEAD}" == *"${term}"* ]]; then
+                return 0
+              fi
+            done
+            return 1
+          }
+
+          branch_starts_with() {
+            local prefix
+            for prefix in "$@"; do
+              if [[ "${PR_HEAD}" == "${prefix}"* ]]; then
+                return 0
+              fi
+            done
+            return 1
+          }
+
+          load_pr_files() {
+            local number="$1"
+            local diff_output
+            PR_FILES=()
+            if ! diff_output="$(gh pr diff "${number}" --name-only)"; then
+              return 1
+            fi
+
+            local file
+            while IFS= read -r file; do
+              if [[ -n "${file}" ]]; then
+                PR_FILES+=("${file,,}")
+              fi
+            done <<< "${diff_output}"
+          }
+
+          compute_pr_labels() {
+            local number="$1"
+            local head="$2"
+            local labels=()
+            PR_HEAD="${head,,}"
+            load_pr_files "${number}" || return 1
+
+            if path_matches 'app/admin/*' || path_matches 'admin_wsgi.py' || path_matches 'ops/*admin*' || path_matches 'tests/test_admin_*.py'; then
+              add_unique labels admin
+            fi
+            if path_matches 'app/web/*' || path_matches 'app/main/*' || path_matches 'app/templates/index.html' || path_matches 'app/templates/dashboard.html' || path_matches 'app/templates/profile.html' || path_matches 'tests/test_dashboard.py' || path_matches 'tests/test_authenticated_portal_ui.py'; then
+              add_unique labels customer
+            fi
+            if path_matches 'app/banking/*' || path_matches 'app/templates/add_payee.html' || path_matches 'app/templates/confirm_payee.html' || path_matches 'app/templates/freeze.html' || path_matches 'app/templates/payees.html' || path_matches 'app/templates/remove_payee.html' || path_matches 'app/static/js/account.js' || path_matches 'app/static/js/payees.js' || path_matches 'tests/test_banking_*.py' || path_matches 'tests/test_account_security_actions.py'; then
+              add_unique labels banking
+            fi
+            if path_matches 'app/auth/*' || path_matches 'app/templates/login.html' || path_matches 'app/templates/register.html' || path_matches 'app/templates/forgot_password.html' || path_matches 'app/templates/reset_password.html' || path_matches 'app/templates/password_change.html' || path_matches 'tests/test_auth_*.py' || path_matches 'tests/test_password*.py'; then
+              add_unique labels auth
+            fi
+            if path_matches 'app/auth/mfa_policy.py' || path_matches 'app/auth/recovery_codes.py' || path_matches 'app/auth/webauthn_services.py' || path_matches 'app/templates/mfa_*.html' || path_matches 'app/templates/security_keys.html' || path_contains mfa totp webauthn passkey security_key recovery_code; then
+              add_unique labels mfa
+            fi
+            if path_matches 'app/security/*' || path_matches 'docs/security/*' || path_matches 'security.md' || path_matches '.trivyignore' || path_matches 'ops/security/*' || path_matches 'ops/fido-*.json' || path_matches 'tests/test_*security*.py' || path_matches 'tests/test_audit_*.py' || path_matches 'tests/test_owasp_regressions.py' || path_matches 'tests/test_pentest_auth_bypass.py' || path_matches 'tests/test_route_inventory_security.py' || path_matches 'tests/test_secret_scanner.py' || path_matches 'tests/test_session_management.py' || path_contains csrf csp hmac crypto secret rate_limit || branch_contains security auth mfa csrf csp session audit admin-isolation webauthn passkey secret rate-limit; then
+              add_unique labels security
+            fi
+            if path_matches 'app/security/session_hmac.py' || path_matches 'app/security/sessions.py' || path_matches 'app/static/js/session-timeout.js' || path_matches 'app/templates/sessions.html' || path_matches 'tests/test_session_management.py' || path_contains session cookie; then
+              add_unique labels session
+            fi
+            if path_matches 'app/security/audit.py' || path_matches 'app/security/alerts.py' || path_matches 'tests/test_audit_*.py' || path_contains audit alert; then
+              add_unique labels audit
+            fi
+            if path_matches 'ops/*' || path_matches 'compose*.yml' || path_matches 'docker-compose*.yml' || path_matches 'dockerfile' || path_matches 'config.py' || path_matches 'docs/deployment.md' || path_matches 'docs/operations.md' || path_matches 'docs/archive/ec2_transition.md' || path_matches 'tests/test_deployment.py'; then
+              add_unique labels deployment
+            fi
+            if path_matches 'migrations/*' || path_matches 'app/models.py' || path_matches 'app/ops/db_privileges.py' || path_matches 'ops/postgres/*' || path_matches 'tests/test_db_session_integrity.py'; then
+              add_unique labels database
+            fi
+            if path_matches '.github/workflows/*' || path_matches '.github/dependabot.yml' || path_matches 'scripts/ci-local' || path_matches 'ops/security/check_dependency_locks.py' || path_matches 'ops/security/validate_pr_body.py' || path_matches 'tests/test_pr_body_policy.py'; then
+              add_unique labels ci
+            fi
+            if path_matches 'requirements.in' || path_matches 'requirements-dev.in' || path_matches 'requirements.lock' || path_matches 'requirements-dev.lock' || path_matches '.github/dependabot.yml' || path_matches 'ops/security/check_dependency_locks.py'; then
+              add_unique labels dependencies
+            fi
+            if path_matches 'docs/*' || path_matches 'readme*' || path_matches 'security.md' || path_matches '*.md' || path_contains .md; then
+              add_unique labels documentation
+            fi
+            if path_matches 'app/templates/*' || path_matches 'app/static/*' || path_matches '*.css' || path_matches '*.js' || path_matches '*.svg' || path_contains .css .js .svg; then
+              add_unique labels frontend
+            fi
+            if path_matches 'tests/*' || path_matches 'pytest.ini'; then
+              add_unique labels tests
+            fi
+            if branch_starts_with feature/ feat/; then
+              add_unique labels feature
+            fi
+            if branch_starts_with fix/ bugfix/ hotfix/; then
+              add_unique labels fix
+            fi
+
+            printf '%s\n' "${labels[@]}"
+          }
+
+          print_plan() {
+            local kind="$1"
+            local number="$2"
+            local current_text="$3"
+            local preserved_text="$4"
+            local removed_text="$5"
+            local computed_text="$6"
+            local final_text="$7"
+
+            echo "::group::${kind} #${number}"
+            echo "current labels: ${current_text}"
+            echo "protected labels preserved: ${preserved_text}"
+            echo "unprotected labels removed: ${removed_text}"
+            echo "computed labels added: ${computed_text}"
+            echo "final expected labels: ${final_text}"
+            echo "::endgroup::"
+          }
+
+          process_issues() {
+            echo "Loading issues with gh issue list --state ${STATE} --limit ${LIMIT}."
+            echo "gh issue list returns issues, not pull requests; PR retagging is handled separately."
+            mapfile -t issue_rows < <(
+              gh issue list \
+                --state "${STATE}" \
+                --limit "${LIMIT}" \
+                --json number,title,body,labels \
+                --jq '.[] | @base64'
+            )
+
+            local row issue_json number title body
+            local current computed final_labels
+            for row in "${issue_rows[@]}"; do
+              issue_json="$(printf '%s' "${row}" | base64 --decode)"
+              number="$(jq -r '.number' <<< "${issue_json}")"
+              title="$(jq -r '.title // ""' <<< "${issue_json}")"
+              body="$(jq -r '.body // ""' <<< "${issue_json}")"
+              mapfile -t current < <(jq -r '.labels[].name' <<< "${issue_json}")
+              mapfile -t computed < <(compute_issue_labels "${title}" "${body}")
+
+              split_labels "${current[@]}"
+              final_labels=()
+              local label
+              for label in "${preserved[@]}"; do
+                add_unique final_labels "${label}"
+              done
+              for label in "${computed[@]}"; do
+                add_unique final_labels "${label}"
+              done
+
+              print_plan \
+                "Issue" \
+                "${number}" \
+                "$(join_labels "${current[@]}")" \
+                "$(join_labels "${preserved[@]}")" \
+                "$(join_labels "${removed[@]}")" \
+                "$(join_labels "${computed[@]}")" \
+                "$(join_labels "${final_labels[@]}")"
+
+              if [[ "${DRY_RUN}" == "false" ]]; then
+                for label in "${removed[@]}"; do
+                  gh issue edit "${number}" --remove-label "${label}"
+                done
+                for label in "${computed[@]}"; do
+                  gh issue edit "${number}" --add-label "${label}"
+                done
+              fi
+            done
+          }
+
+          process_prs() {
+            echo "Loading pull requests with gh pr list --state ${STATE} --limit ${LIMIT}."
+            mapfile -t pr_rows < <(
+              gh pr list \
+                --state "${STATE}" \
+                --limit "${LIMIT}" \
+                --json number,title,body,headRefName,labels \
+                --jq '.[] | @base64'
+            )
+
+            local row pr_json number head
+            local current computed final_labels
+            for row in "${pr_rows[@]}"; do
+              pr_json="$(printf '%s' "${row}" | base64 --decode)"
+              number="$(jq -r '.number' <<< "${pr_json}")"
+              head="$(jq -r '.headRefName // ""' <<< "${pr_json}")"
+              mapfile -t current < <(jq -r '.labels[].name' <<< "${pr_json}")
+
+              if ! mapfile -t computed < <(compute_pr_labels "${number}" "${head}"); then
+                echo "::warning::Could not compute dry-run PR labels for #${number}; actions/labeler@v6 will compute them in apply mode."
+                computed=()
+              fi
+
+              split_labels "${current[@]}"
+              final_labels=()
+              local label
+              for label in "${preserved[@]}"; do
+                add_unique final_labels "${label}"
+              done
+              for label in "${computed[@]}"; do
+                add_unique final_labels "${label}"
+              done
+
+              echo "::group::Pull request #${number}"
+              echo "current labels: $(join_labels "${current[@]}")"
+              echo "protected labels preserved: $(join_labels "${preserved[@]}")"
+              echo "unprotected labels removed: $(join_labels "${removed[@]}")"
+              echo "computed labels added: $(join_labels "${computed[@]}")"
+              echo "actions/labeler@v6 would run for PR #${number} with sync-labels=false."
+              echo "final expected labels: $(join_labels "${final_labels[@]}")"
+              echo "::endgroup::"
+
+              add_unique processed_prs "${number}"
+
+              if [[ "${DRY_RUN}" == "false" ]]; then
+                for label in "${removed[@]}"; do
+                  gh pr edit "${number}" --remove-label "${label}"
+                done
+              fi
+            done
+          }
+
+          echo "Protected labels: $(join_labels "${PROTECTED[@]}")"
+
+          case "${TARGET}" in
+            issues)
+              process_issues
+              ;;
+            prs)
+              process_prs
+              ;;
+            both)
+              process_issues
+              process_prs
+              ;;
+            *)
+              echo "::error::Unsupported target: ${TARGET}"
+              exit 1
+              ;;
+          esac
+
+          {
+            echo "pr_numbers<<EOF"
+            if [[ "${DRY_RUN}" == "false" && "${#processed_prs[@]}" -gt 0 ]]; then
+              printf '%s\n' "${processed_prs[@]}"
+            fi
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      # This privileged manual workflow uses trusted workflow content only. It
+      # does not checkout PR branches or execute untrusted PR code; PR labels are
+      # reapplied through actions/labeler using GitHub API data and sync-labels=false.
+      # zizmor: ignore[unpinned-uses] actions/labeler@v6 is required by the repository labeling policy.
+      - name: Reapply pull request labels
+        if: ${{ inputs.dry_run == 'false' && (inputs.target == 'prs' || inputs.target == 'both') && steps.retag.outputs.pr_numbers != '' }}
+        uses: actions/labeler@v6
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: false
+          pr-number: ${{ steps.retag.outputs.pr_numbers }}

--- a/.github/workflows/retag-labels.yml
+++ b/.github/workflows/retag-labels.yml
@@ -271,9 +271,13 @@ jobs:
             local pattern="$1"
             local file
             for file in "${PR_FILES[@]}"; do
-              if [[ "${file}" == ${pattern} ]]; then
-                return 0
-              fi
+              # pattern is a trusted workflow-defined glob, not user input.
+              # shellcheck disable=SC2254
+              case "${file}" in
+                ${pattern})
+                  return 0
+                  ;;
+              esac
             done
             return 1
           }

--- a/docs/development/github-labeling.md
+++ b/docs/development/github-labeling.md
@@ -5,7 +5,7 @@ a manual workflow for safely retagging historical issues and PRs.
 
 ## Future Pull Requests
 
-`.github/workflows/pr-labeler.yml` runs on `pull_request_target` for opened,
+`.github/workflows/pr-labeler.yml` runs on `pull_request` for opened,
 synchronized, reopened, and ready-for-review pull requests. It uses
 the v6 `actions/labeler` action with `.github/labeler.yml` and
 `sync-labels: false`. The workflow pins the action to an immutable commit SHA.
@@ -14,9 +14,9 @@ The PR workflow only adds computed labels. It does not remove existing labels,
 so Dependabot labels and any maintainer-applied labels remain in place during
 normal future PR labeling.
 
-Because `pull_request_target` is privileged, the workflow must stay label-only.
-Do not add `actions/checkout`, do not checkout PR branches, and do not execute
-scripts or code from pull requests in that workflow.
+The workflow must stay label-only. Do not add `actions/checkout`, do not
+checkout PR branches, and do not execute scripts or code from pull requests in
+that workflow. This repository intentionally avoids `pull_request_target`.
 
 ## Future Issues
 

--- a/docs/development/github-labeling.md
+++ b/docs/development/github-labeling.md
@@ -1,0 +1,98 @@
+# GitHub Labeling
+
+This repository labels new issues and pull requests automatically, and provides
+a manual workflow for safely retagging historical issues and PRs.
+
+## Future Pull Requests
+
+`.github/workflows/pr-labeler.yml` runs on `pull_request_target` for opened,
+synchronized, reopened, and ready-for-review pull requests. It uses
+`actions/labeler@v6` with `.github/labeler.yml` and `sync-labels: false`.
+
+The PR workflow only adds computed labels. It does not remove existing labels,
+so Dependabot labels and any maintainer-applied labels remain in place during
+normal future PR labeling.
+
+Because `pull_request_target` is privileged, the workflow must stay label-only.
+Do not add `actions/checkout`, do not checkout PR branches, and do not execute
+scripts or code from pull requests in that workflow.
+
+## Future Issues
+
+`.github/workflows/issue-labeler.yml` runs when issues are opened, reopened, or
+edited. It reads the issue title and body from the GitHub event payload and adds
+matching labels. Every new or edited issue receives `needs-triage`.
+
+The issue labeler only adds computed labels. It does not remove existing labels.
+
+## Manual Historical Retag
+
+`.github/workflows/retag-labels.yml` is manual-only through
+`workflow_dispatch`. It can retag issues, pull requests, or both, for open,
+closed, or all items.
+
+Retagging is intentionally more aggressive than future auto-labeling:
+
+- It reads the current labels on each selected issue or PR.
+- It preserves protected labels.
+- It removes only unprotected labels from the individual issue or PR.
+- It recomputes labels using the standard issue or PR label rules.
+- It adds the recomputed labels.
+- It never deletes repository labels globally.
+
+The retag workflow defaults to dry-run mode. In dry-run mode it prints the
+current labels, protected labels that would be preserved, unprotected labels
+that would be removed, labels that would be added, and final expected labels.
+It does not edit issues, PRs, or repository label metadata.
+
+To dry-run a historical retag:
+
+```text
+Actions -> Retag issue and pull request labels -> Run workflow
+target: both
+state: all
+limit: 500
+dry_run: true
+```
+
+To apply a real retag:
+
+```text
+Actions -> Retag issue and pull request labels -> Run workflow
+target: both
+state: all
+limit: 500
+dry_run: false
+confirm_retag: RETAG
+```
+
+If `dry_run` is `false` and `confirm_retag` is not exactly `RETAG`, the workflow
+fails before changing labels.
+
+## Protected Labels
+
+Protected labels are preserved on each issue or PR during manual retagging.
+They are not automatically added to every issue or PR.
+
+The current protected labels come from `.github/dependabot.yml`:
+
+- `dependencies`
+- `docker`
+- `github-actions`
+- `python`
+
+These labels must stay protected so Dependabot PRs do not lose labels that
+identify their package ecosystem. The existing workflows were scanned before
+adding the labeler workflows, and no additional issue/PR labels used by GitHub
+Actions logic were found.
+
+If a future workflow depends on a label in conditions, `gh issue edit
+--add-label`, `gh issue edit --remove-label`, API calls, `labels:` blocks, or
+other issue/PR label checks, add that label to `PROTECTED_LABELS` in
+`.github/workflows/retag-labels.yml` before running a retag.
+
+## Label Setup
+
+The labeling workflows create or update the standard labels idempotently with
+`gh label create --force`. This keeps label names, descriptions, and colors
+available without deleting any repository labels.

--- a/docs/development/github-labeling.md
+++ b/docs/development/github-labeling.md
@@ -7,7 +7,8 @@ a manual workflow for safely retagging historical issues and PRs.
 
 `.github/workflows/pr-labeler.yml` runs on `pull_request_target` for opened,
 synchronized, reopened, and ready-for-review pull requests. It uses
-`actions/labeler@v6` with `.github/labeler.yml` and `sync-labels: false`.
+the v6 `actions/labeler` action with `.github/labeler.yml` and
+`sync-labels: false`. The workflow pins the action to an immutable commit SHA.
 
 The PR workflow only adds computed labels. It does not remove existing labels,
 so Dependabot labels and any maintainer-applied labels remain in place during


### PR DESCRIPTION
## Summary

Adds GitHub labeling automation for pull requests, issues, and manual retagging.

The new workflows automatically apply repository labels based on changed files, issue content, and computed title/body rules, while keeping existing labels safe by default. The workflow security posture was also tightened by using job-scoped write permissions, pinning the labeler action to a full commit SHA, and using `pull_request` instead of `pull_request_target` to satisfy the repository workflow policy.

## Why

Manual issue and PR labeling is easy to forget and can become inconsistent across the repository.

This automation keeps triage labels more consistent, improves review visibility, and provides a controlled manual retag workflow for existing issues and PRs without deleting protected labels or repository labels globally.

The workflow-policy fixes also reduce CI risk by keeping permissions scoped to the jobs that need them, avoiding floating third-party action references, and removing `pull_request_target` from `.github/workflows`.

## What changed

* Added `.github/labeler.yml`.
* Added `.github/workflows/pr-labeler.yml`.
* Added `.github/workflows/issue-labeler.yml`.
* Added `.github/workflows/retag-labels.yml`.
* Added `docs/development/github-labeling.md`.
* Added PR labeling with the SHA-pinned v6 labeler action:

  * `actions/labeler@f27b608878404679385c85cfa523b85ccb86e213`
* Changed the PR labeler trigger from `pull_request_target` to `pull_request`.
* Updated workflow comments so `.github/workflows` no longer contains `pull_request_target`.
* Updated `docs/development/github-labeling.md` to match the `pull_request` trigger and repository policy.
* Set `sync-labels: false` so PR labeling does not remove existing labels.
* Added issue labeling for computed title/body labels.
* Added `needs-triage` labeling for issues.
* Added manual retag workflow using `workflow_dispatch`.
* Made manual retag default to `dry_run: true`.
* Required `confirm_retag: RETAG` before apply mode can modify labels.
* Preserved protected labels:

  * `dependencies`
  * `docker`
  * `github-actions`
  * `python`
* Removed only unprotected labels from individual issues and PRs during apply retag.
* Ensured retag never deletes repository labels globally.
* Added idempotent required-label creation/update with `gh label create --force`.
* Limited required-label creation/update during retag to apply mode only.
* Moved write permissions from workflow level to job level in:

  * `.github/workflows/issue-labeler.yml`
  * `.github/workflows/pr-labeler.yml`
  * `.github/workflows/retag-labels.yml`
* Updated docs and workflow log wording to describe the SHA-pinned v6 labeler action.

## Security impact

This is a GitHub automation and repository-maintenance change.

The PR labeler now uses `pull_request` instead of `pull_request_target`, which avoids privileged execution on pull request events and satisfies the repository workflow policy.

Manual retagging is gated behind `workflow_dispatch`, defaults to dry-run mode, and requires an explicit `confirm_retag: RETAG` value before applying changes.

The retag workflow preserves protected dependency/ecosystem labels and does not delete repository labels globally. It only removes unprotected labels from individual issues or PRs when explicitly run in apply mode.

Workflow write permissions are scoped at the job level instead of the workflow level, and the labeler action is pinned to a specific commit instead of a floating version tag.

## Deployment impact

No deployment action.

This PR does not require:

* EC2 bootstrap
* staging deployment
* production deployment
* database migration
* secret changes

## Verification

* `python -m pytest tests/test_deployment.py::test_every_github_action_is_pinned_to_a_full_commit_sha -q`

  * Passed
* YAML parsed successfully for 9 files.
* Embedded workflow Bash blocks passed `bash -n`.
* Custom policy checks passed.
* `rg 'pull_request_target' .github/workflows`

  * No matches
* `actionlint` and `zizmor` were not installed locally, so those exact linters were not run.

## Notes

Manual retagging is intentionally conservative.

Use dry-run mode first to inspect planned changes, then rerun with `dry_run: false` and `confirm_retag: RETAG` only when the proposed retag behavior is acceptable.
