### PR TITLE
Add shared Nginx TLS policy

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -101,11 +101,14 @@ journalctl -u sitbank-security-alerts.service
 
 ## Production Edge and Network Hardening
 
-The reviewed production bootstrap installs and enables the production edge from `ops/nginx/sitbank-default.conf`, `ops/nginx/sitbank-production.conf`, `ops/nginx/sitbank-production-rate-limits.conf`, and `ops/nginx-proxy-headers.conf`. The shared default config owns unknown-host rejection so production and staging can run on the same EC2 without duplicate Nginx `default_server` listeners. Any change to those files requires a production bootstrap after merge.
+The reviewed production bootstrap installs and enables the production edge from `ops/nginx/sitbank-default.conf`, `ops/nginx/sitbank-production.conf`, `ops/nginx/sitbank-production-rate-limits.conf`, `ops/nginx-proxy-headers.conf`, and `ops/nginx/sitbank-tls-policy.conf`. The shared default config owns unknown-host rejection so production and staging can run on the same EC2 without duplicate Nginx `default_server` listeners. Any change to those files requires a production bootstrap after merge.
 
 - Public ingress is TCP `80` and `443` only.
 - SSH is restricted to an administrator IP allowlist, AWS Systems Manager, a bastion, or VPN.
 - Nginx terminates TLS, redirects HTTP to HTTPS, and forwards only expected proxy headers.
+- The shared TLS policy enables only TLS 1.2 and TLS 1.3, restricts TLS 1.2 to
+  ECDHE+AEAD suites, pins the X25519/P-256/P-384 ECDHE curve preference, and
+  limits TLS 1.3 to its standard AEAD suites.
 - Gunicorn binds only to `127.0.0.1:5000`.
 - Admin Gunicorn binds only to `127.0.0.1:5002` and is reached only by the
   `admin-sitbank.duckdns.org` Nginx server block.
@@ -126,6 +129,7 @@ Verification:
 ```bash
 sudo test -r /etc/letsencrypt/live/sitbank.duckdns.org/fullchain.pem
 sudo nginx -t
+sudo nginx -T | grep -E 'ssl_protocols|ssl_ciphers|ssl_ecdh_curve|ssl_conf_command|ssl_session_tickets'
 sudo ss -ltnp | grep -E ':(80|443|5000|5002)([[:space:]]|$)'
 sudo docker inspect --format '{{json .NetworkSettings.Ports}}' sitbank-app
 sudo docker inspect --format '{{json .NetworkSettings.Ports}}' sitbank-admin
@@ -173,7 +177,7 @@ sudo certbot certonly --webroot -w /var/www/certbot -d staging-sitbank.duckdns.o
 sudo certbot renew --dry-run
 ```
 
-Then run `ops/deploy/bootstrap-container-ec2 staging hetp88/SITBank staging-sitbank.duckdns.org`. The bootstrap installs the Nginx proxy header snippet and rate-limit include, then runs `sudo nginx -t` before `sudo systemctl reload nginx`. This edge setup is separate from application deployment.
+Then run `ops/deploy/bootstrap-container-ec2 staging hetp88/SITBank staging-sitbank.duckdns.org`. The bootstrap installs the Nginx proxy header snippet, TLS policy snippet, and rate-limit include, then runs `sudo nginx -t` before `sudo systemctl reload nginx`. This edge setup is separate from application deployment.
 
 Staging verification:
 
@@ -183,6 +187,14 @@ curl -k -I -u "$STAGING_BASIC_AUTH_USER:$STAGING_BASIC_AUTH_PASSWORD" \
   https://staging-sitbank.duckdns.org/
 curl -k -I https://staging-sitbank.duckdns.org/health/ready
 curl -fsS http://127.0.0.1:5001/health/ready
+sudo nginx -T | grep -E 'ssl_protocols|ssl_ciphers|ssl_ecdh_curve|ssl_conf_command|ssl_session_tickets'
+testssl.sh --fast --parallel https://staging-sitbank.duckdns.org
 ```
 
 Expected: unauthenticated `/` returns `401`, authenticated `/` returns `200`, external `/health/ready` returns `403`, and local app readiness succeeds.
+
+After the staging TLS check passes, validate both production HTTPS hostnames
+with `testssl.sh --fast --parallel https://sitbank.duckdns.org` and
+`testssl.sh --fast --parallel https://admin-sitbank.duckdns.org`. The
+`ssl_conf_command` TLS 1.3 setting is runtime-dependent, so `nginx -t` must
+pass on the deployed host before any reload.

--- a/docs/security/cryptography-and-authentication.md
+++ b/docs/security/cryptography-and-authentication.md
@@ -24,7 +24,7 @@ files on the host:
 ```nginx
 ssl_certificate /etc/letsencrypt/live/sitbank.duckdns.org/fullchain.pem;
 ssl_certificate_key /etc/letsencrypt/live/sitbank.duckdns.org/privkey.pem;
-ssl_protocols TLSv1.2 TLSv1.3;
+include /etc/nginx/snippets/sitbank-tls-policy.conf;
 add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 ```
 
@@ -37,7 +37,7 @@ Evidence:
 | Unknown host rejection | `ops/nginx/sitbank-default.conf` returns `444` for the default HTTP server and uses `ssl_reject_handshake on` for the default HTTPS server |
 | HSTS | Production uses `Strict-Transport-Security "max-age=31536000; includeSubDomains"`; staging uses `max-age=300` |
 | Proxy trust boundary | `ops/nginx-proxy-headers.conf` overwrites `Host`, `X-Real-IP`, `X-Forwarded-For`, and `X-Forwarded-Proto`; `app/__init__.py` applies `ProxyFix` using `TRUSTED_PROXY_COUNT` |
-| Deployment validation | `ops/deploy/bootstrap-container-ec2` requires the Certbot files before installing the production or staging Nginx site and runs `nginx -t` before reload |
+| TLS policy and deployment validation | `ops/nginx/sitbank-tls-policy.conf` pins the shared TLS policy; `ops/deploy/bootstrap-container-ec2` requires the Certbot files and TLS snippet before installing the production or staging Nginx site, then runs `nginx -t` before reload |
 | Tests | `tests/test_deployment.py::test_nginx_default_server_is_shared_for_same_host_production_and_staging`, `tests/test_deployment.py::test_production_nginx_edge_config_enforces_network_boundary_and_limits`, `tests/test_deployment.py::test_staging_nginx_enforces_https_auth_health_and_rate_limits`, `tests/test_deployment.py::test_proxyfix_trusts_exactly_the_configured_nginx_hop` |
 
 Short evidence for unknown-host rejection:
@@ -57,22 +57,28 @@ not contain ACME account state, private keys, or a certbot renewal timer.
 
 ## 1.2 HTTPS Cipher Suites
 
-Production and staging Nginx explicitly enable only TLS 1.2 and TLS 1.3:
+Production, production-admin, and staging HTTPS server blocks include the shared
+`ops/nginx/sitbank-tls-policy.conf` policy. It explicitly enables only TLS 1.2
+and TLS 1.3, prefers modern ECDHE curves, and restricts TLS 1.2 to ECDHE with
+AEAD encryption:
 
 ```nginx
 ssl_protocols TLSv1.2 TLSv1.3;
+ssl_ecdh_curve X25519:prime256v1:secp384r1;
+ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305';
 ssl_prefer_server_ciphers off;
 ssl_session_tickets off;
+ssl_conf_command Ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256;
 ```
 
-This disables SSLv2, SSLv3, TLS 1.0, and TLS 1.1 by omission. TLS 1.2 and TLS
-1.3 are the only protocol versions configured in the repository. Session
-tickets are disabled to reduce long-lived ticket-key exposure.
+This excludes SSLv2, SSLv3, TLS 1.0, TLS 1.1, CBC, RC4, 3DES, DES, NULL,
+EXPORT, MD5, anonymous, static-RSA, and finite-field DHE cipher families.
+TLS 1.3 is limited to its standard AES-GCM and ChaCha20-Poly1305 AEAD suites.
+Session tickets remain disabled to reduce long-lived ticket-key exposure.
 
-Current gap: the repo does not explicitly configure `ssl_ciphers` or
-`ssl_ecdh_curve`. Cipher suite selection therefore depends on the installed
-Nginx/OpenSSL defaults on the host. The deployment documentation should verify
-the live host's cipher suites before release.
+`ssl_conf_command` depends on the deployed Nginx and OpenSSL build. Operators
+must run `nginx -t` and inspect the loaded configuration on the target host
+before reload, then validate the externally offered suites after deployment.
 
 ## 1.3 Server Private Key Storage
 

--- a/docs/security/secure-coding.md
+++ b/docs/security/secure-coding.md
@@ -114,13 +114,15 @@ settings are missing.
 | SMTP password-reset backend requires TLS and credentials in production | `config.py`, `app/security/email.py`, `tests/test_config.py::test_production_smtp_email_requires_host_and_credentials_without_secret_leakage` |
 | Password reset base URL must be HTTPS in production | `tests/test_config.py::test_password_reset_base_url_must_be_https_in_production` |
 | Production payee activation delay must be at least 12 hours; short cooldowns are limited to development/test | `config.py::_validate_payee_cooldown_config()`, `app/ops/commands.py::production_check()`, `tests/test_config.py::test_production_payee_cooldown_rejects_short_value_without_secret_leakage` |
-| Nginx rejects unknown hosts and redirects HTTP to HTTPS | `ops/nginx/sitbank-default.conf`, `ops/nginx/sitbank-production.conf` |
+| Nginx rejects unknown hosts, redirects HTTP to HTTPS, and pins TLS 1.2 ECDHE+AEAD suites, TLS 1.3 AEAD suites, and ECDHE curves | `ops/nginx/sitbank-default.conf`, `ops/nginx/sitbank-production.conf`, `ops/nginx/sitbank-tls-policy.conf` |
 | Docker runtime drops capabilities and runs read-only as UID/GID `10001:10001` | `Dockerfile`, `compose.prod.yml`, `tests/test_deployment.py::test_dockerfile_and_compose_enforce_hardened_runtime` |
 | Deployment contract keeps production and staging isolated | `compose.prod.yml`, `compose.staging.yml`, `tests/test_deployment.py` |
 
-Current gap: Nginx does not pin an explicit `ssl_ciphers` list. The repo pins
-protocols to TLS 1.2 and TLS 1.3, but cipher selection depends on deployed
-Nginx/OpenSSL defaults.
+Nginx uses the shared `ops/nginx/sitbank-tls-policy.conf` for all configured
+HTTPS edges. It permits only TLS 1.2 ECDHE+AEAD suites and standard TLS 1.3
+AEAD suites, with `X25519`, `prime256v1`, and `secp384r1` as the explicit ECDHE
+curve preference. Operators still validate the live Nginx/OpenSSL support with
+`nginx -t` before reload.
 
 ## 4.7 Logging, Auditing, And Error Handling
 

--- a/docs/security/session-management.md
+++ b/docs/security/session-management.md
@@ -76,9 +76,11 @@ Transport protections:
 | Flask secure cookie enforcement | `SESSION_COOKIE_SECURE`, `SESSION_COOKIE_HTTPONLY`, and `SESSION_COOKIE_SAMESITE` in `config.py` |
 | Proxy trust boundary | `ops/nginx-proxy-headers.conf` and `tests/test_deployment.py::test_proxyfix_trusts_exactly_the_configured_nginx_hop` |
 
-Current gap: TLS cipher suite pinning is not explicit in Nginx. Session cookie
-transport depends on the deployed host's Nginx/OpenSSL cipher defaults in
-addition to the repository's `ssl_protocols TLSv1.2 TLSv1.3` setting.
+All configured HTTPS edges include `ops/nginx/sitbank-tls-policy.conf`, which
+pins TLS 1.2 to ECDHE+AEAD suites, TLS 1.3 to standard AEAD suites, and the
+ECDHE curve preference. TLS 1.0 and TLS 1.1, legacy weak cipher families, and
+session tickets remain disabled. Operators validate the loaded policy on the
+deployed Nginx/OpenSSL build before release.
 
 ## 2.4 Session Modification And Tamper Resistance
 

--- a/ops/deploy/bootstrap-container-ec2
+++ b/ops/deploy/bootstrap-container-ec2
@@ -9,6 +9,7 @@ readonly COSIGN_SHA256="db15cc99e6e4837daabab023742aaddc3841ce57f193d11b7c3e06c8
 readonly PRODUCTION_PUBLIC_HOST="sitbank.duckdns.org"
 readonly PRODUCTION_ADMIN_PUBLIC_HOST="admin-sitbank.duckdns.org"
 readonly EDGE_DEFAULTS_FILE="/etc/nginx/conf.d/sitbank-default.conf"
+readonly TLS_POLICY_FILE="/etc/nginx/snippets/sitbank-tls-policy.conf"
 readonly PRODUCTION_RATE_LIMITS_FILE="/etc/nginx/conf.d/sitbank-production-rate-limits.conf"
 readonly STAGING_PUBLIC_HOST="staging-sitbank.duckdns.org"
 readonly STAGING_BASIC_AUTH_FILE="/etc/nginx/.htpasswd-sitbank-staging"
@@ -92,6 +93,7 @@ linux_runtime_files=(
     "${repo_root}/ops/deploy/sitbank-container-runtime"
     "${repo_root}/ops/deploy/sitbank-database-cutover"
     "${repo_root}/ops/nginx/sitbank-default.conf"
+    "${repo_root}/ops/nginx/sitbank-tls-policy.conf"
     "${repo_root}/ops/sudoers/sitbank-container-deploy"
 )
 if [[ "${target}" == "staging" ]]; then
@@ -287,6 +289,14 @@ install_edge_default_site() {
         "nginx-sitbank-default"
 }
 
+install_tls_policy() {
+    install_nginx_config \
+        "${repo_root}/ops/nginx/sitbank-tls-policy.conf" \
+        "${TLS_POLICY_FILE}" \
+        "shared Nginx TLS policy" \
+        "nginx-sitbank-tls-policy"
+}
+
 install_admin_verification_page() {
     install -d -o root -g root -m 0755 /var/www/sitbank-admin-verification
     install -o root -g root -m 0644 \
@@ -349,6 +359,7 @@ if [[ "${target}" == "production" ]]; then
     install -d -o root -g root -m 0755 /etc/nginx/conf.d
     install -d -o root -g root -m 0755 /var/www/certbot
     install_edge_default_site
+    install_tls_policy
     install_admin_verification_page
     install -o root -g root -m 0644 \
         "${repo_root}/ops/nginx-proxy-headers.conf" \
@@ -439,6 +450,7 @@ if [[ "${target}" == "staging" ]]; then
     install -d -o root -g root -m 0755 /etc/nginx/conf.d
     install -d -o root -g root -m 0755 /var/www/certbot
     install_edge_default_site
+    install_tls_policy
     install_admin_verification_page
     install -o root -g root -m 0644 \
         "${repo_root}/ops/nginx-proxy-headers.conf" \

--- a/ops/nginx/sitbank-production.conf
+++ b/ops/nginx/sitbank-production.conf
@@ -35,11 +35,9 @@ server {
 
     ssl_certificate /etc/letsencrypt/live/sitbank.duckdns.org/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/sitbank.duckdns.org/privkey.pem;
-    ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_prefer_server_ciphers off;
+    include /etc/nginx/snippets/sitbank-tls-policy.conf;
     ssl_session_cache shared:sitbank_prod_ssl:10m;
     ssl_session_timeout 1d;
-    ssl_session_tickets off;
 
     proxy_hide_header X-Content-Type-Options;
     proxy_hide_header X-Frame-Options;
@@ -198,11 +196,9 @@ server {
 
     ssl_certificate /etc/letsencrypt/live/admin-sitbank.duckdns.org/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/admin-sitbank.duckdns.org/privkey.pem;
-    ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_prefer_server_ciphers off;
+    include /etc/nginx/snippets/sitbank-tls-policy.conf;
     ssl_session_cache shared:sitbank_prod_admin_ssl:10m;
     ssl_session_timeout 1d;
-    ssl_session_tickets off;
 
     proxy_hide_header X-Content-Type-Options;
     proxy_hide_header X-Frame-Options;

--- a/ops/nginx/sitbank-staging.conf
+++ b/ops/nginx/sitbank-staging.conf
@@ -36,11 +36,9 @@ server {
 
     ssl_certificate /etc/letsencrypt/live/staging-sitbank.duckdns.org/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/staging-sitbank.duckdns.org/privkey.pem;
-    ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_prefer_server_ciphers off;
+    include /etc/nginx/snippets/sitbank-tls-policy.conf;
     ssl_session_cache shared:sitbank_staging_ssl:10m;
     ssl_session_timeout 1d;
-    ssl_session_tickets off;
 
     proxy_hide_header X-Content-Type-Options;
     proxy_hide_header X-Frame-Options;

--- a/ops/nginx/sitbank-tls-policy.conf
+++ b/ops/nginx/sitbank-tls-policy.conf
@@ -1,0 +1,12 @@
+# Shared HTTPS policy for the production, production-admin, and staging edges.
+ssl_protocols TLSv1.2 TLSv1.3;
+ssl_ecdh_curve X25519:prime256v1:secp384r1;
+
+# TLS 1.2: ECDHE key exchange with authenticated AEAD encryption only.
+ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305';
+
+ssl_prefer_server_ciphers off;
+ssl_session_tickets off;
+
+# Requires Nginx ssl_conf_command support and OpenSSL TLS 1.3 support.
+ssl_conf_command Ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256;

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -2040,6 +2040,78 @@ def test_nginx_default_server_is_shared_for_same_host_production_and_staging():
     assert "server_name staging-sitbank.duckdns.org;" in combined
 
 
+def test_nginx_tls_policy_pins_strong_suites_curves_and_session_hardening():
+    tls_policy_path = Path("ops/nginx/sitbank-tls-policy.conf")
+    tls_policy = tls_policy_path.read_text(encoding="utf-8")
+    production_nginx = Path("ops/nginx/sitbank-production.conf").read_text(
+        encoding="utf-8"
+    )
+    staging_nginx = Path("ops/nginx/sitbank-staging.conf").read_text(encoding="utf-8")
+    bootstrap = Path("ops/deploy/bootstrap-container-ec2").read_text(encoding="utf-8")
+
+    assert tls_policy_path.exists()
+    assert "ssl_protocols TLSv1.2 TLSv1.3;" in tls_policy
+    assert "ssl_ecdh_curve X25519:prime256v1:secp384r1;" in tls_policy
+    assert "ssl_prefer_server_ciphers off;" in tls_policy
+    assert "ssl_session_tickets off;" in tls_policy
+
+    tls12_match = re.search(r"ssl_ciphers '([^']+)';", tls_policy)
+    assert tls12_match
+    assert tls12_match.group(1).split(":") == [
+        "ECDHE-ECDSA-AES128-GCM-SHA256",
+        "ECDHE-RSA-AES128-GCM-SHA256",
+        "ECDHE-ECDSA-AES256-GCM-SHA384",
+        "ECDHE-RSA-AES256-GCM-SHA384",
+        "ECDHE-ECDSA-CHACHA20-POLY1305",
+        "ECDHE-RSA-CHACHA20-POLY1305",
+    ]
+    for weak_cipher_family in (
+        "RC4",
+        "3DES",
+        "DES",
+        "CBC",
+        "MD5",
+        "aNULL",
+        "eNULL",
+        "EXPORT",
+        "TLS_RSA_",
+    ):
+        assert weak_cipher_family not in tls12_match.group(1)
+    assert not re.search(r"(?:^|:)DHE-", tls12_match.group(1))
+
+    tls13_match = re.search(r"ssl_conf_command Ciphersuites ([^;]+);", tls_policy)
+    assert tls13_match
+    assert tls13_match.group(1).split(":") == [
+        "TLS_AES_128_GCM_SHA256",
+        "TLS_AES_256_GCM_SHA384",
+        "TLS_CHACHA20_POLY1305_SHA256",
+    ]
+
+    policy_include = "include /etc/nginx/snippets/sitbank-tls-policy.conf;"
+    for nginx, server_name, session_cache in (
+        (production_nginx, "sitbank.duckdns.org", "shared:sitbank_prod_ssl:10m"),
+        (
+            production_nginx,
+            "admin-sitbank.duckdns.org",
+            "shared:sitbank_prod_admin_ssl:10m",
+        ),
+        (staging_nginx, "staging-sitbank.duckdns.org", "shared:sitbank_staging_ssl:10m"),
+    ):
+        https_server = _nginx_https_server_prelocation(nginx, server_name=server_name)
+        assert policy_include in https_server
+        assert session_cache in https_server
+        assert "ssl_session_timeout 1d;" in https_server
+
+    assert 'TLS_POLICY_FILE="/etc/nginx/snippets/sitbank-tls-policy.conf"' in bootstrap
+    assert '"${repo_root}/ops/nginx/sitbank-tls-policy.conf"' in bootstrap
+    assert '"${TLS_POLICY_FILE}"' in bootstrap
+    assert '"shared Nginx TLS policy"' in bootstrap
+    assert '"nginx-sitbank-tls-policy"' in bootstrap
+    assert bootstrap.count("    install_tls_policy\n") == 2
+    tls_policy_install = bootstrap.index("install_tls_policy", bootstrap.index("if [[ \"${target}\" == \"production\" ]]"))
+    assert tls_policy_install < bootstrap.index("nginx -t", tls_policy_install)
+
+
 def test_staging_nginx_enforces_https_auth_health_and_rate_limits():
     default_nginx = Path("ops/nginx/sitbank-default.conf").read_text(encoding="utf-8")
     nginx = Path("ops/nginx/sitbank-staging.conf").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Implements a shared Nginx TLS policy for SITBank HTTPS server blocks.

The new shared snippet centralizes TLS protocol, cipher, curve, TLS 1.3 suite, and session-ticket hardening settings. It is applied consistently to production customer, production admin, and staging HTTPS blocks while preserving each environment’s distinct session cache configuration.

## Why

TLS policy should be consistent across customer, admin, and staging HTTPS entry points.

Before this change, TLS settings could drift between Nginx server blocks. A shared snippet makes the policy easier to review, reuse, test, and safely install during bootstrap.

## What changed

* Added `ops/nginx/sitbank-tls-policy.conf`.
* Pinned TLS 1.2 to ECDHE + AEAD cipher suites.
* Added ECDHE curve configuration.
* Added TLS 1.3 AEAD suite configuration.
* Added session-ticket hardening.
* Applied the shared TLS policy to:

  * Production customer HTTPS block
  * Production admin HTTPS block
  * Staging HTTPS block
* Preserved distinct SSL session caches per HTTPS context.
* Updated `ops/deploy/bootstrap-container-ec2` to:

  * Require the TLS policy snippet
  * Safely install the snippet
  * Back up the previous snippet before replacement
  * Run validation before Nginx activation
* Added deployment regression coverage.
* Updated security and deployment documentation.

## Security impact

This strengthens HTTPS configuration consistency across customer, admin, and staging Nginx entry points.

The shared policy reduces TLS drift and makes cipher/protocol hardening easier to audit. TLS 1.2 is restricted to ECDHE + AEAD suites, TLS 1.3 uses AEAD suites, and session-ticket behavior is hardened.

The bootstrap update also reduces deployment risk by requiring and backing up the shared snippet before Nginx validation.

## Deployment impact

This PR requires:

* EC2 bootstrap
* staging deployment
* production deployment

This PR does not require:

* database migration
* secret changes

After deployment/bootstrap, run the final Nginx validation on EC2:

```bash
sudo nginx -t
```

This runtime check is required because `ssl_conf_command` support depends on the EC2 host’s installed Nginx/OpenSSL build.

## Verification

* `git diff --check`

  * Passed
* Deployment regression tests

  * `45 passed, 6 warnings in 1.49s`

## Notes

The final runtime compatibility check must still be performed on EC2 with `sudo nginx -t`.

This is especially important for confirming whether the target host’s Nginx/OpenSSL build supports the configured TLS directives.
