### PR TITLE
Add host-managed TLS preflight

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,6 +13,7 @@ ops/deploy/sitbank-container-bootstrap text eol=lf
 ops/deploy/sitbank-container-deploy text eol=lf
 ops/deploy/sitbank-container-runtime text eol=lf
 ops/deploy/sitbank-database-cutover text eol=lf
+ops/deploy/verify-certbot-host-state text eol=lf
 ops/sudoers/* text eol=lf
 scripts/ci-local text eol=lf
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -206,6 +206,12 @@ checked manually.
   `/etc/letsencrypt/live/sitbank.duckdns.org/` before bootstrap.
 - Issue admin Certbot files under
   `/etc/letsencrypt/live/admin-sitbank.duckdns.org/` before bootstrap.
+- Keep Certbot ACME account state and TLS private keys on the EC2 host; never
+  commit them to the repository or mount them into application containers.
+- Require an enabled, active `certbot.timer` for host-managed renewal, and run
+  the read-only certificate verifier before an edge deployment. The resolved
+  `privkey.pem` targets must be `root:root`, not group-writable or
+  world-readable, and normally mode `0600`.
 - Allow public inbound TCP `80` and `443` only.
 - Restrict SSH to an administrator IP allowlist, AWS Systems Manager, a
   bastion, or VPN; never allow TCP `22` from `0.0.0.0/0` or `::/0`.
@@ -228,6 +234,10 @@ checked manually.
 Verification commands:
 
 ```bash
+sudo certbot certificates
+sudo systemctl status certbot.timer
+sudo /usr/local/sbin/verify-certbot-host-state production
+sudo certbot renew --dry-run
 sudo nginx -t
 sudo ss -ltnp | grep -E ':(80|443|5000|5002)([[:space:]]|$)'
 sudo docker inspect --format '{{json .NetworkSettings.Ports}}' sitbank-app

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -99,6 +99,58 @@ sudo systemctl status sitbank-security-alerts.timer
 journalctl -u sitbank-security-alerts.service
 ```
 
+## Host-Managed TLS Certificate Lifecycle
+
+Certificates are issued and renewed on the EC2 host. Certbot's ACME account
+state, certificate archive, and TLS private keys are host-managed under
+`/etc/letsencrypt`; none of that material may be committed to this repository.
+The Flask application and its containers do not issue certificates and do not
+mount or read TLS private keys. Normal deployment must never generate or
+overwrite a private key.
+
+Before first bootstrap, issue the certificates using the approved host Certbot
+flow. The bootstrap retains its certificate-file preflight and installs
+`ops/deploy/verify-certbot-host-state` as
+`/usr/local/sbin/verify-certbot-host-state`. Once the required files exist, it
+runs the verifier before it installs or reloads Nginx; it does not attempt
+certificate issuance. A failed verification is a host remediation task, not an
+application deployment workaround.
+
+The verifier is read-only. It checks `certbot`, an enabled and active
+`certbot.timer`, every expected `fullchain.pem`, and each resolved
+`privkey.pem` target. The `live` private-key path is normally a symlink; the
+resolved target must remain below `/etc/letsencrypt`, be owned by `root`, be
+group-owned by `root`, be neither group-writable nor world-writable, and grant
+no permissions to other users. The normal state is `root:root` mode `0600` (or
+a stricter equivalent). A `0640` dedicated TLS-read-group design is allowed
+only after that group, its membership, and the Nginx privilege model are
+documented and the verifier's explicit group allowlist has been reviewed and
+updated. Do not use an application or container group for this purpose.
+
+Verify the host state after issuance, after renewal changes, and before an edge
+deployment:
+
+```bash
+sudo certbot certificates
+sudo systemctl status certbot.timer
+sudo /usr/local/sbin/verify-certbot-host-state production
+sudo /usr/local/sbin/verify-certbot-host-state staging
+sudo certbot renew --dry-run
+
+sudo readlink -f /etc/letsencrypt/live/sitbank.duckdns.org/privkey.pem
+sudo stat -c '%U %G %a %n' "$(sudo readlink -f /etc/letsencrypt/live/sitbank.duckdns.org/privkey.pem)"
+sudo readlink -f /etc/letsencrypt/live/admin-sitbank.duckdns.org/privkey.pem
+sudo stat -c '%U %G %a %n' "$(sudo readlink -f /etc/letsencrypt/live/admin-sitbank.duckdns.org/privkey.pem)"
+sudo readlink -f /etc/letsencrypt/live/staging-sitbank.duckdns.org/privkey.pem
+sudo stat -c '%U %G %a %n' "$(sudo readlink -f /etc/letsencrypt/live/staging-sitbank.duckdns.org/privkey.pem)"
+```
+
+When verifying directly from a reviewed checkout before bootstrap has installed
+the script, use `sudo ops/deploy/verify-certbot-host-state production` or
+`sudo ops/deploy/verify-certbot-host-state staging`. `certbot renew --dry-run`
+is the required manual renewal test; do not print or copy private-key contents
+while troubleshooting.
+
 ## Production Edge and Network Hardening
 
 The reviewed production bootstrap installs and enables the production edge from `ops/nginx/sitbank-default.conf`, `ops/nginx/sitbank-production.conf`, `ops/nginx/sitbank-production-rate-limits.conf`, `ops/nginx-proxy-headers.conf`, and `ops/nginx/sitbank-tls-policy.conf`. The shared default config owns unknown-host rejection so production and staging can run on the same EC2 without duplicate Nginx `default_server` listeners. Any change to those files requires a production bootstrap after merge.
@@ -128,6 +180,7 @@ Verification:
 
 ```bash
 sudo test -r /etc/letsencrypt/live/sitbank.duckdns.org/fullchain.pem
+sudo /usr/local/sbin/verify-certbot-host-state production
 sudo nginx -t
 sudo nginx -T | grep -E 'ssl_protocols|ssl_ciphers|ssl_ecdh_curve|ssl_conf_command|ssl_session_tickets'
 sudo ss -ltnp | grep -E ':(80|443|5000|5002)([[:space:]]|$)'
@@ -174,6 +227,8 @@ Issue or renew staging TLS before bootstrap:
 ```bash
 sudo certbot --nginx -d staging-sitbank.duckdns.org
 sudo certbot certonly --webroot -w /var/www/certbot -d staging-sitbank.duckdns.org
+sudo systemctl status certbot.timer
+sudo /usr/local/sbin/verify-certbot-host-state staging
 sudo certbot renew --dry-run
 ```
 

--- a/docs/security/cryptography-and-authentication.md
+++ b/docs/security/cryptography-and-authentication.md
@@ -37,7 +37,7 @@ Evidence:
 | Unknown host rejection | `ops/nginx/sitbank-default.conf` returns `444` for the default HTTP server and uses `ssl_reject_handshake on` for the default HTTPS server |
 | HSTS | Production uses `Strict-Transport-Security "max-age=31536000; includeSubDomains"`; staging uses `max-age=300` |
 | Proxy trust boundary | `ops/nginx-proxy-headers.conf` overwrites `Host`, `X-Real-IP`, `X-Forwarded-For`, and `X-Forwarded-Proto`; `app/__init__.py` applies `ProxyFix` using `TRUSTED_PROXY_COUNT` |
-| TLS policy and deployment validation | `ops/nginx/sitbank-tls-policy.conf` pins the shared TLS policy; `ops/deploy/bootstrap-container-ec2` requires the Certbot files and TLS snippet before installing the production or staging Nginx site, then runs `nginx -t` before reload |
+| TLS policy and deployment validation | `ops/nginx/sitbank-tls-policy.conf` pins the shared TLS policy; `ops/deploy/bootstrap-container-ec2` requires the Certbot files, invokes `ops/deploy/verify-certbot-host-state`, and installs the TLS snippet before installing the production or staging Nginx site, then runs `nginx -t` before reload |
 | Tests | `tests/test_deployment.py::test_nginx_default_server_is_shared_for_same_host_production_and_staging`, `tests/test_deployment.py::test_production_nginx_edge_config_enforces_network_boundary_and_limits`, `tests/test_deployment.py::test_staging_nginx_enforces_https_auth_health_and_rate_limits`, `tests/test_deployment.py::test_proxyfix_trusts_exactly_the_configured_nginx_hop` |
 
 Short evidence for unknown-host rejection:
@@ -51,9 +51,13 @@ server {
 }
 ```
 
-Current gap: certificate issuance and renewal are deployment operations. The
-repo checks that expected certificate files exist before bootstrap, but it does
-not contain ACME account state, private keys, or a certbot renewal timer.
+Certificate issuance and renewal are host-managed deployment operations. ACME
+account state, certificate archives, and private keys remain on the EC2 host;
+they are never stored in Git or mounted into application containers. The
+read-only `ops/deploy/verify-certbot-host-state` verifier checks that Certbot
+is installed, the expected host files exist, and `certbot.timer` is enabled and
+active. Operators must also run `sudo certbot renew --dry-run` as the manual
+renewal test.
 
 ## 1.2 HTTPS Cipher Suites
 
@@ -93,13 +97,20 @@ Certbot-managed paths, for example:
 
 The private key is not committed to Git. `ops/deploy/bootstrap-container-ec2`
 checks that the expected key files are readable before installing the Nginx
-site. The application containers in `compose.prod.yml` and `compose.staging.yml`
-mount application secrets from `/run/secrets`, but they do not mount
-`/etc/letsencrypt`; only host Nginx needs the TLS private key.
+site, then invokes `ops/deploy/verify-certbot-host-state` before Nginx changes.
+The verifier resolves each `live/.../privkey.pem` symlink with `readlink -f` and
+checks the real target rather than the symlink mode. It requires a target below
+`/etc/letsencrypt`, `root:root` ownership, no group write permission, and no
+permissions for other users; `0600` is the normal mode. The application
+containers in `compose.prod.yml` and `compose.staging.yml` mount application
+secrets from `/run/secrets`, but they do not mount `/etc/letsencrypt`; only host
+Nginx needs the TLS private key.
 
-Current gap: the repo does not set or verify the final filesystem mode or owner
-of `/etc/letsencrypt/.../privkey.pem`. That remains a Certbot/host hardening
-responsibility.
+If a dedicated TLS-read group is ever necessary, it is a host-hardening change:
+document its membership and Nginx privilege model, explicitly add it to the
+verifier's reviewed allowlist, and use at most mode `0640`. Application users,
+repository-owned paths, container mounts, world-readable keys, group-writable
+keys, and world-writable keys are not acceptable.
 
 ## 1.4 Key Establishment And Secret Key Derivation
 

--- a/ops/deploy/bootstrap-container-ec2
+++ b/ops/deploy/bootstrap-container-ec2
@@ -92,6 +92,7 @@ linux_runtime_files=(
     "${repo_root}/ops/deploy/sitbank-container-deploy"
     "${repo_root}/ops/deploy/sitbank-container-runtime"
     "${repo_root}/ops/deploy/sitbank-database-cutover"
+    "${repo_root}/ops/deploy/verify-certbot-host-state"
     "${repo_root}/ops/nginx/sitbank-default.conf"
     "${repo_root}/ops/nginx/sitbank-tls-policy.conf"
     "${repo_root}/ops/sudoers/sitbank-container-deploy"
@@ -225,6 +226,9 @@ install -o root -g root -m 0755 \
 install -o root -g root -m 0755 \
     "${repo_root}/ops/deploy/sitbank-database-cutover" \
     /usr/local/sbin/sitbank-database-cutover
+install -o root -g root -m 0755 \
+    "${repo_root}/ops/deploy/verify-certbot-host-state" \
+    /usr/local/sbin/verify-certbot-host-state
 if [[ "${target}" == "staging" ]]; then
     install -d -o root -g root -m 0755 "${config_root}/postgres"
     install -o root -g root -m 0755 \
@@ -336,6 +340,7 @@ if [[ "${target}" == "production" ]]; then
             exit 1
         fi
     done
+    /usr/local/sbin/verify-certbot-host-state production
 
     nginx_conflict=0
     while IFS= read -r enabled_site; do
@@ -422,6 +427,7 @@ if [[ "${target}" == "staging" ]]; then
             exit 1
         fi
     done
+    /usr/local/sbin/verify-certbot-host-state staging
     if [[ "$(stat -c '%U:%G' -- "${STAGING_BASIC_AUTH_FILE}")" != "root:www-data" \
         || "$(stat -c '%a' -- "${STAGING_BASIC_AUTH_FILE}")" != "640" ]]; then
         echo "${STAGING_BASIC_AUTH_FILE} must be owned by root:www-data with mode 0640" >&2

--- a/ops/deploy/verify-certbot-host-state
+++ b/ops/deploy/verify-certbot-host-state
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# Verify host-managed Certbot state without changing certificates or permissions.
+set -Eeuo pipefail
+
+readonly LETSENCRYPT_ROOT="/etc/letsencrypt"
+readonly PRODUCTION_PUBLIC_HOST="sitbank.duckdns.org"
+readonly PRODUCTION_ADMIN_PUBLIC_HOST="admin-sitbank.duckdns.org"
+readonly STAGING_PUBLIC_HOST="staging-sitbank.duckdns.org"
+readonly -a APPROVED_TLS_KEY_GROUPS=(root)
+
+usage() {
+    echo "Usage: verify-certbot-host-state [production|staging]" >&2
+}
+
+if [[ "${EUID}" -ne 0 ]]; then
+    echo "Run this host verification as root, for example: sudo $0 production" >&2
+    exit 1
+fi
+
+target="${1:-}"
+if [[ "${target}" != "production" && "${target}" != "staging" ]]; then
+    usage
+    exit 2
+fi
+
+failures=0
+
+fail() {
+    echo "ERROR: $*" >&2
+    failures=1
+}
+
+verify_certbot() {
+    if ! command -v certbot >/dev/null 2>&1; then
+        fail "certbot is not installed"
+        return
+    fi
+    echo "OK: certbot is installed"
+}
+
+verify_renewal_timer() {
+    if ! command -v systemctl >/dev/null 2>&1; then
+        fail "systemctl is required to verify the host-managed certbot.timer"
+        return
+    fi
+    if ! systemctl cat certbot.timer >/dev/null 2>&1; then
+        fail "certbot.timer is not installed; configure and document an active Certbot renewal scheduler"
+        return
+    fi
+    if ! systemctl is-enabled --quiet certbot.timer; then
+        fail "certbot.timer is not enabled"
+    fi
+    if ! systemctl is-active --quiet certbot.timer; then
+        fail "certbot.timer is not active"
+    fi
+    if [[ "${failures}" -eq 0 ]]; then
+        echo "OK: certbot.timer is enabled and active"
+    fi
+}
+
+verify_certificate_file() {
+    local domain="$1"
+    local filename="$2"
+    local certificate_path="${LETSENCRYPT_ROOT}/live/${domain}/${filename}"
+    local resolved_path
+
+    if [[ ! -d "${LETSENCRYPT_ROOT}/live/${domain}" ]]; then
+        fail "missing expected certificate directory: ${LETSENCRYPT_ROOT}/live/${domain}"
+        return
+    fi
+    if [[ ! -e "${certificate_path}" || ! -f "${certificate_path}" ]]; then
+        fail "missing expected certificate file: ${certificate_path}"
+        return
+    fi
+    resolved_path="$(readlink -f -- "${certificate_path}" || true)"
+    if [[ -z "${resolved_path}" || ! -f "${resolved_path}" ]]; then
+        fail "certificate file does not resolve to a regular file: ${certificate_path}"
+        return
+    fi
+    # Certbot live paths normally resolve into /etc/letsencrypt/archive. Requiring
+    # that host-owned tree prevents repository-local or container-mounted material.
+    if [[ "${resolved_path}" != "${LETSENCRYPT_ROOT}/"* ]]; then
+        fail "certificate file resolves outside ${LETSENCRYPT_ROOT}: ${certificate_path}"
+        return
+    fi
+    echo "OK: ${certificate_path} resolves inside ${LETSENCRYPT_ROOT}"
+}
+
+is_approved_tls_key_group() {
+    local candidate_group="$1"
+    local approved_group
+
+    for approved_group in "${APPROVED_TLS_KEY_GROUPS[@]}"; do
+        if [[ "${candidate_group}" == "${approved_group}" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+verify_private_key() {
+    local domain="$1"
+    local key_path="${LETSENCRYPT_ROOT}/live/${domain}/privkey.pem"
+    local resolved_key_path
+    local owner
+    local group
+    local mode
+    local mode_value
+
+    if [[ ! -e "${key_path}" || ! -f "${key_path}" ]]; then
+        fail "missing expected private key: ${key_path}"
+        return
+    fi
+    resolved_key_path="$(readlink -f -- "${key_path}" || true)"
+    if [[ -z "${resolved_key_path}" || ! -f "${resolved_key_path}" ]]; then
+        fail "private key does not resolve to a regular file: ${key_path}"
+        return
+    fi
+    if [[ "${resolved_key_path}" != "${LETSENCRYPT_ROOT}/"* ]]; then
+        fail "private key resolves outside ${LETSENCRYPT_ROOT}: ${key_path}"
+        return
+    fi
+
+    owner="$(stat -c '%U' -- "${resolved_key_path}")"
+    group="$(stat -c '%G' -- "${resolved_key_path}")"
+    mode="$(stat -c '%a' -- "${resolved_key_path}")"
+    if [[ "${owner}" != "root" ]]; then
+        fail "private key must be owned by root: ${resolved_key_path} is owned by ${owner}"
+    fi
+    # This deployment uses host Nginx's privileged master process, so root is the
+    # only approved TLS-key group. Add a reviewed, dedicated TLS group to the
+    # explicit allowlist only when its membership and Nginx privilege model are documented.
+    if ! is_approved_tls_key_group "${group}"; then
+        fail "private key must be group-owned by an approved TLS group: ${resolved_key_path} is group-owned by ${group}"
+    fi
+    if [[ ! "${mode}" =~ ^[0-7]{3,4}$ ]]; then
+        fail "private key mode is not an octal mode: ${resolved_key_path} has ${mode}"
+        return
+    fi
+    mode_value=$((8#${mode}))
+    if (( (mode_value & 0007) != 0 )); then
+        fail "private key must not grant any permissions to other users (including world-readable or world-writable): ${resolved_key_path} has mode ${mode}"
+    fi
+    if (( (mode_value & 0022) != 0 )); then
+        fail "private key must not be group-writable or world-writable: ${resolved_key_path} has mode ${mode}"
+    fi
+    if (( (mode_value & 0010) != 0 )); then
+        fail "private key must not be group-executable: ${resolved_key_path} has mode ${mode}"
+    fi
+    if [[ "${failures}" -eq 0 ]]; then
+        echo "OK: ${key_path} resolves to root:root mode ${mode}"
+    fi
+}
+
+case "${target}" in
+    production)
+        domains=("${PRODUCTION_PUBLIC_HOST}" "${PRODUCTION_ADMIN_PUBLIC_HOST}")
+        ;;
+    staging)
+        domains=("${STAGING_PUBLIC_HOST}")
+        ;;
+esac
+
+verify_certbot
+verify_renewal_timer
+for domain in "${domains[@]}"; do
+    verify_certificate_file "${domain}" "fullchain.pem"
+    verify_private_key "${domain}"
+done
+
+if [[ "${failures}" -ne 0 ]]; then
+    echo "Certbot host-state verification failed for ${target}. No files were changed." >&2
+    exit 1
+fi
+
+echo "Certbot host-state verification passed for ${target}."
+echo "Manual renewal verification remains required: sudo certbot renew --dry-run"

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1947,6 +1947,7 @@ def test_linux_deployment_artifacts_are_forced_to_lf_and_reject_crlf():
         Path("ops/deploy/sitbank-container-deploy"),
         Path("ops/deploy/sitbank-container-runtime"),
         Path("ops/deploy/sitbank-database-cutover"),
+        Path("ops/deploy/verify-certbot-host-state"),
         Path("ops/nginx-proxy-headers.conf"),
         Path("ops/nginx/sitbank-default.conf"),
         Path("ops/nginx/sitbank-production.conf"),
@@ -1967,12 +1968,102 @@ def test_linux_deployment_artifacts_are_forced_to_lf_and_reject_crlf():
     assert "*.timer text eol=lf" in attributes
     assert "ops/deploy/bootstrap-container-ec2 text eol=lf" in attributes
     assert "ops/deploy/sitbank-container-bootstrap text eol=lf" in attributes
+    assert "ops/deploy/verify-certbot-host-state text eol=lf" in attributes
     assert "ops/sudoers/* text eol=lf" in attributes
     for path in linux_files:
         assert b"\r\n" not in path.read_bytes(), f"{path} must use LF line endings"
 
     assert "Refusing to install CRLF-formatted Linux file" in bootstrap
     assert "grep -q $'\\r$'" in bootstrap
+
+
+def test_certbot_host_state_verifier_enforces_host_managed_tls():
+    verifier_path = Path("ops/deploy/verify-certbot-host-state")
+    verifier = verifier_path.read_text(encoding="utf-8")
+    bootstrap = Path("ops/deploy/bootstrap-container-ec2").read_text(
+        encoding="utf-8"
+    )
+    production_nginx = Path("ops/nginx/sitbank-production.conf").read_text(
+        encoding="utf-8"
+    )
+    staging_nginx = Path("ops/nginx/sitbank-staging.conf").read_text(
+        encoding="utf-8"
+    )
+
+    assert verifier_path.exists()
+    assert verifier.startswith("#!/usr/bin/env bash\n")
+    assert 'LETSENCRYPT_ROOT="/etc/letsencrypt"' in verifier
+    assert 'PRODUCTION_PUBLIC_HOST="sitbank.duckdns.org"' in verifier
+    assert 'PRODUCTION_ADMIN_PUBLIC_HOST="admin-sitbank.duckdns.org"' in verifier
+    assert 'STAGING_PUBLIC_HOST="staging-sitbank.duckdns.org"' in verifier
+    assert 'readlink -f -- "${key_path}"' in verifier
+    assert "stat -c '%U'" in verifier
+    assert "stat -c '%G'" in verifier
+    assert "stat -c '%a'" in verifier
+    assert "world-readable or world-writable" in verifier
+    assert "group-writable or world-writable" in verifier
+    assert "mode_value & 0007" in verifier
+    assert "mode_value & 0022" in verifier
+    assert "certbot.timer" in verifier
+    assert "systemctl is-enabled --quiet certbot.timer" in verifier
+    assert "systemctl is-active --quiet certbot.timer" in verifier
+    assert "certbot renew --dry-run" in verifier
+    assert "chmod " not in verifier
+    assert "chown " not in verifier
+    assert "cat \"${key_path}\"" not in verifier
+
+    expected_key_paths = {
+        "/etc/letsencrypt/live/sitbank.duckdns.org/privkey.pem",
+        "/etc/letsencrypt/live/admin-sitbank.duckdns.org/privkey.pem",
+        "/etc/letsencrypt/live/staging-sitbank.duckdns.org/privkey.pem",
+    }
+    configured_key_paths = set(
+        re.findall(
+            r"^\s*ssl_certificate_key\s+([^;]+);$",
+            "\n".join([production_nginx, staging_nginx]),
+            flags=re.MULTILINE,
+        )
+    )
+    assert configured_key_paths == expected_key_paths
+    assert all(path.startswith("/etc/letsencrypt/live/") for path in configured_key_paths)
+    assert all("/opt/sitbank" not in path for path in configured_key_paths)
+
+    assert '"${repo_root}/ops/deploy/verify-certbot-host-state"' in bootstrap
+    assert "/usr/local/sbin/verify-certbot-host-state" in bootstrap
+    assert "/usr/local/sbin/verify-certbot-host-state production" in bootstrap
+    assert "/usr/local/sbin/verify-certbot-host-state staging" in bootstrap
+    assert "Missing required production TLS file" in bootstrap
+    assert "Missing required staging TLS file" in bootstrap
+
+
+def test_repository_keeps_acme_state_and_tls_private_keys_out_of_git():
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        check=True,
+        capture_output=True,
+    )
+    tracked_paths = [
+        Path(item.decode("utf-8")) for item in result.stdout.split(b"\0") if item
+    ]
+    forbidden_directories = (
+        Path(".well-known") / "acme-challenge",
+        Path("letsencrypt") / "accounts",
+        Path("letsencrypt") / "archive",
+        Path("letsencrypt") / "live",
+    )
+    private_key_marker = "-----BEGIN " + "PRIVATE KEY-----"
+
+    assert all(path.name != "privkey.pem" for path in tracked_paths)
+    for directory in forbidden_directories:
+        assert not any(path.is_relative_to(directory) for path in tracked_paths)
+    for path in tracked_paths:
+        if not path.is_file():
+            continue
+        try:
+            contents = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        assert private_key_marker not in contents, path
 
 
 def test_security_alert_scheduler_units_are_committed_and_safe():


### PR DESCRIPTION
## Summary

Implements host-managed TLS hardening for production and staging deployments.

This adds a read-only Certbot host-state preflight that verifies the host-managed TLS certificate setup before Nginx changes are applied.

## Why

TLS certificate state is managed on the host, not inside the application repository or container.

Deployment should fail early if Certbot, renewal timers, certificate symlinks, resolved private-key ownership, or permissions are unsafe or missing. This reduces the risk of deploying Nginx changes against broken or insecure TLS material.

## What changed

* Added executable preflight script:

  * `ops/deploy/verify-certbot-host-state`
* Added read-only production/staging checks for:

  * Certbot availability
  * Active Certbot renewal timer
  * Expected certificate paths
  * Resolved private-key ownership
  * Safe private-key permissions
* Updated bootstrap so it installs and runs the TLS host-state preflight before Nginx changes.
* Added deployment tests for TLS path safety.
* Added Git hygiene tests to ensure ACME state and private keys are not committed.
* Updated deployment documentation with:

  * Certificate issuance procedure
  * Renewal procedure
  * Symlink expectations
  * Permission requirements
* Updated security documentation for host-managed TLS handling.

## Security impact

This strengthens deployment-time TLS safety.

The preflight helps ensure production and staging only proceed when host-managed certificate state is present and safe. It checks that private-key material remains host-managed, has safe ownership/permissions, and is not accidentally introduced into the repository.

This does not add secrets to the repo and does not move TLS private keys into application-managed storage.

## Deployment impact

This PR requires:

* EC2 bootstrap
* staging deployment
* production deployment

This PR does not require:

* database migration
* secret changes

Operators should ensure Certbot is installed, renewal is active, certificate symlinks resolve correctly, and private-key permissions are safe before deployment.

## Verification

* `python -m pytest -q tests/test_deployment.py`

  * `47 passed`
* `git diff --check`
* `bash -n ops/deploy/verify-certbot-host-state`

## Notes

The TLS preflight is read-only and intended to validate host state before Nginx changes are applied.

Certificate issuance and renewal remain host-managed through Certbot.
