### PR TITLE
Gate production release on TLS evidence

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -813,17 +813,29 @@ jobs:
             "runtime-staging-${RELEASE_SHA}.sigstore.json" \
             "registry-staging-${RELEASE_SHA}.credentials"
 
+  verify-staging-tls:
+    if: >-
+      always() &&
+      needs.deploy-staging.result == 'success'
+    needs: deploy-staging
+    uses: ./.github/workflows/tls-scan.yml
+    with:
+      scan_scope: staging
+      staging_host: ${{ vars.STAGING_PUBLIC_HOST }}
+
   deploy-production:
     if: >-
       always() &&
       needs.release-verify.result == 'success' &&
       needs.deploy-staging.result == 'success' &&
+      needs.verify-staging-tls.result == 'success' &&
       github.event_name == 'push' &&
       github.ref == 'refs/heads/main' &&
       vars.PROD_DEPLOY_ENABLED == 'true'
     needs:
       - release-verify
       - deploy-staging
+      - verify-staging-tls
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -1010,3 +1022,13 @@ jobs:
             "runtime-${RELEASE_SHA}.sha256" \
             "runtime-${RELEASE_SHA}.sigstore.json" \
             "registry-${RELEASE_SHA}.credentials"
+
+  verify-production-tls:
+    if: >-
+      always() &&
+      needs.deploy-production.result == 'success'
+    needs: deploy-production
+    uses: ./.github/workflows/tls-scan.yml
+    with:
+      scan_scope: production
+      production_host: ${{ vars.PROD_PUBLIC_HOST }}

--- a/.github/workflows/tls-scan.yml
+++ b/.github/workflows/tls-scan.yml
@@ -1,8 +1,39 @@
 name: Live TLS scan evidence
 
 on:
+  workflow_call:
+    inputs:
+      scan_scope:
+        description: "Set of deployed endpoints to scan: all, staging, or production."
+        required: false
+        default: all
+        type: string
+      staging_host:
+        description: Staging HTTPS hostname to scan (hostname only).
+        required: false
+        default: staging-sitbank.duckdns.org
+        type: string
+      production_host:
+        description: Production customer HTTPS hostname to scan (hostname only).
+        required: false
+        default: sitbank.duckdns.org
+        type: string
+      admin_host:
+        description: Production admin HTTPS hostname to scan (hostname only).
+        required: false
+        default: admin-sitbank.duckdns.org
+        type: string
   workflow_dispatch:
     inputs:
+      scan_scope:
+        description: Set of endpoints to scan.
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - staging
+          - production
       staging_host:
         description: Staging HTTPS hostname to scan (hostname only).
         required: true
@@ -29,24 +60,48 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  resolve-targets:
+    name: Select TLS scan targets
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.select.outputs.matrix }}
+    steps:
+      - name: Select requested endpoints
+        id: select
+        shell: bash
+        env:
+          SCAN_SCOPE: ${{ inputs.scan_scope || 'all' }}
+        run: |
+          set -euo pipefail
+
+          case "${SCAN_SCOPE}" in
+            all)
+              targets='[{"label":"staging-sitbank","input":"staging","artifact":"tls-scan-staging-sitbank"},{"label":"prod-sitbank","input":"production","artifact":"tls-scan-prod-sitbank"},{"label":"admin-sitbank","input":"admin","artifact":"tls-scan-admin-sitbank"}]'
+              ;;
+            staging)
+              targets='[{"label":"staging-sitbank","input":"staging","artifact":"tls-scan-staging-sitbank"}]'
+              ;;
+            production)
+              targets='[{"label":"prod-sitbank","input":"production","artifact":"tls-scan-prod-sitbank"},{"label":"admin-sitbank","input":"admin","artifact":"tls-scan-admin-sitbank"}]'
+              ;;
+            *)
+              echo "::error::scan_scope must be all, staging, or production."
+              exit 1
+              ;;
+          esac
+
+          echo "matrix={\"target\":${targets}}" >> "${GITHUB_OUTPUT}"
+
   scan:
     name: Scan ${{ matrix.target.label }}
+    needs: resolve-targets
     runs-on: ubuntu-24.04
     timeout-minutes: 35
     strategy:
       fail-fast: false
       max-parallel: 3
-      matrix:
-        target:
-          - label: staging-sitbank
-            input: staging
-            artifact: tls-scan-staging-sitbank
-          - label: prod-sitbank
-            input: production
-            artifact: tls-scan-prod-sitbank
-          - label: admin-sitbank
-            input: admin
-            artifact: tls-scan-admin-sitbank
+      matrix: ${{ fromJSON(needs.resolve-targets.outputs.matrix) }}
     env:
       STAGING_HOST: ${{ inputs.staging_host || 'staging-sitbank.duckdns.org' }}
       PRODUCTION_HOST: ${{ inputs.production_host || 'sitbank.duckdns.org' }}

--- a/.github/workflows/tls-scan.yml
+++ b/.github/workflows/tls-scan.yml
@@ -1,0 +1,192 @@
+name: Live TLS scan evidence
+
+on:
+  workflow_dispatch:
+    inputs:
+      staging_host:
+        description: Staging HTTPS hostname to scan (hostname only).
+        required: true
+        default: staging-sitbank.duckdns.org
+        type: string
+      production_host:
+        description: Production customer HTTPS hostname to scan (hostname only).
+        required: true
+        default: sitbank.duckdns.org
+        type: string
+      admin_host:
+        description: Production admin HTTPS hostname to scan (hostname only).
+        required: true
+        default: admin-sitbank.duckdns.org
+        type: string
+  schedule:
+    # Weekly evidence collection. Manual runs should also follow every edge/TLS deployment.
+    - cron: "23 3 * * 1"
+
+permissions: {}
+
+concurrency:
+  group: live-tls-scan
+  cancel-in-progress: false
+
+jobs:
+  scan:
+    name: Scan ${{ matrix.target.label }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        target:
+          - label: staging-sitbank
+            input: staging
+            artifact: tls-scan-staging-sitbank
+          - label: prod-sitbank
+            input: production
+            artifact: tls-scan-prod-sitbank
+          - label: admin-sitbank
+            input: admin
+            artifact: tls-scan-admin-sitbank
+    env:
+      STAGING_HOST: ${{ inputs.staging_host || 'staging-sitbank.duckdns.org' }}
+      PRODUCTION_HOST: ${{ inputs.production_host || 'sitbank.duckdns.org' }}
+      ADMIN_HOST: ${{ inputs.admin_host || 'admin-sitbank.duckdns.org' }}
+      TARGET_INPUT: ${{ matrix.target.input }}
+      TARGET_LABEL: ${{ matrix.target.label }}
+
+    steps:
+      - name: Download verified testssl.sh
+        shell: bash
+        run: |
+          set -euo pipefail
+          readonly version="3.2.3"
+          readonly commit="d2d9d2a04120033a7d1e01e52d9b409168544cc6"
+          readonly archive="${RUNNER_TEMP}/testssl.sh-${commit}.tar.gz"
+          readonly expected_sha256="d35d2454e2a86d1748381602fcc51783f79bf70263cd17f1b8030da49dfc0ef6"
+          readonly install_dir="${RUNNER_TEMP}/testssl.sh-${commit}"
+
+          curl --fail --location --retry 3 --proto '=https' --tlsv1.2 \
+            --output "${archive}" \
+            "https://github.com/testssl/testssl.sh/archive/${commit}.tar.gz"
+          printf '%s  %s\n' "${expected_sha256}" "${archive}" \
+            | sha256sum --check --strict
+          mkdir --parents "${install_dir}"
+          tar --extract --gzip --file "${archive}" \
+            --directory "${install_dir}" --strip-components=1
+          test -x "${install_dir}/testssl.sh"
+
+      - name: Scan live TLS endpoint and enforce policy
+        id: scan
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          case "${TARGET_INPUT}" in
+            staging) target_host="${STAGING_HOST}" ;;
+            production) target_host="${PRODUCTION_HOST}" ;;
+            admin) target_host="${ADMIN_HOST}" ;;
+            *)
+              echo "::error::Unknown TLS scan target '${TARGET_INPUT}'."
+              exit 1
+              ;;
+          esac
+
+          if [[ ! "${target_host}" =~ ^[A-Za-z0-9]([A-Za-z0-9.-]{0,251}[A-Za-z0-9])?$ ]]; then
+            echo "::error::TLS scan target must be a hostname, not a URL or command fragment."
+            exit 1
+          fi
+
+          readonly target_url="https://${target_host}"
+          readonly evidence_dir="tls-scan/${TARGET_LABEL}"
+          readonly json_file="${evidence_dir}/testssl.json"
+          readonly log_file="${evidence_dir}/testssl.log"
+          readonly html_file="${evidence_dir}/testssl.html"
+          readonly violations_file="${evidence_dir}/policy-violations.txt"
+          readonly metadata_file="${evidence_dir}/metadata.txt"
+          readonly started_at="$(date --utc --iso-8601=seconds)"
+          scan_failed=0
+
+          mkdir --parents "${evidence_dir}"
+          {
+            echo "scan_time_utc=${started_at}"
+            echo "target_host=${target_host}"
+            echo "target_url=${target_url}"
+            echo "workflow_run_id=${GITHUB_RUN_ID}"
+            echo "workflow_run_attempt=${GITHUB_RUN_ATTEMPT}"
+            echo "workflow_sha=${GITHUB_SHA}"
+            echo "testssl_version=3.2.3"
+            echo "testssl_commit=d2d9d2a04120033a7d1e01e52d9b409168544cc6"
+          } > "${metadata_file}"
+
+          if ! TERM_WIDTH=120 bash "${RUNNER_TEMP}/testssl.sh-d2d9d2a04120033a7d1e01e52d9b409168544cc6/testssl.sh" \
+            --quiet --warnings batch --color 0 \
+            --jsonfile "${json_file}" --logfile "${log_file}" --htmlfile "${html_file}" \
+            "${target_url}"; then
+            scan_failed=1
+            echo "testssl.sh did not complete successfully." > "${violations_file}"
+          fi
+
+          if [[ ! -s "${json_file}" ]] || ! jq empty "${json_file}" >/dev/null 2>&1; then
+            scan_failed=1
+            echo "testssl.sh did not produce valid JSON evidence." >> "${violations_file}"
+          else
+            jq -r '
+              def id: (.id // "");
+              def finding: (.finding // "");
+              def offered:
+                (finding | test("offered|enabled"; "i")) and
+                ((finding | test("not offered|not enabled"; "i")) | not);
+              def severe: (.severity // "") | IN("HIGH"; "CRITICAL"; "FATAL");
+              select(
+                severe
+                or ((id == "SSLv2" or id == "SSLv3" or id == "TLS1" or id == "TLS1_1") and offered)
+                or ((id | test("^cipherlist_(NULL|aNULL|EXPORT|LOW|OBSOLETED|3DES|RC4)")) and ((finding | test("^not offered$"; "i")) | not))
+                or (id == "RC4" and ((finding | test("not vulnerable"; "i")) | not))
+                or (id == "cert_expirationStatus" and (finding | test("^expired"; "i")))
+                or (id == "cert_trust" and (finding | test("does not match supplied uri|hostname mismatch"; "i")))
+                or (id == "cert_chain_of_trust" and (finding | test("not trusted|untrusted|incomplete|missing"; "i")))
+              )
+              | "[\(.severity // "UNKNOWN")] \(id): \(finding)"
+            ' "${json_file}" > "${violations_file}"
+
+            if [[ -s "${violations_file}" ]]; then
+              scan_failed=1
+            fi
+          fi
+
+          {
+            echo "## Live TLS scan - ${target_host}"
+            echo
+            echo "- Scan time (UTC): \`${started_at}\`"
+            echo "- Target: \`${target_url}\`"
+            echo "- Workflow run: [${GITHUB_RUN_ID}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}) (attempt ${GITHUB_RUN_ATTEMPT})"
+            echo "- Scanner: \`testssl.sh 3.2.3\` at \`d2d9d2a04120033a7d1e01e52d9b409168544cc6\`"
+            echo
+            if [[ "${scan_failed}" -eq 0 ]]; then
+              echo "Result: **passed** - no policy violations found."
+            else
+              echo "Result: **failed** - policy violations or a scan error were recorded."
+              echo
+              echo "### Findings that fail verification"
+              echo
+              echo '```text'
+              sed -n '1,100p' "${violations_file}"
+              echo '```'
+            fi
+            echo
+            echo "JSON, log, HTML, metadata, and policy findings are retained in the \`${TARGET_LABEL}\` artifact."
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          if [[ "${scan_failed}" -ne 0 ]]; then
+            echo "::error::Live TLS verification failed for ${target_host}; see uploaded evidence."
+            exit 1
+          fi
+
+      - name: Upload TLS scan evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: ${{ matrix.target.artifact }}
+          path: tls-scan/${{ matrix.target.label }}
+          if-no-files-found: warn
+          retention-days: 90

--- a/.github/workflows/tls-scan.yml
+++ b/.github/workflows/tls-scan.yml
@@ -114,7 +114,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          readonly version="3.2.3"
           readonly commit="d2d9d2a04120033a7d1e01e52d9b409168544cc6"
           readonly archive="${RUNNER_TEMP}/testssl.sh-${commit}.tar.gz"
           readonly expected_sha256="d35d2454e2a86d1748381602fcc51783f79bf70263cd17f1b8030da49dfc0ef6"
@@ -158,7 +157,8 @@ jobs:
           readonly html_file="${evidence_dir}/testssl.html"
           readonly violations_file="${evidence_dir}/policy-violations.txt"
           readonly metadata_file="${evidence_dir}/metadata.txt"
-          readonly started_at="$(date --utc --iso-8601=seconds)"
+          started_at="$(date --utc --iso-8601=seconds)"
+          readonly started_at
           scan_failed=0
 
           mkdir --parents "${evidence_dir}"

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -49,9 +49,10 @@ Deploy the signed image through the restricted wrapper so it runs
 `verify-runtime-db-privileges`, and readiness checks before declaring success.
 
 Production deployment runs from the trusted `main` workflow only after release
-verification and staging deployment both succeed. Leave the repository variable
-`PROD_DEPLOY_ENABLED` unset or false until the production admin secret files and
-matching `PROD_ADMIN_SESSION_HMAC_ACTIVE_KEY_ID` are ready; when the flag is not
+verification, staging deployment, and the post-deployment staging TLS scan all
+succeed. Leave the repository variable `PROD_DEPLOY_ENABLED` unset or false
+until the production admin secret files and matching
+`PROD_ADMIN_SESSION_HMAC_ACTIVE_KEY_ID` are ready; when the flag is not
 explicitly true, production deployment is skipped.
 
 Production also requires a DNS record for `admin-sitbank.duckdns.org` pointing
@@ -116,11 +117,16 @@ configuration decide what Internet clients are actually offered. The **Live TLS
 scan evidence** GitHub Actions workflow records that external evidence with the
 checksum-verified `testssl.sh` 3.2.3 source release.
 
-The workflow runs weekly and can be started manually from the Actions tab. Run
-it after every Nginx, certificate, DNS, load-balancer, CDN/WAF, or host TLS
-change, and attach the successful workflow run to the staging or production
-release record. It deliberately does not run on pull requests: PRs do not
-create a separate public TLS endpoint.
+The workflow runs weekly, can be started manually from the Actions tab, and is
+called by the trusted deployment workflow. After a successful staging deploy it
+scans the staging customer endpoint; production deployment is blocked until
+that evidence passes. After a successful production deploy it scans both the
+production customer and admin endpoints, making the resulting artifacts the
+release's live TLS evidence. A production scan failure marks the deployment
+workflow failed and requires investigation before the release is accepted. Run
+the workflow manually after Nginx, certificate, DNS, load-balancer, CDN/WAF,
+or host TLS changes outside the normal deployment path. It deliberately does
+not run on pull requests: PRs do not create a separate public TLS endpoint.
 
 By default it scans these hostname-only targets, which can be overridden as
 manual workflow inputs when an approved endpoint changes:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -108,6 +108,61 @@ The Flask application and its containers do not issue certificates and do not
 mount or read TLS private keys. Normal deployment must never generate or
 overwrite a private key.
 
+## Live TLS Scan Evidence
+
+The host configuration is necessary but not sufficient evidence of the public
+TLS posture: the deployed certificate chain, Nginx/OpenSSL build, DNS, and edge
+configuration decide what Internet clients are actually offered. The **Live TLS
+scan evidence** GitHub Actions workflow records that external evidence with the
+checksum-verified `testssl.sh` 3.2.3 source release.
+
+The workflow runs weekly and can be started manually from the Actions tab. Run
+it after every Nginx, certificate, DNS, load-balancer, CDN/WAF, or host TLS
+change, and attach the successful workflow run to the staging or production
+release record. It deliberately does not run on pull requests: PRs do not
+create a separate public TLS endpoint.
+
+By default it scans these hostname-only targets, which can be overridden as
+manual workflow inputs when an approved endpoint changes:
+
+| Environment | Workflow input | Default target | Artifact |
+| --- | --- | --- | --- |
+| Staging customer | `staging_host` | `https://staging-sitbank.duckdns.org` | `tls-scan-staging-sitbank` |
+| Production customer | `production_host` | `https://sitbank.duckdns.org` | `tls-scan-prod-sitbank` |
+| Production admin | `admin_host` | `https://admin-sitbank.duckdns.org` | `tls-scan-admin-sitbank` |
+
+Each target produces JSON, text log, HTML, scan metadata, and a policy-finding
+file. They are retained as GitHub Actions artifacts for 90 days. The target job
+summary identifies the UTC scan time, host, run ID/attempt, scanner version,
+and pass/fail result. TLS scanning uses no application credentials and the
+workflow contains no application secrets.
+
+The verification gate fails for SSLv2, SSLv3, TLS 1.0, or TLS 1.1; weak, NULL,
+anonymous, export, RC4, or 3DES ciphers; expired certificates; hostname
+mismatches; untrusted, incomplete, or missing certificate chains; any
+`testssl.sh` HIGH, CRITICAL, or FATAL finding; and scan/JSON-generation errors.
+MEDIUM/LOW/INFO findings remain in the evidence and require operator review;
+they are not an automatic release block unless they match one of the explicit
+prohibited classes above.
+
+For a host-side/manual check, use the same full scan (do not use `-k` or supply
+application credentials):
+
+```bash
+testssl.sh --warnings batch --color 0 --jsonfile testssl.json \
+  --logfile testssl.log --htmlfile testssl.html \
+  https://staging-sitbank.duckdns.org
+testssl.sh --warnings batch --color 0 https://sitbank.duckdns.org
+testssl.sh --warnings batch --color 0 https://admin-sitbank.duckdns.org
+```
+
+SSL Labs remains optional, manual corroborating evidence. Use its public
+report when an independently rendered assessment is useful for a release,
+certificate renewal, CDN/WAF change, or incident record; retain a link or
+screenshot with the release evidence. Production deployment must not depend on
+SSL Labs automation because public API capacity and rate limits are external to
+this repository.
+
 Before first bootstrap, issue the certificates using the approved host Certbot
 flow. The bootstrap retains its certificate-file preflight and installs
 `ops/deploy/verify-certbot-host-state` as
@@ -243,13 +298,13 @@ curl -k -I -u "$STAGING_BASIC_AUTH_USER:$STAGING_BASIC_AUTH_PASSWORD" \
 curl -k -I https://staging-sitbank.duckdns.org/health/ready
 curl -fsS http://127.0.0.1:5001/health/ready
 sudo nginx -T | grep -E 'ssl_protocols|ssl_ciphers|ssl_ecdh_curve|ssl_conf_command|ssl_session_tickets'
-testssl.sh --fast --parallel https://staging-sitbank.duckdns.org
+testssl.sh --warnings batch --color 0 https://staging-sitbank.duckdns.org
 ```
 
 Expected: unauthenticated `/` returns `401`, authenticated `/` returns `200`, external `/health/ready` returns `403`, and local app readiness succeeds.
 
 After the staging TLS check passes, validate both production HTTPS hostnames
-with `testssl.sh --fast --parallel https://sitbank.duckdns.org` and
-`testssl.sh --fast --parallel https://admin-sitbank.duckdns.org`. The
+with `testssl.sh --warnings batch --color 0 https://sitbank.duckdns.org` and
+`testssl.sh --warnings batch --color 0 https://admin-sitbank.duckdns.org`. The
 `ssl_conf_command` TLS 1.3 setting is runtime-dependent, so `nginx -t` must
 pass on the deployed host before any reload.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -172,6 +172,31 @@ anchor mismatch; database table regression; failed deployments; signature or
 revision mismatches; unexpected image digests; and changes to root-managed
 secret files.
 
+## Live TLS Evidence Operations
+
+The **Live TLS scan evidence** workflow provides scheduled weekly and
+operator-dispatched evidence of the Internet-facing TLS posture for
+`staging-sitbank.duckdns.org`, `sitbank.duckdns.org`, and
+`admin-sitbank.duckdns.org`. Dispatch it after edge, certificate, DNS,
+Nginx/OpenSSL, CDN/WAF, or load-balancer changes, then retain the successful
+run with the release or change record. Do not run a public-endpoint scan from
+ordinary pull requests.
+
+Each target artifact (`tls-scan-staging-sitbank`, `tls-scan-prod-sitbank`, or
+`tls-scan-admin-sitbank`) retains `testssl.sh` JSON, log, HTML, metadata, and
+the policy-finding file for 90 days. The job summary records the target, UTC
+scan time, GitHub run, scanner revision, and result. No application credentials
+or secrets are needed or permitted.
+
+Treat a failed scan as a release/deployment verification failure. The automated
+gate blocks legacy TLS protocols, weak/NULL/anonymous/export/RC4/3DES ciphers,
+expired or mismatched certificates, missing/untrusted chains, all HIGH,
+CRITICAL, or FATAL `testssl.sh` findings, and scanner errors. Review
+MEDIUM/LOW/INFO results in the retained evidence and create a security change
+or explicit risk decision where appropriate. SSL Labs is an optional manual
+second opinion; save its public report link or screenshot with the change
+record, but do not make a production release depend on its API.
+
 ## Password Reset Operations
 
 Customer password reset is customer-domain only. Admin account recovery is not

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -174,13 +174,17 @@ secret files.
 
 ## Live TLS Evidence Operations
 
-The **Live TLS scan evidence** workflow provides scheduled weekly and
-operator-dispatched evidence of the Internet-facing TLS posture for
+The **Live TLS scan evidence** workflow provides scheduled weekly,
+operator-dispatched, and post-deployment evidence of the Internet-facing TLS
+posture for
 `staging-sitbank.duckdns.org`, `sitbank.duckdns.org`, and
-`admin-sitbank.duckdns.org`. Dispatch it after edge, certificate, DNS,
-Nginx/OpenSSL, CDN/WAF, or load-balancer changes, then retain the successful
-run with the release or change record. Do not run a public-endpoint scan from
-ordinary pull requests.
+`admin-sitbank.duckdns.org`. The deployment workflow calls the staging scan
+after staging deploy and blocks production deployment until it passes; it calls
+the production scan after production deploy to complete the release evidence.
+Dispatch it after edge, certificate, DNS, Nginx/OpenSSL, CDN/WAF, or
+load-balancer changes outside deployment, then retain the successful run with
+the release or change record. Do not run a public-endpoint scan from ordinary
+pull requests.
 
 Each target artifact (`tls-scan-staging-sitbank`, `tls-scan-prod-sitbank`, or
 `tls-scan-admin-sitbank`) retains `testssl.sh` JSON, log, HTML, metadata, and
@@ -188,10 +192,12 @@ the policy-finding file for 90 days. The job summary records the target, UTC
 scan time, GitHub run, scanner revision, and result. No application credentials
 or secrets are needed or permitted.
 
-Treat a failed scan as a release/deployment verification failure. The automated
-gate blocks legacy TLS protocols, weak/NULL/anonymous/export/RC4/3DES ciphers,
-expired or mismatched certificates, missing/untrusted chains, all HIGH,
-CRITICAL, or FATAL `testssl.sh` findings, and scanner errors. Review
+Treat a failed scan as a release/deployment verification failure. A failed
+staging scan blocks production deployment, while a failed production scan
+marks the completed deployment workflow failed. The automated gate blocks
+legacy TLS protocols, weak/NULL/anonymous/export/RC4/3DES ciphers, expired or
+mismatched certificates, missing/untrusted chains, all HIGH, CRITICAL, or FATAL
+`testssl.sh` findings, and scanner errors. Review
 MEDIUM/LOW/INFO results in the retained evidence and create a security change
 or explicit risk decision where appropriate. SSL Labs is an optional manual
 second opinion; save its public report link or screenshot with the change

--- a/docs/security/cryptography-and-authentication.md
+++ b/docs/security/cryptography-and-authentication.md
@@ -84,6 +84,23 @@ Session tickets remain disabled to reduce long-lived ticket-key exposure.
 must run `nginx -t` and inspect the loaded configuration on the target host
 before reload, then validate the externally offered suites after deployment.
 
+The `.github/workflows/tls-scan.yml` **Live TLS scan evidence** workflow is
+the primary automated external validation. It runs weekly and can be manually
+dispatched after a TLS-relevant deployment or infrastructure change. It scans
+`staging-sitbank.duckdns.org`, `sitbank.duckdns.org`, and
+`admin-sitbank.duckdns.org` with a checksum-verified `testssl.sh` release,
+retaining JSON, log, HTML, metadata, and policy findings as per-target GitHub
+Actions artifacts. The job summary records the UTC time, target, workflow run,
+and result. It intentionally does not run on ordinary pull requests because
+they do not create public TLS endpoints.
+
+Verification fails for SSLv2/SSLv3/TLS 1.0/TLS 1.1, weak/NULL/anonymous/export/
+RC4/3DES cipher classes, expired certificates, hostname mismatches, untrusted or
+incomplete chains, and every HIGH, CRITICAL, or FATAL `testssl.sh` finding.
+MEDIUM/LOW/INFO findings are retained for manual review. SSL Labs is optional
+manual corroboration for a release, certificate renewal, edge change, or
+incident record; it is not a release-blocking automation dependency.
+
 ## 1.3 Server Private Key Storage
 
 The TLS private key is expected to exist only on the deployment host under

--- a/docs/security/cryptography-and-authentication.md
+++ b/docs/security/cryptography-and-authentication.md
@@ -85,14 +85,17 @@ must run `nginx -t` and inspect the loaded configuration on the target host
 before reload, then validate the externally offered suites after deployment.
 
 The `.github/workflows/tls-scan.yml` **Live TLS scan evidence** workflow is
-the primary automated external validation. It runs weekly and can be manually
-dispatched after a TLS-relevant deployment or infrastructure change. It scans
-`staging-sitbank.duckdns.org`, `sitbank.duckdns.org`, and
-`admin-sitbank.duckdns.org` with a checksum-verified `testssl.sh` release,
-retaining JSON, log, HTML, metadata, and policy findings as per-target GitHub
-Actions artifacts. The job summary records the UTC time, target, workflow run,
-and result. It intentionally does not run on ordinary pull requests because
-they do not create public TLS endpoints.
+the primary automated external validation. It runs weekly, can be manually
+dispatched after a TLS-relevant infrastructure change, and is called from the
+trusted deployment workflow. It verifies staging immediately after staging
+deploy (and blocks production deployment until that verification passes), then
+verifies both production endpoints after production deploy to complete the
+release evidence. It scans `staging-sitbank.duckdns.org`,
+`sitbank.duckdns.org`, and `admin-sitbank.duckdns.org` with a checksum-verified
+`testssl.sh` release, retaining JSON, log, HTML, metadata, and policy findings
+as per-target GitHub Actions artifacts. The job summary records the UTC time,
+target, workflow run, and result. It intentionally does not run on ordinary
+pull requests because they do not create public TLS endpoints.
 
 Verification fails for SSLv2/SSLv3/TLS 1.0/TLS 1.1, weak/NULL/anonymous/export/
 RC4/3DES cipher classes, expired certificates, hostname mismatches, untrusted or

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1920,6 +1920,88 @@ def test_every_github_action_is_pinned_to_a_full_commit_sha():
     assert "pull_request_target:" not in workflow_text
 
 
+def test_live_tls_scan_workflow_collects_evidence_without_running_on_pull_requests():
+    workflow_path = Path(".github/workflows/tls-scan.yml")
+    workflow_text = workflow_path.read_text(encoding="utf-8")
+    workflow = yaml.safe_load(workflow_text)
+    triggers = workflow[True]
+
+    assert workflow["name"] == "Live TLS scan evidence"
+    assert set(triggers) == {"workflow_dispatch", "schedule"}
+    assert "pull_request" not in workflow_text
+    assert workflow["permissions"] == {}
+    assert workflow["concurrency"] == {
+        "group": "live-tls-scan",
+        "cancel-in-progress": False,
+    }
+
+    inputs = triggers["workflow_dispatch"]["inputs"]
+    assert inputs["staging_host"]["default"] == "staging-sitbank.duckdns.org"
+    assert inputs["production_host"]["default"] == "sitbank.duckdns.org"
+    assert inputs["admin_host"]["default"] == "admin-sitbank.duckdns.org"
+
+    scan = workflow["jobs"]["scan"]
+    assert scan["timeout-minutes"] == 35
+    assert scan["strategy"]["fail-fast"] is False
+    assert scan["strategy"]["max-parallel"] == 3
+    targets = scan["strategy"]["matrix"]["target"]
+    assert targets == [
+        {
+            "label": "staging-sitbank",
+            "input": "staging",
+            "artifact": "tls-scan-staging-sitbank",
+        },
+        {
+            "label": "prod-sitbank",
+            "input": "production",
+            "artifact": "tls-scan-prod-sitbank",
+        },
+        {
+            "label": "admin-sitbank",
+            "input": "admin",
+            "artifact": "tls-scan-admin-sitbank",
+        },
+    ]
+    assert "testssl.sh/archive/${commit}.tar.gz" in workflow_text
+    assert 'readonly commit="d2d9d2a04120033a7d1e01e52d9b409168544cc6"' in workflow_text
+    assert "d35d2454e2a86d1748381602fcc51783f79bf70263cd17f1b8030da49dfc0ef6" in workflow_text
+    assert "sha256sum --check --strict" in workflow_text
+    assert "--jsonfile" in workflow_text
+    assert "--logfile" in workflow_text
+    assert "--htmlfile" in workflow_text
+    assert "GITHUB_STEP_SUMMARY" in workflow_text
+    assert "TLS1_1" in workflow_text
+    assert "cipherlist_(NULL|aNULL|EXPORT|LOW|OBSOLETED|3DES|RC4)" in workflow_text
+    assert "cert_expirationStatus" in workflow_text
+    assert "cert_trust" in workflow_text
+    assert "cert_chain_of_trust" in workflow_text
+    assert "IN(\"HIGH\"; \"CRITICAL\"; \"FATAL\")" in workflow_text
+    assert "secrets." not in workflow_text
+
+    uses = _workflow_uses(workflow_text)
+    assert uses == [
+        "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
+    ]
+    _assert_pinned_actions(uses, context="Live TLS scan workflow")
+
+    deployment_docs = Path("docs/DEPLOYMENT.md").read_text(encoding="utf-8")
+    operations_docs = Path("docs/OPERATIONS.md").read_text(encoding="utf-8")
+    crypto_docs = Path("docs/security/cryptography-and-authentication.md").read_text(
+        encoding="utf-8"
+    )
+    for docs in (deployment_docs, operations_docs, crypto_docs):
+        assert "live tls scan evidence" in docs.lower()
+        assert "staging-sitbank.duckdns.org" in docs
+        assert "sitbank.duckdns.org" in docs
+        assert "admin-sitbank.duckdns.org" in docs
+        assert "SSL Labs" in docs
+        assert re.search(r"HIGH,\s+CRITICAL,\s+or FATAL", docs)
+    assert "testssl.sh --warnings batch --color 0" in deployment_docs
+    assert "tls-scan-staging-sitbank" in deployment_docs
+    assert "tls-scan-prod-sitbank" in deployment_docs
+    assert "tls-scan-admin-sitbank" in deployment_docs
+
+
 def test_only_sitbank_container_deployment_units_are_active():
     assert not Path("ops/deploy/bootstrap-ec2").exists()
     assert Path("ops/deploy/sitbank-container-bootstrap").exists()

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -279,6 +279,11 @@ def _workflow_uses(workflow_text: str) -> list[str]:
 def _assert_pinned_actions(actions: list[str], *, context: str) -> None:
     assert actions, f"{context} must use at least one pinned action"
     for action in actions:
+        if action.startswith("./.github/workflows/"):
+            assert action.endswith(".yml"), (
+                f"{context} has an invalid local reusable workflow reference: {action}"
+            )
+            continue
         assert ACTION_USES_PIN_RE.fullmatch(action), f"{context} is not pinned: {action}"
 
 
@@ -1240,7 +1245,9 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
         "publish",
         "release-verify",
         "deploy-staging",
+        "verify-staging-tls",
         "deploy-production",
+        "verify-production-tls",
     }
     assert workflow["permissions"] == {}
     assert workflow["jobs"]["workflow-security"]["permissions"]["contents"] == "read"
@@ -1405,11 +1412,31 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     assert "vars.PROD_DEPLOY_ENABLED == 'true'" in production_condition
     assert "needs.release-verify.result == 'success'" in production_condition
     assert "needs.deploy-staging.result == 'success'" in production_condition
+    assert "needs.verify-staging-tls.result == 'success'" in production_condition
     assert "vars.STAGING_DEPLOY_ENABLED != 'true'" not in production_condition
     assert workflow["jobs"]["deploy-production"]["needs"] == [
         "release-verify",
         "deploy-staging",
+        "verify-staging-tls",
     ]
+    staging_tls = workflow["jobs"]["verify-staging-tls"]
+    production_tls = workflow["jobs"]["verify-production-tls"]
+    assert staging_tls["uses"] == "./.github/workflows/tls-scan.yml"
+    assert staging_tls["needs"] == "deploy-staging"
+    assert "always()" in staging_tls["if"]
+    assert "needs.deploy-staging.result == 'success'" in staging_tls["if"]
+    assert staging_tls["with"] == {
+        "scan_scope": "staging",
+        "staging_host": "${{ vars.STAGING_PUBLIC_HOST }}",
+    }
+    assert production_tls["uses"] == "./.github/workflows/tls-scan.yml"
+    assert production_tls["needs"] == "deploy-production"
+    assert "always()" in production_tls["if"]
+    assert "needs.deploy-production.result == 'success'" in production_tls["if"]
+    assert production_tls["with"] == {
+        "scan_scope": "production",
+        "production_host": "${{ vars.PROD_PUBLIC_HOST }}",
+    }
     staging_deploy_env = workflow["jobs"]["deploy-staging"]["env"]
     production_deploy_env = workflow["jobs"]["deploy-production"]["env"]
     assert not any(name.startswith("PROD_") for name in staging_deploy_env)
@@ -1485,7 +1512,10 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     )
     assert "schedule" in workflow[True]
     assert "github.event_name == 'schedule'" not in workflow["jobs"]["publish"]["if"]
-    assert all(job["timeout-minutes"] > 0 for job in workflow["jobs"].values())
+    assert all(
+        "uses" in job or job["timeout-minutes"] > 0
+        for job in workflow["jobs"].values()
+    )
     assert "vars.PROD_DEPLOY_ENABLED == 'true'" in workflow_text
     assert "vars.STAGING_DEPLOY_ENABLED == 'true'" in workflow_text
     assert "workflow_dispatch" in workflow_text
@@ -1927,7 +1957,7 @@ def test_live_tls_scan_workflow_collects_evidence_without_running_on_pull_reques
     triggers = workflow[True]
 
     assert workflow["name"] == "Live TLS scan evidence"
-    assert set(triggers) == {"workflow_dispatch", "schedule"}
+    assert set(triggers) == {"workflow_call", "workflow_dispatch", "schedule"}
     assert "pull_request" not in workflow_text
     assert workflow["permissions"] == {}
     assert workflow["concurrency"] == {
@@ -1936,32 +1966,38 @@ def test_live_tls_scan_workflow_collects_evidence_without_running_on_pull_reques
     }
 
     inputs = triggers["workflow_dispatch"]["inputs"]
+    assert inputs["scan_scope"]["options"] == ["all", "staging", "production"]
     assert inputs["staging_host"]["default"] == "staging-sitbank.duckdns.org"
     assert inputs["production_host"]["default"] == "sitbank.duckdns.org"
     assert inputs["admin_host"]["default"] == "admin-sitbank.duckdns.org"
 
+    call_inputs = triggers["workflow_call"]["inputs"]
+    assert call_inputs["scan_scope"] == {
+        "description": "Set of deployed endpoints to scan: all, staging, or production.",
+        "required": False,
+        "default": "all",
+        "type": "string",
+    }
+    assert call_inputs["staging_host"]["required"] is False
+    assert call_inputs["production_host"]["required"] is False
+    assert call_inputs["admin_host"]["required"] is False
+
+    resolver = workflow["jobs"]["resolve-targets"]
+    assert resolver["timeout-minutes"] == 5
+    assert resolver["outputs"]["matrix"] == "${{ steps.select.outputs.matrix }}"
+    select_step = resolver["steps"][0]
+    assert select_step["env"]["SCAN_SCOPE"] == "${{ inputs.scan_scope || 'all' }}"
+    assert "scan_scope must be all, staging, or production" in select_step["run"]
+    assert "tls-scan-staging-sitbank" in select_step["run"]
+    assert "tls-scan-prod-sitbank" in select_step["run"]
+    assert "tls-scan-admin-sitbank" in select_step["run"]
+
     scan = workflow["jobs"]["scan"]
+    assert scan["needs"] == "resolve-targets"
     assert scan["timeout-minutes"] == 35
     assert scan["strategy"]["fail-fast"] is False
     assert scan["strategy"]["max-parallel"] == 3
-    targets = scan["strategy"]["matrix"]["target"]
-    assert targets == [
-        {
-            "label": "staging-sitbank",
-            "input": "staging",
-            "artifact": "tls-scan-staging-sitbank",
-        },
-        {
-            "label": "prod-sitbank",
-            "input": "production",
-            "artifact": "tls-scan-prod-sitbank",
-        },
-        {
-            "label": "admin-sitbank",
-            "input": "admin",
-            "artifact": "tls-scan-admin-sitbank",
-        },
-    ]
+    assert scan["strategy"]["matrix"] == "${{ fromJSON(needs.resolve-targets.outputs.matrix) }}"
     assert "testssl.sh/archive/${commit}.tar.gz" in workflow_text
     assert 'readonly commit="d2d9d2a04120033a7d1e01e52d9b409168544cc6"' in workflow_text
     assert "d35d2454e2a86d1748381602fcc51783f79bf70263cd17f1b8030da49dfc0ef6" in workflow_text


### PR DESCRIPTION
## Summary

Implements live TLS evidence verification and wires it into the release-control flow.

The TLS scan workflow now supports manual, weekly, and reusable workflow execution. It can scan staging, production customer, production admin, or all endpoints, upload per-target evidence artifacts, write run summaries, and fail when the documented TLS policy is not met.

The deployment workflow now enforces the stronger release sequence:

* staging deploy
* staging TLS scan
* production deploy
* production customer and admin TLS scan

Production deployment is blocked unless the post-deployment staging TLS scan passes.

## Why

Static Nginx configuration tests prove the intended TLS policy exists in the repository, but they do not prove that live deployed endpoints are serving that policy.

Adding live TLS evidence checks into the release workflow helps catch certificate issues, TLS policy drift, deployment mistakes, and runtime endpoint misconfiguration before production deployment proceeds.

Running production and admin scans after production deployment also ensures the release workflow fails if the deployed production endpoints violate the documented TLS policy.

## What changed

* Added `.github/workflows/tls-scan.yml`.
* Configured TLS scans to run:

  * Manually through `workflow_dispatch`
  * Weekly on schedule
  * As a reusable workflow from deployment CI
* Added scoped scan support for:

  * staging
  * production
  * all endpoints
* Added scans for:

  * staging endpoint
  * production customer endpoint
  * production admin endpoint
* Added per-target artifact uploads for:

  * JSON output
  * log output
  * HTML output
* Added GitHub Actions run summaries for TLS scan results.
* Made TLS scans fail when the documented TLS policy is not met.
* Pinned `testssl.sh` to `v3.2.3`.
* Added SHA-256 verification for the downloaded `testssl.sh` release before scanning.
* Updated the CI deployment workflow so production deployment is blocked unless staging TLS evidence passes after staging deployment.
* Added production customer and admin TLS scans after production deployment.
* Kept weekly and manual TLS scans available.
* Updated deployment documentation with live TLS verification and release-gate behavior.
* Updated operations documentation with live TLS verification guidance.
* Updated TLS security documentation with live TLS evidence guidance.
* Added optional SSL Labs guidance.
* Added workflow/documentation contract coverage in `tests/test_deployment.py`.

## Security impact

This improves TLS assurance and release safety.

The workflow verifies the live HTTPS behavior of staging, production customer, and production admin endpoints instead of relying only on static Nginx configuration checks.

Production deployment is now blocked unless staging TLS evidence passes after staging deployment, reducing the chance of promoting a release when the deployed staging endpoint violates TLS policy.

Production and admin TLS scans run after production deployment and mark the release workflow failed if they detect a policy violation.

Pinning and SHA-256 verifying `testssl.sh` reduces supply-chain risk before executing the scanner in CI.

This does not change application authentication, authorization, secrets, database schema, or runtime application logic.

## Deployment impact

No separate deployment action.

This PR does not require:

* EC2 bootstrap
* staging deployment
* production deployment
* database migration
* secret changes

The new TLS checks run as part of the deployment workflow and can also be run manually after deployment to collect fresh evidence from live endpoints.

## Verification

* `python -m pytest -q tests/test_deployment.py`

  * `48 passed`
* `git diff --check`

## Notes

The TLS scan workflow remains available for manual and weekly evidence collection.

Optional SSL Labs checks are documented as an additional external verification step, but the GitHub workflow provides repository-managed TLS evidence artifacts and release-gating behavior.
