### PR TITLE
Use portable jq severity lookup for TLS scan

### DIFF
--- a/.github/workflows/tls-scan.yml
+++ b/.github/workflows/tls-scan.yml
@@ -191,7 +191,10 @@ jobs:
               def offered:
                 (finding | test("offered|enabled"; "i")) and
                 ((finding | test("not offered|not enabled"; "i")) | not);
-              def severe: (.severity // "") | IN("HIGH"; "CRITICAL"; "FATAL");
+              def severe:
+                (.severity // "") as $severity
+                | ["HIGH", "CRITICAL", "FATAL"]
+                | index($severity) != null;
               select(
                 severe
                 or ((id == "SSLv2" or id == "SSLv3" or id == "TLS1" or id == "TLS1_1") and offered)

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -2011,7 +2011,7 @@ def test_live_tls_scan_workflow_collects_evidence_without_running_on_pull_reques
     assert "cert_expirationStatus" in workflow_text
     assert "cert_trust" in workflow_text
     assert "cert_chain_of_trust" in workflow_text
-    assert "IN(\"HIGH\"; \"CRITICAL\"; \"FATAL\")" in workflow_text
+    assert "index($severity) != null" in workflow_text
     assert "secrets." not in workflow_text
 
     uses = _workflow_uses(workflow_text)


### PR DESCRIPTION
## Summary

Fixes the TLS scan workflow severity check so it works with portable `jq` syntax.

The TLS policy evaluation now uses an `index()` lookup instead of the unsupported `IN()` expression when checking severity values.

## Why

The previous `jq` expression used `IN()`, which may not be available in the `jq` version used by the GitHub Actions runner.

That could make the TLS scan workflow fail because of expression compatibility instead of an actual TLS policy violation.

## What changed

* Replaced the unsupported `jq IN()` severity check in `.github/workflows/tls-scan.yml`.
* Used a portable `index()` lookup for severity matching.
* Added regression coverage in `tests/test_deployment.py` to prevent reintroducing the unsupported syntax.

## Security impact

This keeps the live TLS evidence workflow reliable.

The TLS policy check still fails on documented severity violations, but now avoids depending on unsupported `jq` syntax.

## Deployment impact

No deployment action.

This PR does not require:

* EC2 bootstrap
* staging deployment
* production deployment
* database migration
* secret changes

## Verification

* TLS scan workflow syntax updated.
* Regression coverage added for the portable `jq` severity lookup.
* Run deployment workflow contract tests:

  * `python -m pytest -q tests/test_deployment.py`

## Notes

This is a CI compatibility fix only. It does not change the documented TLS policy or application runtime behavior.
