### PR TITLE
Fix TLS scan JSON severity parsing

### DIFF
--- a/.github/workflows/tls-scan.yml
+++ b/.github/workflows/tls-scan.yml
@@ -194,8 +194,10 @@ jobs:
               def severe:
                 (.severity // "") as $severity
                 | ["HIGH", "CRITICAL", "FATAL"]
-                | index($severity) != null;
-              select(
+              | index($severity) != null;
+              .[]
+              | select(type == "object")
+              | select(
                 severe
                 or ((id == "SSLv2" or id == "SSLv3" or id == "TLS1" or id == "TLS1_1") and offered)
                 or ((id | test("^cipherlist_(NULL|aNULL|EXPORT|LOW|OBSOLETED|3DES|RC4)")) and ((finding | test("^not offered$"; "i")) | not))

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -2012,6 +2012,7 @@ def test_live_tls_scan_workflow_collects_evidence_without_running_on_pull_reques
     assert "cert_trust" in workflow_text
     assert "cert_chain_of_trust" in workflow_text
     assert "index($severity) != null" in workflow_text
+    assert '.[]\n              | select(type == "object")\n              | select(' in workflow_text
     assert "secrets." not in workflow_text
 
     uses = _workflow_uses(workflow_text)


### PR DESCRIPTION
## Summary

Fixes the TLS scan workflow JSON parsing logic for `testssl.sh` results.

The workflow now iterates over each JSON finding before reading `.severity`, avoiding the previous array-index error during TLS policy evaluation.

## Why

`testssl.sh` outputs JSON findings as an array. Reading `.severity` directly from the array can fail because severity belongs to each finding object, not the array itself.

This could make the TLS scan workflow fail due to JSON parsing behavior instead of a real TLS policy violation.

## What changed

* Updated `.github/workflows/tls-scan.yml` to iterate each `testssl.sh` JSON finding before reading `.severity`.
* Kept the TLS severity policy behavior unchanged.
* Added regression coverage in `tests/test_deployment.py` to ensure the workflow handles the JSON array structure correctly.

## Security impact

This keeps live TLS evidence verification reliable.

The workflow still fails when TLS findings violate the documented policy, but now evaluates `testssl.sh` JSON output correctly.

## Deployment impact

No deployment action.

This PR does not require:

* EC2 bootstrap
* staging deployment
* production deployment
* database migration
* secret changes

## Verification

* Run deployment workflow contract tests:

  * `python -m pytest -q tests/test_deployment.py`

## Notes

This is a CI compatibility fix only. It does not change the TLS policy, deployment flow, or application runtime behavior.
