### PR TITLE
Secure admin and staging access with Cloudflare Access and Tailscale

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,6 +5,9 @@ admin:
           - 'admin_wsgi.py'
           - 'ops/**/admin*'
           - 'ops/**/admin/**'
+          - 'docs/security/admin-and-staging-zero-trust-access.md'
+          - 'docs/security/access-control.md'
+          - 'docs/security/session-management.md'
           - 'tests/test_admin_*.py'
 
 customer:
@@ -71,6 +74,7 @@ security:
           - 'docs/security/**'
           - 'SECURITY.md'
           - '.trivyignore'
+          - 'ops/nginx/**'
           - 'ops/security/**'
           - 'ops/fido-*.json'
           - 'tests/test_*security*.py'
@@ -99,6 +103,58 @@ security:
       - 'passkey'
       - 'secret'
       - 'rate-limit'
+
+zero-trust:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/security/admin-and-staging-zero-trust-access.md'
+          - '**/*zero-trust*'
+          - '**/*zero_trust*'
+          - '**/*cloudflare*'
+          - '**/*tailscale*'
+          - '**/*private-access*'
+          - '**/*access-boundary*'
+  - head-branch:
+      - 'zero-trust'
+      - 'cloudflare'
+      - 'tailscale'
+      - 'private-access'
+      - 'access-boundary'
+
+network-security:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'ops/nginx/**'
+          - 'docs/security/admin-and-staging-zero-trust-access.md'
+          - '**/*firewall*'
+          - '**/*allowlist*'
+          - '**/*vpn*'
+          - '**/*tailscale*'
+          - '**/*cloudflare*'
+          - '**/*origin-bypass*'
+          - '**/*private-network*'
+          - '**/*network-boundary*'
+  - head-branch:
+      - 'network-security'
+      - 'firewall'
+      - 'vpn'
+      - 'tailscale'
+      - 'cloudflare'
+      - 'origin-bypass'
+      - 'private-network'
+
+staging:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'compose.staging.yml'
+          - 'ops/**/staging*'
+          - 'ops/**/staging/**'
+          - 'ops/staging/**'
+          - 'docs/**/staging*'
+          - 'tests/**/*staging*.py'
+  - head-branch:
+      - 'staging'
+      - 'staging-sitbank'
 
 session:
   - changed-files:

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -44,6 +44,9 @@ jobs:
           create_label session "Session state, cookies, HMAC, Redis namespace, logout, or active sessions." 0b7285
           create_label audit "Audit logs, hash chains, HMAC, metadata, alerting, or audit events." d93f0b
           create_label deployment "Deployment, Docker, compose, nginx, systemd, EC2, runtime, or operations." 006b75
+          create_label zero-trust "Identity-aware or private-network access boundary changes." 5319e7
+          create_label network-security "Firewall, VPN, origin access, private access, or network boundary changes." d73a4a
+          create_label staging "Staging environment, staging deployment, or staging access changes." 006b75
           create_label database "Database schema, migrations, Postgres, roles, privileges, or DB integrity." 531dab
           create_label ci "GitHub Actions, CI policy, CodeQL, dependency audit, build, or pipeline changes." a2eeef
           create_label dependencies "Dependency updates, lock files, package manager changes, or Dependabot PRs." 0366d6
@@ -110,6 +113,12 @@ jobs:
           if contains_any admin administrator staff invite "staff invite" "admin portal" "admin route" "admin isolation" "admin session" "admin database" "admin deployment"; then
             add_label admin
           fi
+          if contains_any "zero trust" "zero-trust" "cloudflare zero trust" "cloudflare access" tailscale tailnet vpn "private access" "private-access" "identity-aware access" "access boundary" "origin bypass" "origin protection" "admin exposure" "staging exposure"; then
+            add_label zero-trust
+          fi
+          if contains_any firewall "security group" "nginx allowlist" "ip allowlist" vpn tailscale "cloudflare access" "origin bypass" "private network" "network boundary" "admin network" "staging network" "private access" "private-access"; then
+            add_label network-security
+          fi
           if contains_any customer "user portal" dashboard profile "account page" "customer route"; then
             add_label customer
           fi
@@ -130,6 +139,9 @@ jobs:
           fi
           if contains_any deploy deployment staging production ec2 nginx docker compose bootstrap systemd runtime "environment variable" "secret file"; then
             add_label deployment
+          fi
+          if contains_any staging "staging-sitbank" "compose.staging" "ops/staging" "staging deployment" "staging access"; then
+            add_label staging
           fi
           if contains_any database postgres migration schema role privilege alembic || contains_regex '(^|[^a-z0-9])db([^a-z0-9]|$)' '(^|[^a-z0-9])sql([^a-z0-9]|$)'; then
             add_label database

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -46,6 +46,9 @@ jobs:
           create_label session "Session state, cookies, HMAC, Redis namespace, logout, or active sessions." 0b7285
           create_label audit "Audit logs, hash chains, HMAC, metadata, alerting, or audit events." d93f0b
           create_label deployment "Deployment, Docker, compose, nginx, systemd, EC2, runtime, or operations." 006b75
+          create_label zero-trust "Identity-aware or private-network access boundary changes." 5319e7
+          create_label network-security "Firewall, VPN, origin access, private access, or network boundary changes." d73a4a
+          create_label staging "Staging environment, staging deployment, or staging access changes." 006b75
           create_label database "Database schema, migrations, Postgres, roles, privileges, or DB integrity." 531dab
           create_label ci "GitHub Actions, CI policy, CodeQL, dependency audit, build, or pipeline changes." a2eeef
           create_label dependencies "Dependency updates, lock files, package manager changes, or Dependabot PRs." 0366d6
@@ -61,6 +64,73 @@ jobs:
       # Keep this workflow label-only: do not checkout or execute pull request
       # code here. The ordinary pull_request trigger avoids privileged PR
       # trigger execution.
+      - name: Add computed pull request text labels
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -Eeuo pipefail
+
+          PR_NUMBER="$(jq -r '.pull_request.number' "${GITHUB_EVENT_PATH}")"
+          PR_TITLE="$(jq -r '.pull_request.title // ""' "${GITHUB_EVENT_PATH}")"
+          PR_BODY="$(jq -r '.pull_request.body // ""' "${GITHUB_EVENT_PATH}")"
+          PR_HEAD="$(jq -r '.pull_request.head.ref // ""' "${GITHUB_EVENT_PATH}")"
+          PR_PATHS=""
+          PR_PATCH=""
+          if ! PR_PATHS="$(gh pr diff "${PR_NUMBER}" --name-only 2>/dev/null)"; then
+            echo "::warning::Could not load changed file paths for PR #${PR_NUMBER}; path labels will still be handled by actions/labeler."
+            PR_PATHS=""
+          fi
+          if ! PR_PATCH="$(gh pr diff "${PR_NUMBER}" --patch 2>/dev/null)"; then
+            PR_PATCH=""
+          fi
+          TEXT="$(
+            printf '%s\n%s\n%s\n%s\n%s\n' \
+              "${PR_TITLE}" "${PR_BODY}" "${PR_HEAD}" "${PR_PATHS}" "${PR_PATCH}" \
+              | tr '[:upper:]' '[:lower:]'
+          )"
+
+          labels=()
+
+          add_label() {
+            local label="$1"
+            local existing
+            for existing in "${labels[@]}"; do
+              if [[ "${existing}" == "${label}" ]]; then
+                return 0
+              fi
+            done
+            labels+=("${label}")
+          }
+
+          contains_any() {
+            local term
+            for term in "$@"; do
+              if [[ "${TEXT}" == *"${term}"* ]]; then
+                return 0
+              fi
+            done
+            return 1
+          }
+
+          if contains_any "zero trust" "zero-trust" "cloudflare zero trust" "cloudflare access" tailscale tailnet vpn "private access" "private-access" "identity-aware access" "access boundary" "origin bypass" "origin protection" "admin exposure" "staging exposure"; then
+            add_label zero-trust
+          fi
+          if contains_any firewall "security group" "nginx allowlist" "ip allowlist" vpn tailscale "cloudflare access" "origin bypass" "private network" "network boundary" "admin network" "staging network" "private access" "private-access"; then
+            add_label network-security
+          fi
+          if contains_any staging "staging-sitbank" "compose.staging" "ops/staging" "staging deployment" "staging access"; then
+            add_label staging
+          fi
+
+          if [[ "${#labels[@]}" -eq 0 ]]; then
+            exit 0
+          fi
+
+          IFS=,
+          gh pr edit "${PR_NUMBER}" --add-label "${labels[*]}"
+
       # Pinned to the actions/labeler v6.1.0 commit.
       - name: Label pull request
         uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213

--- a/.github/workflows/retag-labels.yml
+++ b/.github/workflows/retag-labels.yml
@@ -113,6 +113,9 @@ jobs:
           create_label session "Session state, cookies, HMAC, Redis namespace, logout, or active sessions." 0b7285
           create_label audit "Audit logs, hash chains, HMAC, metadata, alerting, or audit events." d93f0b
           create_label deployment "Deployment, Docker, compose, nginx, systemd, EC2, runtime, or operations." 006b75
+          create_label zero-trust "Identity-aware or private-network access boundary changes." 5319e7
+          create_label network-security "Firewall, VPN, origin access, private access, or network boundary changes." d73a4a
+          create_label staging "Staging environment, staging deployment, or staging access changes." 006b75
           create_label database "Database schema, migrations, Postgres, roles, privileges, or DB integrity." 531dab
           create_label ci "GitHub Actions, CI policy, CodeQL, dependency audit, build, or pipeline changes." a2eeef
           create_label dependencies "Dependency updates, lock files, package manager changes, or Dependabot PRs." 0366d6
@@ -222,6 +225,12 @@ jobs:
             if contains_any admin administrator staff invite "staff invite" "admin portal" "admin route" "admin isolation" "admin session" "admin database" "admin deployment"; then
               add_unique labels admin
             fi
+            if contains_any "zero trust" "zero-trust" "cloudflare zero trust" "cloudflare access" tailscale tailnet vpn "private access" "private-access" "identity-aware access" "access boundary" "origin bypass" "origin protection" "admin exposure" "staging exposure"; then
+              add_unique labels zero-trust
+            fi
+            if contains_any firewall "security group" "nginx allowlist" "ip allowlist" vpn tailscale "cloudflare access" "origin bypass" "private network" "network boundary" "admin network" "staging network" "private access" "private-access"; then
+              add_unique labels network-security
+            fi
             if contains_any customer "user portal" dashboard profile "account page" "customer route"; then
               add_unique labels customer
             fi
@@ -242,6 +251,9 @@ jobs:
             fi
             if contains_any deploy deployment staging production ec2 nginx docker compose bootstrap systemd runtime "environment variable" "secret file"; then
               add_unique labels deployment
+            fi
+            if contains_any staging "staging-sitbank" "compose.staging" "ops/staging" "staging deployment" "staging access"; then
+              add_unique labels staging
             fi
             if contains_any database postgres migration schema role privilege alembic || contains_regex '(^|[^a-z0-9])db([^a-z0-9]|$)' '(^|[^a-z0-9])sql([^a-z0-9]|$)'; then
               add_unique labels database
@@ -334,12 +346,25 @@ jobs:
 
           compute_pr_labels() {
             local number="$1"
-            local head="$2"
+            local title="$2"
+            local body="$3"
+            local head="$4"
+            local diff_patch=""
+            local path_text=""
             local labels=()
             PR_HEAD="${head,,}"
             load_pr_files "${number}" || return 1
+            if ! diff_patch="$(gh pr diff "${number}" --patch 2>/dev/null)"; then
+              diff_patch=""
+            fi
+            path_text="$(printf '%s\n' "${PR_FILES[@]}")"
+            MATCH_TEXT="$(
+              printf '%s\n%s\n%s\n%s\n%s\n' \
+                "${title}" "${body}" "${head}" "${path_text}" "${diff_patch}" \
+                | tr '[:upper:]' '[:lower:]'
+            )"
 
-            if path_matches 'app/admin/*' || path_matches 'admin_wsgi.py' || path_matches 'ops/*admin*' || path_matches 'tests/test_admin_*.py'; then
+            if path_matches 'app/admin/*' || path_matches 'admin_wsgi.py' || path_matches 'ops/*admin*' || path_matches 'docs/security/admin-and-staging-zero-trust-access.md' || path_matches 'docs/security/access-control.md' || path_matches 'docs/security/session-management.md' || path_matches 'tests/test_admin_*.py'; then
               add_unique labels admin
             fi
             if path_matches 'app/web/*' || path_matches 'app/main/*' || path_matches 'app/templates/index.html' || path_matches 'app/templates/dashboard.html' || path_matches 'app/templates/profile.html' || path_matches 'tests/test_dashboard.py' || path_matches 'tests/test_authenticated_portal_ui.py'; then
@@ -354,8 +379,14 @@ jobs:
             if path_matches 'app/auth/mfa_policy.py' || path_matches 'app/auth/recovery_codes.py' || path_matches 'app/auth/webauthn_services.py' || path_matches 'app/templates/mfa_*.html' || path_matches 'app/templates/security_keys.html' || path_contains mfa totp webauthn passkey security_key recovery_code; then
               add_unique labels mfa
             fi
-            if path_matches 'app/security/*' || path_matches 'docs/security/*' || path_matches 'security.md' || path_matches '.trivyignore' || path_matches 'ops/security/*' || path_matches 'ops/fido-*.json' || path_matches 'tests/test_*security*.py' || path_matches 'tests/test_audit_*.py' || path_matches 'tests/test_owasp_regressions.py' || path_matches 'tests/test_pentest_auth_bypass.py' || path_matches 'tests/test_route_inventory_security.py' || path_matches 'tests/test_secret_scanner.py' || path_matches 'tests/test_session_management.py' || path_contains csrf csp hmac crypto secret rate_limit || branch_contains security auth mfa csrf csp session audit admin-isolation webauthn passkey secret rate-limit; then
+            if path_matches 'app/security/*' || path_matches 'docs/security/*' || path_matches 'security.md' || path_matches '.trivyignore' || path_matches 'ops/nginx/*' || path_matches 'ops/security/*' || path_matches 'ops/fido-*.json' || path_matches 'tests/test_*security*.py' || path_matches 'tests/test_audit_*.py' || path_matches 'tests/test_owasp_regressions.py' || path_matches 'tests/test_pentest_auth_bypass.py' || path_matches 'tests/test_route_inventory_security.py' || path_matches 'tests/test_secret_scanner.py' || path_matches 'tests/test_session_management.py' || path_contains csrf csp hmac crypto secret rate_limit || branch_contains security auth mfa csrf csp session audit admin-isolation webauthn passkey secret rate-limit; then
               add_unique labels security
+            fi
+            if contains_any "zero trust" "zero-trust" "cloudflare zero trust" "cloudflare access" tailscale tailnet vpn "private access" "private-access" "identity-aware access" "access boundary" "origin bypass" "origin protection" "admin exposure" "staging exposure" || path_matches 'docs/security/admin-and-staging-zero-trust-access.md' || path_contains zero-trust zero_trust cloudflare tailscale private-access access-boundary || branch_contains zero-trust cloudflare tailscale private-access access-boundary; then
+              add_unique labels zero-trust
+            fi
+            if contains_any firewall "security group" "nginx allowlist" "ip allowlist" vpn tailscale "cloudflare access" "origin bypass" "private network" "network boundary" "admin network" "staging network" "private access" "private-access" || path_matches 'ops/nginx/*' || path_matches 'docs/security/admin-and-staging-zero-trust-access.md' || path_contains firewall allowlist vpn tailscale cloudflare origin-bypass private-network network-boundary || branch_contains network-security firewall vpn tailscale cloudflare origin-bypass private-network; then
+              add_unique labels network-security
             fi
             if path_matches 'app/security/session_hmac.py' || path_matches 'app/security/sessions.py' || path_matches 'app/static/js/session-timeout.js' || path_matches 'app/templates/sessions.html' || path_matches 'tests/test_session_management.py' || path_contains session cookie; then
               add_unique labels session
@@ -365,6 +396,9 @@ jobs:
             fi
             if path_matches 'ops/*' || path_matches 'compose*.yml' || path_matches 'docker-compose*.yml' || path_matches 'dockerfile' || path_matches 'config.py' || path_matches 'docs/deployment.md' || path_matches 'docs/operations.md' || path_matches 'docs/archive/ec2_transition.md' || path_matches 'tests/test_deployment.py'; then
               add_unique labels deployment
+            fi
+            if contains_any staging "staging-sitbank" "compose.staging" "ops/staging" "staging deployment" "staging access" || path_matches 'compose.staging.yml' || path_contains staging || branch_contains staging staging-sitbank; then
+              add_unique labels staging
             fi
             if path_matches 'migrations/*' || path_matches 'app/models.py' || path_matches 'app/ops/db_privileges.py' || path_matches 'ops/postgres/*' || path_matches 'tests/test_db_session_integrity.py'; then
               add_unique labels database
@@ -473,15 +507,17 @@ jobs:
                 --jq '.[] | @base64'
             )
 
-            local row pr_json number head
+            local row pr_json number title body head
             local current computed final_labels
             for row in "${pr_rows[@]}"; do
               pr_json="$(printf '%s' "${row}" | base64 --decode)"
               number="$(jq -r '.number' <<< "${pr_json}")"
+              title="$(jq -r '.title // ""' <<< "${pr_json}")"
+              body="$(jq -r '.body // ""' <<< "${pr_json}")"
               head="$(jq -r '.headRefName // ""' <<< "${pr_json}")"
               mapfile -t current < <(jq -r '.labels[].name' <<< "${pr_json}")
 
-              if ! mapfile -t computed < <(compute_pr_labels "${number}" "${head}"); then
+              if ! mapfile -t computed < <(compute_pr_labels "${number}" "${title}" "${body}" "${head}"); then
                 echo "::warning::Could not compute dry-run PR labels for #${number}; the SHA-pinned actions/labeler v6 action will compute them in apply mode."
                 computed=()
               fi

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,13 +52,20 @@ so audit records are append-only to the running app. Rotate `database_url` and
 Production admin runtime uses a separate Flask app, Docker Compose service,
 session cookie, session-signing material, session-lookup HMAC key, and database
 runtime role. The admin role must be distinct from both `sitbank_app` and
-`sitbank_owner`; it must not use migration/schema-owner credentials. Admin MFA,
-administrator step-up, VPN, Tailscale, WireGuard, and administrator IP allowlist
-setup are Phase 2 items pending an approved design. Until those controls exist,
-`admin-sitbank.duckdns.org` remains isolated at the edge and should be protected
-with an explicit network allowlist. The Flask admin app uses a separate cookie,
-session HMAC keyring, database role, root-admin-controlled staff invites, and
-mandatory TOTP.
+`sitbank_owner`; it must not use migration/schema-owner credentials. Admin
+access is private operator access only through Tailscale; do not enable
+Tailscale Funnel and do not expose admin through the customer app or public
+admin Nginx routes. `admin-sitbank.duckdns.org` remains isolated at the public
+edge with only the static verification page at `/`; app routes stay denied.
+The Flask admin app still uses a separate cookie, session HMAC keyring,
+database role, root-admin-controlled staff invites, and mandatory TOTP.
+
+Staging access is protected by Cloudflare Access before Nginx/Flask and by
+Cloudflare Authenticated Origin Pulls at the staging Nginx origin. Direct
+EC2-origin access to staging app paths must return `403` without Cloudflare's
+origin-pull client certificate. Staging `/health/ready` remains loopback-only
+so EC2-local deployment checks continue to work. Cloudflare and Tailscale
+credentials are host/operator-managed and must never be committed.
 
 Staging secrets must never be copied from production. The staging deployment
 wrapper rejects identical application secret files when production secrets are
@@ -219,9 +226,13 @@ checked manually.
 - Keep customer Gunicorn bound to `127.0.0.1:5000`, admin Gunicorn bound to
   `127.0.0.1:5002`, and keep `compose.prod.yml` free of published app ports.
 - Restrict `/health/ready` to loopback and allow public `/health/live` only.
-- Keep admin routes denied by default. Do not make
-  `admin-sitbank.duckdns.org` usable until a reviewed admin MFA design and VPN
-  or explicit IP allowlist controls are implemented.
+- Keep public admin app routes denied by default. Admin application access is
+  Tailscale/private operator access only, followed by Flask admin login and
+  TOTP. Do not enable Tailscale Funnel or make `admin-sitbank.duckdns.org`
+  publicly usable for app routes.
+- Require Cloudflare Access and Cloudflare Authenticated Origin Pulls for
+  `staging-sitbank.duckdns.org`; do not disable the origin-pull check to make
+  direct EC2-origin staging access work.
 - Enable WAF managed common, SQL injection, XSS, bot, and protocol anomaly
   rules.
 - Add WAF rate-based rules for `/login`, `/register`, `/mfa/verify`,

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -7,6 +7,9 @@ Only Flask/Gunicorn runs in the SITBank container. Nginx, TLS, PostgreSQL, and b
 - Production public host: `sitbank.duckdns.org`
 - Production admin host: `admin-sitbank.duckdns.org`
 - Staging public host: `staging-sitbank.duckdns.org`
+- Production customer access: public HTTPS
+- Staging access boundary: Cloudflare Access plus Authenticated Origin Pull
+- Admin access boundary: Tailscale/private operator access only
 - Production image form: `ghcr.io/hetp88/sitbank@sha256:<digest>`
 - Repository identity: `hetp88/SITBank`
 - Production config root: `/etc/sitbank`
@@ -224,13 +227,16 @@ The reviewed production bootstrap installs and enables the production edge from 
   limits TLS 1.3 to its standard AEAD suites.
 - Gunicorn binds only to `127.0.0.1:5000`.
 - Admin Gunicorn binds only to `127.0.0.1:5002` and is reached only by the
-  `admin-sitbank.duckdns.org` Nginx server block.
+  public `admin-sitbank.duckdns.org` Nginx server block for denied health and
+  verification responses, or by a Tailscale/private operator path for the
+  actual admin application.
 - `compose.prod.yml` publishes no app ports.
 - `/health/ready` is for local deployment and load-balancer checks and should deny public traffic.
 - Admin `/` serves only a static Google verification and restricted-access
   notice at the public edge. Admin `/health/ready`, `/login`, and all other
-  admin routes should remain denied by default at Nginx until a VPN, explicit
-  IP allowlist, or equivalent network control is configured.
+  admin routes remain denied by default at the public Nginx edge. Admin app
+  access is through Tailscale/private operator access only; do not enable
+  Tailscale Funnel or expose the admin app through the customer host.
 - Cloudflare or AWS WAF should sit in front of Nginx for managed common, SQL injection, XSS, bot, and protocol anomaly rules.
 - Cloudflare or AWS WAF rules and security-group allowlists are still infrastructure state and must be checked manually.
 - Flask admin auth is implemented only for root-admin-controlled invite
@@ -265,15 +271,21 @@ Staging admin must follow the same boundary pattern as production. Do not expose
 admin routes publicly. The staging admin service must bind only to localhost
 and use a separate loopback port from production admin when both environments
 share one EC2 host. Production admin owns `127.0.0.1:5002`; staging admin owns
-`127.0.0.1:5003`. If a staging admin Nginx server block is added later, deny
-public admin traffic unless an
-approved access path such as VPN, SSH tunnel, or explicit allowlist is
-configured. Staging admin secrets must be root-managed under
-`/etc/sitbank-staging/secrets` and must not reuse customer runtime secrets.
+`127.0.0.1:5003`. Use Tailscale SSH, Tailscale Serve, or another approved
+private operator path for admin access; do not enable Tailscale Funnel and do
+not add a public staging admin Nginx server block. Staging admin secrets must
+be root-managed under `/etc/sitbank-staging/secrets` and must not reuse
+customer runtime secrets.
 
 ## Staging Edge Setup
 
-Create a staging Basic Auth file before running the staging bootstrap:
+Staging uses Cloudflare Access as the identity-aware boundary and Cloudflare
+Authenticated Origin Pulls to prevent direct EC2-origin bypass. The staging
+Nginx app paths require a verified Cloudflare origin-pull client certificate
+before proxying to Flask. The production customer hostname remains public.
+
+Create a staging Basic Auth file before running the staging bootstrap. This is
+a secondary staging control and must not replace Cloudflare Access:
 
 ```bash
 sudo htpasswd -c /etc/nginx/.htpasswd-sitbank-staging <username>
@@ -282,6 +294,20 @@ sudo chmod 0640 /etc/nginx/.htpasswd-sitbank-staging
 ```
 
 Do not store the Basic Auth password or generated htpasswd hash in the repo.
+
+Install the Cloudflare Authenticated Origin Pull CA certificate on the EC2
+host before running staging bootstrap:
+
+```bash
+sudo install -o root -g root -m 0644 \
+  cloudflare-authenticated-origin-pull-ca.pem \
+  /etc/nginx/cloudflare-authenticated-origin-pull-ca.pem
+```
+
+Do not store Cloudflare API tokens, tunnel credentials, Access IdP secrets, or
+origin certificate private keys in the repo. If the staging hostname cannot be
+proxied by Cloudflare in the current DNS model, stop and make an approved DNS
+change instead of disabling the origin-pull protection.
 
 Issue or renew staging TLS before bootstrap:
 
@@ -293,21 +319,32 @@ sudo /usr/local/sbin/verify-certbot-host-state staging
 sudo certbot renew --dry-run
 ```
 
-Then run `ops/deploy/bootstrap-container-ec2 staging hetp88/SITBank staging-sitbank.duckdns.org`. The bootstrap installs the Nginx proxy header snippet, TLS policy snippet, and rate-limit include, then runs `sudo nginx -t` before `sudo systemctl reload nginx`. This edge setup is separate from application deployment.
+Then run `ops/deploy/bootstrap-container-ec2 staging hetp88/SITBank staging-sitbank.duckdns.org`. The bootstrap installs the Nginx proxy header snippet, TLS policy snippet, and rate-limit include, verifies the staging Basic Auth file and Cloudflare origin-pull CA file, then runs `sudo nginx -t` before `sudo systemctl reload nginx`. This edge setup is separate from application deployment.
 
 Staging verification:
 
 ```bash
-curl -k -I https://staging-sitbank.duckdns.org/
-curl -k -I -u "$STAGING_BASIC_AUTH_USER:$STAGING_BASIC_AUTH_PASSWORD" \
+curl -I https://staging-sitbank.duckdns.org/
+curl -I -u "$STAGING_BASIC_AUTH_USER:$STAGING_BASIC_AUTH_PASSWORD" \
   https://staging-sitbank.duckdns.org/
-curl -k -I https://staging-sitbank.duckdns.org/health/ready
+curl -I https://staging-sitbank.duckdns.org/health/ready
 curl -fsS http://127.0.0.1:5001/health/ready
+curl --fail --resolve staging-sitbank.duckdns.org:443:127.0.0.1 \
+  https://staging-sitbank.duckdns.org/health/ready
+curl -I --resolve staging-sitbank.duckdns.org:443:<EC2_PUBLIC_IP> \
+  https://staging-sitbank.duckdns.org/
 sudo nginx -T | grep -E 'ssl_protocols|ssl_ciphers|ssl_ecdh_curve|ssl_conf_command|ssl_session_tickets'
 testssl.sh --warnings batch --color 0 https://staging-sitbank.duckdns.org
 ```
 
-Expected: unauthenticated `/` returns `401`, authenticated `/` returns `200`, external `/health/ready` returns `403`, and local app readiness succeeds.
+Expected: unauthenticated browser traffic receives the Cloudflare Access
+challenge before reaching staging, approved operators can pass Cloudflare
+Access and then reach the normal staging controls, direct EC2-origin access to
+`/` returns `403` without Cloudflare's origin-pull client certificate,
+external `/health/ready` returns `403`, and local app readiness succeeds.
+
+The complete operator runbook is
+`docs/security/admin-and-staging-zero-trust-access.md`.
 
 After the staging TLS check passes, validate both production HTTPS hostnames
 with `testssl.sh --warnings batch --color 0 https://sitbank.duckdns.org` and

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -19,6 +19,43 @@ roles.
 
 MFA/TOTP seed encryption uses envelope encryption. Keep old KEKs in `mfa_kek_keys_json` until `rewrap-mfa-deks` has moved stored records to the new active KEK. Then update `MFA_KEK_ACTIVE_ID` and the root-managed keyring together.
 
+## Admin And Staging Access Operations
+
+SITBank uses a hybrid private-access model:
+
+- Staging is protected by Cloudflare Access and Cloudflare Authenticated Origin
+  Pulls at `staging-sitbank.duckdns.org`.
+- Admin is protected by Tailscale/private operator access and remains denied
+  on the public `admin-sitbank.duckdns.org` app routes.
+- The production customer site `sitbank.duckdns.org` remains public.
+
+Cloudflare Access policy, IdP configuration, API tokens, tunnel credentials,
+origin certificate private keys, and origin-pull client credentials are
+operator-managed. Tailscale auth keys, API keys, tailnet policy, device
+approval state, and Serve state are also operator-managed. None of those values
+belong in the repository.
+
+Routine verification:
+
+```bash
+sudo test -r /etc/nginx/cloudflare-authenticated-origin-pull-ca.pem
+sudo nginx -t
+curl --fail --resolve staging-sitbank.duckdns.org:443:127.0.0.1 \
+  https://staging-sitbank.duckdns.org/health/ready
+curl -I --resolve staging-sitbank.duckdns.org:443:<EC2_PUBLIC_IP> \
+  https://staging-sitbank.duckdns.org/
+sudo tailscale serve status
+```
+
+Expected: local staging readiness succeeds, direct origin access to staging
+returns `403` without Cloudflare's origin-pull client certificate, and admin
+Serve status is present only when the approved tailnet path is intentionally
+enabled. Tailscale Funnel must stay disabled for SITBank admin.
+
+The detailed onboarding, offboarding, emergency lockout, rollback, and live
+operator verification steps are in
+`docs/security/admin-and-staging-zero-trust-access.md`.
+
 ## Trivy Exception
 
 The temporary `.trivyignore` exception covers only `CVE-2026-42496` and `CVE-2026-8376` inherited from the official python:3.12 slim-trixie / Debian Trixie base image.

--- a/docs/development/github-labeling.md
+++ b/docs/development/github-labeling.md
@@ -14,6 +14,11 @@ The PR workflow only adds computed labels. It does not remove existing labels,
 so Dependabot labels and any maintainer-applied labels remain in place during
 normal future PR labeling.
 
+The PR workflow uses a trusted shell step for title, body, branch, file path,
+and patch-text terms that `actions/labeler` does not cover directly. It does
+not checkout or execute pull request code. The SHA-pinned `actions/labeler`
+step still handles path-oriented labels from `.github/labeler.yml`.
+
 The workflow must stay label-only. Do not add `actions/checkout`, do not
 checkout PR branches, and do not execute scripts or code from pull requests in
 that workflow. This repository intentionally avoids `pull_request_target`.
@@ -25,6 +30,10 @@ edited. It reads the issue title and body from the GitHub event payload and adds
 matching labels. Every new or edited issue receives `needs-triage`.
 
 The issue labeler only adds computed labels. It does not remove existing labels.
+It applies `zero-trust`, `network-security`, and `staging` when titles or
+bodies mention Cloudflare Access, Tailscale, VPN/private access, origin
+bypass/protection, admin exposure, staging exposure, or staging deployment
+terms.
 
 ## Manual Historical Retag
 
@@ -97,3 +106,23 @@ other issue/PR label checks, add that label to `PROTECTED_LABELS` in
 The labeling workflows create or update the standard labels idempotently with
 `gh label create --force`. This keeps label names, descriptions, and colors
 available without deleting any repository labels.
+
+Security/network labels added for zero-trust work:
+
+- `zero-trust`: Identity-aware or private-network access boundary changes.
+- `network-security`: Firewall, VPN, origin access, private access, or network
+  boundary changes.
+- `staging`: Staging environment, staging deployment, or staging access
+  changes.
+
+Path rules:
+
+- `ops/nginx/**` receives `deployment`, `network-security`, and `security`.
+- `ops/deploy/**` receives `deployment`.
+- `compose.staging.yml`, staging env templates, and staging deployment files
+  receive `staging` and `deployment`.
+- `docs/security/**` receives `documentation` and `security`.
+- Admin deployment, admin Nginx, and admin isolation docs/tests receive
+  `admin` and `security`.
+- Zero-trust, Cloudflare, Tailscale, and private-access docs receive
+  `zero-trust`, `network-security`, `documentation`, and `security`.

--- a/docs/security/access-control.md
+++ b/docs/security/access-control.md
@@ -110,9 +110,11 @@ Admin/staff access is invite-only and uses the admin runtime.
 
 Production Nginx currently defines an admin hostname in
 `ops/nginx/sitbank-production.conf` but denies public access to the primary
-admin paths with `deny all`. This keeps the admin app available for deployment
-health and future controlled exposure while preventing public browser access
-unless the edge policy is deliberately changed.
+admin paths with `deny all`. This keeps the public admin hostname limited to
+the static verification page and denied health/app responses. The actual admin
+application access path is Tailscale/private operator access to the loopback
+admin listener, followed by the normal Flask admin login and TOTP controls.
+Do not enable Tailscale Funnel or expose admin through the customer app.
 
 Manual recovery operator review is exposed only by the isolated admin app.
 `GET /manual-recovery/requests` lists public-safe request summaries for root
@@ -159,3 +161,20 @@ High-risk customer actions use `verify_high_risk_authorization()` in
 Admin route authorization is covered by the generated admin inventory plus
 targeted admin service and flow tests. New admin routes must be added to
 `tests/test_admin_route_inventory_security.py` before the suite passes.
+
+## 3.7 Staging And Admin Network Boundaries
+
+Network boundaries complement, but do not replace, Flask authorization:
+
+| Surface | Network boundary | Application controls that still apply |
+| --- | --- | --- |
+| Production customer | Public HTTPS at `sitbank.duckdns.org` | Customer login, MFA onboarding, CSRF, route inventory, rate limiting |
+| Staging customer | Cloudflare Access before Nginx, Cloudflare Authenticated Origin Pull at Nginx, staging Basic Auth | Customer login, MFA, CSRF, route inventory, rate limiting |
+| Production admin | Tailscale/private operator access to `127.0.0.1:5002`; public admin app routes denied | Staff/root-admin login, mandatory TOTP, CSRF, admin route inventory, admin rate limiting |
+| Staging admin | Tailscale/private operator access to `127.0.0.1:5003`; no public admin host | Staff/root-admin login, mandatory TOTP, CSRF, admin route inventory, admin rate limiting |
+
+The staging Nginx config uses Cloudflare Authenticated Origin Pulls so direct
+EC2-origin requests to staging browser/app paths return `403` unless
+Cloudflare's client certificate verifies successfully. Staging `/health/ready`
+remains loopback-only for deployment checks. The shared default Nginx config
+continues to reject unknown hostnames.

--- a/docs/security/admin-and-staging-zero-trust-access.md
+++ b/docs/security/admin-and-staging-zero-trust-access.md
@@ -1,0 +1,298 @@
+# Admin And Staging Zero-Trust Access
+
+Issue #184 uses a hybrid access boundary:
+
+- Staging uses Cloudflare Zero Trust Access.
+- Admin uses Tailscale private access.
+
+This intentionally uses both products because the surfaces have different
+access patterns. Staging must stay browser-accessible at the staging hostname
+for approved operators, and Cloudflare Access can challenge the operator before
+traffic reaches Nginx or Flask. Admin is an operator-only surface and should
+not be reachable from the public internet at all, so the admin app remains
+behind Tailscale/private device access.
+
+References:
+
+- Cloudflare Access self-hosted applications:
+  <https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/>
+- Cloudflare Authenticated Origin Pulls:
+  <https://developers.cloudflare.com/ssl/origin-configuration/authenticated-origin-pull/>
+- Tailscale Serve:
+  <https://tailscale.com/docs/reference/tailscale-cli/serve>
+- Tailscale ACLs and tags:
+  <https://tailscale.com/docs/features/access-control/acls> and
+  <https://tailscale.com/docs/features/tags>
+
+## Protected Paths
+
+| Surface | Host or path | Boundary | Public exposure |
+| --- | --- | --- | --- |
+| Production customer | `https://sitbank.duckdns.org` | Public HTTPS edge, Flask customer login and MFA | Public |
+| Staging customer | `https://staging-sitbank.duckdns.org` | Cloudflare Access, Cloudflare Authenticated Origin Pull, staging Basic Auth, Flask login and MFA | Not directly public at the origin |
+| Production admin public host | `https://admin-sitbank.duckdns.org` | Nginx denial for app routes; static verification page only | Public verification page only |
+| Production admin app | Tailscale Serve or Tailscale SSH to `127.0.0.1:5002` | Tailscale ACLs, approved devices, Flask admin login and TOTP | Private tailnet only |
+| Staging admin app | Tailscale SSH or other approved private operator path to `127.0.0.1:5003` | Tailscale ACLs, approved devices, Flask admin login and TOTP | Private tailnet only |
+
+The customer production site remains public. The admin app is not exposed
+through the customer app, and the customer Nginx server block continues to
+return `404` for `/admin`.
+
+`admin-sitbank.duckdns.org` exists in the production Nginx configuration today,
+but it is not the admin application access path. It serves only the Google
+verification page at `/`; `/login`, `/health/ready`, and other admin app paths
+remain denied at Nginx for non-private traffic.
+
+## Staging Cloudflare Access
+
+Configure Cloudflare for `staging-sitbank.duckdns.org` as a self-hosted Access
+application:
+
+1. Ensure the staging hostname is a proxied Cloudflare hostname. If the DuckDNS
+   hostname cannot be proxied in the current account model, do not make the EC2
+   origin public as a workaround. Move staging to an approved operator-owned
+   Cloudflare hostname and update this repository in a separate reviewed change.
+2. Add a Cloudflare Access application for `staging-sitbank.duckdns.org`.
+3. Add an Allow policy for approved staging operators only.
+4. Keep the default deny posture for everyone else.
+5. Enable Cloudflare Authenticated Origin Pulls for staging. Prefer
+   per-hostname or zone-level Authenticated Origin Pulls with an
+   operator-managed client certificate when available. Global Authenticated
+   Origin Pulls are acceptable only with the existing strict hostname routing
+   and unknown-host rejection.
+6. Install the origin-pull CA certificate on the EC2 host at
+   `/etc/nginx/cloudflare-authenticated-origin-pull-ca.pem`. This CA file is
+   host-managed and is not committed to the repository.
+
+The staging Nginx server requests a client certificate with:
+
+```nginx
+ssl_client_certificate /etc/nginx/cloudflare-authenticated-origin-pull-ca.pem;
+ssl_verify_client optional;
+```
+
+All staging browser/app paths return `403` unless
+`$ssl_client_verify` is `SUCCESS`. This blocks direct EC2-origin bypass for the
+staging app and `/health/live` while preserving loopback readiness checks.
+`/health/ready` remains loopback-only and does not require the Cloudflare
+client certificate so the deployment wrapper can still check local Nginx and
+Flask readiness on the EC2 host.
+
+Keep the existing staging Basic Auth file until a separate reviewed change
+removes it. Cloudflare Access is the identity-aware boundary; Basic Auth is a
+secondary staging control and its password or htpasswd hash must not be stored
+in the repository.
+
+## Admin Tailscale Access
+
+Install Tailscale on the EC2 host and enroll it as a tagged service node such
+as `tag:sitbank-admin`. Restrict access with the tailnet policy so only
+approved operator users, groups, or managed devices can reach the SITBank host
+and admin service ports. Do not rely on a shared password as the private
+network boundary.
+
+Recommended admin access path:
+
+```bash
+sudo tailscale up --ssh --advertise-tags=tag:sitbank-admin
+sudo tailscale serve --bg --https=443 127.0.0.1:5002
+sudo tailscale serve status
+```
+
+The `tailscale serve` command exposes the local admin service inside the
+tailnet. It must not be paired with `tailscale funnel`; Funnel would publish
+the service to the public internet and is not approved for SITBank admin.
+
+If Tailscale Serve is not enabled in the tailnet, use Tailscale SSH or an
+operator-approved local port forward to reach `127.0.0.1:5002` on the EC2
+host. In all cases, the Flask admin login and TOTP remain mandatory after the
+private network boundary is satisfied.
+
+## Operator Onboarding
+
+Staging operators:
+
+1. Add the operator to the approved identity provider group or email allowlist
+   used by the Cloudflare Access policy.
+2. Confirm the operator can authenticate to Cloudflare Access with the required
+   IdP and any required MFA or device posture.
+3. Provide the staging Basic Auth credential only through the approved secret
+   channel while that secondary control remains active.
+4. Verify the operator reaches the staging hostname through Cloudflare Access
+   and then reaches the normal Flask staging login.
+
+Admin operators:
+
+1. Add the operator to the Tailscale group allowed by the tailnet policy.
+2. Approve the operator device according to the tailnet device-approval policy.
+3. Confirm the device can reach only the approved SITBank admin service path.
+4. Create or maintain the operator's staff/admin account through the
+   root-admin invite flow.
+5. Confirm admin login still requires password plus TOTP after Tailscale
+   access is established.
+
+## Offboarding
+
+When an operator or device is removed:
+
+1. Remove the user or group membership from Cloudflare Access.
+2. Revoke the user's active Cloudflare sessions if immediate staging lockout is
+   required.
+3. Disable or delete the Tailscale device from the tailnet.
+4. Remove the user from the Tailscale admin group and confirm ACL tests still
+   pass.
+5. Revoke or disable the SITBank admin staff account if applicable.
+6. Rotate staging Basic Auth, Tailscale auth keys, or other affected
+   host-managed credentials if they were shared with the removed operator.
+7. Review audit logs for staging/admin access near the offboarding time.
+
+## Deployment Verification
+
+Repository-side checks:
+
+```bash
+git diff --check
+.\.venv\Scripts\python.exe -m pytest -q tests/test_deployment.py tests/test_admin_isolation.py
+.\.venv\Scripts\python.exe -m pytest -q tests/test_zero_trust_access_boundary.py
+```
+
+Host-side staging checks after bootstrap:
+
+```bash
+sudo test -r /etc/nginx/cloudflare-authenticated-origin-pull-ca.pem
+sudo /usr/local/sbin/verify-certbot-host-state staging
+sudo nginx -t
+curl --fail --resolve staging-sitbank.duckdns.org:443:127.0.0.1 \
+  https://staging-sitbank.duckdns.org/health/ready
+curl -I --resolve staging-sitbank.duckdns.org:443:<EC2_PUBLIC_IP> \
+  https://staging-sitbank.duckdns.org/
+```
+
+Expected: local readiness succeeds through loopback, and direct origin access
+to `/` returns `403` without Cloudflare's authenticated origin-pull client
+certificate.
+
+Live Cloudflare staging checks:
+
+1. An unauthenticated browser receives a Cloudflare Access challenge before
+   reaching staging.
+2. An approved operator passes Cloudflare Access.
+3. An unapproved account is denied.
+4. Direct EC2-origin access cannot bypass Cloudflare Access.
+5. Staging Flask login still works after Cloudflare Access and staging Basic
+   Auth.
+6. Staging `/health/ready` is blocked externally.
+7. EC2-local deployment health checks still pass.
+
+Live Tailscale admin checks:
+
+1. An approved operator reaches admin only from an approved tailnet device.
+2. A non-tailnet network cannot reach the admin app.
+3. A removed user or deleted device loses access.
+4. Admin Flask login and TOTP are still required after Tailscale access.
+5. Admin readiness endpoints remain private or restricted.
+6. `https://sitbank.duckdns.org` remains public.
+
+## Emergency Lockout
+
+For staging compromise or suspected unauthorized staging access:
+
+1. Disable the Cloudflare Access Allow policy or replace it with an empty
+   allowlist.
+2. Keep the EC2 staging Nginx origin-pull requirement in place.
+3. Rotate staging Basic Auth and any affected staging application credentials.
+4. Preserve Cloudflare Access logs, Nginx logs, and SITBank audit logs.
+
+For admin compromise or suspected unauthorized admin access:
+
+1. Disable Tailscale Serve for the admin service:
+
+   ```bash
+   sudo tailscale serve reset
+   sudo tailscale serve status
+   ```
+
+2. Remove the affected Tailscale devices or users from the tailnet.
+3. Keep the public admin Nginx app routes denied.
+4. Revoke affected SITBank admin sessions and disable staff accounts as needed.
+5. Preserve Tailscale logs, Nginx logs, and SITBank admin audit logs.
+
+Break-glass access must use an approved operator device and must still complete
+Flask admin login plus TOTP. Do not enable Tailscale Funnel or make the public
+admin Nginx routes usable as a shortcut.
+
+## Rollback
+
+If the Cloudflare staging setup fails after merge:
+
+1. Keep production unchanged and public.
+2. Keep the staging app unavailable externally rather than removing the
+   origin-pull requirement.
+3. Roll back the staging Nginx file through the reviewed bootstrap only after a
+   security owner approves the temporary exposure decision.
+4. Redeploy staging and verify readiness before allowing production to proceed
+   through the normal pipeline.
+
+If Tailscale admin setup fails:
+
+1. Disable Tailscale Serve or the private admin path.
+2. Leave the public admin Nginx app routes denied.
+3. Use only approved break-glass host access to recover.
+4. Do not expose admin through the customer app or public Nginx routes.
+
+## Secrets And Host-Managed State
+
+Host-managed values:
+
+- Cloudflare Access application, policies, IdP settings, and session settings.
+- Cloudflare Authenticated Origin Pull client certificate/private key if using
+  zone-level or per-hostname AOP.
+- Cloudflare origin-pull CA file at
+  `/etc/nginx/cloudflare-authenticated-origin-pull-ca.pem`.
+- Tailscale tailnet policy, ACLs/grants, device approvals, and tagged node
+  state.
+- Tailscale Serve configuration.
+- Staging Basic Auth password and htpasswd hash.
+
+Never commit:
+
+- Tailscale auth keys, API keys, device enrollment secrets, or private keys.
+- Cloudflare API tokens, tunnel credentials, Access IdP secrets, or origin
+  certificate private keys.
+- Private SSH keys.
+- Staging Basic Auth passwords or generated htpasswd hashes.
+- Any SITBank Flask, CSRF, session, MFA, password-pepper, webhook, SMTP, or
+  database secrets.
+
+## How The Layers Fit
+
+Cloudflare Access and Tailscale decide whether a request may reach the SITBank
+origin or admin listener. They do not replace Flask login, CSRF, rate limiting,
+root-admin authorization, admin TOTP, admin/customer route isolation, admin
+cookie isolation, or database runtime role separation.
+
+Readiness remains restricted:
+
+- Production customer `/health/ready` is loopback-only.
+- Staging `/health/ready` is loopback-only and bypasses the origin-pull client
+  certificate check only for local deployment verification.
+- Public admin `/health/ready` returns `403`.
+- Admin `/health/live` is loopback-only in the public Nginx server block.
+
+Unknown-host rejection remains in `ops/nginx/sitbank-default.conf`; direct
+origin requests with unexpected hostnames are rejected by the shared default
+server.
+
+## Labels
+
+Zero-trust and network-boundary work should use these repository labels:
+
+- `zero-trust`: identity-aware or private-network access boundary changes.
+- `network-security`: firewall, VPN, origin access, private access, or network
+  boundary changes.
+- `staging`: staging environment, staging deployment, or staging access changes.
+
+Issue and PR labelers apply these labels from terms such as `Cloudflare
+Access`, `Tailscale`, `tailnet`, `VPN`, `private access`, `origin bypass`,
+`admin exposure`, `staging exposure`, and path changes under `ops/nginx/**`,
+staging configuration, and zero-trust documentation.

--- a/docs/security/session-management.md
+++ b/docs/security/session-management.md
@@ -66,6 +66,14 @@ Gunicorn listeners. Nginx overwrites proxy headers in
 `ops/nginx-proxy-headers.conf`, and `app/__init__.py` applies `ProxyFix` with
 `TRUSTED_PROXY_COUNT`.
 
+Staging browser traffic must pass Cloudflare Access before the staging Nginx
+server reaches Flask, and the staging origin requires Cloudflare Authenticated
+Origin Pulls for browser/app paths. Admin browser traffic must use a
+Tailscale/private operator path before it can reach the loopback admin service.
+These network boundaries do not merge session state: customer and admin
+cookies, lookup HMAC keys, session key prefixes, rate-limit prefixes, and
+runtime database roles remain separate.
+
 Transport protections:
 
 | Control | Evidence |

--- a/ops/deploy/bootstrap-container-ec2
+++ b/ops/deploy/bootstrap-container-ec2
@@ -13,6 +13,7 @@ readonly TLS_POLICY_FILE="/etc/nginx/snippets/sitbank-tls-policy.conf"
 readonly PRODUCTION_RATE_LIMITS_FILE="/etc/nginx/conf.d/sitbank-production-rate-limits.conf"
 readonly STAGING_PUBLIC_HOST="staging-sitbank.duckdns.org"
 readonly STAGING_BASIC_AUTH_FILE="/etc/nginx/.htpasswd-sitbank-staging"
+readonly STAGING_CLOUDFLARE_ORIGIN_PULL_CA_FILE="/etc/nginx/cloudflare-authenticated-origin-pull-ca.pem"
 readonly STAGING_RATE_LIMITS_FILE="/etc/nginx/conf.d/sitbank-staging-rate-limits.conf"
 
 if [[ "${EUID}" -ne 0 ]]; then
@@ -416,6 +417,13 @@ if [[ "${target}" == "staging" ]]; then
         || ! -r "${STAGING_BASIC_AUTH_FILE}" ]]; then
         echo "Missing required staging Basic Auth file: ${STAGING_BASIC_AUTH_FILE}" >&2
         echo "Create it with htpasswd, owned by root:www-data and mode 0640, before rerunning bootstrap." >&2
+        exit 1
+    fi
+    if [[ ! -f "${STAGING_CLOUDFLARE_ORIGIN_PULL_CA_FILE}" \
+        || -L "${STAGING_CLOUDFLARE_ORIGIN_PULL_CA_FILE}" \
+        || ! -r "${STAGING_CLOUDFLARE_ORIGIN_PULL_CA_FILE}" ]]; then
+        echo "Missing required Cloudflare Authenticated Origin Pull CA file: ${STAGING_CLOUDFLARE_ORIGIN_PULL_CA_FILE}" >&2
+        echo "Install the Cloudflare origin-pull CA certificate before rerunning staging bootstrap." >&2
         exit 1
     fi
     for required_staging_file in \

--- a/ops/nginx/sitbank-staging.conf
+++ b/ops/nginx/sitbank-staging.conf
@@ -37,6 +37,8 @@ server {
     ssl_certificate /etc/letsencrypt/live/staging-sitbank.duckdns.org/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/staging-sitbank.duckdns.org/privkey.pem;
     include /etc/nginx/snippets/sitbank-tls-policy.conf;
+    ssl_client_certificate /etc/nginx/cloudflare-authenticated-origin-pull-ca.pem;
+    ssl_verify_client optional;
     ssl_session_cache shared:sitbank_staging_ssl:10m;
     ssl_session_timeout 1d;
 
@@ -85,6 +87,8 @@ server {
     }
 
     location = /health/live {
+        if ($ssl_client_verify != SUCCESS) { return 403; }
+
         limit_req zone=sitbank_staging_app burst=40 nodelay;
         proxy_pass http://127.0.0.1:5001;
         include /etc/nginx/snippets/sitbank-proxy-headers.conf;
@@ -99,30 +103,40 @@ server {
     }
 
     location = /login {
+        if ($ssl_client_verify != SUCCESS) { return 403; }
+
         limit_req zone=sitbank_staging_login burst=5 nodelay;
         proxy_pass http://127.0.0.1:5001;
         include /etc/nginx/snippets/sitbank-proxy-headers.conf;
     }
 
     location = /register {
+        if ($ssl_client_verify != SUCCESS) { return 403; }
+
         limit_req zone=sitbank_staging_login burst=5 nodelay;
         proxy_pass http://127.0.0.1:5001;
         include /etc/nginx/snippets/sitbank-proxy-headers.conf;
     }
 
     location = /mfa/verify {
+        if ($ssl_client_verify != SUCCESS) { return 403; }
+
         limit_req zone=sitbank_staging_login burst=5 nodelay;
         proxy_pass http://127.0.0.1:5001;
         include /etc/nginx/snippets/sitbank-proxy-headers.conf;
     }
 
     location ^~ /auth/ {
+        if ($ssl_client_verify != SUCCESS) { return 403; }
+
         limit_req zone=sitbank_staging_login burst=5 nodelay;
         proxy_pass http://127.0.0.1:5001;
         include /etc/nginx/snippets/sitbank-proxy-headers.conf;
     }
 
     location / {
+        if ($ssl_client_verify != SUCCESS) { return 403; }
+
         limit_req zone=sitbank_staging_app burst=40 nodelay;
         proxy_pass http://127.0.0.1:5001;
         include /etc/nginx/snippets/sitbank-proxy-headers.conf;

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -2351,6 +2351,8 @@ def test_staging_nginx_enforces_https_auth_health_and_rate_limits():
     assert "server_name staging-sitbank.duckdns.org;" in nginx
     assert "ssl_certificate /etc/letsencrypt/live/staging-sitbank.duckdns.org/fullchain.pem;" in nginx
     assert "ssl_certificate_key /etc/letsencrypt/live/staging-sitbank.duckdns.org/privkey.pem;" in nginx
+    assert "ssl_client_certificate /etc/nginx/cloudflare-authenticated-origin-pull-ca.pem;" in nginx
+    assert "ssl_verify_client optional;" in nginx
     _assert_nginx_owns_duplicate_edge_security_headers(
         nginx,
         hsts_add_header='add_header Strict-Transport-Security "max-age=300" always;',
@@ -2384,6 +2386,8 @@ def test_staging_nginx_enforces_https_auth_health_and_rate_limits():
 
     health_live_bodies = _nginx_location_bodies(nginx, "= /health/live")
     assert len(health_live_bodies) == 1
+    assert "$ssl_client_verify != SUCCESS" in health_live_bodies[0]
+    assert "return 403;" in health_live_bodies[0]
     assert "limit_req zone=sitbank_staging_app" in health_live_bodies[0]
     assert "proxy_pass http://127.0.0.1:5001;" in health_live_bodies[0]
 
@@ -2406,9 +2410,13 @@ def test_staging_nginx_enforces_https_auth_health_and_rate_limits():
     for selector in ("= /login", "= /register", "= /mfa/verify", "^~ /auth/"):
         bodies = _nginx_location_bodies(nginx, selector)
         assert len(bodies) == 1
+        assert "$ssl_client_verify != SUCCESS" in bodies[0]
+        assert "return 403;" in bodies[0]
         assert "limit_req zone=sitbank_staging_login" in bodies[0]
     assert any(
-        "limit_req zone=sitbank_staging_app" in body
+        "$ssl_client_verify != SUCCESS" in body
+        and "return 403;" in body
+        and "limit_req zone=sitbank_staging_app" in body
         for body in _nginx_location_bodies(nginx, "/")
     )
 
@@ -2421,6 +2429,9 @@ def test_staging_nginx_enforces_https_auth_health_and_rate_limits():
         '${public_host_regex}([[:space:];]|$)" \\'
     ) in bootstrap
     assert "Missing required staging Basic Auth file" in bootstrap
+    assert "STAGING_CLOUDFLARE_ORIGIN_PULL_CA_FILE=\"/etc/nginx/cloudflare-authenticated-origin-pull-ca.pem\"" in bootstrap
+    assert "Missing required Cloudflare Authenticated Origin Pull CA file" in bootstrap
+    assert "Install the Cloudflare origin-pull CA certificate before rerunning staging bootstrap." in bootstrap
     assert "Missing required staging TLS file" in bootstrap
     assert "apache2-utils" in bootstrap
     assert "certbot" in bootstrap
@@ -2708,7 +2719,10 @@ def test_production_edge_runbook_documents_network_waf_and_verification_steps():
         "admin Gunicorn bound to",
         "`127.0.0.1:5002`",
         "Restrict `/health/ready` to loopback",
-        "Keep admin routes denied by default",
+        "Keep public admin app routes denied by default",
+        "Tailscale/private operator access only",
+        "Do not enable Tailscale Funnel",
+        "Require Cloudflare Access and Cloudflare Authenticated Origin Pulls",
         "Enable WAF managed common, SQL injection, XSS, bot, and protocol anomaly",
         "rules.",
         "Add WAF rate-based rules for `/login`, `/register`, `/mfa/verify`,",
@@ -2724,30 +2738,41 @@ def test_staging_edge_runbook_documents_operator_verification_steps():
     docs = _project_docs_text()
 
     for required in (
+        "Staging uses Cloudflare Access as the identity-aware boundary",
+        "Cloudflare Authenticated Origin Pulls",
+        "The production customer hostname remains public.",
         "sudo htpasswd -c /etc/nginx/.htpasswd-sitbank-staging",
         "sudo chown root:www-data /etc/nginx/.htpasswd-sitbank-staging",
         "sudo chmod 0640 /etc/nginx/.htpasswd-sitbank-staging",
         "Do not store the Basic Auth password or generated htpasswd hash in the repo.",
+        "sudo install -o root -g root -m 0644",
+        "/etc/nginx/cloudflare-authenticated-origin-pull-ca.pem",
+        "Do not store Cloudflare API tokens, tunnel credentials, Access IdP secrets, or",
         "sudo certbot --nginx -d staging-sitbank.duckdns.org",
         "sudo certbot certonly --webroot",
         "sudo certbot renew --dry-run",
         "ops/deploy/bootstrap-container-ec2",
         "staging-sitbank.duckdns.org",
         "Nginx proxy header snippet",
+        "Cloudflare origin-pull CA file",
         "rate-limit include",
         "sudo nginx -t",
         "sudo systemctl reload nginx",
-        "curl -k -I https://staging-sitbank.duckdns.org/",
-        'curl -k -I -u "$STAGING_BASIC_AUTH_USER:$STAGING_BASIC_AUTH_PASSWORD"',
-        "curl -k -I https://staging-sitbank.duckdns.org/health/ready",
+        "curl -I https://staging-sitbank.duckdns.org/",
+        'curl -I -u "$STAGING_BASIC_AUTH_USER:$STAGING_BASIC_AUTH_PASSWORD"',
+        "curl -I https://staging-sitbank.duckdns.org/health/ready",
         "curl -fsS http://127.0.0.1:5001/health/ready",
-        "unauthenticated `/` returns `401`",
+        "curl --fail --resolve staging-sitbank.duckdns.org:443:127.0.0.1",
+        "curl -I --resolve staging-sitbank.duckdns.org:443:<EC2_PUBLIC_IP>",
+        "unauthenticated browser traffic receives the Cloudflare Access",
+        "direct EC2-origin access to",
+        "returns `403` without Cloudflare's origin-pull client certificate",
         "external `/health/ready` returns `403`",
         "local app readiness",
         "separate from application deployment",
+        "docs/security/admin-and-staging-zero-trust-access.md",
     ):
         assert required in docs
-    assert re.search(r"authenticated `/` returns\s+`200`", docs)
 
 
 def test_dependency_manifests_have_one_hashed_lockfile_source_of_truth():

--- a/tests/test_zero_trust_access_boundary.py
+++ b/tests/test_zero_trust_access_boundary.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import yaml
+
+
+def _docs_text() -> str:
+    paths = [Path("README.md"), Path("SECURITY.md")]
+    paths.extend(sorted(Path("docs").rglob("*.md")))
+    return "\n".join(path.read_text(encoding="utf-8") for path in paths)
+
+
+def _nginx_location_bodies(config: str, selector: str) -> list[str]:
+    return re.findall(
+        rf"location\s+{re.escape(selector)}\s*\{{(.*?)\n\s*\}}",
+        config,
+        flags=re.DOTALL,
+    )
+
+
+def _nginx_server_block(config: str, server_name: str) -> str:
+    marker = f"server_name {server_name};"
+    blocks = []
+    search_from = 0
+    while True:
+        marker_index = config.find(marker, search_from)
+        if marker_index == -1:
+            break
+        start = config.rfind("\nserver {", 0, marker_index)
+        start = 0 if start == -1 else start + 1
+        end = config.find("\nserver {", marker_index)
+        blocks.append(config[start:] if end == -1 else config[start:end])
+        search_from = marker_index + len(marker)
+    assert blocks, f"Missing Nginx server block for {server_name}"
+    for block in blocks:
+        if "listen 443 ssl http2;" in block:
+            return block
+    return blocks[0]
+
+
+def _tracked_files() -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        check=True,
+        capture_output=True,
+    )
+    return [Path(item.decode("utf-8")) for item in result.stdout.split(b"\0") if item]
+
+
+def test_hybrid_cloudflare_staging_and_tailscale_admin_design_is_documented():
+    docs = _docs_text()
+
+    for required in (
+        "Issue #184 uses a hybrid access boundary",
+        "Staging uses Cloudflare Zero Trust Access.",
+        "Admin uses Tailscale private access.",
+        "This intentionally uses both products because the surfaces have different",
+        "Production customer | `https://sitbank.duckdns.org`",
+        "Staging customer | `https://staging-sitbank.duckdns.org`",
+        "Production admin app | Tailscale Serve or Tailscale SSH to `127.0.0.1:5002`",
+        "The customer production site remains public.",
+        "Cloudflare Access application for `staging-sitbank.duckdns.org`",
+        "Cloudflare Authenticated Origin Pulls",
+        "Do not enable Tailscale Funnel",
+        "Flask admin login and TOTP remain mandatory",
+        "onboarding, offboarding, emergency lockout, rollback",
+        "local readiness succeeds through loopback",
+        "direct origin access",
+        "Cloudflare Access and Tailscale decide whether a request may reach",
+        "Zero-trust and network-boundary work should use these repository labels",
+    ):
+        assert required in docs
+
+    assert "staging is documented/configured as public-only" not in docs.lower()
+    assert "admin is documented/configured as public-only" not in docs.lower()
+
+
+def test_staging_nginx_blocks_direct_origin_bypass_but_keeps_local_health():
+    default_nginx = Path("ops/nginx/sitbank-default.conf").read_text(encoding="utf-8")
+    staging_nginx = Path("ops/nginx/sitbank-staging.conf").read_text(encoding="utf-8")
+    bootstrap = Path("ops/deploy/bootstrap-container-ec2").read_text(encoding="utf-8")
+
+    assert "listen 80 default_server;" in default_nginx
+    assert "listen 443 ssl http2 default_server;" in default_nginx
+    assert "ssl_reject_handshake on;" in default_nginx
+    assert "return 444;" in default_nginx
+
+    assert "server_name staging-sitbank.duckdns.org;" in staging_nginx
+    assert "ssl_client_certificate /etc/nginx/cloudflare-authenticated-origin-pull-ca.pem;" in staging_nginx
+    assert "ssl_verify_client optional;" in staging_nginx
+    assert "auth_basic \"SITBank staging\";" in staging_nginx
+
+    for selector in (
+        "= /health/live",
+        "= /login",
+        "= /register",
+        "= /mfa/verify",
+        "^~ /auth/",
+        "/",
+    ):
+        bodies = _nginx_location_bodies(staging_nginx, selector)
+        assert bodies, f"Missing staging Nginx location {selector}"
+        assert any("$ssl_client_verify != SUCCESS" in body for body in bodies)
+        assert any("return 403;" in body for body in bodies)
+
+    ready_bodies = _nginx_location_bodies(staging_nginx, "= /health/ready")
+    assert len(ready_bodies) == 1
+    ready = ready_bodies[0]
+    assert "$ssl_client_verify" not in ready
+    assert "allow 127.0.0.1;" in ready
+    assert "allow ::1;" in ready
+    assert "deny all;" in ready
+    assert "proxy_pass http://127.0.0.1:5001;" in ready
+
+    assert "STAGING_CLOUDFLARE_ORIGIN_PULL_CA_FILE" in bootstrap
+    assert "Missing required Cloudflare Authenticated Origin Pull CA file" in bootstrap
+    assert "nginx -t" in bootstrap
+
+
+def test_admin_public_routes_stay_denied_and_private_access_is_tailscale_only():
+    production_nginx = Path("ops/nginx/sitbank-production.conf").read_text(
+        encoding="utf-8"
+    )
+    docs = _docs_text()
+    admin_server = _nginx_server_block(production_nginx, "admin-sitbank.duckdns.org")
+    customer_server = _nginx_server_block(production_nginx, "sitbank.duckdns.org")
+
+    assert "server_name sitbank.duckdns.org;" in customer_server
+    assert "server_name staging-sitbank.duckdns.org;" not in customer_server
+    assert "server_name admin-sitbank.duckdns.org;" not in customer_server
+    assert "location ^~ /admin" in customer_server
+    assert "return 404;" in customer_server
+
+    login_bodies = _nginx_location_bodies(admin_server, "= /login")
+    assert len(login_bodies) == 1
+    assert "deny all;" in login_bodies[0]
+    assert "proxy_pass http://127.0.0.1:5002;" in login_bodies[0]
+
+    ready_bodies = _nginx_location_bodies(admin_server, "= /health/ready")
+    assert len(ready_bodies) == 1
+    assert "deny all;" in ready_bodies[0]
+    assert "return 403;" in ready_bodies[0]
+    assert "proxy_pass" not in ready_bodies[0]
+
+    assert "Tailscale/private operator access" in docs
+    assert "Do not enable Tailscale Funnel" in docs
+    assert "public admin Nginx app routes denied" in docs
+
+
+def test_admin_customer_session_and_runtime_isolation_remains_covered():
+    admin_test = Path("tests/test_admin_isolation.py").read_text(encoding="utf-8")
+    deployment_test = Path("tests/test_deployment.py").read_text(encoding="utf-8")
+    deploy_script = Path("ops/deploy/sitbank-container-deploy").read_text(
+        encoding="utf-8"
+    )
+    production_compose = Path("compose.prod.yml").read_text(encoding="utf-8")
+    staging_compose = Path("compose.staging.yml").read_text(encoding="utf-8")
+
+    for required in (
+        "SESSION_COOKIE_NAME",
+        "__Host-sitbank_session",
+        "__Host-sitbank_admin_session",
+        "SESSION_LOOKUP_HMAC_KEY",
+        "SESSION_KEY_PREFIX",
+        "RATELIMIT_KEY_PREFIX",
+        "AUTH_FAILURE_KEY_PREFIX",
+        "SQLALCHEMY_DATABASE_URI",
+        "ADMIN_AUTH_ENABLED",
+    ):
+        assert required in admin_test
+
+    for required in (
+        "Admin runtime database role must be distinct from customer runtime role",
+        "Admin session lookup HMAC key must be distinct from customer session lookup HMAC key",
+    ):
+        assert required in deploy_script
+
+    for required in (
+        "ADMIN_PUBLIC_HOST='admin-sitbank.duckdns.org'",
+        "127.0.0.1:5002",
+        "127.0.0.1:5003",
+    ):
+        assert required in deployment_test
+
+    assert "127.0.0.1:5002" in production_compose
+    assert "127.0.0.1:5003" in staging_compose
+
+
+def test_required_zero_trust_labels_and_labelers_are_configured():
+    issue_labeler = Path(".github/workflows/issue-labeler.yml").read_text(
+        encoding="utf-8"
+    )
+    pr_labeler = Path(".github/workflows/pr-labeler.yml").read_text(encoding="utf-8")
+    retag = Path(".github/workflows/retag-labels.yml").read_text(encoding="utf-8")
+    labeler = Path(".github/labeler.yml").read_text(encoding="utf-8")
+    labeler_config = yaml.safe_load(labeler)
+
+    for workflow in (issue_labeler, pr_labeler, retag):
+        assert 'create_label zero-trust "Identity-aware or private-network access boundary changes."' in workflow
+        assert 'create_label network-security "Firewall, VPN, origin access, private access, or network boundary changes."' in workflow
+        assert 'create_label staging "Staging environment, staging deployment, or staging access changes."' in workflow
+        for term in (
+            "cloudflare access",
+            "tailscale",
+            "tailnet",
+            "vpn",
+            "private access",
+            "origin bypass",
+            "admin exposure",
+            "staging exposure",
+        ):
+            assert term in workflow.lower()
+
+    assert "gh pr diff \"${PR_NUMBER}\" --patch" in pr_labeler
+    assert "gh pr diff \"${number}\" --patch" in retag
+    assert "sync-labels: false" in pr_labeler
+    assert "sync-labels: false" in retag
+
+    for label in (
+        "zero-trust",
+        "network-security",
+        "staging",
+        "security",
+        "deployment",
+        "admin",
+        "documentation",
+    ):
+        assert label in labeler_config
+
+    assert "ops/nginx/**" in labeler_config["network-security"][0]["changed-files"][0][
+        "any-glob-to-any-file"
+    ]
+    assert "ops/nginx/**" in labeler_config["security"][0]["changed-files"][0][
+        "any-glob-to-any-file"
+    ]
+    assert "compose.staging.yml" in labeler_config["staging"][0]["changed-files"][0][
+        "any-glob-to-any-file"
+    ]
+    assert "docs/security/admin-and-staging-zero-trust-access.md" in labeler
+    assert "PROTECTED_LABELS" in retag
+    for protected in ("dependencies", "docker", "github-actions", "python"):
+        assert protected in retag
+    assert "Dry-run mode is active" in retag
+    assert "computed labels added" in retag
+
+
+def test_provider_credentials_are_not_committed_or_required_by_ci():
+    ci_workflow = Path(".github/workflows/ci-deploy.yml").read_text(encoding="utf-8")
+    tracked_text = []
+    for path in _tracked_files():
+        if not path.is_file():
+            continue
+        try:
+            tracked_text.append(path.read_text(encoding="utf-8"))
+        except UnicodeDecodeError:
+            continue
+    combined = "\n".join(tracked_text)
+
+    assert "CLOUDFLARE_API_TOKEN" not in ci_workflow
+    assert "TAILSCALE_AUTH_KEY" not in ci_workflow
+    assert "TS_AUTHKEY" not in ci_workflow
+    assert "CF_API_TOKEN" not in ci_workflow
+
+    forbidden_patterns = (
+        r"tskey-(?:auth|api)-[A-Za-z0-9_-]{12,}",
+        r"-----BEGIN (?:RSA |EC |OPENSSH |)PRIVATE KEY-----",
+        r"cloudflared/[A-Za-z0-9_-]+\.json",
+        r"CLOUDFLARE_API_TOKEN=['\"][^'\"]+['\"]",
+        r"TAILSCALE_AUTH_KEY=['\"][^'\"]+['\"]",
+        r"TS_AUTHKEY=['\"][^'\"]+['\"]",
+    )
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, combined)
+
+
+def test_repository_identity_ghcr_cosign_and_bootstrap_references_are_consistent():
+    docs = _docs_text()
+    workflow = Path(".github/workflows/ci-deploy.yml").read_text(encoding="utf-8")
+    bootstrap = Path("ops/deploy/bootstrap-container-ec2").read_text(encoding="utf-8")
+    deploy = Path("ops/deploy/sitbank-container-deploy").read_text(encoding="utf-8")
+    old_owner = "wenjiang" + "ggg"
+    old_repo = f"ghcr.io/{old_owner}/sitbank"
+
+    for path in _tracked_files():
+        if not path.is_file():
+            continue
+        try:
+            contents = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        lowered = contents.casefold()
+        assert old_owner not in lowered, path
+        assert old_repo not in lowered, path
+
+    assert "Repository identity: `hetp88/SITBank`" in docs
+    assert "Production image form: `ghcr.io/hetp88/sitbank@sha256:<digest>`" in docs
+    assert 'repository="ghcr.io/${GITHUB_REPOSITORY,,}"' in workflow
+    assert "GITHUB_REPOSITORY=${github_repository}" in bootstrap
+    assert "GHCR_REPOSITORY=ghcr.io/${repository_lower}" in bootstrap
+    assert "COSIGN_CERTIFICATE_IDENTITY=https://github.com/${github_repository}/.github/workflows/ci-deploy.yml@refs/heads/main" in bootstrap
+    assert "expected_identity=\"https://github.com/${GITHUB_REPOSITORY}/.github/workflows/ci-deploy.yml@refs/heads/main\"" in deploy
+    assert "cosign verify" in deploy
+    assert "--certificate-identity \"${COSIGN_CERTIFICATE_IDENTITY}\"" in deploy
+
+
+def test_deployment_policy_and_wrapper_validation_are_not_weakened():
+    workflow = yaml.safe_load(Path(".github/workflows/ci-deploy.yml").read_text(encoding="utf-8"))
+    workflow_text = Path(".github/workflows/ci-deploy.yml").read_text(encoding="utf-8")
+    deploy_script = Path("ops/deploy/sitbank-container-deploy").read_text(encoding="utf-8")
+
+    assert workflow["jobs"]["deploy-production"]["needs"] == [
+        "release-verify",
+        "deploy-staging",
+        "verify-staging-tls",
+    ]
+    assert "needs.deploy-staging.result == 'success'" in workflow_text
+    assert "vars.PROD_DEPLOY_ENABLED == 'true'" in workflow_text
+    assert "workflow_dispatch" in workflow_text
+    assert "target_environment == 'staging'" in workflow_text
+    assert "target_environment == 'production'" not in workflow_text
+    assert "sha256sum /usr/local/sbin/sitbank-container-deploy" in workflow_text
+    assert "/opt/sitbank-staging/compose.yml" in workflow_text
+    assert "/opt/sitbank/compose.yml" in workflow_text
+    assert "cosign verify-blob" in deploy_script
+    assert "cosign verify \\" in deploy_script
+    assert "production-check" in deploy_script
+    assert "db upgrade" in deploy_script


### PR DESCRIPTION
## Summary
Fixes #184.

Secures SITBank staging and admin access using a hybrid zero-trust design:
- Cloudflare Access for staging.
- Tailscale/private access for admin.

## Why
Admin and staging surfaces are high-risk internal areas and should not be broadly reachable from the public internet before Flask authentication is reached.

Staging should remain browser-accessible through staging-sitbank.duckdns.org, but only after Cloudflare Access authentication.

Admin should remain private operator/device access only through Tailscale, with Flask admin login and MFA still required after network access.

## What changed
* Added Cloudflare Authenticated Origin Pull support and direct-origin guards for staging Nginx paths.
* Updated staging bootstrap to require the Cloudflare Authenticated Origin Pull CA file.
* Added a zero-trust operator runbook for Cloudflare staging access and Tailscale admin access.
* Updated deployment, operations, access-control, session-management, security, and GitHub labeling documentation.
* Updated issue, PR, retag, and path-based labeler rules.
* Added zero-trust, network-security, and staging label coverage.
* Added regression tests for access boundaries, labels, secrets, and repo identity.

## Security impact
Improves defense in depth by requiring an additional access boundary before staging/admin app access.

Staging is protected by Cloudflare Access plus Authenticated Origin Pull origin-bypass mitigation.

Admin remains denied on public Nginx app routes and is documented as Tailscale/private access only.

Existing Flask authentication, admin MFA, root-admin authorization, CSRF protection, rate limiting, admin/customer isolation, cookie isolation, database/runtime role separation, health endpoint restrictions, deployment wrapper verification, Cosign verification, and security gates remain in place.

No Cloudflare, Tailscale, provider, SSH, tunnel, or private-key secrets are committed.

## Deployment impact
Staging EC2 bootstrap is required after merge because staging Nginx/bootstrap behavior changed.

Operator follow-up is required:
* Install the Cloudflare Authenticated Origin Pull CA file on EC2.
* Configure Cloudflare Access for staging.
* Enroll EC2/admin operators into Tailscale.
* Verify direct-origin staging access returns 403.
* Verify approved Cloudflare/Tailscale operator paths work.

Production customer site remains public.

Production deployment remains the normal automatic path after successful release verification and staging deployment. No manual production deployment is performed by this PR.

## Verification
* git diff --check passed.
* tests/test_deployment.py and tests/test_admin_isolation.py passed: 55 passed, 6 warnings.
* tests/test_zero_trust_access_boundary.py passed: 8 passed.
* scripts/ci-local passed: 454 passed, 2 skipped, 6 warnings.
* Docker/Compose-only local check skipped because Docker is unavailable.

## Notes
Cloudflare dashboard setup and Tailscale operator/device enrollment are operator-managed and intentionally not committed to the repository.

After merge, complete staging bootstrap and live access verification before relying on the new staging/admin boundary.