### PR TITLE
Fix DAST smoke cookie read

### DIFF
--- a/ops/container/smoke-test.sh
+++ b/ops/container/smoke-test.sh
@@ -439,7 +439,16 @@ if [[ "${RUN_ZAP_DAST:-false}" == "true" ]]; then
             --base-url "${dast_base_url}" \
             --allow-host "${app_container}" \
             --output /run/dast/auth-cookie
-    dast_cookie="$(cat "${work_dir}/dast/auth-cookie")"
+    dast_cookie="$(
+        docker run --rm --interactive "${docker_args[@]}" \
+            --volume "${dast_mount_source}:/run/dast:ro" \
+            "${IMAGE}" \
+            python - <<'PY'
+from pathlib import Path
+
+print(Path("/run/dast/auth-cookie").read_text(encoding="utf-8"), end="")
+PY
+    )"
     if [[ ! "${dast_cookie}" =~ ^__Host-sitbank_session=[A-Za-z0-9._~-]+$ ]]; then
         echo "Authenticated DAST session cookie is malformed" >&2
         exit 1

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1050,6 +1050,9 @@ def test_dockerfile_and_compose_enforce_hardened_runtime():
     assert "RUN_ZAP_DAST" in smoke_test
     assert "zaproxy/zap-stable:2.17.0@sha256:" in smoke_test
     assert "create_dast_session.py" in smoke_test
+    assert 'cat "${work_dir}/dast/auth-cookie"' not in smoke_test
+    assert '"${dast_mount_source}:/run/dast:ro"' in smoke_test
+    assert 'Path("/run/dast/auth-cookie").read_text(encoding="utf-8")' in smoke_test
     assert "docker compose" in compose_validation
     assert "SITBANK_IMAGE" in compose_validation
     assert "compose.prod.yml" in compose_validation


### PR DESCRIPTION
## Summary

Fixes the release/container smoke failure where authenticated DAST could create a private auth-cookie file that the host runner could not read.

## Why

The DAST session helper correctly writes the generated session cookie with restrictive `0600` permissions. In CI, that file is owned by the container runtime UID, so the host-side `cat` in `ops/container/smoke-test.sh` fails with `Permission denied`.

## What changed

* Read the DAST auth cookie through a short-lived container running with the same smoke-test user instead of reading it from the host.
* Mount the DAST artifact directory read-only for the cookie read step.
* Added a deployment regression assertion so the smoke script does not reintroduce host-side `cat` for the private cookie file.

## Security impact

Preserves restrictive cookie-file permissions while fixing CI. The auth cookie is still not made world-readable, and the ZAP replacement still receives only the generated authenticated session cookie value.

## Deployment impact

No deployment action required. This only changes the CI/release smoke-test script.

## Verification

* `git diff --check`
* `bash -n ops/container/smoke-test.sh`
* `python -m pytest -q tests/test_deployment.py::test_dockerfile_and_compose_enforce_hardened_runtime tests/test_deployment.py::test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest tests/test_deployment.py::test_dast_session_creator_requires_loopback_or_explicit_smoke_host tests/test_deployment.py::test_dast_session_creator_matches_registration_contract`
* `python -m pytest -q tests/test_deployment.py`

## Notes

This is a follow-up fix for the failed squash/release verification smoke run.