### PR TITLE
Fix staging HSTS duration

### DIFF
--- a/docs/security/cryptography-and-authentication.md
+++ b/docs/security/cryptography-and-authentication.md
@@ -38,7 +38,7 @@ Evidence:
 | TLS server block and certificate path | `ops/nginx/sitbank-production.conf`; `ops/nginx/sitbank-staging.conf` |
 | HTTP handling | Customer HTTP redirects with `return 301 https://sitbank.duckdns.org$request_uri;`; public admin non-ACME HTTP returns `403` in `ops/nginx/sitbank-production.conf` |
 | Unknown host rejection | `ops/nginx/sitbank-default.conf` returns `444` for the default HTTP server and uses `ssl_reject_handshake on` for the default HTTPS server |
-| HSTS | Production uses `Strict-Transport-Security "max-age=31536000; includeSubDomains"`; staging uses `max-age=300` |
+| HSTS | Production uses `Strict-Transport-Security "max-age=31536000; includeSubDomains"`; staging uses `Strict-Transport-Security "max-age=31536000"` |
 | Proxy trust boundary | `ops/nginx-proxy-headers.conf` overwrites `Host`, `X-Real-IP`, `X-Forwarded-For`, and `X-Forwarded-Proto`; `app/__init__.py` applies `ProxyFix` using `TRUSTED_PROXY_COUNT` |
 | TLS policy and deployment validation | `ops/nginx/sitbank-tls-policy.conf` pins the shared TLS policy; `ops/deploy/bootstrap-container-ec2` requires the Certbot files, invokes `ops/deploy/verify-certbot-host-state`, and installs the TLS snippet before installing the production or staging Nginx site, then runs `nginx -t` before reload |
 | Tests | `tests/test_deployment.py::test_nginx_default_server_is_shared_for_same_host_production_and_staging`, `tests/test_deployment.py::test_production_nginx_edge_config_enforces_network_boundary_and_limits`, `tests/test_deployment.py::test_staging_nginx_enforces_https_auth_health_and_rate_limits`, `tests/test_deployment.py::test_proxyfix_trusts_exactly_the_configured_nginx_hop` |

--- a/ops/nginx/sitbank-staging.conf
+++ b/ops/nginx/sitbank-staging.conf
@@ -52,7 +52,7 @@ server {
     add_header X-Frame-Options "DENY" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()" always;
-    add_header Strict-Transport-Security "max-age=300" always;
+    add_header Strict-Transport-Security "max-age=31536000" always;
 
     limit_req_status 429;
     limit_req_log_level warn;

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -2397,7 +2397,7 @@ def test_staging_nginx_enforces_https_auth_health_and_rate_limits():
     assert "ssl_verify_client optional;" in nginx
     _assert_nginx_owns_duplicate_edge_security_headers(
         nginx,
-        hsts_add_header='add_header Strict-Transport-Security "max-age=300" always;',
+        hsts_add_header='add_header Strict-Transport-Security "max-age=31536000" always;',
     )
     assert "preload" not in nginx
     assert 'auth_basic "SITBank staging";' in nginx


### PR DESCRIPTION
## Summary

Fixes the live TLS verification failure for staging by increasing the staging HSTS max-age from 300 seconds to 31536000 seconds.

## Why

The live TLS scan for `staging-sitbank.duckdns.org` failed because testssl reported:

`Strict Transport Security 300 s = 0 days is too short`

That caused the endpoint to receive an A- grade and fail the GitHub Actions live TLS verification gate.

## What changed

* Updated `ops/nginx/sitbank-staging.conf` to send `Strict-Transport-Security "max-age=31536000"`.
* Updated the deployment regression test to expect the stronger staging HSTS value.
* Updated the cryptography/authentication documentation so it no longer documents the outdated 300-second staging HSTS value.

## Security impact

This improves staging HTTPS hardening by requiring browsers to remember HTTPS-only access for a longer period.

This does not change secrets, database access, authentication logic, application permissions, production runtime behavior, or CI/CD credentials.

## Deployment impact

This requires the staging Nginx configuration to be applied after merge.

After merging, run the staging edge/bootstrap path:

`ops/deploy/bootstrap-container-ec2 staging hetp88/SITBank staging-sitbank.duckdns.org`

Alternatively, install the updated staging Nginx config on the host, then run:

`sudo nginx -t`
`sudo systemctl reload nginx`

No database migration, secret change, EC2 re-provisioning, or production deployment is required.

## Verification

* `git diff --check`
* `python -m pytest -q tests/test_deployment.py::test_staging_nginx_enforces_https_auth_health_and_rate_limits tests/test_deployment.py::test_live_tls_scan_workflow_collects_evidence_without_running_on_pull_requests tests/test_deployment.py::test_nginx_tls_policy_pins_strong_suites_curves_and_session_hardening`
* `python -m pytest -q tests/test_deployment.py`
* Confirmed no remaining checked-in staging/docs/test references to `max-age=300`.

## Notes

The live TLS scan will keep failing until staging Nginx is reloaded with the merged config. After reload, rerun the live TLS verification workflow.