### PR TITLE
Migrate workflow actions to Node.js 24

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -198,7 +198,7 @@ jobs:
           persist-credentials: false
 
       - name: Review dependency changes
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294
         with:
           fail-on-severity: high
 

--- a/.github/workflows/tls-scan.yml
+++ b/.github/workflows/tls-scan.yml
@@ -270,7 +270,7 @@ jobs:
 
       - name: Upload TLS scan evidence
         if: ${{ always() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ matrix.target.artifact }}
           path: tls-scan/${{ matrix.target.label }}

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -80,3 +80,10 @@ Authenticated DAST still runs before staging/production deployment during releas
 Dependabot updates are review-only. Base-image updates must not be auto-merged. For dependency or image changes, maintainers should review release notes, regenerate hash-locked dependency files, and require the container smoke test, Compose validation, Trivy gates, dependency audits, and relevant application tests before merging.
 
 Base image updates must change the pinned Dockerfile digest and the deployment/security test constants in the same reviewed PR.
+
+Treat GitHub Actions runner-runtime deprecation warnings as CI maintenance
+issues. Keep JavaScript actions compatible with GitHub's current runner runtime
+by replacing deprecated pins with reviewed full commit SHAs; never change them
+to floating tags. Runtime updates to the live TLS scan must preserve its
+per-target JSON, log, and HTML evidence artifacts, names, failure behavior, and
+retention policy.

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -38,6 +38,10 @@ from ops.runtime_contract import (
 
 
 ACTION_USES_PIN_RE = re.compile(r"[^@]+@[0-9a-f]{40}")
+KNOWN_NODE20_ACTION_USES = {
+    "actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48",
+    "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02",
+}
 PYTHON_SLIM_TRIXIE_DIGEST_RE = re.compile(
     r"python:3\.12(?:\.\d+)?-slim-trixie@sha256:[0-9a-f]{64}"
 )
@@ -1996,6 +2000,10 @@ def test_every_github_action_is_pinned_to_a_full_commit_sha():
     uses = _workflow_uses(workflow_text)
 
     _assert_pinned_actions(uses, context="GitHub Actions workflow")
+    deprecated_actions = sorted(set(uses) & KNOWN_NODE20_ACTION_USES)
+    assert not deprecated_actions, (
+        f"GitHub Actions workflows use known Node.js 20 action pins: {deprecated_actions}"
+    )
     assert "pull_request_target:" not in workflow_text
 
 
@@ -2007,6 +2015,7 @@ def test_live_tls_scan_workflow_collects_evidence_without_running_on_pull_reques
 
     assert workflow["name"] == "Live TLS scan evidence"
     assert set(triggers) == {"workflow_call", "workflow_dispatch", "schedule"}
+    assert triggers["schedule"] == [{"cron": "23 3 * * 1"}]
     assert "pull_request" not in workflow_text
     assert workflow["permissions"] == {}
     assert workflow["concurrency"] == {
@@ -2056,6 +2065,8 @@ def test_live_tls_scan_workflow_collects_evidence_without_running_on_pull_reques
     assert "--htmlfile" in workflow_text
     assert 'raw_json_file="${evidence_dir}/testssl.raw.json"' in workflow_text
     assert 'json_file="${evidence_dir}/testssl.json"' in workflow_text
+    assert 'log_file="${evidence_dir}/testssl.log"' in workflow_text
+    assert 'html_file="${evidence_dir}/testssl.html"' in workflow_text
     assert '--jsonfile "${raw_json_file}"' in workflow_text
     assert 'python3 - "${raw_json_file}" "${json_file}"' in workflow_text
     assert 'data = raw_path.read_text(encoding="utf-8")' in workflow_text
@@ -2085,14 +2096,34 @@ def test_live_tls_scan_workflow_collects_evidence_without_running_on_pull_reques
     assert "index($severity) != null" in workflow_text
     assert 'policy-violations.txt"' in workflow_text
     assert 'if [[ "${scan_failed}" -ne 0 ]]' in workflow_text
-    assert "actions/upload-artifact@" in workflow_text
     assert '.[]\n              | select(type == "object")\n              | select(' in workflow_text
     assert "secrets." not in workflow_text
 
+    upload_steps = [
+        step for step in scan["steps"]
+        if step.get("name") == "Upload TLS scan evidence"
+    ]
+    assert len(upload_steps) == 1
+    upload_step = upload_steps[0]
+    assert upload_step == {
+        "name": "Upload TLS scan evidence",
+        "if": "${{ always() }}",
+        "uses": (
+            "actions/upload-artifact@"
+            "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
+        ),
+        "with": {
+            "name": "${{ matrix.target.artifact }}",
+            "path": "tls-scan/${{ matrix.target.label }}",
+            "if-no-files-found": "warn",
+            "retention-days": 90,
+        },
+    }
     uses = _workflow_uses(workflow_text)
     assert uses == [
-        "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
+        "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
     ]
+    assert not set(uses) & KNOWN_NODE20_ACTION_USES
     _assert_pinned_actions(uses, context="Live TLS scan workflow")
 
     deployment_docs = Path("docs/DEPLOYMENT.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Migrates GitHub workflow actions to Node.js 24-compatible pinned versions.

This updates workflow dependencies that were still using Node.js 20 action runtimes while preserving the existing workflow behavior, permissions, TLS evidence artifacts, retention settings, summaries, and failure gates.

## Why

GitHub Actions is moving away from older Node.js action runtimes. Keeping workflow actions on supported Node.js 24-compatible versions avoids deprecation warnings and reduces CI maintenance risk.

This also keeps the TLS evidence workflow and dependency review workflow aligned with the repository’s pinned-action policy.

## What changed

* Updated `actions/upload-artifact` from the previous pinned commit to the pinned `v7.0.1` commit:

  * `043fb46...`
* Updated `actions/dependency-review-action` from the previous pinned commit to the pinned `v5.0.0` commit:

  * `a1d282b...`
* Audited all workflow actions.
* Audited nested composite-action dependencies.
* Confirmed no Node.js 20 actions remain.
* Preserved existing workflow permissions.
* Preserved TLS artifact names and contents.
* Preserved 90-day artifact retention.
* Preserved workflow summaries.
* Preserved failure gates.
* Added regression coverage for the workflow runtime migration.
* Added maintenance guidance for future action runtime upgrades.

## Security impact

This is a CI hardening and maintenance change.

It does not change application authentication, authorization, secrets, database schema, deployment runtime behavior, or TLS policy logic.

The change keeps actions pinned to full commit SHAs, preserving supply-chain control while moving to Node.js 24-compatible action versions.

## Deployment impact

No deployment action.

This PR does not require:

* EC2 bootstrap
* staging deployment
* production deployment
* database migration
* secret changes

Live warning removal requires dispatching the affected workflow after these changes are pushed.

## Verification

* `python -m pytest -q tests/test_deployment.py`

  * `48 passed`
* All 9 workflows parsed successfully.
* `git diff --check`

  * Passed
* Full suite was attempted but exceeded the execution timeout.

  * No failure was reported before the timeout.

## Notes

The live GitHub Actions warning will only disappear after the updated workflow is pushed and dispatched.

The migration preserves current workflow behavior and only updates the pinned action runtime dependencies.
