### PR TITLE
Keep staging TLS scan on deployed hostname

### DIFF
--- a/.github/workflows/tls-scan.yml
+++ b/.github/workflows/tls-scan.yml
@@ -11,7 +11,7 @@ on:
       staging_host:
         description: Staging HTTPS hostname to scan (hostname only).
         required: false
-        default: staging-sitbank.pp.ua
+        default: staging-sitbank.duckdns.org
         type: string
       production_host:
         description: Production customer HTTPS hostname to scan (hostname only).
@@ -37,7 +37,7 @@ on:
       staging_host:
         description: Staging HTTPS hostname to scan (hostname only).
         required: true
-        default: staging-sitbank.pp.ua
+        default: staging-sitbank.duckdns.org
         type: string
       production_host:
         description: Production customer HTTPS hostname to scan (hostname only).
@@ -103,7 +103,7 @@ jobs:
       max-parallel: 3
       matrix: ${{ fromJSON(needs.resolve-targets.outputs.matrix) }}
     env:
-      STAGING_HOST: ${{ inputs.staging_host || 'staging-sitbank.pp.ua' }}
+      STAGING_HOST: ${{ inputs.staging_host || 'staging-sitbank.duckdns.org' }}
       PRODUCTION_HOST: ${{ inputs.production_host || 'sitbank.duckdns.org' }}
       ADMIN_HOST: ${{ inputs.admin_host || 'admin-sitbank.duckdns.org' }}
       TARGET_INPUT: ${{ matrix.target.input }}

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -198,9 +198,18 @@ manual workflow inputs when an approved endpoint changes:
 
 | Environment | Workflow input | Default target | Artifact |
 | --- | --- | --- | --- |
-| Staging customer | `staging_host` | `https://staging-sitbank.pp.ua` | `tls-scan-staging-sitbank` |
+| Staging customer | `staging_host` | `https://staging-sitbank.duckdns.org` | `tls-scan-staging-sitbank` |
 | Production customer | `production_host` | `https://sitbank.duckdns.org` | `tls-scan-prod-sitbank` |
 | Production admin | `admin_host` | `https://admin-sitbank.duckdns.org` | `tls-scan-admin-sitbank` |
+
+During the `staging-sitbank.pp.ua` transition, the scheduled and deployment
+gate staging scan stays on the currently deployed
+`staging-sitbank.duckdns.org` endpoint until the EC2 origin has been updated.
+`staging-sitbank.pp.ua` live TLS evidence must be run manually with
+`staging_host=staging-sitbank.pp.ua` after PR merge, staging bootstrap,
+Certbot certificate issuance, and Cloudflare Access/AOP verification. Do not
+use Cloudflare Flexible SSL, disable TLS verification, turn off the Cloudflare
+proxy, or bypass Authenticated Origin Pulls to make the scan pass.
 
 Each target preserves the scanner's original `testssl.raw.json` and produces a
 separate `testssl.json` for policy parsing, plus a text log, HTML report, scan
@@ -233,10 +242,16 @@ application credentials):
 ```bash
 testssl.sh --warnings batch --color 0 --jsonfile testssl.json \
   --logfile testssl.log --htmlfile testssl.html \
-  https://staging-sitbank.pp.ua
+  https://staging-sitbank.duckdns.org
 testssl.sh --warnings batch --color 0 https://sitbank.duckdns.org
 testssl.sh --warnings batch --color 0 https://admin-sitbank.duckdns.org
 ```
+
+After the staging bootstrap has installed the updated Nginx server block, the
+staging certificate includes `staging-sitbank.pp.ua`, and Cloudflare
+Access/AOP verification succeeds, run the same workflow manually with
+`scan_scope=staging` and `staging_host=staging-sitbank.pp.ua`, then retain the
+`tls-scan-staging-sitbank` artifact as the Cloudflare-managed staging evidence.
 
 SSL Labs remains optional, manual corroborating evidence. Use its public
 report when an independently rendered assessment is useful for a release,

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -326,7 +326,7 @@ contents. Finally run `sudo nginx -t` before reload.
 The **Live TLS scan evidence** workflow provides scheduled weekly,
 operator-dispatched, and post-deployment evidence of the Internet-facing TLS
 posture for
-`staging-sitbank.pp.ua`, `sitbank.duckdns.org`, and
+`staging-sitbank.duckdns.org`, `sitbank.duckdns.org`, and
 `admin-sitbank.duckdns.org`. The deployment workflow calls the staging scan
 after staging deploy and blocks production deployment until it passes; it calls
 the production scan after production deploy to complete the release evidence.
@@ -334,6 +334,14 @@ Dispatch it after edge, certificate, DNS, Nginx/OpenSSL, CDN/WAF, or
 load-balancer changes outside deployment, then retain the successful run with
 the release or change record. Do not run a public-endpoint scan from ordinary
 pull requests.
+
+During the `staging-sitbank.pp.ua` transition, leave the scheduled and
+deployment-gate staging scan on the currently deployed DuckDNS endpoint. Run
+`staging-sitbank.pp.ua` as a manual `staging_host` override only after PR
+merge, staging bootstrap, Certbot certificate issuance, and Cloudflare
+Access/AOP verification. Do not make the scan pass by switching Cloudflare to
+Flexible SSL, disabling TLS verification, disabling the Cloudflare proxy, or
+bypassing Authenticated Origin Pulls.
 
 Each target artifact (`tls-scan-staging-sitbank`, `tls-scan-prod-sitbank`, or
 `tls-scan-admin-sitbank`) retains the untouched scanner output as

--- a/docs/security/cryptography-and-authentication.md
+++ b/docs/security/cryptography-and-authentication.md
@@ -100,7 +100,7 @@ dispatched after a TLS-relevant infrastructure change, and is called from the
 trusted deployment workflow. It verifies staging immediately after staging
 deploy (and blocks production deployment until that verification passes), then
 verifies both production endpoints after production deploy to complete the
-release evidence. It scans `staging-sitbank.pp.ua`,
+release evidence. It scans `staging-sitbank.duckdns.org`,
 `sitbank.duckdns.org`, and `admin-sitbank.duckdns.org` with a checksum-verified
 `testssl.sh` release. Each per-target artifact retains untouched scanner JSON
 as `testssl.raw.json` and a separate `testssl.json` policy copy, along with the
@@ -111,6 +111,13 @@ Cloudflare Origin Pull CA subject as raw evidence without relaxing invalid-JSON
 or TLS findings generally. The job summary records the UTC time, target,
 workflow run, and result. It intentionally does not run on ordinary pull
 requests because they do not create public TLS endpoints.
+
+`staging-sitbank.pp.ua` is a manual post-rollout TLS evidence target during
+the transition. Run it with the workflow's `staging_host` override only after
+PR merge, staging bootstrap, Certbot certificate issuance, and Cloudflare
+Access/AOP verification. That sequencing avoids requiring the Cloudflare edge
+hostname before the origin TLS certificate and Authenticated Origin Pull path
+are ready.
 
 Verification fails for SSLv2/SSLv3/TLS 1.0/TLS 1.1, weak/NULL/anonymous/export/
 RC4/3DES cipher classes, missing, disabled, or too-short HSTS, expired

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -2030,7 +2030,7 @@ def test_live_tls_scan_workflow_collects_evidence_without_running_on_pull_reques
 
     inputs = triggers["workflow_dispatch"]["inputs"]
     assert inputs["scan_scope"]["options"] == ["all", "staging", "production"]
-    assert inputs["staging_host"]["default"] == "staging-sitbank.pp.ua"
+    assert inputs["staging_host"]["default"] == "staging-sitbank.duckdns.org"
     assert inputs["production_host"]["default"] == "sitbank.duckdns.org"
     assert inputs["admin_host"]["default"] == "admin-sitbank.duckdns.org"
 
@@ -2042,6 +2042,7 @@ def test_live_tls_scan_workflow_collects_evidence_without_running_on_pull_reques
         "type": "string",
     }
     assert call_inputs["staging_host"]["required"] is False
+    assert call_inputs["staging_host"]["default"] == "staging-sitbank.duckdns.org"
     assert call_inputs["production_host"]["required"] is False
     assert call_inputs["admin_host"]["required"] is False
 
@@ -2137,9 +2138,12 @@ def test_live_tls_scan_workflow_collects_evidence_without_running_on_pull_reques
         encoding="utf-8"
     )
     for docs in (deployment_docs, operations_docs, crypto_docs):
+        normalized_docs = re.sub(r"\s+", " ", docs)
         assert "live tls scan evidence" in docs.lower()
         assert "staging-sitbank.pp.ua" in docs
         assert "staging-sitbank.duckdns.org" in docs
+        assert "staging_host" in docs
+        assert "after PR merge, staging bootstrap, Certbot certificate issuance, and Cloudflare Access/AOP verification" in normalized_docs
         assert "sitbank.duckdns.org" in docs
         assert "admin-sitbank.duckdns.org" in docs
         assert "SSL Labs" in docs


### PR DESCRIPTION
## Summary
Keeps the live TLS scan staging default on the currently deployed DuckDNS hostname while `staging-sitbank.pp.ua` is rolled out.

## Why
`staging-sitbank.pp.ua` can return Cloudflare 525 before the EC2 origin has the updated Nginx hostname config, certificate SAN, and Cloudflare Access/AOP path verified. The scan gate should not require that hostname before server-side rollout is complete.

## What changed
- Restored the live TLS scan default `staging_host` to `staging-sitbank.duckdns.org` for workflow calls, manual dispatch defaults, and scheduled fallback behavior.
- Documented `staging-sitbank.pp.ua` as a manual post-rollout TLS evidence target after merge, staging bootstrap, Certbot issuance, and Cloudflare Access/AOP verification.
- Updated deployment tests to assert the DuckDNS default and the documented manual `pp.ua` evidence path.

## Security impact
No staging origin protections were weakened. Cloudflare Authenticated Origin Pull, direct-origin `403`, staging Basic Auth, TLS verification, Cloudflare proxy expectations, admin public-deny behavior, Tailscale admin access, and security gates remain unchanged.

## Deployment impact
No database migration, secret changes, new environment variables, or EC2 bootstrap are introduced by this workflow/documentation fix.

## Verification
- `git diff --check`
- `.\.venv\Scripts\python.exe -m pytest -q tests/test_zero_trust_access_boundary.py`
- `.\.venv\Scripts\python.exe -m pytest -q tests/test_deployment.py tests/test_admin_isolation.py`

## Notes
PR #214 is already merged on `main`; this follow-up corrects the rollout ordering without removing either staging hostname.