### PR TITLE
Finalize staging Cloudflare migration for #215

### DIFF
--- a/.github/workflows/tls-scan.yml
+++ b/.github/workflows/tls-scan.yml
@@ -11,7 +11,7 @@ on:
       staging_host:
         description: Staging HTTPS hostname to scan (hostname only).
         required: false
-        default: staging-sitbank.duckdns.org
+        default: staging-sitbank.pp.ua
         type: string
       production_host:
         description: Production customer HTTPS hostname to scan (hostname only).
@@ -37,7 +37,7 @@ on:
       staging_host:
         description: Staging HTTPS hostname to scan (hostname only).
         required: true
-        default: staging-sitbank.duckdns.org
+        default: staging-sitbank.pp.ua
         type: string
       production_host:
         description: Production customer HTTPS hostname to scan (hostname only).
@@ -103,7 +103,7 @@ jobs:
       max-parallel: 3
       matrix: ${{ fromJSON(needs.resolve-targets.outputs.matrix) }}
     env:
-      STAGING_HOST: ${{ inputs.staging_host || 'staging-sitbank.duckdns.org' }}
+      STAGING_HOST: ${{ inputs.staging_host || 'staging-sitbank.pp.ua' }}
       PRODUCTION_HOST: ${{ inputs.production_host || 'sitbank.duckdns.org' }}
       ADMIN_HOST: ${{ inputs.admin_host || 'admin-sitbank.duckdns.org' }}
       TARGET_INPUT: ${{ matrix.target.input }}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SITBank is a student cybersecurity project and demonstration site. Do not enter 
 
 ## Overview
 
-SITBank is a Flask/Gunicorn application deployed as hardened Docker containers behind host-managed Nginx, TLS, and PostgreSQL. Production customer traffic runs at `https://sitbank.duckdns.org`; the isolated production admin boundary at `https://admin-sitbank.duckdns.org` uses a separate admin app, cookie, session keys, database role, root-admin-controlled staff invites, and mandatory TOTP. Staging runs separately at `https://staging-sitbank.duckdns.org`.
+SITBank is a Flask/Gunicorn application deployed as hardened Docker containers behind host-managed Nginx, TLS, and PostgreSQL. Production customer traffic runs at `https://sitbank.duckdns.org`; the public admin hostname `https://admin-sitbank.duckdns.org` remains denied for app routes while operators use the private Tailscale Serve URL `https://sitbank-ec2.tailca101b.ts.net/` with a separate admin app, cookie, session keys, database role, root-admin-controlled staff invites, and mandatory TOTP. Staging runs separately at `https://staging-sitbank.pp.ua`.
 
 Security-critical state is stored in application-owned PostgreSQL tables. Server-side sessions, authentication failure counters, TOTP replay markers, registration OTP challenges, password-reset transactions, security-alert dedupe windows, and breached-password circuit-breaker state are stored in dedicated tables. Browser cookies keep only opaque identifiers; lookup hashes are HMAC-derived with `SESSION_LOOKUP_HMAC_KEY` or `ADMIN_SESSION_LOOKUP_HMAC_KEY`, and stored session payloads remain signed with the session HMAC keyring.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,10 +66,11 @@ Production admin runtime uses a separate Flask app, Docker Compose service,
 session cookie, session-signing material, session-lookup HMAC key, and database
 runtime role. The admin role must be distinct from both `sitbank_app` and
 `sitbank_owner`; it must not use migration/schema-owner credentials. Admin
-access is private operator access only through Tailscale; do not enable
-Tailscale Funnel and do not expose admin through the customer app or public
-admin Nginx routes. `admin-sitbank.duckdns.org` remains isolated at the public
-edge with public `/` and app routes denied.
+access is private operator access only through Tailscale Serve at
+`https://sitbank-ec2.tailca101b.ts.net/`; do not enable Tailscale Funnel and
+do not expose admin through the customer app or public admin Nginx routes.
+`admin-sitbank.duckdns.org` remains isolated at the public edge with public `/`
+and app routes denied.
 The Flask admin app still uses a separate cookie, session HMAC keyring,
 database role, root-admin-controlled staff invites, and mandatory TOTP.
 
@@ -309,7 +310,7 @@ checked manually.
   TOTP. Do not enable Tailscale Funnel or make `admin-sitbank.duckdns.org`
   publicly usable for app routes.
 - Require Cloudflare Access and Cloudflare Authenticated Origin Pulls for
-  `staging-sitbank.duckdns.org`; do not disable the origin-pull check to make
+  `staging-sitbank.pp.ua`; do not disable the origin-pull check to make
   direct EC2-origin staging access work.
 - Enable WAF managed common, SQL injection, XSS, bot, and protocol anomaly
   rules.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -6,7 +6,7 @@ Only Flask/Gunicorn runs in the SITBank container. Nginx, TLS, PostgreSQL, and b
 
 - Production public host: `sitbank.duckdns.org`
 - Production admin host: `admin-sitbank.duckdns.org`
-- Staging public hosts: `staging-sitbank.duckdns.org`, `staging-sitbank.pp.ua`
+- Staging public host: `staging-sitbank.pp.ua`
 - Staging Cloudflare Access host: `staging-sitbank.pp.ua`
 - Production customer access: public HTTPS
 - Staging access boundary: Cloudflare Access plus Authenticated Origin Pull
@@ -198,18 +198,9 @@ manual workflow inputs when an approved endpoint changes:
 
 | Environment | Workflow input | Default target | Artifact |
 | --- | --- | --- | --- |
-| Staging customer | `staging_host` | `https://staging-sitbank.duckdns.org` | `tls-scan-staging-sitbank` |
+| Staging customer | `staging_host` | `https://staging-sitbank.pp.ua` | `tls-scan-staging-sitbank` |
 | Production customer | `production_host` | `https://sitbank.duckdns.org` | `tls-scan-prod-sitbank` |
 | Production admin | `admin_host` | `https://admin-sitbank.duckdns.org` | `tls-scan-admin-sitbank` |
-
-During the `staging-sitbank.pp.ua` transition, the scheduled and deployment
-gate staging scan stays on the currently deployed
-`staging-sitbank.duckdns.org` endpoint until the EC2 origin has been updated.
-`staging-sitbank.pp.ua` live TLS evidence must be run manually with
-`staging_host=staging-sitbank.pp.ua` after PR merge, staging bootstrap,
-Certbot certificate issuance, and Cloudflare Access/AOP verification. Do not
-use Cloudflare Flexible SSL, disable TLS verification, turn off the Cloudflare
-proxy, or bypass Authenticated Origin Pulls to make the scan pass.
 
 Each target preserves the scanner's original `testssl.raw.json` and produces a
 separate `testssl.json` for policy parsing, plus a text log, HTML report, scan
@@ -242,16 +233,10 @@ application credentials):
 ```bash
 testssl.sh --warnings batch --color 0 --jsonfile testssl.json \
   --logfile testssl.log --htmlfile testssl.html \
-  https://staging-sitbank.duckdns.org
+  https://staging-sitbank.pp.ua
 testssl.sh --warnings batch --color 0 https://sitbank.duckdns.org
 testssl.sh --warnings batch --color 0 https://admin-sitbank.duckdns.org
 ```
-
-After the staging bootstrap has installed the updated Nginx server block, the
-staging certificate includes `staging-sitbank.pp.ua`, and Cloudflare
-Access/AOP verification succeeds, run the same workflow manually with
-`scan_scope=staging` and `staging_host=staging-sitbank.pp.ua`, then retain the
-`tls-scan-staging-sitbank` artifact as the Cloudflare-managed staging evidence.
 
 SSL Labs remains optional, manual corroborating evidence. Use its public
 report when an independently rendered assessment is useful for a release,
@@ -275,7 +260,7 @@ and active `certbot.timer`, and every expected Certbot certificate and key:
 | --- | --- | --- |
 | `sitbank.duckdns.org` | `/etc/letsencrypt/live/sitbank.duckdns.org/fullchain.pem` | `/etc/letsencrypt/live/sitbank.duckdns.org/privkey.pem` |
 | `admin-sitbank.duckdns.org` | `/etc/letsencrypt/live/admin-sitbank.duckdns.org/fullchain.pem` | `/etc/letsencrypt/live/admin-sitbank.duckdns.org/privkey.pem` |
-| `staging-sitbank.duckdns.org` | `/etc/letsencrypt/live/staging-sitbank.duckdns.org/fullchain.pem` | `/etc/letsencrypt/live/staging-sitbank.duckdns.org/privkey.pem` |
+| `staging-sitbank.pp.ua` | `/etc/letsencrypt/live/staging-sitbank.pp.ua/fullchain.pem` | `/etc/letsencrypt/live/staging-sitbank.pp.ua/privkey.pem` |
 
 Each `fullchain.pem` symlink must resolve to a regular file below
 `/etc/letsencrypt`. OpenSSL must parse it, expose a valid `notAfter`, and confirm
@@ -308,8 +293,8 @@ sudo readlink -f /etc/letsencrypt/live/sitbank.duckdns.org/privkey.pem
 sudo stat -c '%U %G %a %n' "$(sudo readlink -f /etc/letsencrypt/live/sitbank.duckdns.org/privkey.pem)"
 sudo readlink -f /etc/letsencrypt/live/admin-sitbank.duckdns.org/privkey.pem
 sudo stat -c '%U %G %a %n' "$(sudo readlink -f /etc/letsencrypt/live/admin-sitbank.duckdns.org/privkey.pem)"
-sudo readlink -f /etc/letsencrypt/live/staging-sitbank.duckdns.org/privkey.pem
-sudo stat -c '%U %G %a %n' "$(sudo readlink -f /etc/letsencrypt/live/staging-sitbank.duckdns.org/privkey.pem)"
+sudo readlink -f /etc/letsencrypt/live/staging-sitbank.pp.ua/privkey.pem
+sudo stat -c '%U %G %a %n' "$(sudo readlink -f /etc/letsencrypt/live/staging-sitbank.pp.ua/privkey.pem)"
 ```
 
 When verifying directly from a reviewed checkout before bootstrap has installed
@@ -400,11 +385,12 @@ Staging admin must follow the same boundary pattern as production. Do not expose
 admin routes publicly. The staging admin service must bind only to localhost
 and use a separate loopback port from production admin when both environments
 share one EC2 host. Production admin owns `127.0.0.1:5002`; staging admin owns
-`127.0.0.1:5003`. Use Tailscale SSH, Tailscale Serve, or another approved
-private operator path for admin access; do not enable Tailscale Funnel and do
-not add a public staging admin Nginx server block. Staging admin secrets must
-be root-managed under `/etc/sitbank-staging/secrets` and must not reuse
-customer runtime secrets.
+`127.0.0.1:5003`. Operators use Tailscale VPN before opening the private
+production admin URL `https://sitbank-ec2.tailca101b.ts.net/`; staging admin
+must use the same private-network pattern through an approved tailnet path. Do
+not enable Tailscale Funnel and do not add a public staging admin Nginx server
+block. Staging admin secrets must be root-managed under
+`/etc/sitbank-staging/secrets` and must not reuse customer runtime secrets.
 
 ## Staging Edge Setup
 
@@ -440,22 +426,20 @@ change instead of disabling the origin-pull protection.
 `staging-sitbank.pp.ua` is the Cloudflare-managed staging hostname for Access.
 Use a Cloudflare-managed zone/hostname or Cloudflare Tunnel for this boundary;
 for this deployment, the approved Cloudflare-managed hostname is
-`staging-sitbank.pp.ua`.
-The existing `staging-sitbank.duckdns.org` hostname remains accepted by Nginx,
-but it resolves directly to EC2 and must not be treated as the Cloudflare
-Access boundary.
+`staging-sitbank.pp.ua`. The retired `staging-sitbank.duckdns.org` hostname is
+not an active staging deployment, Nginx, Certbot, or TLS-scan target.
 
 Issue or renew staging TLS before bootstrap:
 
 ```bash
-sudo certbot --nginx -d staging-sitbank.duckdns.org -d staging-sitbank.pp.ua --cert-name staging-sitbank.duckdns.org
-sudo certbot certonly --webroot -w /var/www/certbot -d staging-sitbank.duckdns.org -d staging-sitbank.pp.ua --cert-name staging-sitbank.duckdns.org
+sudo certbot --nginx -d staging-sitbank.pp.ua --cert-name staging-sitbank.pp.ua
+sudo certbot certonly --webroot -w /var/www/certbot -d staging-sitbank.pp.ua --cert-name staging-sitbank.pp.ua
 sudo systemctl status certbot.timer
 sudo /usr/local/sbin/verify-certbot-host-state staging
 sudo /usr/local/sbin/verify-certbot-host-state --renewal-dry-run staging
 ```
 
-Then run `ops/deploy/bootstrap-container-ec2 staging hetp88/SITBank staging-sitbank.duckdns.org`. The bootstrap installs the Nginx proxy header snippet, TLS policy snippet, rate-limit include, and staging Nginx server block for both `staging-sitbank.duckdns.org` and `staging-sitbank.pp.ua`; verifies the staging Basic Auth file and Cloudflare origin-pull CA file; then runs `sudo nginx -t` before `sudo systemctl reload nginx`. This edge setup is separate from application deployment.
+Then run `ops/deploy/bootstrap-container-ec2 staging hetp88/SITBank staging-sitbank.pp.ua`. The bootstrap installs the Nginx proxy header snippet, TLS policy snippet, rate-limit include, and staging Nginx server block for `staging-sitbank.pp.ua`; verifies the staging Basic Auth file and Cloudflare origin-pull CA file; then runs `sudo nginx -t` before `sudo systemctl reload nginx`. This edge setup is separate from application deployment.
 
 Staging verification:
 
@@ -472,7 +456,6 @@ curl -I --resolve staging-sitbank.pp.ua:443:<EC2_PUBLIC_IP> \
 sudo nginx -T | grep -E 'ssl_protocols|ssl_ciphers|ssl_ecdh_curve|ssl_conf_command|ssl_session_tickets'
 curl -fsSI https://staging-sitbank.pp.ua/ | grep -i '^strict-transport-security:'
 testssl.sh --warnings batch --color 0 https://staging-sitbank.pp.ua
-curl -I https://staging-sitbank.duckdns.org/
 ```
 
 Expected: unauthenticated browser traffic receives the Cloudflare Access
@@ -480,7 +463,7 @@ challenge at `staging-sitbank.pp.ua` before reaching staging, approved operators
 Access and then reach the normal staging controls, direct EC2-origin access to
 `/` returns `403` without Cloudflare's origin-pull client certificate,
 external `/health/ready` returns `403`, local app readiness succeeds, and the
-existing DuckDNS staging hostname remains recognized by Nginx.
+retired DuckDNS staging hostname is no longer an active Nginx target.
 
 The complete operator runbook is
 `docs/security/admin-and-staging-zero-trust-access.md`.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -34,8 +34,7 @@ maintenance record.
 SITBank uses a hybrid private-access model:
 
 - Staging is protected by Cloudflare Access and Cloudflare Authenticated Origin
-  Pulls at `staging-sitbank.pp.ua`; the existing
-  `staging-sitbank.duckdns.org` hostname remains accepted by Nginx.
+  Pulls at `staging-sitbank.pp.ua`.
 - Admin is protected by Tailscale/private operator access and remains denied
   on the public `admin-sitbank.duckdns.org` app routes.
 - The production customer site `sitbank.duckdns.org` remains public.
@@ -45,9 +44,9 @@ origin certificate private keys, and origin-pull client credentials are
 operator-managed. Tailscale auth keys, API keys, tailnet policy, device
 approval state, and Serve state are also operator-managed. None of those values
 belong in the repository. `staging-sitbank.pp.ua` is the Cloudflare-managed
-staging hostname for Access. The observed `staging-sitbank.duckdns.org`
-hostname resolves directly to EC2 and must not be treated as the Cloudflare
-Access boundary.
+staging hostname for Access. The retired `staging-sitbank.duckdns.org`
+hostname is not an active staging deployment, Nginx, Certbot, or TLS-scan
+target.
 
 Routine verification:
 
@@ -58,16 +57,15 @@ curl --fail --resolve staging-sitbank.pp.ua:443:127.0.0.1 \
   https://staging-sitbank.pp.ua/health/ready
 curl -I --resolve staging-sitbank.pp.ua:443:<EC2_PUBLIC_IP> \
   https://staging-sitbank.pp.ua/
-curl -I https://staging-sitbank.duckdns.org/
 curl -I https://admin-sitbank.duckdns.org/
 sudo tailscale serve status
+curl -I https://sitbank-ec2.tailca101b.ts.net/
 ```
 
 Expected: local staging readiness succeeds, direct origin access to staging
 returns `403` without Cloudflare's origin-pull client certificate, public
-admin `/` returns `403`, and admin Serve status is present only when the
-approved tailnet path is intentionally enabled. Tailscale Funnel must stay
-disabled for SITBank admin.
+admin `/` returns `403`, and the private admin URL is reachable only from an
+approved tailnet path. Tailscale Funnel must stay disabled for SITBank admin.
 
 The detailed onboarding, offboarding, emergency lockout, rollback, and live
 operator verification steps are in
@@ -326,22 +324,23 @@ contents. Finally run `sudo nginx -t` before reload.
 The **Live TLS scan evidence** workflow provides scheduled weekly,
 operator-dispatched, and post-deployment evidence of the Internet-facing TLS
 posture for
-`staging-sitbank.duckdns.org`, `sitbank.duckdns.org`, and
+`staging-sitbank.pp.ua`, `sitbank.duckdns.org`, and
 `admin-sitbank.duckdns.org`. The deployment workflow calls the staging scan
 after staging deploy and blocks production deployment until it passes; it calls
 the production scan after production deploy to complete the release evidence.
+The manual workflow input `staging_host` defaults to
+`staging-sitbank.pp.ua`.
 Dispatch it after edge, certificate, DNS, Nginx/OpenSSL, CDN/WAF, or
 load-balancer changes outside deployment, then retain the successful run with
 the release or change record. Do not run a public-endpoint scan from ordinary
 pull requests.
 
-During the `staging-sitbank.pp.ua` transition, leave the scheduled and
-deployment-gate staging scan on the currently deployed DuckDNS endpoint. Run
-`staging-sitbank.pp.ua` as a manual `staging_host` override only after PR
-merge, staging bootstrap, Certbot certificate issuance, and Cloudflare
-Access/AOP verification. Do not make the scan pass by switching Cloudflare to
-Flexible SSL, disabling TLS verification, disabling the Cloudflare proxy, or
-bypassing Authenticated Origin Pulls.
+The normal public TLS scan deliberately excludes the private Tailscale admin hostname
+`sitbank-ec2.tailca101b.ts.net`; a GitHub-hosted public runner cannot reach it
+unless a separate protected job joins the tailnet or uses a tailnet self-hosted
+runner. Do not make staging or admin verification pass by switching Cloudflare
+to Flexible SSL, disabling TLS verification, disabling the Cloudflare proxy,
+bypassing Authenticated Origin Pulls, or enabling Tailscale Funnel.
 
 Each target artifact (`tls-scan-staging-sitbank`, `tls-scan-prod-sitbank`, or
 `tls-scan-admin-sitbank`) retains the untouched scanner output as

--- a/docs/security/access-control.md
+++ b/docs/security/access-control.md
@@ -124,9 +124,9 @@ Production Nginx currently defines an admin hostname in
 `ops/nginx/sitbank-production.conf` but denies public access to the primary
 admin paths with `deny all` or explicit `403` responses. This keeps the public
 admin hostname limited to denied root, health, and app responses. The actual
-admin application access path is Tailscale/private operator access to the
-loopback admin listener, followed by the normal Flask admin login and TOTP
-controls.
+admin application access path is the Tailscale Serve URL
+`https://sitbank-ec2.tailca101b.ts.net/`, followed by the normal Flask admin
+login and TOTP controls.
 Do not enable Tailscale Funnel or expose admin through the customer app.
 
 Manual recovery operator review is exposed only by the isolated admin app.
@@ -190,7 +190,7 @@ Network boundaries complement, but do not replace, Flask authorization:
 | --- | --- | --- |
 | Production customer | Public HTTPS at `sitbank.duckdns.org` | Customer login, MFA onboarding, CSRF, route inventory, rate limiting |
 | Staging customer | Cloudflare Access before Nginx, Cloudflare Authenticated Origin Pull at Nginx, staging Basic Auth | Customer login, MFA, CSRF, route inventory, rate limiting |
-| Production admin | Tailscale/private operator access to `127.0.0.1:5002`; public admin app routes denied | Staff/root-admin login, mandatory TOTP, CSRF, admin route inventory, admin rate limiting |
+| Production admin | Tailscale Serve at `https://sitbank-ec2.tailca101b.ts.net/`; public admin app routes denied | Staff/root-admin login, mandatory TOTP, CSRF, admin route inventory, admin rate limiting |
 | Staging admin | Tailscale/private operator access to `127.0.0.1:5003`; no public admin host | Staff/root-admin login, mandatory TOTP, CSRF, admin route inventory, admin rate limiting |
 
 The staging Nginx config uses Cloudflare Authenticated Origin Pulls so direct

--- a/docs/security/admin-and-staging-zero-trust-access.md
+++ b/docs/security/admin-and-staging-zero-trust-access.md
@@ -29,10 +29,10 @@ References:
 | Surface | Host or path | Boundary | Public exposure |
 | --- | --- | --- | --- |
 | Production customer | `https://sitbank.duckdns.org` | Public HTTPS edge, Flask customer login and MFA | Public |
-| Staging customer | `https://staging-sitbank.pp.ua` and `https://staging-sitbank.duckdns.org` | Cloudflare Access on `staging-sitbank.pp.ua`, Cloudflare Authenticated Origin Pull, staging Basic Auth, Flask login and MFA | Not directly public at the origin |
+| Staging customer | `https://staging-sitbank.pp.ua` | Cloudflare Access, Cloudflare Authenticated Origin Pull, staging Basic Auth, Flask login and MFA | Not directly public at the origin |
 | Production admin public host | `https://admin-sitbank.duckdns.org` | Nginx denial for `/`, health, and app routes | Public `403` except ACME challenge paths |
-| Production admin app | Tailscale Serve or Tailscale SSH to `127.0.0.1:5002` | Tailscale ACLs, approved devices, Flask admin login and TOTP | Private tailnet only |
-| Staging admin app | Tailscale SSH or other approved private operator path to `127.0.0.1:5003` | Tailscale ACLs, approved devices, Flask admin login and TOTP | Private tailnet only |
+| Production admin app | `https://sitbank-ec2.tailca101b.ts.net/` through Tailscale Serve | Tailscale ACLs, approved devices, Flask admin login and TOTP | Private tailnet only |
+| Staging admin app | Approved Tailscale/private operator path to `127.0.0.1:5003` | Tailscale ACLs, approved devices, Flask admin login and TOTP | Private tailnet only |
 
 The customer production site remains public. The admin app is not exposed
 through the customer app, and the customer Nginx server block continues to
@@ -47,14 +47,11 @@ certificate renewal.
 ## Staging Cloudflare Access
 
 Configure Cloudflare for `staging-sitbank.pp.ua` as a self-hosted Access
-application. Keep `staging-sitbank.duckdns.org` in the staging Nginx
-`server_name` so the existing staging hostname continues to work while the
-Cloudflare-managed hostname becomes the Access-protected browser entry point:
+application. The retired `staging-sitbank.duckdns.org` hostname is no longer
+an active staging deployment, Nginx, Certbot, or TLS-scan target:
 
-1. Ensure `staging-sitbank.pp.ua` is proxied through Cloudflare. The observed
-   DuckDNS hostname resolves directly to the EC2 origin, so Cloudflare Access
-   cannot fully protect DuckDNS-origin traffic. Do not make the EC2 origin
-   public as a workaround.
+1. Ensure `staging-sitbank.pp.ua` is proxied through Cloudflare. Do not make
+   the EC2 origin public as a workaround.
 2. Add a Cloudflare Access application for `staging-sitbank.pp.ua`.
 3. Add an Allow policy for approved staging operators only.
 4. Keep the default deny posture for everyone else.
@@ -67,8 +64,7 @@ Cloudflare-managed hostname becomes the Access-protected browser entry point:
    `/etc/nginx/cloudflare-authenticated-origin-pull-ca.pem`. This CA file is
    host-managed and is not committed to the repository.
 
-The staging Nginx server blocks accept both
-`staging-sitbank.duckdns.org` and `staging-sitbank.pp.ua`, then request a
+The staging Nginx server blocks accept `staging-sitbank.pp.ua`, then request a
 client certificate with:
 
 ```nginx
@@ -98,22 +94,25 @@ approved operator users, groups, or managed devices can reach the SITBank host
 and admin service ports. Do not rely on a shared password as the private
 network boundary.
 
-Recommended admin access path:
+Current admin access path:
 
 ```bash
-sudo tailscale up --ssh --advertise-tags=tag:sitbank-admin
+sudo tailscale up --advertise-tags=tag:sitbank-admin
 sudo tailscale serve --bg --https=443 127.0.0.1:5002
 sudo tailscale serve status
 ```
 
-The `tailscale serve` command exposes the local admin service inside the
-tailnet. It must not be paired with `tailscale funnel`; Funnel would publish
-the service to the public internet and is not approved for SITBank admin.
+Admins connect to the Tailscale VPN first, then open
+`https://sitbank-ec2.tailca101b.ts.net/`. The `tailscale serve` command exposes
+the local admin service inside the tailnet. It must not be paired with
+`tailscale funnel`; Funnel would publish the service to the public internet and
+is not approved for SITBank admin. Flask admin login and TOTP remain mandatory
+after the private network boundary is satisfied.
 
-If Tailscale Serve is not enabled in the tailnet, use Tailscale SSH or an
-operator-approved local port forward to reach `127.0.0.1:5002` on the EC2
-host. In all cases, the Flask admin login and TOTP remain mandatory after the
-private network boundary is satisfied.
+If Tailscale Serve is unavailable, use a separate reviewed private operator
+path rather than exposing the admin app publicly. In all cases, the Flask
+admin login and TOTP remain mandatory after the private network boundary is
+satisfied.
 
 ## Operator Onboarding
 
@@ -193,7 +192,7 @@ Live Cloudflare staging checks:
 
 Live Tailscale admin checks:
 
-1. An approved operator reaches admin only from an approved tailnet device.
+1. An approved operator reaches `https://sitbank-ec2.tailca101b.ts.net/` only from an approved tailnet device.
 2. A non-tailnet network cannot reach the admin app.
 3. A removed user or deleted device loses access.
 4. Admin Flask login and TOTP are still required after Tailscale access.

--- a/docs/security/cryptography-and-authentication.md
+++ b/docs/security/cryptography-and-authentication.md
@@ -18,7 +18,7 @@ proxy headers.
 | --- | --- | --- | --- |
 | Production customer | `sitbank.duckdns.org` | Nginx in `ops/nginx/sitbank-production.conf` | `http://127.0.0.1:5000` |
 | Production admin | `admin-sitbank.duckdns.org` | Nginx in `ops/nginx/sitbank-production.conf` | `http://127.0.0.1:5002` |
-| Staging customer | `staging-sitbank.duckdns.org`, `staging-sitbank.pp.ua` | Nginx in `ops/nginx/sitbank-staging.conf` | `http://127.0.0.1:5001` |
+| Staging customer | `staging-sitbank.pp.ua` | Nginx in `ops/nginx/sitbank-staging.conf` | `http://127.0.0.1:5001` |
 
 The client authenticates the server through the normal browser TLS certificate
 chain for the relevant hostname. The repository expects Certbot/Let's Encrypt
@@ -100,7 +100,7 @@ dispatched after a TLS-relevant infrastructure change, and is called from the
 trusted deployment workflow. It verifies staging immediately after staging
 deploy (and blocks production deployment until that verification passes), then
 verifies both production endpoints after production deploy to complete the
-release evidence. It scans `staging-sitbank.duckdns.org`,
+release evidence. It scans `staging-sitbank.pp.ua`,
 `sitbank.duckdns.org`, and `admin-sitbank.duckdns.org` with a checksum-verified
 `testssl.sh` release. Each per-target artifact retains untouched scanner JSON
 as `testssl.raw.json` and a separate `testssl.json` policy copy, along with the
@@ -111,13 +111,6 @@ Cloudflare Origin Pull CA subject as raw evidence without relaxing invalid-JSON
 or TLS findings generally. The job summary records the UTC time, target,
 workflow run, and result. It intentionally does not run on ordinary pull
 requests because they do not create public TLS endpoints.
-
-`staging-sitbank.pp.ua` is a manual post-rollout TLS evidence target during
-the transition. Run it with the workflow's `staging_host` override only after
-PR merge, staging bootstrap, Certbot certificate issuance, and Cloudflare
-Access/AOP verification. That sequencing avoids requiring the Cloudflare edge
-hostname before the origin TLS certificate and Authenticated Origin Pull path
-are ready.
 
 Verification fails for SSLv2/SSLv3/TLS 1.0/TLS 1.1, weak/NULL/anonymous/export/
 RC4/3DES cipher classes, missing, disabled, or too-short HSTS, expired
@@ -136,8 +129,7 @@ Certbot-managed paths, for example:
 | --- | --- |
 | `sitbank.duckdns.org` | `/etc/letsencrypt/live/sitbank.duckdns.org/privkey.pem` |
 | `admin-sitbank.duckdns.org` | `/etc/letsencrypt/live/admin-sitbank.duckdns.org/privkey.pem` |
-| `staging-sitbank.duckdns.org` | `/etc/letsencrypt/live/staging-sitbank.duckdns.org/privkey.pem` |
-| `staging-sitbank.pp.ua` | Covered by the staging certificate under `/etc/letsencrypt/live/staging-sitbank.duckdns.org/privkey.pem` |
+| `staging-sitbank.pp.ua` | `/etc/letsencrypt/live/staging-sitbank.pp.ua/privkey.pem` |
 
 The private key is not committed to Git. `ops/deploy/bootstrap-container-ec2`
 checks that the expected key files are readable before installing the Nginx

--- a/ops/deploy/bootstrap-container-ec2
+++ b/ops/deploy/bootstrap-container-ec2
@@ -11,8 +11,7 @@ readonly PRODUCTION_ADMIN_PUBLIC_HOST="admin-sitbank.duckdns.org"
 readonly EDGE_DEFAULTS_FILE="/etc/nginx/conf.d/sitbank-default.conf"
 readonly TLS_POLICY_FILE="/etc/nginx/snippets/sitbank-tls-policy.conf"
 readonly PRODUCTION_RATE_LIMITS_FILE="/etc/nginx/conf.d/sitbank-production-rate-limits.conf"
-readonly STAGING_PUBLIC_HOST="staging-sitbank.duckdns.org"
-readonly STAGING_CLOUDFLARE_PUBLIC_HOST="staging-sitbank.pp.ua"
+readonly STAGING_PUBLIC_HOST="staging-sitbank.pp.ua"
 readonly STAGING_BASIC_AUTH_FILE="/etc/nginx/.htpasswd-sitbank-staging"
 readonly STAGING_CLOUDFLARE_ORIGIN_PULL_CA_FILE="/etc/nginx/cloudflare-authenticated-origin-pull-ca.pem"
 readonly STAGING_RATE_LIMITS_FILE="/etc/nginx/conf.d/sitbank-staging-rate-limits.conf"
@@ -42,7 +41,7 @@ if [[ -z "${public_host}" ]]; then
     if [[ "${target}" == "production" ]]; then
         public_host="sitbank.duckdns.org"
     else
-        public_host="staging-sitbank.duckdns.org"
+        public_host="staging-sitbank.pp.ua"
     fi
 fi
 if [[ ! "${public_host}" =~ ^[A-Za-z0-9.-]+$ ]]; then
@@ -51,7 +50,6 @@ if [[ ! "${public_host}" =~ ^[A-Za-z0-9.-]+$ ]]; then
 fi
 public_host_regex="${public_host//./\\.}"
 admin_public_host_regex="${PRODUCTION_ADMIN_PUBLIC_HOST//./\\.}"
-staging_cloudflare_public_host_regex="${STAGING_CLOUDFLARE_PUBLIC_HOST//./\\.}"
 if [[ "${target}" == "production" && "${public_host}" != "${PRODUCTION_PUBLIC_HOST}" ]]; then
     echo "Production PUBLIC_HOST must be ${PRODUCTION_PUBLIC_HOST}" >&2
     exit 2
@@ -453,7 +451,7 @@ if [[ "${target}" == "staging" ]]; then
         fi
     done < <(
         grep -RlE \
-            "^[[:space:]]*server_name[[:space:]].*(^|[[:space:]])(${public_host_regex}|${staging_cloudflare_public_host_regex})([[:space:];]|$)" \
+            "^[[:space:]]*server_name[[:space:]].*(^|[[:space:]])${public_host_regex}([[:space:];]|$)" \
             /etc/nginx/sites-enabled /etc/nginx/conf.d \
             2>/dev/null || true
     )

--- a/ops/deploy/sitbank-container-bootstrap
+++ b/ops/deploy/sitbank-container-bootstrap
@@ -51,7 +51,7 @@ if [[ ! "${GITHUB_REPOSITORY:-}" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ \
     exit 1
 fi
 if [[ "${target}" == "staging" \
-    && "${PUBLIC_HOST}" != "staging-sitbank.duckdns.org" ]]; then
+    && "${PUBLIC_HOST}" != "staging-sitbank.pp.ua" ]]; then
     echo "Trusted staging public host is invalid" >&2
     exit 1
 fi

--- a/ops/deploy/verify-certbot-host-state
+++ b/ops/deploy/verify-certbot-host-state
@@ -5,7 +5,7 @@ set -Eeuo pipefail
 readonly LETSENCRYPT_ROOT="/etc/letsencrypt"
 readonly PRODUCTION_PUBLIC_HOST="sitbank.duckdns.org"
 readonly PRODUCTION_ADMIN_PUBLIC_HOST="admin-sitbank.duckdns.org"
-readonly STAGING_PUBLIC_HOST="staging-sitbank.duckdns.org"
+readonly STAGING_PUBLIC_HOST="staging-sitbank.pp.ua"
 readonly CERTBOT_MIN_VALID_DAYS="${CERTBOT_MIN_VALID_DAYS:-14}"
 readonly -a APPROVED_TLS_KEY_GROUPS=(root)
 

--- a/ops/nginx/sitbank-staging.conf
+++ b/ops/nginx/sitbank-staging.conf
@@ -1,7 +1,7 @@
 server {
     listen 80;
     listen [::]:80;
-    server_name staging-sitbank.duckdns.org staging-sitbank.pp.ua;
+    server_name staging-sitbank.pp.ua;
 
     server_tokens off;
 
@@ -28,14 +28,14 @@ server {
 server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
-    server_name staging-sitbank.duckdns.org staging-sitbank.pp.ua;
+    server_name staging-sitbank.pp.ua;
 
     server_tokens off;
     access_log /var/log/nginx/sitbank-staging.access.log;
     error_log /var/log/nginx/sitbank-staging.error.log warn;
 
-    ssl_certificate /etc/letsencrypt/live/staging-sitbank.duckdns.org/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/staging-sitbank.duckdns.org/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/staging-sitbank.pp.ua/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/staging-sitbank.pp.ua/privkey.pem;
     include /etc/nginx/snippets/sitbank-tls-policy.conf;
     ssl_client_certificate /etc/nginx/cloudflare-authenticated-origin-pull-ca.pem;
     ssl_verify_client optional;

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -522,7 +522,7 @@ def test_deployment_profiles_keep_production_and_staging_isolated(monkeypatch):
     _set_prefixed_deployment_values(
         monkeypatch,
         "STAGING",
-        "staging-sitbank.duckdns.org",
+        "staging-sitbank.pp.ua",
     )
 
     production = build_deployment_environment("PROD")
@@ -554,7 +554,7 @@ def test_deployment_profiles_keep_production_and_staging_isolated(monkeypatch):
     assert staging["POSTGRES_VOLUME_NAME"] == "sitbank-staging-postgres-data"
     assert "REDIS_CONTAINER_NAME" not in staging
     assert "REDIS_VOLUME_NAME" not in staging
-    assert staging["PUBLIC_HOST"] == "staging-sitbank.duckdns.org"
+    assert staging["PUBLIC_HOST"] == "staging-sitbank.pp.ua"
 
     for key in (
         "CONFIG_ROOT",
@@ -2030,7 +2030,7 @@ def test_live_tls_scan_workflow_collects_evidence_without_running_on_pull_reques
 
     inputs = triggers["workflow_dispatch"]["inputs"]
     assert inputs["scan_scope"]["options"] == ["all", "staging", "production"]
-    assert inputs["staging_host"]["default"] == "staging-sitbank.duckdns.org"
+    assert inputs["staging_host"]["default"] == "staging-sitbank.pp.ua"
     assert inputs["production_host"]["default"] == "sitbank.duckdns.org"
     assert inputs["admin_host"]["default"] == "admin-sitbank.duckdns.org"
 
@@ -2042,7 +2042,7 @@ def test_live_tls_scan_workflow_collects_evidence_without_running_on_pull_reques
         "type": "string",
     }
     assert call_inputs["staging_host"]["required"] is False
-    assert call_inputs["staging_host"]["default"] == "staging-sitbank.duckdns.org"
+    assert call_inputs["staging_host"]["default"] == "staging-sitbank.pp.ua"
     assert call_inputs["production_host"]["required"] is False
     assert call_inputs["admin_host"]["required"] is False
 
@@ -2104,6 +2104,7 @@ def test_live_tls_scan_workflow_collects_evidence_without_running_on_pull_reques
     assert 'if [[ "${scan_failed}" -ne 0 ]]' in workflow_text
     assert '.[]\n              | select(type == "object")\n              | select(' in workflow_text
     assert "secrets." not in workflow_text
+    assert "sitbank-ec2.tailca101b.ts.net" not in workflow_text
 
     upload_steps = [
         step for step in scan["steps"]
@@ -2138,16 +2139,18 @@ def test_live_tls_scan_workflow_collects_evidence_without_running_on_pull_reques
         encoding="utf-8"
     )
     for docs in (deployment_docs, operations_docs, crypto_docs):
-        normalized_docs = re.sub(r"\s+", " ", docs)
         assert "live tls scan evidence" in docs.lower()
         assert "staging-sitbank.pp.ua" in docs
-        assert "staging-sitbank.duckdns.org" in docs
-        assert "staging_host" in docs
-        assert "after PR merge, staging bootstrap, Certbot certificate issuance, and Cloudflare Access/AOP verification" in normalized_docs
         assert "sitbank.duckdns.org" in docs
         assert "admin-sitbank.duckdns.org" in docs
         assert "SSL Labs" in docs
         assert re.search(r"HIGH,\s+CRITICAL,\s+or FATAL", docs)
+    assert "staging_host" in deployment_docs
+    assert "staging_host" in operations_docs
+    assert "retired `staging-sitbank.duckdns.org`" in deployment_docs
+    assert "retired `staging-sitbank.duckdns.org`" in operations_docs
+    assert "sitbank-ec2.tailca101b.ts.net" in operations_docs
+    assert "private Tailscale admin hostname" in operations_docs
     assert "testssl.sh --warnings batch --color 0" in deployment_docs
     assert "tls-scan-staging-sitbank" in deployment_docs
     assert "tls-scan-prod-sitbank" in deployment_docs
@@ -2234,7 +2237,7 @@ def test_certbot_host_state_verifier_enforces_host_managed_tls():
     assert 'LETSENCRYPT_ROOT="/etc/letsencrypt"' in verifier
     assert 'PRODUCTION_PUBLIC_HOST="sitbank.duckdns.org"' in verifier
     assert 'PRODUCTION_ADMIN_PUBLIC_HOST="admin-sitbank.duckdns.org"' in verifier
-    assert 'STAGING_PUBLIC_HOST="staging-sitbank.duckdns.org"' in verifier
+    assert 'STAGING_PUBLIC_HOST="staging-sitbank.pp.ua"' in verifier
     assert 'readlink -f -- "${key_path}"' in verifier
     assert "stat -c '%U'" in verifier
     assert "stat -c '%G'" in verifier
@@ -2269,7 +2272,7 @@ def test_certbot_host_state_verifier_enforces_host_managed_tls():
     expected_key_paths = {
         "/etc/letsencrypt/live/sitbank.duckdns.org/privkey.pem",
         "/etc/letsencrypt/live/admin-sitbank.duckdns.org/privkey.pem",
-        "/etc/letsencrypt/live/staging-sitbank.duckdns.org/privkey.pem",
+        "/etc/letsencrypt/live/staging-sitbank.pp.ua/privkey.pem",
     }
     configured_key_paths = set(
         re.findall(
@@ -2382,7 +2385,8 @@ def test_nginx_default_server_is_shared_for_same_host_production_and_staging():
     assert "listen 80 default_server;" not in staging_nginx
     assert "server_name sitbank.duckdns.org;" in combined
     assert "server_name admin-sitbank.duckdns.org;" in combined
-    assert "server_name staging-sitbank.duckdns.org staging-sitbank.pp.ua;" in combined
+    assert "server_name staging-sitbank.pp.ua;" in combined
+    assert "server_name staging-sitbank.duckdns.org" not in combined
 
 
 def test_nginx_tls_policy_pins_strong_suites_curves_and_session_hardening():
@@ -2440,7 +2444,7 @@ def test_nginx_tls_policy_pins_strong_suites_curves_and_session_hardening():
             "admin-sitbank.duckdns.org",
             "shared:sitbank_prod_admin_ssl:10m",
         ),
-        (staging_nginx, "staging-sitbank.duckdns.org", "shared:sitbank_staging_ssl:10m"),
+        (staging_nginx, "staging-sitbank.pp.ua", "shared:sitbank_staging_ssl:10m"),
     ):
         https_server = _nginx_https_server_prelocation(nginx, server_name=server_name)
         assert policy_include in https_server
@@ -2469,7 +2473,7 @@ def test_staging_nginx_enforces_https_auth_health_and_rate_limits():
     )
     staging_http_nginx = _nginx_http_server_block(
         nginx,
-        "staging-sitbank.duckdns.org",
+        "staging-sitbank.pp.ua",
     )
 
     assert Path("ops/nginx/sitbank-default.conf").exists()
@@ -2486,13 +2490,10 @@ def test_staging_nginx_enforces_https_auth_health_and_rate_limits():
     assert "listen 443 ssl http2 default_server;" not in nginx
     assert "server_name _;" not in nginx
     assert "listen 443 ssl http2;" in nginx
-    assert "server_name staging-sitbank.duckdns.org staging-sitbank.pp.ua;" in nginx
-    assert _nginx_server_block(nginx, "staging-sitbank.pp.ua") == _nginx_server_block(
-        nginx,
-        "staging-sitbank.duckdns.org",
-    )
-    assert "ssl_certificate /etc/letsencrypt/live/staging-sitbank.duckdns.org/fullchain.pem;" in nginx
-    assert "ssl_certificate_key /etc/letsencrypt/live/staging-sitbank.duckdns.org/privkey.pem;" in nginx
+    assert "server_name staging-sitbank.pp.ua;" in nginx
+    assert "staging-sitbank.duckdns.org" not in nginx
+    assert "ssl_certificate /etc/letsencrypt/live/staging-sitbank.pp.ua/fullchain.pem;" in nginx
+    assert "ssl_certificate_key /etc/letsencrypt/live/staging-sitbank.pp.ua/privkey.pem;" in nginx
     assert "ssl_client_certificate /etc/nginx/cloudflare-authenticated-origin-pull-ca.pem;" in nginx
     assert "ssl_verify_client optional;" in nginx
     _assert_nginx_owns_duplicate_edge_security_headers(
@@ -2504,7 +2505,7 @@ def test_staging_nginx_enforces_https_auth_health_and_rate_limits():
     assert "auth_basic_user_file /etc/nginx/.htpasswd-sitbank-staging;" in nginx
     staging_https_prelocation = _nginx_https_server_prelocation(
         nginx,
-        server_name="staging-sitbank.duckdns.org",
+        server_name="staging-sitbank.pp.ua",
     )
     assert 'auth_basic "SITBank staging";' not in staging_https_prelocation
     assert "auth_basic_user_file /etc/nginx/.htpasswd-sitbank-staging;" not in staging_https_prelocation
@@ -2590,12 +2591,13 @@ def test_staging_nginx_enforces_https_auth_health_and_rate_limits():
     assert "Conflicting Nginx staging site is already enabled" in bootstrap
     assert "Disable the duplicate staging server block" in bootstrap
     assert 'public_host_regex="${public_host//./\\\\.}"' in bootstrap
-    assert 'STAGING_CLOUDFLARE_PUBLIC_HOST="staging-sitbank.pp.ua"' in bootstrap
-    assert 'staging_cloudflare_public_host_regex="${STAGING_CLOUDFLARE_PUBLIC_HOST//./\\\\.}"' in bootstrap
+    assert 'STAGING_PUBLIC_HOST="staging-sitbank.pp.ua"' in bootstrap
+    assert "STAGING_CLOUDFLARE_PUBLIC_HOST" not in bootstrap
+    assert "staging_cloudflare_public_host_regex" not in bootstrap
     assert "grep -RlE \\" in bootstrap
     assert (
         '"^[[:space:]]*server_name[[:space:]].*(^|[[:space:]])'
-        '(${public_host_regex}|${staging_cloudflare_public_host_regex})([[:space:];]|$)" \\'
+        '${public_host_regex}([[:space:];]|$)" \\'
     ) in bootstrap
     assert "Missing required staging Basic Auth file" in bootstrap
     assert "STAGING_CLOUDFLARE_ORIGIN_PULL_CA_FILE=\"/etc/nginx/cloudflare-authenticated-origin-pull-ca.pem\"" in bootstrap
@@ -2942,11 +2944,14 @@ def test_staging_edge_runbook_documents_operator_verification_steps():
         "Do not store Cloudflare API tokens, tunnel credentials, Access IdP secrets, or",
         "Cloudflare-managed zone/hostname or Cloudflare Tunnel",
         "staging-sitbank.pp.ua",
-        "sudo certbot --nginx -d staging-sitbank.duckdns.org",
+        "sudo certbot --nginx -d staging-sitbank.pp.ua",
         "sudo certbot certonly --webroot",
         "sudo certbot renew --dry-run",
         "ops/deploy/bootstrap-container-ec2",
-        "staging-sitbank.duckdns.org",
+        "staging-sitbank.pp.ua",
+        "retired `staging-sitbank.duckdns.org`",
+        "https://sitbank-ec2.tailca101b.ts.net/",
+        "private Tailscale admin hostname",
         "Nginx proxy header snippet",
         "Cloudflare origin-pull CA file",
         "rate-limit include",

--- a/tests/test_zero_trust_access_boundary.py
+++ b/tests/test_zero_trust_access_boundary.py
@@ -59,8 +59,7 @@ def test_hybrid_cloudflare_staging_and_tailscale_admin_design_is_documented():
         "This intentionally uses both products because the surfaces have different",
         "Production customer | `https://sitbank.duckdns.org`",
         "Staging customer | `https://staging-sitbank.pp.ua`",
-        "`https://staging-sitbank.duckdns.org`",
-        "Production admin app | Tailscale Serve or Tailscale SSH to `127.0.0.1:5002`",
+        "Production admin app | `https://sitbank-ec2.tailca101b.ts.net/` through Tailscale Serve",
         "The customer production site remains public.",
         "Cloudflare Access application for `staging-sitbank.pp.ua`",
         "Cloudflare Authenticated Origin Pulls",
@@ -71,6 +70,9 @@ def test_hybrid_cloudflare_staging_and_tailscale_admin_design_is_documented():
         "direct origin access",
         "Cloudflare-managed zone/hostname or Cloudflare Tunnel",
         "Cloudflare Access and Tailscale decide whether a request may reach",
+        "retired `staging-sitbank.duckdns.org` hostname is no longer",
+        "Admins connect to the Tailscale VPN first, then open",
+        "https://sitbank-ec2.tailca101b.ts.net/",
         "old public admin verification page has been removed",
         "Public admin `/` returns `403`",
         "Zero-trust and network-boundary work should use these repository labels",
@@ -91,20 +93,14 @@ def test_staging_nginx_blocks_direct_origin_bypass_but_keeps_local_health():
     assert "ssl_reject_handshake on;" in default_nginx
     assert "return 444;" in default_nginx
 
-    assert (
-        "server_name staging-sitbank.duckdns.org staging-sitbank.pp.ua;"
-        in staging_nginx
-    )
+    assert "server_name staging-sitbank.pp.ua;" in staging_nginx
+    assert "staging-sitbank.duckdns.org" not in staging_nginx
     assert "ssl_client_certificate /etc/nginx/cloudflare-authenticated-origin-pull-ca.pem;" in staging_nginx
     assert "ssl_verify_client optional;" in staging_nginx
     staging_https_prelocation = _nginx_server_block(
         staging_nginx,
-        "staging-sitbank.duckdns.org",
-    ).split("\n    location ", 1)[0]
-    assert _nginx_server_block(
-        staging_nginx,
         "staging-sitbank.pp.ua",
-    ) == _nginx_server_block(staging_nginx, "staging-sitbank.duckdns.org")
+    ).split("\n    location ", 1)[0]
     assert "auth_basic \"SITBank staging\";" not in staging_https_prelocation
     assert "auth_basic_user_file /etc/nginx/.htpasswd-sitbank-staging;" not in staging_https_prelocation
 
@@ -178,6 +174,7 @@ def test_admin_public_routes_stay_denied_and_private_access_is_tailscale_only():
     assert "proxy_pass" not in ready_bodies[0]
 
     assert "Tailscale/private operator access" in docs
+    assert "https://sitbank-ec2.tailca101b.ts.net/" in docs
     assert "Do not enable Tailscale Funnel" in docs
     assert "old public admin verification page has been removed" in docs
     assert "public admin Nginx app routes denied" in docs


### PR DESCRIPTION
## Summary
Refs #215

Finalize the active staging hostname migration to `staging-sitbank.pp.ua` while keeping production `sitbank.duckdns.org` and the public-denied admin hostname unchanged.

## Why
Cloudflare Access and Authenticated Origin Pulls are now verified for `staging-sitbank.pp.ua`, so the repo defaults should no longer point active staging deployment, TLS, Nginx, scripts, docs, or tests at the old transition DuckDNS staging hostname.

## What changed
- Updated staging Nginx to serve only `staging-sitbank.pp.ua` and use the matching Certbot live certificate path.
- Updated bootstrap, trusted deployment bootstrap, Certbot verifier, and live TLS scan defaults to use `staging-sitbank.pp.ua`.
- Updated deployment, operations, security, access-control, and crypto docs for the final staging hostname and the private Tailscale Serve admin URL `https://sitbank-ec2.tailca101b.ts.net/`.
- Updated deployment and zero-trust tests to assert the final staging hostname behavior and to keep private Tailscale admin out of public TLS scan targets.

## Security impact
Cloudflare Authenticated Origin Pull enforcement, direct-origin `403` behavior, Cloudflare Access, staging Basic Auth, admin isolation, Tailscale private admin access, and CI security gates were not weakened. The public admin app remains denied, Basic Auth still occurs only after the Cloudflare/origin boundary checks, the private Tailscale admin URL is documented without adding it to public GitHub-hosted TLS scans, and no secrets or generated credentials are committed.

## Deployment impact
EC2 bootstrap is required after merge to apply the updated staging Nginx hostname and Certbot path configuration. No database migration, secret changes, or new environment variables are required. No additional Cloudflare, NIC.UA, or Tailscale configuration changes are required by this PR based on the verified current state; operators should keep Cloudflare proxying, Full (strict), Cloudflare Access, Authenticated Origin Pulls, and Tailscale Serve enabled.

## Verification
- `git diff --check` -> passed
- `.\.venv\Scripts\python.exe -m pytest -q tests/test_zero_trust_access_boundary.py` -> `8 passed in 0.26s`
- `.\.venv\Scripts\python.exe -m pytest -q tests/test_deployment.py tests/test_admin_isolation.py` -> `55 passed, 6 warnings in 6.04s`
- `.\.venv\Scripts\python.exe -m pytest -q tests/test_deployment.py::test_live_tls_scan_workflow_collects_evidence_without_running_on_pull_requests tests/test_deployment.py::test_staging_nginx_enforces_https_auth_health_and_rate_limits tests/test_deployment.py::test_staging_edge_runbook_documents_operator_verification_steps` -> `3 passed in 0.18s`

## Notes
The remaining `staging-sitbank.duckdns.org` references are retired-hostname documentation or negative regression assertions. Public GitHub-hosted TLS scans still target only intended public hostnames and do not scan the private Tailscale admin hostname.