### PR TITLE
Accept Cloudflare Access staging TLS evidence

### DIFF
--- a/.github/workflows/tls-scan.yml
+++ b/.github/workflows/tls-scan.yml
@@ -210,7 +210,7 @@ jobs:
             fi
             echo "testssl.sh did not produce JSON evidence that is valid after the narrowly scoped scanner-escape normalization." >> "${violations_file}"
           else
-            jq -r '
+            jq -r --arg target_input "${TARGET_INPUT}" --arg target_host "${target_host}" '
               def id: (.id // "");
               def finding: (.finding // "");
               def offered:
@@ -220,9 +220,25 @@ jobs:
                 (.severity // "") as $severity
                 | ["HIGH", "CRITICAL", "FATAL"]
               | index($severity) != null;
-              .[]
-              | select(type == "object")
-              | select(
+              def staging_access_target:
+                $target_input == "staging" and $target_host == "staging-sitbank.pp.ua";
+              def has_id($items; $wanted):
+                any($items[]; type == "object" and (.id // "") == $wanted);
+              def final_grade_ok($items):
+                any(
+                  $items[];
+                  type == "object"
+                  and (.id // "") == "overall_grade"
+                  and ((.finding // "") | test("^A\\+?$"))
+                );
+              def staging_http_access_ok($items):
+                any(
+                  $items[];
+                  type == "object"
+                  and (.id // "") == "HTTP_status_code"
+                  and ((.finding // "") | test("^302[[:space:]]+Found"; "i"))
+                );
+              def production_public_violation:
                 severe
                 or ((id == "SSLv2" or id == "SSLv3" or id == "TLS1" or id == "TLS1_1") and offered)
                 or ((id | test("^cipherlist_(NULL|aNULL|EXPORT|LOW|OBSOLETED|3DES|RC4)")) and ((finding | test("^not offered$"; "i")) | not))
@@ -230,9 +246,38 @@ jobs:
                 or ((id | test("HSTS|STS"; "i")) and (finding | test("too short|not offered|not sent|missing|disabled"; "i")))
                 or (id == "cert_expirationStatus" and (finding | test("^expired"; "i")))
                 or (id == "cert_trust" and (finding | test("does not match supplied uri|hostname mismatch"; "i")))
-                or (id == "cert_chain_of_trust" and (finding | test("not trusted|untrusted|incomplete|missing"; "i")))
-              )
-              | "[\(.severity // "UNKNOWN")] \(id): \(finding)"
+                or (id == "cert_chain_of_trust" and (finding | test("not trusted|untrusted|incomplete|missing"; "i")));
+              def staging_access_violation:
+                ((id == "SSLv2" or id == "SSLv3" or id == "TLS1" or id == "TLS1_1") and offered)
+                or (id == "insecure_redirect")
+                or (id == "cert_expirationStatus" and (finding | test("^expired"; "i")))
+                or (
+                  id == "cert_trust"
+                  and (((.severity // "") != "OK") or ((finding | test("^Ok(\\b|$)"; "i")) | not))
+                )
+                or (id == "cert_chain_of_trust" and ((.severity // "") != "OK"));
+              . as $items
+              | if staging_access_target then
+                  (
+                    $items[]
+                    | select(type == "object")
+                    | select(staging_access_violation)
+                    | "[\(.severity // "UNKNOWN")] \(id): \(finding)"
+                  ),
+                  (if has_id($items; "TLS1") then empty else "[UNKNOWN] TLS1: missing TLS 1.0 evidence" end),
+                  (if has_id($items; "TLS1_1") then empty else "[UNKNOWN] TLS1_1: missing TLS 1.1 evidence" end),
+                  (if has_id($items; "HTTP_status_code") then
+                    if staging_http_access_ok($items) then empty else "[UNKNOWN] HTTP_status_code: expected 302 Found Cloudflare Access challenge" end
+                  else "[UNKNOWN] HTTP_status_code: missing Cloudflare Access challenge evidence" end),
+                  (if has_id($items; "cert_trust") then empty else "[UNKNOWN] cert_trust: missing certificate hostname/trust evidence" end),
+                  (if has_id($items; "cert_chain_of_trust") then empty else "[UNKNOWN] cert_chain_of_trust: missing certificate chain evidence" end),
+                  (if final_grade_ok($items) then empty else "[UNKNOWN] overall_grade: missing or lower than A for Cloudflare Access staging" end)
+                else
+                  $items[]
+                  | select(type == "object")
+                  | select(production_public_violation)
+                  | "[\(.severity // "UNKNOWN")] \(id): \(finding)"
+                end
             ' "${json_file}" > "${violations_file}"
 
             if [[ -s "${violations_file}" ]]; then

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -213,19 +213,28 @@ target job summary identifies the UTC scan time, host, run ID/attempt, scanner
 version, and pass/fail result. TLS scanning uses no application credentials
 and the workflow contains no application secrets.
 
-The verification gate fails for SSLv2, SSLv3, TLS 1.0, or TLS 1.1; weak, NULL,
-anonymous, export, RC4, or 3DES ciphers; missing, disabled, or too-short HSTS;
-expired certificates; hostname mismatches; untrusted, incomplete, or missing
-certificate chains; any `testssl.sh` HIGH, CRITICAL, or FATAL finding; and
-missing/invalid JSON evidence. MEDIUM/LOW/INFO findings remain in the evidence
-and require operator review; they are not an automatic release block unless
-they match one of the explicit prohibited classes above.
+The production customer and public-denied admin verification gate fails for
+SSLv2, SSLv3, TLS 1.0, or TLS 1.1; weak, NULL, anonymous, export, RC4, or 3DES
+ciphers; missing, disabled, or too-short HSTS; expired certificates; hostname
+mismatches; untrusted, incomplete, or missing certificate chains; any
+`testssl.sh` HIGH, CRITICAL, or FATAL finding; and missing/invalid JSON
+evidence. MEDIUM/LOW/INFO findings remain in the evidence and require operator
+review; they are not an automatic release block unless they match one of the
+explicit prohibited classes above.
+
+The Cloudflare Access-protected staging target `staging-sitbank.pp.ua` uses a
+staging-specific acceptance gate because unauthenticated HTTP requests should
+receive a `302 Found` Access challenge before the app. The staging scan still
+fails unless TLS 1.0 and TLS 1.1 are not offered, certificate hostname/trust
+and chain checks are OK, the certificate is not expired, insecure redirects
+are absent, and the final `overall_grade` is `A` or `A+`. Generic
+Cloudflare-managed CBC/LUCKY13 wording does not fail protected staging by
+itself when those hard requirements pass.
 
 Normalization does not suppress malformed JSON generally or change policy
-findings. All protocol, cipher, HSTS, certificate, chain, and severity gates
-run against the strictly validated policy copy. Cloudflare Access readiness is
-a separate zero-trust deployment concern and does not make staging TLS
-evidence optional.
+findings. All gates run against the strictly validated policy copy. Cloudflare
+Access readiness is a separate zero-trust deployment concern and does not make
+staging TLS evidence optional.
 
 For a host-side/manual check, use the same full scan (do not use `-k` or supply
 application credentials):

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -355,14 +355,24 @@ credentials or secrets are needed or permitted.
 
 Treat a failed scan as a release/deployment verification failure. A failed
 staging scan blocks production deployment, while a failed production scan
-marks the completed deployment workflow failed. The automated gate blocks
-legacy TLS protocols, weak/NULL/anonymous/export/RC4/3DES ciphers, expired or
-mismatched certificates, missing/untrusted chains, all HIGH, CRITICAL, or FATAL
-`testssl.sh` findings, and scanner errors. Review
-MEDIUM/LOW/INFO results in the retained evidence and create a security change
-or explicit risk decision where appropriate. SSL Labs is an optional manual
-second opinion; save its public report link or screenshot with the change
-record, but do not make a production release depend on its API.
+marks the completed deployment workflow failed. The production customer and
+public-denied admin automated gate blocks legacy TLS protocols,
+weak/NULL/anonymous/export/RC4/3DES ciphers, expired or mismatched
+certificates, missing/untrusted chains, all HIGH, CRITICAL, or FATAL
+`testssl.sh` findings, and scanner errors. Review MEDIUM/LOW/INFO results in
+the retained evidence and create a security change or explicit risk decision
+where appropriate. SSL Labs is an optional manual second opinion; save its
+public report link or screenshot with the change record, but do not make a
+production release depend on its API.
+
+For the Cloudflare Access-protected staging target, an unauthenticated
+`302 Found` response is the expected Access challenge and is accepted by the
+TLS evidence workflow. The staging gate still requires TLS 1.0 and TLS 1.1 to
+be not offered, certificate hostname/trust and chain checks to be OK, the
+certificate to be unexpired, no insecure redirect finding, and a final
+`overall_grade` of `A` or `A+`. Generic Cloudflare-managed CBC/LUCKY13 wording
+does not fail the protected staging scan by itself when those requirements
+pass.
 
 Cloudflare Access rollout is separate from TLS evidence collection. An
 incomplete Access setup does not make the staging scan optional, and the JSON

--- a/docs/security/cryptography-and-authentication.md
+++ b/docs/security/cryptography-and-authentication.md
@@ -112,13 +112,18 @@ or TLS findings generally. The job summary records the UTC time, target,
 workflow run, and result. It intentionally does not run on ordinary pull
 requests because they do not create public TLS endpoints.
 
-Verification fails for SSLv2/SSLv3/TLS 1.0/TLS 1.1, weak/NULL/anonymous/export/
-RC4/3DES cipher classes, missing, disabled, or too-short HSTS, expired
-certificates, hostname mismatches, untrusted or incomplete chains, and every
-HIGH, CRITICAL, or FATAL `testssl.sh` finding.
-MEDIUM/LOW/INFO findings are retained for manual review. SSL Labs is optional
-manual corroboration for a release, certificate renewal, edge change, or
-incident record; it is not a release-blocking automation dependency.
+Production customer and public-denied admin verification fails for SSLv2/SSLv3/
+TLS 1.0/TLS 1.1, weak/NULL/anonymous/export/RC4/3DES cipher classes, missing,
+disabled, or too-short HSTS, expired certificates, hostname mismatches,
+untrusted or incomplete chains, and every HIGH, CRITICAL, or FATAL
+`testssl.sh` finding. The Cloudflare Access-protected staging target accepts
+the expected unauthenticated `302 Found` Access challenge, but still requires
+TLS 1.0 and TLS 1.1 to be not offered, certificate hostname/trust and chain
+checks to be OK, no expiration or insecure redirect finding, and final
+`overall_grade` `A` or `A+`. MEDIUM/LOW/INFO findings are retained for manual
+review. SSL Labs is optional manual corroboration for a release, certificate
+renewal, edge change, or incident record; it is not a release-blocking
+automation dependency.
 
 ## Server Private Key Storage
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -2102,7 +2102,8 @@ def test_live_tls_scan_workflow_collects_evidence_without_running_on_pull_reques
     assert "index($severity) != null" in workflow_text
     assert 'policy-violations.txt"' in workflow_text
     assert 'if [[ "${scan_failed}" -ne 0 ]]' in workflow_text
-    assert '.[]\n              | select(type == "object")\n              | select(' in workflow_text
+    assert '$items[]\n                    | select(type == "object")' in workflow_text
+    assert '$items[]\n                  | select(type == "object")' in workflow_text
     assert "secrets." not in workflow_text
     assert "sitbank-ec2.tailca101b.ts.net" not in workflow_text
 
@@ -2155,6 +2156,50 @@ def test_live_tls_scan_workflow_collects_evidence_without_running_on_pull_reques
     assert "tls-scan-staging-sitbank" in deployment_docs
     assert "tls-scan-prod-sitbank" in deployment_docs
     assert "tls-scan-admin-sitbank" in deployment_docs
+
+
+def test_live_tls_scan_has_cloudflare_access_staging_acceptance_policy():
+    workflow_text = Path(".github/workflows/tls-scan.yml").read_text(encoding="utf-8")
+
+    for required in (
+        '--arg target_input "${TARGET_INPUT}" --arg target_host "${target_host}"',
+        "def staging_access_target:",
+        '$target_input == "staging" and $target_host == "staging-sitbank.pp.ua"',
+        "def staging_http_access_ok($items):",
+        '(.id // "") == "HTTP_status_code"',
+        'test("^302[[:space:]]+Found"; "i")',
+        "expected 302 Found Cloudflare Access challenge",
+        "def final_grade_ok($items):",
+        '(.id // "") == "overall_grade"',
+        'test("^A\\\\+?$")',
+        "missing or lower than A for Cloudflare Access staging",
+        "TLS1: missing TLS 1.0 evidence",
+        "TLS1_1: missing TLS 1.1 evidence",
+        "cert_trust: missing certificate hostname/trust evidence",
+        "cert_chain_of_trust: missing certificate chain evidence",
+        "def staging_access_violation:",
+        "def production_public_violation:",
+        "id == \"insecure_redirect\"",
+    ):
+        assert required in workflow_text
+
+    staging_policy = workflow_text[
+        workflow_text.index("def staging_access_violation:"):
+        workflow_text.index(". as $items")
+    ]
+    assert "severe" not in staging_policy
+    assert "cipherlist_(NULL|aNULL|EXPORT|LOW|OBSOLETED|3DES|RC4)" not in staging_policy
+    assert 'id == "TLS1" or id == "TLS1_1"' in staging_policy
+    assert 'id == "cert_trust"' in staging_policy
+    assert 'id == "cert_chain_of_trust"' in staging_policy
+
+    production_policy = workflow_text[
+        workflow_text.index("def production_public_violation:"):
+        workflow_text.index("def staging_access_violation:")
+    ]
+    assert "severe" in production_policy
+    assert "cipherlist_(NULL|aNULL|EXPORT|LOW|OBSOLETED|3DES|RC4)" in production_policy
+    assert 'id | test("HSTS|STS"; "i")' in production_policy
 
 
 def test_only_sitbank_container_deployment_units_are_active():


### PR DESCRIPTION
Summary
---

Adjust the live TLS scan policy so the Cloudflare Access-protected staging hostname `staging-sitbank.pp.ua` can pass when evidence shows the expected Access challenge and strong TLS posture.

Why
---

`staging-sitbank.pp.ua` is protected by Cloudflare Access, so the expected public response is a Cloudflare Access `302` challenge before the app is reached. The previous TLS scan logic treated the protected response as a failure even when TLS posture was strong and the hostname was correctly protected.

What changed
---

* Updated the live TLS scan workflow acceptance logic for the Cloudflare Access-protected staging hostname.
* Kept the relaxed Access-aware acceptance scoped to `staging-sitbank.pp.ua` only.
* Required TLS 1.0 and TLS 1.1 to remain disabled.
* Required certificate trust and hostname validation to remain valid.
* Required the final TLS grade to be A or A+.
* Updated deployment and operations documentation for the staging TLS evidence flow.
* Added focused workflow/parser test coverage for the Access-protected staging scan behavior.

Security impact
---

Cloudflare Access, Full strict TLS, Authenticated Origin Pulls, Cloudflare proxying, direct-origin `403 Forbidden`, staging Basic Auth, admin isolation, and CI security gates were not weakened. Production and admin TLS checks remain strict. The Access-aware TLS scan handling applies only to `staging-sitbank.pp.ua`.

Deployment impact
---

No deployment action required.

Verification
---

* `git diff --check`
* `.\.venv\Scripts\python.exe -m pytest -q tests/test_zero_trust_access_boundary.py`
* `.\.venv\Scripts\python.exe -m pytest -q tests/test_deployment.py tests/test_admin_isolation.py`
* Focused workflow tests passed.
* Extra jq sample validation passed: A+ staging Access sample with CBC/LUCKY13 wording produced no violations; TLS 1.0 offered was flagged.

Notes
---

Refs #215. This PR only adjusts the staging TLS evidence acceptance logic after the Cloudflare Access migration. It does not change Cloudflare configuration, Nginx runtime behavior, AOP, Basic Auth, or direct-origin protections.