### PR TITLE
Require staging HSTS and document Universal SSL ciphers

### DIFF
--- a/.github/workflows/tls-scan.yml
+++ b/.github/workflows/tls-scan.yml
@@ -238,6 +238,20 @@ jobs:
                   and (.id // "") == "HTTP_status_code"
                   and ((.finding // "") | test("^302[[:space:]]+Found"; "i"))
                 );
+              def protocol_offered_ok($items; $wanted):
+                any(
+                  $items[];
+                  type == "object"
+                  and (.id // "") == $wanted
+                  and offered
+                );
+              def hsts_minimum_ok($items):
+                any(
+                  $items[];
+                  type == "object"
+                  and (.id // "") == "HSTS_time"
+                  and (.severity // "") == "OK"
+                );
               def production_public_violation:
                 severe
                 or ((id == "SSLv2" or id == "SSLv3" or id == "TLS1" or id == "TLS1_1") and offered)
@@ -249,6 +263,7 @@ jobs:
                 or (id == "cert_chain_of_trust" and (finding | test("not trusted|untrusted|incomplete|missing"; "i")));
               def staging_access_violation:
                 ((id == "SSLv2" or id == "SSLv3" or id == "TLS1" or id == "TLS1_1") and offered)
+                or ((id | test("HSTS|STS"; "i")) and (finding | test("too short|not offered|not sent|missing|disabled"; "i")))
                 or (id == "insecure_redirect")
                 or (id == "cert_expirationStatus" and (finding | test("^expired"; "i")))
                 or (
@@ -266,9 +281,12 @@ jobs:
                   ),
                   (if has_id($items; "TLS1") then empty else "[UNKNOWN] TLS1: missing TLS 1.0 evidence" end),
                   (if has_id($items; "TLS1_1") then empty else "[UNKNOWN] TLS1_1: missing TLS 1.1 evidence" end),
+                  (if protocol_offered_ok($items; "TLS1_2") then empty else "[UNKNOWN] TLS1_2: missing or not offered" end),
+                  (if protocol_offered_ok($items; "TLS1_3") then empty else "[UNKNOWN] TLS1_3: missing or not offered" end),
                   (if has_id($items; "HTTP_status_code") then
                     if staging_http_access_ok($items) then empty else "[UNKNOWN] HTTP_status_code: expected 302 Found Cloudflare Access challenge" end
                   else "[UNKNOWN] HTTP_status_code: missing Cloudflare Access challenge evidence" end),
+                  (if hsts_minimum_ok($items) then empty else "[UNKNOWN] HSTS_time: missing or below the required HSTS minimum" end),
                   (if has_id($items; "cert_trust") then empty else "[UNKNOWN] cert_trust: missing certificate hostname/trust evidence" end),
                   (if has_id($items; "cert_chain_of_trust") then empty else "[UNKNOWN] cert_chain_of_trust: missing certificate chain evidence" end),
                   (if final_grade_ok($items) then empty else "[UNKNOWN] overall_grade: missing or lower than A for Cloudflare Access staging" end)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -225,11 +225,22 @@ explicit prohibited classes above.
 The Cloudflare Access-protected staging target `staging-sitbank.pp.ua` uses a
 staging-specific acceptance gate because unauthenticated HTTP requests should
 receive a `302 Found` Access challenge before the app. The staging scan still
-fails unless TLS 1.0 and TLS 1.1 are not offered, certificate hostname/trust
-and chain checks are OK, the certificate is not expired, insecure redirects
-are absent, and the final `overall_grade` is `A` or `A+`. Generic
-Cloudflare-managed CBC/LUCKY13 wording does not fail protected staging by
-itself when those hard requirements pass.
+fails unless TLS 1.0 and TLS 1.1 are not offered, TLS 1.2 and TLS 1.3 are
+offered, certificate hostname/trust and chain checks are OK, the certificate
+is not expired, HSTS meets the scanner minimum, insecure redirects are absent,
+and the final `overall_grade` is `A` or `A+`. Generic LUCKY13 wording and
+`cipherlist_OBSOLETED: offered` on Cloudflare Universal SSL are retained as
+review evidence for protected staging, not automatic failures.
+
+Because Cloudflare Access can generate the unauthenticated `302 Found`
+response before traffic reaches origin Nginx, origin-side HSTS headers are not
+sufficient evidence for staging. Configure the Cloudflare edge response for
+`staging-sitbank.pp.ua` so the Access challenge includes
+`Strict-Transport-Security` with at least the scanner minimum. Removing
+Cloudflare Universal SSL obsolete CBC cipher offerings requires Advanced
+Certificate Manager/custom cipher suite support; do not claim that
+`cipherlist_OBSOLETED: offered` is fixed until that paid capability is enabled
+and verified.
 
 Normalization does not suppress malformed JSON generally or change policy
 findings. All gates run against the strictly validated policy copy. Cloudflare

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -368,11 +368,22 @@ production release depend on its API.
 For the Cloudflare Access-protected staging target, an unauthenticated
 `302 Found` response is the expected Access challenge and is accepted by the
 TLS evidence workflow. The staging gate still requires TLS 1.0 and TLS 1.1 to
-be not offered, certificate hostname/trust and chain checks to be OK, the
-certificate to be unexpired, no insecure redirect finding, and a final
-`overall_grade` of `A` or `A+`. Generic Cloudflare-managed CBC/LUCKY13 wording
-does not fail the protected staging scan by itself when those requirements
-pass.
+be not offered, TLS 1.2 and TLS 1.3 to be offered, certificate
+hostname/trust and chain checks to be OK, the certificate to be unexpired,
+HSTS to meet the scanner minimum, no insecure redirect finding, and a final
+`overall_grade` of `A` or `A+`. Generic LUCKY13 wording and
+`cipherlist_OBSOLETED: offered` on Cloudflare Universal SSL are retained as
+review evidence for protected staging, not automatic failures.
+
+If staging reports `HSTS: not offered`, fix the Cloudflare edge response for
+`staging-sitbank.pp.ua`; the unauthenticated Access challenge is generated
+before origin Nginx can add its own HSTS header. If staging reports
+`cipherlist_OBSOLETED: offered`, document it as a Cloudflare Universal SSL
+edge limitation. Removing that finding requires Advanced Certificate Manager
+with custom cipher suite support; do not claim it is fixed until that paid
+capability is enabled and verified. Do not make HSTS pass by disabling
+Cloudflare Access, turning off the proxy, changing SSL mode away from Full
+strict, or bypassing Authenticated Origin Pulls.
 
 Cloudflare Access rollout is separate from TLS evidence collection. An
 incomplete Access setup does not make the staging scan optional, and the JSON

--- a/docs/security/cryptography-and-authentication.md
+++ b/docs/security/cryptography-and-authentication.md
@@ -119,11 +119,16 @@ untrusted or incomplete chains, and every HIGH, CRITICAL, or FATAL
 `testssl.sh` finding. The Cloudflare Access-protected staging target accepts
 the expected unauthenticated `302 Found` Access challenge, but still requires
 TLS 1.0 and TLS 1.1 to be not offered, certificate hostname/trust and chain
-checks to be OK, no expiration or insecure redirect finding, and final
-`overall_grade` `A` or `A+`. MEDIUM/LOW/INFO findings are retained for manual
-review. SSL Labs is optional manual corroboration for a release, certificate
-renewal, edge change, or incident record; it is not a release-blocking
-automation dependency.
+checks to be OK, TLS 1.2 and TLS 1.3 to be offered, HSTS to meet the scanner
+minimum, no expiration or insecure redirect finding, and final `overall_grade`
+`A` or `A+`. `HSTS: not offered` is a failure for staging because the public
+Cloudflare edge, not only origin Nginx, is part of the deployed HTTPS
+boundary. `cipherlist_OBSOLETED: offered` on Cloudflare Universal SSL is
+retained as review evidence; removing it requires Advanced Certificate
+Manager/custom cipher suite support.
+MEDIUM/LOW/INFO findings are retained for manual review. SSL Labs is optional
+manual corroboration for a release, certificate renewal, edge change, or
+incident record; it is not a release-blocking automation dependency.
 
 ## Server Private Key Storage
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -2169,12 +2169,18 @@ def test_live_tls_scan_has_cloudflare_access_staging_acceptance_policy():
         '(.id // "") == "HTTP_status_code"',
         'test("^302[[:space:]]+Found"; "i")',
         "expected 302 Found Cloudflare Access challenge",
+        "def protocol_offered_ok($items; $wanted):",
+        "def hsts_minimum_ok($items):",
+        '(.id // "") == "HSTS_time"',
+        "missing or below the required HSTS minimum",
         "def final_grade_ok($items):",
         '(.id // "") == "overall_grade"',
         'test("^A\\\\+?$")',
         "missing or lower than A for Cloudflare Access staging",
         "TLS1: missing TLS 1.0 evidence",
         "TLS1_1: missing TLS 1.1 evidence",
+        "TLS1_2: missing or not offered",
+        "TLS1_3: missing or not offered",
         "cert_trust: missing certificate hostname/trust evidence",
         "cert_chain_of_trust: missing certificate chain evidence",
         "def staging_access_violation:",
@@ -2189,6 +2195,7 @@ def test_live_tls_scan_has_cloudflare_access_staging_acceptance_policy():
     ]
     assert "severe" not in staging_policy
     assert "cipherlist_(NULL|aNULL|EXPORT|LOW|OBSOLETED|3DES|RC4)" not in staging_policy
+    assert 'id | test("HSTS|STS"; "i")' in staging_policy
     assert 'id == "TLS1" or id == "TLS1_1"' in staging_policy
     assert 'id == "cert_trust"' in staging_policy
     assert 'id == "cert_chain_of_trust"' in staging_policy


### PR DESCRIPTION
## Summary

Follow-up to PR #226. Keeps the Cloudflare Access staging scan exception for the expected `302 Found`, keeps HSTS as a hard failure, and treats `cipherlist_OBSOLETED: offered` as Cloudflare Universal SSL review evidence instead of a hard failure for `staging-sitbank.pp.ua`.

## Why

The current Cloudflare Free/Universal SSL edge can report obsolete CBC cipher wording, and custom cipher suite control requires paid Advanced Certificate Manager. HSTS is separately configurable at the Cloudflare edge, so `HSTS: not offered` remains a real deployed-edge finding that should fail.

## What changed

* Staging TLS scan policy no longer hard-fails `cipherlist_OBSOLETED: offered` for the Cloudflare Access-protected staging hostname.
* Staging TLS scan policy still fails missing or too-short HSTS.
* Staging TLS scan policy now explicitly requires TLS 1.0 and TLS 1.1 to be not offered.
* Staging TLS scan policy now explicitly requires TLS 1.2 and TLS 1.3 to be offered.
* Staging TLS scan policy requires certificate trust and hostname evidence to be OK.
* Staging TLS scan policy accepts Cloudflare Access `302 Found` only for the protected staging hostname.
* Staging TLS scan policy requires final grade A or A+.
* Production customer and public-denied admin TLS gates keep the strict obsolete/weak cipher-list failure behavior.
* Docs describe `cipherlist_OBSOLETED: offered` as a Cloudflare Universal SSL edge limitation and note that removal requires Advanced Certificate Manager/custom cipher suite support.

## Security impact

Preserves Cloudflare Access, Full strict TLS, Authenticated Origin Pulls, Cloudflare proxying, direct-origin `403 Forbidden` behavior, and production/admin strict TLS gates. HSTS remains a hard failure for protected staging because it is configurable at the Cloudflare edge. Obsolete cipher findings on Cloudflare Universal SSL are retained as review evidence until paid custom cipher controls are available.

## Deployment impact

No EC2 bootstrap, database migration, secret change, or new environment variable is required for this repository change.

Manual Cloudflare edge configuration is required before the live staging TLS scan passes if `HSTS: not offered` remains present. The current live staging response has been updated to include `Strict-Transport-Security: max-age=15552000; includeSubDomains` on the Cloudflare Access `302 Found` response.

Removing `cipherlist_OBSOLETED: offered` requires Advanced Certificate Manager/custom cipher suite support.

## Verification

* `git diff --check` -> passed
* `.\.venv\Scripts\python.exe -m pytest -q tests/test_zero_trust_access_boundary.py` -> 8 passed in 0.97s
* `.\.venv\Scripts\python.exe -m pytest -q tests/test_deployment.py tests/test_admin_isolation.py` -> 56 passed, 6 warnings in 8.86s
* `.\.venv\Scripts\python.exe -m pytest -q tests/test_deployment.py::test_live_tls_scan_workflow_collects_evidence_without_running_on_pull_requests tests/test_deployment.py::test_live_tls_scan_has_cloudflare_access_staging_acceptance_policy` -> 2 passed in 0.69s
* Temporary jq-1.7.1 sample validation -> Universal SSL staging sample with `cipherlist_OBSOLETED: offered` and valid HSTS passed; missing HSTS failed; missing TLS 1.3 failed.
* Live curl verification confirmed the Cloudflare Access `302 Found` response now includes `Strict-Transport-Security: max-age=15552000; includeSubDomains`.

## Notes

Refs #215. The Cloudflare edge HSTS setting is now configured for the staging Access challenge response. `cipherlist_OBSOLETED: offered` is not claimed as fixed because removing Cloudflare Universal SSL obsolete CBC cipher offerings requires Advanced Certificate Manager/custom cipher suite support. Production customer and public-denied admin responses include HSTS and keep stricter TLS gate behavior.
