### PR TITLE
Fix ZAP smoke startup workdir

### DIFF
--- a/ops/container/smoke-test.sh
+++ b/ops/container/smoke-test.sh
@@ -467,6 +467,7 @@ PY
     docker run --rm --network "${network_name}" \
         --user 10001:10001 \
         --env HOME=/zap/wrk \
+        --workdir /zap/wrk \
         --volume "${zap_mount_source}:/zap/wrk:rw" \
         --volume "${dast_mount_source}:/run/dast:ro" \
         "${ZAP_IMAGE}" \

--- a/tests/test_dast_helper_security.py
+++ b/tests/test_dast_helper_security.py
@@ -34,6 +34,7 @@ def test_smoke_test_keeps_dast_cookie_out_of_host_command_arguments():
     assert "--volume \"${dast_mount_source}:/run/dast:ro\"" in smoke_test
     assert "--user 10001:10001" in smoke_test
     assert "--env HOME=/zap/wrk" in smoke_test
+    assert "--workdir /zap/wrk" in smoke_test
 
 
 def test_dast_secret_files_are_restricted_and_cleaned_up_by_contract():

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1136,6 +1136,7 @@ def test_dockerfile_and_compose_enforce_hardened_runtime():
     assert '"${dast_mount_source}:/run/dast:ro"' in smoke_test
     assert "--zap-replacer-config-output /run/dast/zap-replacer.properties" in smoke_test
     assert "-configfile /run/dast/zap-replacer.properties" in smoke_test
+    assert "--workdir /zap/wrk" in smoke_test
     assert "replacer.full_list(0).replacement=${" not in smoke_test
     assert "dast_cookie=" not in smoke_test
     assert "docker compose" in compose_validation


### PR DESCRIPTION
## Summary

Fix the authenticated DAST smoke-test ZAP startup by running the ZAP container from its writable work directory.

## Why

The release smoke test reached the ZAP container but failed with `Failed to start ZAP :(` after the DAST cookie-hardening changes. ZAP needs a writable working directory for its runtime files and reports; without an explicit workdir, the hardened non-root container invocation can fail before the scan starts.

## What changed

* Added `--workdir /zap/wrk` to the ZAP smoke-test container invocation.
* Preserved the existing non-root ZAP user, read-only DAST cookie/config mount, and cookie-not-in-process-args behavior.
* Added regression assertions in DAST/deployment tests so the writable ZAP workdir contract stays in place.

## Security impact

This keeps the DAST hardening intact while restoring scan startup reliability. The authenticated cookie still stays in restricted temporary files, the ZAP replacer config remains mounted read-only, and the raw cookie is not passed through command-line arguments. No authentication, session, MFA, deployment, or secret-handling controls are weakened.

## Deployment impact

No EC2 bootstrap required.

No staging deployment required.

No production deployment required.

No database migration required.

No secret changes required.

No deployment action required beyond rerunning the affected CI/release smoke workflow.

## Verification

* `git diff --check`
* `C:\Program Files\Git\bin\bash.exe -n ops/container/smoke-test.sh`
* `.\.venv\Scripts\python.exe -m pytest -q -n auto tests/test_dast_helper_security.py tests/test_deployment.py` - 58 passed
* `.\.venv\Scripts\python.exe -m pytest -q -n auto` - 607 passed, 2 skipped

## Notes

Local live Docker/ZAP reproduction could not be completed because the local Docker Desktop Linux engine pipe was unavailable. The fix is covered by static smoke-script contract tests and should be confirmed by rerunning the GitHub release/smoke workflow.