### PR TITLE
Fix DAST smoke cleanup failure

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -229,6 +229,9 @@ scanner home option `-dir /zap/wrk/.ZAP` plus
 `-configfile /run/dast/zap-replacer.properties`; it must not include a raw cookie
 value or `replacement=${...}` argument. Do not retain the DAST temporary
 directory, upload it as an artifact, or paste its contents into release notes.
+ZAP's own cache, browser profile, and report workspace run on container tmpfs
+so scanner-owned files disappear with the container instead of breaking host
+cleanup.
 
 The production customer verification gate fails for
 SSLv2, SSLv3, TLS 1.0, or TLS 1.1; weak, NULL, anonymous, export, RC4, or 3DES

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -404,12 +404,14 @@ and `zap-replacer.properties` as temporary `0600` files under `umask 077`, and
 passes only non-secret startup options plus
 `-configfile /run/dast/zap-replacer.properties` to ZAP. The non-secret
 `-dir /zap/wrk/.ZAP` option gives the scanner UID a writable ZAP home without
-relaxing cookie-file permissions. The cookie is not passed as a raw process
-argument, and neither file belongs in GitHub artifacts, job summaries, chat,
-screenshots, or issue comments. If a DAST cookie or full replacer config is
-exposed, cancel the run, remove the artifact, treat the synthetic session as
-compromised until the run cleanup completes, and review the workflow/script
-change before retrying.
+relaxing cookie-file permissions. ZAP's cache, browser profile, and report
+workspace run on container tmpfs and are discarded with the scanner container, so
+host cleanup does not depend on deleting scanner-owned cache files. The cookie is
+not passed as a raw process argument, and neither file belongs in GitHub
+artifacts, job summaries, chat, screenshots, or issue comments. If a DAST cookie
+or full replacer config is exposed, cancel the run, remove the artifact, treat
+the synthetic session as compromised until the run cleanup completes, and review
+the workflow/script change before retrying.
 
 Treat a failed scan as a release/deployment verification failure. A failed
 staging scan blocks production deployment, while a failed production scan

--- a/docs/security/test-automation-and-dependencies.md
+++ b/docs/security/test-automation-and-dependencies.md
@@ -183,7 +183,10 @@ the non-secret scanner home option `-dir /zap/wrk/.ZAP` plus
 `-configfile /run/dast/zap-replacer.properties` on the host-visible ZAP command
 line. ZAP loads the authenticated-cookie replacer from a restricted file, so the
 DAST cookie is not passed as a raw process argument. The temporary directory is
-removed by the smoke-test cleanup trap on success and failure.
+removed by the smoke-test cleanup trap on success and failure. ZAP's own cache,
+browser profile, and report workspace run on container tmpfs so scanner-owned
+files are discarded with the container instead of becoming host cleanup
+artifacts.
 
 The DAST bind-mount directory is relaxed for container UID compatibility, but
 the secret files inside remain owner-only and are not uploaded as GitHub

--- a/ops/container/smoke-test.sh
+++ b/ops/container/smoke-test.sh
@@ -498,16 +498,16 @@ for path in (cookie_path, zap_config_path):
     if mode & 0o077:
         raise SystemExit(f"{path.name} permissions are too broad: {mode:o}")
 PY
-    install_host_dir 0777 "${work_dir}/zap"
-    zap_mount_source="$(docker_bind_source "${work_dir}/zap")"
     # ZAP derives an unusable home such as /zap/?/.ZAP for this unknown UID.
     # Keep the UID aligned with the 0600 DAST config owner and provide a
-    # writable non-secret ZAP home with -dir instead of relaxing cookie files.
+    # writable tmpfs-backed ZAP home with -dir instead of relaxing cookie files.
+    # Keeping ZAP caches and reports off the host avoids root-owned cleanup
+    # failures after a successful GitHub Actions scan.
     docker run --rm --network "${network_name}" \
         --user 10001:10001 \
         --env HOME=/zap/wrk \
         --workdir /zap/wrk \
-        --volume "${zap_mount_source}:/zap/wrk:rw" \
+        --tmpfs "/zap/wrk:rw,nosuid,nodev,size=1g,uid=10001,gid=10001,mode=1770" \
         --volume "${dast_mount_source}:/run/dast:ro" \
         "${ZAP_IMAGE}" \
         zap-full-scan.py \

--- a/tests/test_account_security_actions.py
+++ b/tests/test_account_security_actions.py
@@ -257,8 +257,12 @@ def test_password_change_uses_configured_new_password_minimum(app, client):
 
 
 def test_password_change_rejects_common_or_reused_password(client):
-    register(client)
-    login(client)
+    current_password = "correct horse battery staple"
+    register_response = register(client, password=current_password)
+    login_response = login(client, password=current_password)
+    assert register_response.status_code == 302
+    assert login_response.status_code == 302
+
     user, secret = enable_mfa_for_user()
     add_security_keys_for_user(user)
     mark_recent_mfa(client, user)
@@ -266,15 +270,15 @@ def test_password_change_rejects_common_or_reused_password(client):
     reused_response = client.post(
         "/password/change",
         data={
-            "current_password": "correct horse battery staple",
-            "new_password": "correct horse battery staple",
-            "confirm_new_password": "correct horse battery staple",
+            "current_password": current_password,
+            "new_password": current_password,
+            "confirm_new_password": current_password,
         },
     )
     common_response = client.post(
         "/password/change",
         data={
-            "current_password": "correct horse battery staple",
+            "current_password": current_password,
             "new_password": "password",
             "confirm_new_password": "password",
             "totp_code": pyotp.TOTP(secret, digits=6, interval=30).now(),

--- a/tests/test_dast_helper_security.py
+++ b/tests/test_dast_helper_security.py
@@ -37,6 +37,9 @@ def test_smoke_test_keeps_dast_cookie_out_of_host_command_arguments():
     assert "--env HOME=/zap/wrk" in smoke_test
     assert "--workdir /zap/wrk" in smoke_test
     assert "Keep the UID aligned with the 0600 DAST config owner" in smoke_test
+    assert "--tmpfs \"/zap/wrk:rw,nosuid,nodev,size=1g,uid=10001,gid=10001,mode=1770\"" in smoke_test
+    assert 'zap_mount_source="$(docker_bind_source "${work_dir}/zap")"' not in smoke_test
+    assert '"${zap_mount_source}:/zap/wrk:rw"' not in smoke_test
     assert "export MSYS_NO_PATHCONV=1" in smoke_test
     assert "converted explicitly by docker_bind_source" in smoke_test
 
@@ -52,6 +55,7 @@ def test_dast_secret_files_are_restricted_and_cleaned_up_by_contract():
     assert "umask 077" in smoke_test
     assert "install_host_dir 0700 \"${work_dir}/dast\"" in smoke_test
     assert "chmod_host_path 0777 \"${work_dir}/dast\"" in smoke_test
+    assert "Keeping ZAP caches and reports off the host" in smoke_test
     assert "install -d -m \"${mode}\" \"$@\"" in smoke_test
     assert "chmod \"${mode}\" \"$@\" 2>/dev/null || true" in smoke_test
     assert "the cookie and ZAP config files inside remain 0600" in smoke_test

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1141,7 +1141,11 @@ def test_dockerfile_and_compose_enforce_hardened_runtime():
     assert "-configfile /run/dast/zap-replacer.properties" in smoke_test
     assert "-dir /zap/wrk/.ZAP -configfile /run/dast/zap-replacer.properties" in smoke_test
     assert "--workdir /zap/wrk" in smoke_test
+    assert "--tmpfs \"/zap/wrk:rw,nosuid,nodev,size=1g,uid=10001,gid=10001,mode=1770\"" in smoke_test
+    assert 'zap_mount_source="$(docker_bind_source "${work_dir}/zap")"' not in smoke_test
+    assert '"${zap_mount_source}:/zap/wrk:rw"' not in smoke_test
     assert "Keep the UID aligned with the 0600 DAST config owner" in smoke_test
+    assert "Keeping ZAP caches and reports off the host" in smoke_test
     assert "export MSYS_NO_PATHCONV=1" in smoke_test
     assert "converted explicitly by docker_bind_source" in smoke_test
     assert "replacer.full_list(0).replacement=${" not in smoke_test


### PR DESCRIPTION
## Summary

Fixes the authenticated DAST smoke-test failure where GitHub Actions completed the ZAP scan successfully but failed during temporary workspace cleanup.

## Why

The release verification smoke test was reaching ZAP successfully and reporting `FAIL-NEW: 0`, but the job still failed afterward because ZAP wrote cache, browser profile, and report workspace files into a host bind-mounted temporary directory. Those scanner-owned files could not be removed by the GitHub Actions cleanup trap, causing `rm: cannot remove ... Permission denied` and failing the workflow after a successful scan.

## What changed

* Moved ZAP's `/zap/wrk` scanner workspace from a host bind mount to Docker `tmpfs`.
* Kept the restricted DAST cookie and ZAP replacer config mounted read-only from the temporary DAST directory.
* Added regression tests and documentation so future changes do not reintroduce host-mounted ZAP cache/report cleanup failures.

## Security impact

This preserves the safer DAST authentication model: the authenticated session cookie is still stored in a restricted temporary config file, mounted read-only into ZAP, and not passed as a raw process argument.

The change improves CI/CD reliability without relaxing cookie-file permissions, authentication controls, MFA behavior, session handling, audit behavior, or deployment gates. ZAP runtime/cache/report files are now discarded with the scanner container instead of remaining as host cleanup artifacts.

## Deployment impact

* EC2 bootstrap: not required
* staging deployment: normal merge-to-main workflow may deploy according to existing GitHub Actions settings
* production deployment: not required by this PR alone
* database migration: not required
* secret changes: not required
* no deployment action: no manual operator action required beyond the normal PR merge flow

## Verification

* Installed and ran ShellCheck locally against the same deployment scripts linted by GitHub Actions
* `docker build -t sitbank:dast-cleanup-fix .`
* `RUN_ZAP_DAST=true ops/container/smoke-test.sh sitbank:dast-cleanup-fix` passed with `FAIL-NEW: 0` and no cleanup error
* `.\.venv\Scripts\python.exe -m pytest -q -n auto tests/test_dast_helper_security.py` passed: `6 passed`
* `.\.venv\Scripts\python.exe -m pytest -q -n auto tests/test_deployment.py` passed: `52 passed`
* Security documentation tests passed: `22 passed`
* `.\.venv\Scripts\python.exe scripts\ci-local --require-docker` passed: `607 passed, 2 skipped`
* `git diff --check` and Compose validation passed

## Notes

No follow-up operator action is required. The ZAP scan may still report tolerated `WARN-NEW` items under the existing `-I` smoke-test behavior, but the blocking failure was the post-scan cleanup error and that path now passes locally.