### PR TITLE
Fix dark mode flash on page navigation

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -6,7 +6,7 @@
     <meta name="google-site-verification" content="TdWqsa4Ln9t_GIYl4Devi4rrU48Z7XNSue_PiImREJs">
     <title>{% block title %}SITBank{% endblock %}</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
-    <script src="{{ url_for('static', filename='js/theme.js') }}" defer></script>
+    <script src="{{ url_for('static', filename='js/theme.js') }}"></script>
     <script src="{{ url_for('static', filename='js/account.js') }}" defer></script>
     {% if g.current_user %}
     <meta name="session-timeout" content="{{ config['SESSION_INACTIVITY_SECONDS'] }}">


### PR DESCRIPTION
## Summary
Fixes a flash of light mode that appeared on every page navigation when the user had dark mode enabled. The root cause was theme.js being loaded with defer, which delayed theme application until after the browser had already painted the page in its default light styles. Loading theme.js synchronously in the head ensures the correct data-theme attribute is set on the html element before any content is rendered.

## Why
Users in dark mode saw a brief white flash every time they navigated between pages such as Dashboard and Local Transfer. This happened because defer causes the script to run after HTML parsing completes, by which point the browser has already laid out and painted the page without the dark theme.

## What changed
- Removed defer attribute from theme.js script tag in base.html

## Security impact
No security impact. No logic changed, only script loading order. The theme.js script only reads localStorage and sets a data attribute on the html element.

## Deployment impact
No deployment action required.

## Verification
- Log in, toggle dark mode, navigate between Dashboard and Local Transfer — no flash visible

## Notes
No follow-up required.