### PR TITLE
Add SonarQube Cloud analysis workflow and project config

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,66 @@
+name: SonarQube Cloud Analysis
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: read
+    env:
+      APP_ENV: testing
+      SECRET_KEY: ci-secret-key-that-is-long-enough-for-tests
+      WTF_CSRF_SECRET_KEY: ci-csrf-key-that-is-long-enough-for-tests
+      SESSION_HMAC_ACTIVE_KEY_ID: ci-current
+      SESSION_HMAC_KEYS_JSON: '{"ci-current":"MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjI=","ci-previous":"MzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzM="}'
+      SESSION_LOOKUP_HMAC_KEY: OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk=
+      MFA_KEK_ACTIVE_ID: ci-mfa
+      MFA_KEK_KEYS_JSON: '{"ci-mfa":"NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ="}'
+      PASSWORD_PEPPER_B64: MTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTE=
+      PASSWORD_PBKDF2_ITERATIONS: "600000"
+      COMMON_PASSWORDS_PATH: tests/fixtures/common_passwords.txt
+      COMMON_PASSWORDS_MIN_ENTRIES: "100000"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            requirements.lock
+            requirements-dev.lock
+
+      - name: Install locked dependencies
+        run: python -m pip install --require-hashes -r requirements-dev.lock
+
+      - name: Install coverage tool
+        run: python -m pip install pytest-cov
+
+      - name: Run tests and generate coverage report
+        run: |
+          python -m pytest -q -n auto \
+            --cov=app \
+            --cov-report=xml:coverage.xml \
+            --cov-report=term-missing
+
+      - name: SonarQube Cloud scan
+        # zizmor: ignore[unpinned-uses]
+        uses: SonarSource/sonarqube-scan-action@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,8 @@
+sonar.projectKey=WenJiangg_SITBank
+sonar.organization=wenjiangg
+
+sonar.sources=app
+sonar.tests=tests
+sonar.python.coverage.reportPaths=coverage.xml
+
+sonar.qualitygate.wait=false


### PR DESCRIPTION
## Summary
Adds SonarQube Cloud static analysis to the CI pipeline. On every push to main and every pull request, the workflow runs the full test suite to generate a coverage report, then uploads the results to SonarCloud for code quality and security analysis.

## Why
SonarQube Cloud provides continuous code quality and security scanning including detection of code smells, bugs, and security hotspots. Required as part of the project security toolchain.

## What changed
- sonar-project.properties defines the project key, organization, source paths, and coverage report location
- .github/workflows/sonarcloud.yml runs tests with coverage then uploads to SonarCloud

## Security impact
SONAR_TOKEN is stored as a GitHub Actions repository secret and never logged. The workflow uses minimal permissions (contents: read, pull-requests: read). The SonarSource action is not SHA-pinned yet and is suppressed with a zizmor ignore annotation pending a stable release SHA.

## Deployment impact
No deployment action required.

## Verification
- Open a PR and check that SonarQube Cloud Analysis appears in the checks list
- Visit sonarcloud.io to confirm the analysis ran

## Notes
The SonarSource/sonarqube-scan-action should be SHA-pinned once a stable release SHA is confirmed. Quality gate is set to wait=false so it reports without blocking the pipeline.