### PR TITLE
Add root admin bootstrap command

### DIFF
--- a/app/admin/bootstrap_root.py
+++ b/app/admin/bootstrap_root.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import pyotp
+from flask import current_app
+from sqlalchemy import func, or_
+from sqlalchemy.exc import IntegrityError
+
+from app.extensions import db
+from app.auth.services import AuthError
+from app.models import User
+from app.security.audit import audit_reference, audit_system_event
+from app.security.crypto import encrypt_mfa_secret
+from app.security.passwords import PasswordPolicyError, hash_password, validate_password_policy
+
+from .services import (
+    ACCOUNT_CUSTOMER,
+    ACCOUNT_ROOT_ADMIN,
+    STAFF_ACCOUNT_TYPES,
+    STAFF_USERNAME_RE,
+    normalize_workplace_email,
+    validate_full_name,
+)
+
+
+class RootAdminBootstrapError(ValueError):
+    """Raised when the root-admin bootstrap request is not allowed."""
+
+
+@dataclass(frozen=True)
+class RootAdminBootstrapResult:
+    user_id: int
+    workplace_email: str
+    username: str
+    created: bool
+    reset_existing: bool
+    manual_entry_secret: str
+    otpauth_uri: str
+
+
+def bootstrap_root_admin(
+    *,
+    workplace_email: str,
+    username: str,
+    full_name: str,
+    password: str,
+    reset_existing: bool = False,
+) -> RootAdminBootstrapResult:
+    """Create or explicitly reset one allowlisted root-admin identity."""
+
+    _require_admin_runtime()
+    normalized_email = _validate_workplace_email(workplace_email)
+    normalized_username = _validate_username(username)
+    normalized_full_name = _validate_full_name(full_name)
+    _require_allowlisted_root_email(normalized_email)
+    _validate_bootstrap_password(password)
+
+    existing = _user_for_update(normalized_email)
+    created = existing is None
+    if existing is not None and existing.account_type == ACCOUNT_CUSTOMER:
+        _audit_bootstrap("blocked", normalized_email, reason="customer_identity_exists")
+        raise RootAdminBootstrapError(
+            "Refusing to convert an existing customer account into a root admin"
+        )
+    if existing is not None and not reset_existing:
+        _audit_bootstrap("blocked", normalized_email, user_id=existing.id, reason="reset_existing_required")
+        raise RootAdminBootstrapError(
+            "Root admin identity already exists; rerun with --reset-existing to rotate credentials"
+        )
+
+    _reject_username_conflict(normalized_username, existing.id if existing else None)
+    password_hash = hash_password(password)
+
+    user = existing or User(
+        username=normalized_username,
+        email=normalized_email,
+        password_hash=password_hash,
+        account_type=ACCOUNT_ROOT_ADMIN,
+        account_status="active",
+        full_name=normalized_full_name,
+        phone_number=None,
+        account_number=None,
+        staff_personal_email=None,
+    )
+    if existing is None:
+        db.session.add(user)
+        db.session.flush()
+
+    secret = pyotp.random_base32(length=32)
+    user.username = normalized_username
+    user.email = normalized_email
+    user.full_name = normalized_full_name
+    user.password_hash = password_hash
+    user.account_type = ACCOUNT_ROOT_ADMIN
+    user.account_status = "active"
+    user.account_number = None
+    user.staff_personal_email = None
+    user.workplace_email_verified_at = datetime.now(timezone.utc)
+    user.mfa_secret_nonce, user.mfa_secret_ciphertext = encrypt_mfa_secret(secret, user.id)
+    user.mfa_enabled = True
+    user.mfa_step_up_preference = "totp"
+
+    try:
+        db.session.commit()
+    except IntegrityError as exc:
+        db.session.rollback()
+        _audit_bootstrap("failure", normalized_email, reason="integrity_error")
+        raise RootAdminBootstrapError("Root admin bootstrap failed integrity checks") from exc
+
+    _audit_bootstrap(
+        "success",
+        normalized_email,
+        user_id=user.id,
+        created=created,
+        reset_existing=bool(reset_existing and not created),
+    )
+    return RootAdminBootstrapResult(
+        user_id=user.id,
+        workplace_email=normalized_email,
+        username=user.username,
+        created=created,
+        reset_existing=bool(reset_existing and not created),
+        manual_entry_secret=secret,
+        otpauth_uri=_totp_provisioning_uri(normalized_email, secret),
+    )
+
+
+def _require_admin_runtime() -> None:
+    if current_app.config.get("APP_MODE") != "admin":
+        raise RootAdminBootstrapError("Root admin bootstrap must run with the admin app")
+
+
+def _require_allowlisted_root_email(email: str) -> None:
+    root_emails = frozenset(str(item).casefold() for item in current_app.config["ROOT_ADMIN_EMAILS"])
+    if email.casefold() not in root_emails:
+        _audit_bootstrap("blocked", email, reason="email_not_allowlisted")
+        raise RootAdminBootstrapError("Root admin email is not listed in ROOT_ADMIN_EMAILS")
+
+
+def _validate_username(username: str) -> str:
+    text = str(username or "").strip()
+    if not STAFF_USERNAME_RE.fullmatch(text):
+        raise RootAdminBootstrapError(
+            "Username must be 3-64 characters and contain only letters, numbers, dots, underscores, or hyphens"
+        )
+    return text
+
+
+def _validate_workplace_email(email: str) -> str:
+    try:
+        return normalize_workplace_email(email)
+    except AuthError as exc:
+        raise RootAdminBootstrapError(str(exc)) from exc
+
+
+def _validate_full_name(full_name: str) -> str:
+    try:
+        return validate_full_name(full_name)
+    except AuthError as exc:
+        raise RootAdminBootstrapError(str(exc)) from exc
+
+
+def _validate_bootstrap_password(password: str) -> None:
+    try:
+        validate_password_policy(password)
+    except PasswordPolicyError as exc:
+        raise RootAdminBootstrapError(str(exc)) from exc
+
+
+def _user_for_update(email: str) -> User | None:
+    statement = db.select(User).where(
+        func.lower(User.email) == email.casefold(),
+        User.account_type.in_(tuple(STAFF_ACCOUNT_TYPES | {ACCOUNT_CUSTOMER})),
+    )
+    if db.engine.dialect.name == "postgresql":
+        statement = statement.with_for_update()
+    return db.session.execute(statement).scalar_one_or_none()
+
+
+def _reject_username_conflict(username: str, current_user_id: int | None) -> None:
+    statement = db.select(User).where(func.lower(User.username) == username.casefold())
+    if current_user_id is not None:
+        statement = statement.where(User.id != current_user_id)
+    if db.session.execute(statement).scalar_one_or_none() is not None:
+        raise RootAdminBootstrapError("Username is already in use")
+
+
+def _totp_provisioning_uri(email: str, secret: str) -> str:
+    return pyotp.TOTP(secret, digits=6, interval=30).provisioning_uri(
+        name=email,
+        issuer_name=current_app.config["MFA_ISSUER_NAME"],
+    )
+
+
+def _audit_bootstrap(
+    outcome: str,
+    email: str,
+    *,
+    user_id: int | None = None,
+    reason: str | None = None,
+    created: bool | None = None,
+    reset_existing: bool | None = None,
+) -> None:
+    metadata: dict[str, object] = {
+        "root_admin_email_ref": audit_reference("root_admin_email", email),
+    }
+    if reason:
+        metadata["reason"] = reason
+    if created is not None:
+        metadata["created"] = created
+    if reset_existing is not None:
+        metadata["reset_existing"] = reset_existing
+    audit_system_event("root_admin_bootstrap", outcome, user_id=user_id, metadata=metadata)

--- a/app/ops/commands.py
+++ b/app/ops/commands.py
@@ -10,6 +10,7 @@ from alembic.autogenerate import compare_metadata
 from alembic.migration import MigrationContext
 from flask import Flask
 
+from app.admin.bootstrap_root import RootAdminBootstrapError, bootstrap_root_admin
 from app.extensions import db
 from app.models import User
 from app.security.alerts import build_security_alert_report, deliver_security_alerts
@@ -28,6 +29,71 @@ from app.ops.db_privileges import (
 
 
 def register_ops_commands(app: Flask) -> None:
+    @app.cli.group("admin")
+    def admin_cli() -> None:
+        """Admin-only management commands."""
+
+    @admin_cli.command("bootstrap-root")
+    @click.option(
+        "--email",
+        "workplace_email",
+        prompt="Root admin workplace email",
+        help="Allowlisted workplace email from ROOT_ADMIN_EMAILS.",
+    )
+    @click.option(
+        "--username",
+        prompt="Username",
+        help="Root admin username to create or set.",
+    )
+    @click.option(
+        "--full-name",
+        prompt="Full name",
+        help="Root admin display name.",
+    )
+    @click.option(
+        "--reset-existing",
+        is_flag=True,
+        help="Rotate password and TOTP for an existing allowlisted root admin.",
+    )
+    def bootstrap_root_admin_command(
+        workplace_email: str,
+        username: str,
+        full_name: str,
+        reset_existing: bool,
+    ) -> None:
+        """Create the first allowlisted root admin from the server shell."""
+
+        password = click.prompt(
+            "Root admin password",
+            hide_input=True,
+            confirmation_prompt=True,
+        )
+        try:
+            result = bootstrap_root_admin(
+                workplace_email=workplace_email,
+                username=username,
+                full_name=full_name,
+                password=password,
+                reset_existing=reset_existing,
+            )
+        except RootAdminBootstrapError as exc:
+            raise click.ClickException(str(exc)) from exc
+
+        action = "created" if result.created else "updated"
+        click.echo(f"Root admin account {action}: {result.workplace_email}")
+        click.echo("")
+        click.secho(
+            "ONE-TIME SENSITIVE TOTP SETUP OUTPUT",
+            fg="yellow",
+            bold=True,
+            err=True,
+        )
+        click.echo("Add this account to an authenticator app now. Do not store this output in logs, tickets, or chat.")
+        click.echo(f"Manual entry secret: {result.manual_entry_secret}")
+        click.echo(f"Provisioning URI: {result.otpauth_uri}")
+        click.echo("")
+        click.echo("The password was accepted from a hidden prompt and was not printed.")
+
     @app.cli.command("verify-migration-baseline")
     def verify_migration_baseline() -> None:
         """Verify an existing schema before adopting the initial revision."""

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -117,6 +117,41 @@ operator verification steps are in
 Provider automation and origin assertion details are in
 `docs/security/cloudflare-staging-access.md`.
 
+## Root Admin Bootstrap
+
+Root admins remain a fixed allowlisted group. `ROOT_ADMIN_EMAILS` must contain
+the approved workplace email before any database user can become `root_admin`;
+normal customer registration and staff invites must not create `root_admin`
+accounts.
+
+When no usable root admin exists, run the shell-only bootstrap command from the
+already deployed private admin container:
+
+```bash
+sudo docker exec -it sitbank-admin \
+  python -m flask --app admin_wsgi:app admin bootstrap-root
+```
+
+For staging, use the staging admin container:
+
+```bash
+sudo docker exec -it sitbank-staging-admin \
+  python -m flask --app admin_wsgi:app admin bootstrap-root
+```
+
+The command prompts for the workplace email, username, full name, and password.
+Do not pass the password on the command line. The workplace email must already
+be listed in `ROOT_ADMIN_EMAILS`, or the command fails without creating a user.
+If the allowlisted account already exists, rerun only with `--reset-existing`
+when you intentionally want to rotate its password and TOTP seed.
+
+The command prints one-time sensitive TOTP setup output: a manual-entry secret
+and provisioning URI. Add it to an authenticator app immediately. Do not paste
+that output into logs, tickets, chat, shell history, or committed files. The
+bootstrap stores only the protected password hash and envelope-encrypted TOTP
+secret, sets the account active, marks the workplace email verified, and records
+a safe `root_admin_bootstrap` audit event without the password or TOTP secret.
+
 ## EC2 SSH And Deployment Access Operations
 
 Issue 186 EC2 SSH hardening is deferred and is not implemented by this branch.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -212,6 +212,7 @@ class TestConfig:
 SECURITY_TEST_FILES = frozenset(
     {
         "tests/test_account_security_actions.py",
+        "tests/test_admin_bootstrap_root.py",
         "tests/test_admin_manual_recovery.py",
         "tests/test_admin_route_inventory_security.py",
         "tests/test_admin_staff_invites.py",

--- a/tests/test_admin_bootstrap_root.py
+++ b/tests/test_admin_bootstrap_root.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+
+import pyotp
+import pytest
+
+from app.extensions import db
+from app.models import SecurityAuditEvent, User
+from app.security.crypto import encrypt_mfa_secret
+from app.security.passwords import hash_password, verify_password
+from conftest import TestConfig
+
+
+ROOT_EMAIL = "root1@sit.singaporetech.edu.sg"
+
+
+def _credential_input(label: str) -> str:
+    return f"SITBank-{label}-Root-Admin-2026!"
+
+
+@pytest.fixture()
+def admin_app(monkeypatch):
+    from app import create_app
+    from app.security import passwords
+
+    monkeypatch.setattr(passwords, "_is_password_pwned_by_hibp", lambda _password: False)
+    flask_app = create_app(TestConfig, app_mode="admin")
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.session.remove()
+        db.drop_all()
+
+
+def _command_input(credential: str | None = None) -> str:
+    credential = credential or _credential_input("Primary")
+    return "\n".join(
+        [
+            ROOT_EMAIL,
+            "root-admin",
+            "Root Admin",
+            credential,
+            credential,
+            "",
+        ]
+    )
+
+
+def _secret_from_output(output: str) -> str:
+    match = re.search(r"Manual entry secret: ([A-Z2-7]+)", output)
+    assert match, output
+    return match.group(1)
+
+
+def _login_admin(client, *, credential: str, secret: str, email: str = ROOT_EMAIL):
+    password_response = client.post(
+        "/login",
+        json={"workplace_email": email, "password": credential},
+    )
+    assert password_response.status_code == 200
+    verify_response = client.post(
+        "/mfa/verify",
+        json={"totp_code": pyotp.TOTP(secret, digits=6, interval=30).now()},
+    )
+    assert verify_response.status_code == 200
+    return verify_response
+
+
+def _create_existing_root_admin(credential: str) -> tuple[User, str]:
+    user = User(
+        username="root-admin",
+        email=ROOT_EMAIL,
+        password_hash=hash_password(credential),
+        account_type="root_admin",
+        account_status="active",
+        full_name="Root Admin",
+        phone_number=None,
+        account_number=None,
+        workplace_email_verified_at=datetime.now(timezone.utc),
+        mfa_enabled=True,
+    )
+    db.session.add(user)
+    db.session.flush()
+    secret = pyotp.random_base32(length=32)
+    user.mfa_secret_nonce, user.mfa_secret_ciphertext = encrypt_mfa_secret(secret, user.id)
+    db.session.commit()
+    return user, secret
+
+
+def test_bootstrap_root_admin_cli_creates_allowlisted_active_totp_root(admin_app):
+    runner = admin_app.test_cli_runner()
+    credential = _credential_input("Primary")
+
+    result = runner.invoke(args=["admin", "bootstrap-root"], input=_command_input(credential))
+
+    assert result.exit_code == 0, result.output
+    assert credential not in result.output
+    assert "ONE-TIME SENSITIVE TOTP SETUP OUTPUT" in result.output
+    assert "otpauth://totp/" in result.output
+    secret = _secret_from_output(result.output)
+    user = db.session.execute(db.select(User).where(User.email == ROOT_EMAIL)).scalar_one()
+    assert user.account_type == "root_admin"
+    assert user.account_status == "active"
+    assert user.workplace_email_verified_at is not None
+    assert user.mfa_enabled is True
+    assert user.mfa_secret_ciphertext is not None
+    assert user.account_number is None
+    assert db.session.query(User).filter_by(account_type="root_admin").count() == 1
+
+    _login_admin(admin_app.test_client(), credential=credential, secret=secret)
+
+    event = db.session.query(SecurityAuditEvent).filter_by(
+        event_type="root_admin_bootstrap",
+        outcome="success",
+    ).one()
+    assert event.user_id == user.id
+    assert event.event_metadata["created"] is True
+    assert "manual_entry_secret" not in str(event.event_metadata).casefold()
+    assert "otpauth" not in str(event.event_metadata).casefold()
+
+
+def test_bootstrap_root_admin_cli_requires_root_admin_allowlist(admin_app):
+    runner = admin_app.test_cli_runner()
+    command_input = _command_input().replace(ROOT_EMAIL, "operator@sit.singaporetech.edu.sg", 1)
+
+    result = runner.invoke(args=["admin", "bootstrap-root"], input=command_input)
+
+    assert result.exit_code != 0
+    assert "ROOT_ADMIN_EMAILS" in result.output
+    assert db.session.query(User).count() == 0
+
+
+def test_bootstrap_root_admin_cli_refuses_customer_account_conversion(admin_app):
+    credential = _credential_input("Primary")
+    customer = User(
+        username="root-customer",
+        email=ROOT_EMAIL,
+        password_hash=hash_password(credential),
+        account_type="customer",
+        account_status="active",
+        full_name="Root Customer",
+        phone_number="91234567",
+        account_number="123456789",
+    )
+    db.session.add(customer)
+    db.session.commit()
+
+    result = admin_app.test_cli_runner().invoke(
+        args=["admin", "bootstrap-root", "--reset-existing"],
+        input=_command_input(),
+    )
+
+    db.session.refresh(customer)
+    assert result.exit_code != 0
+    assert "customer account" in result.output
+    assert customer.account_type == "customer"
+    assert customer.account_number == "123456789"
+    assert db.session.query(User).filter_by(account_type="root_admin").count() == 0
+
+
+def test_bootstrap_root_admin_cli_resets_existing_root_only_with_flag(admin_app):
+    old_credential = _credential_input("Prior")
+    updated_credential = _credential_input("Rotated")
+    user, old_secret = _create_existing_root_admin(old_credential)
+    runner = admin_app.test_cli_runner()
+
+    refused = runner.invoke(args=["admin", "bootstrap-root"], input=_command_input(updated_credential))
+    accepted = runner.invoke(
+        args=["admin", "bootstrap-root", "--reset-existing"],
+        input=_command_input(updated_credential),
+    )
+
+    assert refused.exit_code != 0
+    assert "--reset-existing" in refused.output
+    assert accepted.exit_code == 0, accepted.output
+    new_secret = _secret_from_output(accepted.output)
+    db.session.refresh(user)
+    assert db.session.query(User).filter_by(email=ROOT_EMAIL).count() == 1
+    assert user.account_type == "root_admin"
+    assert user.account_status == "active"
+    assert user.mfa_enabled is True
+    assert old_secret != new_secret
+
+    assert not verify_password(old_credential, user.password_hash)
+    _login_admin(admin_app.test_client(), credential=updated_credential, secret=new_secret)
+
+    event = db.session.query(SecurityAuditEvent).filter_by(
+        event_type="root_admin_bootstrap",
+        outcome="success",
+    ).order_by(SecurityAuditEvent.id.desc()).first()
+    assert event is not None
+    assert event.event_metadata["created"] is False
+    assert event.event_metadata["reset_existing"] is True


### PR DESCRIPTION
## Summary
Adds a shell-only root admin bootstrap command for allowlisted production/staging admin access.

## Why
The private admin app is deployed, but there may be no usable root_admin account to enter the invite and dashboard workflows. Operators need a controlled first-account path that does not use customer registration or weaken admin auth.

## What changed
* Added `flask admin bootstrap-root` under the existing Flask CLI registration.
* Added `app.admin.bootstrap_root` to create or explicitly reset one allowlisted root_admin account.
* Added tests for allowlist enforcement, customer-account non-conversion, explicit reset, TOTP setup, audit metadata, and normal admin login compatibility.
* Documented the production and staging container commands in `docs/OPERATIONS.md`.

## Security impact
The command runs only from the server/container shell, requires the email to already be in `ROOT_ADMIN_EMAILS`, prompts for the password instead of accepting it as a command-line argument, stores password and TOTP material through existing hashing/envelope helpers, keeps normal invite roles limited to staff/admin, and writes safe audit metadata without secrets.

## Deployment impact
Production deployment and staging deployment are required before operators can run the new command. No EC2 bootstrap, database migration, or secret changes are required unless `ROOT_ADMIN_EMAILS` does not already include the intended workplace email.

## Verification
* git diff --check
* git diff --cached --check
* .\.venv\Scripts\python.exe -m pytest -q tests/test_admin_bootstrap_root.py
* .\.venv\Scripts\python.exe -m pytest -q tests/test_admin_staff_invites.py tests/test_admin_dashboard_operations.py tests/test_admin_manual_recovery.py tests/test_admin_isolation.py
* .\.venv\Scripts\python.exe -m pytest -q tests/test_pytest_optimization.py
* .\.venv\Scripts\python.exe -m pytest -q

## Notes
The one-time TOTP setup output is intentionally printed only to the operator terminal and must not be copied into logs, tickets, chat, or committed files.