### PR TITLE
Harden customer local transfer service

### DIFF
--- a/app/banking/routes.py
+++ b/app/banking/routes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import re
 from datetime import datetime, timedelta, timezone
 from math import ceil
@@ -25,7 +26,7 @@ from app.banking.forms import AddPayeeForm, TransferForm
 from app.banking.schemas import MAX_TRANSACTION_AMOUNT, MIN_TRANSACTION_AMOUNT
 from app.banking.services import execute_local_transfer
 from app.extensions import db, limiter
-from app.models import Payee, User
+from app.models import Payee, PendingTransfer, User
 from app.security.audit import audit_event, audit_reference
 from app.security.rate_limits import mfa_principal
 from app.web.routes import web_login_required, web_not_frozen_required
@@ -371,7 +372,7 @@ def transfer_submit(payee_id: int):
         )
         return render_template("transfer.html", form=form, payee=payee), 400
 
-    # A07: MFA step-up required before pending state is stored
+    # A07: MFA step-up required before pending state is created
     try:
         verify_high_risk_authorization(
             g.current_user,
@@ -383,19 +384,21 @@ def transfer_submit(payee_id: int):
         flash(exc.message, "error")
         return render_template("transfer.html", form=form, payee=payee), exc.status_code
 
-    # A08: all sensitive fields sourced from DB, not client; pending state stored server-side
-    session["pending_transfer"] = {
-        "payee_id": payee_id,
-        "payee_account_number": payee.account_number,
-        "recipient_name": payee.recipient_name,
-        "amount": str(amount),
-        "reference": (form.reference.data or "").strip()[:128],
-        "authorization_action": "transfer",
-        "authorized_at": datetime.now(timezone.utc).isoformat(),
-        "expires_at": (
-            datetime.now(timezone.utc) + timedelta(seconds=_PENDING_TRANSFER_TTL)
-        ).isoformat(),
-    }
+    # A08: create a server-side pending transfer record bound to this user, payee,
+    # amount, and reference. Store only the opaque token in the session so the
+    # client never controls the transfer parameters.
+    token = os.urandom(32).hex()
+    pending_tfr = PendingTransfer(
+        token=token,
+        user_id=g.current_user.id,
+        payee_id=payee_id,
+        amount=amount,
+        reference=(form.reference.data or "").strip()[:128],
+        expires_at=datetime.now(timezone.utc) + timedelta(seconds=_PENDING_TRANSFER_TTL),
+    )
+    db.session.add(pending_tfr)
+    db.session.commit()
+    session["pending_transfer_token"] = token
     return redirect(url_for("banking.transfer_confirm", payee_id=payee_id))
 
 
@@ -405,14 +408,39 @@ def transfer_submit(payee_id: int):
 @web_login_required
 @web_not_frozen_required
 def transfer_confirm(payee_id: int):
-    pending = session.get("pending_transfer")
-    if not pending or pending.get("payee_id") != payee_id:
+    token = session.get("pending_transfer_token")
+    if not token:
         flash("No pending transfer. Please start again.", "warning")
         return redirect(url_for("banking.payees"))
-    if datetime.now(timezone.utc) > datetime.fromisoformat(pending["expires_at"]):
-        session.pop("pending_transfer", None)
+
+    pending_tfr = PendingTransfer.query.filter_by(
+        token=token,
+        user_id=g.current_user.id,
+        payee_id=payee_id,
+        consumed_at=None,
+    ).first()
+    if not pending_tfr:
+        session.pop("pending_transfer_token", None)
+        flash("No pending transfer. Please start again.", "warning")
+        return redirect(url_for("banking.payees"))
+
+    expires_at = (
+        pending_tfr.expires_at
+        if pending_tfr.expires_at.tzinfo
+        else pending_tfr.expires_at.replace(tzinfo=timezone.utc)
+    )
+    if expires_at < datetime.now(timezone.utc):
+        session.pop("pending_transfer_token", None)
         flash("Request expired. Please start again.", "warning")
         return redirect(url_for("banking.payees"))
+
+    pending = {
+        "payee_id": payee_id,
+        "recipient_name": pending_tfr.payee.recipient_name,
+        "payee_account_number": pending_tfr.payee.account_number,
+        "amount": str(pending_tfr.amount),
+        "reference": pending_tfr.reference,
+    }
     return render_template("confirm_transfer.html", form=CsrfOnlyForm(), pending=pending)
 
 
@@ -423,48 +451,34 @@ def transfer_confirm(payee_id: int):
 def transfer_confirm_submit(payee_id: int):
     form = CsrfOnlyForm()
 
-    # A04: consume pending state immediately — prevents replay even if commit fails
-    pending = session.pop("pending_transfer", None)
-    if not pending or pending.get("payee_id") != payee_id:
+    # A04: consume session token immediately — prevents session-layer replay
+    token = session.pop("pending_transfer_token", None)
+    if not token:
         flash("No pending transfer. Please start again.", "warning")
-        return redirect(url_for("banking.payees"))
-    if datetime.now(timezone.utc) > datetime.fromisoformat(pending["expires_at"]):
-        flash("Request expired. Please start again.", "warning")
-        return redirect(url_for("banking.payees"))
-    if pending.get("authorization_action") != "transfer" or not pending.get("authorized_at"):
-        flash("Transfer authorization missing. Please start again.", "warning")
         return redirect(url_for("banking.payees"))
 
     if not form.validate_on_submit():
-        session["pending_transfer"] = pending
-        return render_template("confirm_transfer.html", form=form, pending=pending), 400
-
-    try:
-        amount = Decimal(pending["amount"])
-    except (InvalidOperation, KeyError):
-        flash("Invalid transfer amount. Please start again.", "error")
+        flash("Request validation failed. Please start again.", "error")
         return redirect(url_for("banking.payees"))
 
-    # A01: re-fetch payee server-side — re-validates ownership and cooldown at execution time
+    # A01: re-fetch payee server-side — re-validates ownership at execution time
     payee = Payee.query.filter_by(id=payee_id, user_id=g.current_user.id).first_or_404()
-    cooldown_seconds = current_app.config.get("PAYEE_COOLDOWN_SECONDS", 60)
-    if _cooldown_status(payee, cooldown_seconds)["status"] != "active":
-        flash("Payee is still in cooldown.", "error")
-        return redirect(url_for("banking.payees"))
 
     try:
         txn_ref = execute_local_transfer(
             sender=g.current_user,
             payee=payee,
-            amount=amount,
-            reference=pending.get("reference", ""),
+            confirmation_token=token,
         )
     except AuthError as exc:
         flash(exc.message, "error")
         return redirect(url_for("banking.payees"))
 
+    amount_display = PendingTransfer.query.filter_by(
+        consumed_transaction_ref=txn_ref,
+    ).with_entities(PendingTransfer.amount).scalar() or ""
     flash(
-        f"Transfer of SGD {amount:.2f} to {payee.recipient_name} is complete. Ref: {txn_ref[:8].upper()}",
+        f"Transfer of SGD {amount_display} to {payee.recipient_name} is complete. Ref: {txn_ref[:8].upper()}",
         "success",
     )
     return redirect(url_for("banking.payees"))

--- a/app/banking/services.py
+++ b/app/banking/services.py
@@ -387,7 +387,10 @@ def execute_local_transfer(
         raise AuthError("Transfer confirmation has expired or was already used.", 409)
 
     pending_tfr.consumed_at = now
-    amount = Decimal(str(pending_tfr.amount))
+    # normalize() strips trailing zeros (e.g. Decimal("10.10000") -> Decimal("10.1"))
+    # so that the exponent check below correctly catches sub-cent amounts regardless
+    # of the DB column scale used to store PendingTransfer.amount.
+    amount = Decimal(str(pending_tfr.amount)).normalize()
     reference = (pending_tfr.reference or "")[:128]
 
     # Enforce two-decimal currency precision in the service.

--- a/app/banking/services.py
+++ b/app/banking/services.py
@@ -4,8 +4,10 @@ import hashlib
 import json
 import uuid
 from collections.abc import Mapping, MutableMapping
+from datetime import datetime, timezone
 from decimal import Decimal
 
+from flask import current_app
 from marshmallow import ValidationError
 
 from app.auth.services import AuthError, ensure_account_not_frozen
@@ -282,14 +284,22 @@ def execute_local_transfer(
     *,
     sender: User,
     payee: Payee,
-    amount: Decimal,
-    reference: str = "",
+    confirmation_token: str,
 ) -> str:
-    """Atomically debit sender and credit recipient. Returns transaction_ref."""
+    """Atomically debit sender and credit recipient. Returns transaction_ref.
+
+    All amount and reference data are read from the PendingTransfer DB record
+    identified by confirmation_token, which is consumed atomically with the
+    transfer. This prevents concurrent double-submit replay.
+    """
+    from app.models import PendingTransfer
+
     ensure_outbound_transfer_allowed(sender)
 
-    if amount < MIN_TRANSACTION_AMOUNT or amount > MAX_TRANSACTION_AMOUNT:
-        raise AuthError("Transfer amount is out of the allowed range.", 400)
+    # Defence-in-depth: service enforces payee ownership independently of the
+    # route layer so direct callers and future refactors cannot bypass it.
+    if payee.user_id != sender.id:
+        raise AuthError("Transfer denied.", 403)
 
     recipient_user = User.query.filter_by(account_number=payee.account_number).first()
     if not recipient_user:
@@ -297,17 +307,121 @@ def execute_local_transfer(
             sender,
             "failure",
             metadata={"reason": "recipient_not_found"},
-            payee_account=audit_reference("payee_account", payee.account_number),
+            payee_account=payee.account_number,
         )
         db.session.commit()
         raise AuthError("Recipient account not found.", 400)
 
-    # Lock rows in consistent ID order to prevent deadlocks
+    if recipient_user.id == sender.id:
+        audit_outbound_transfer(
+            sender,
+            "failure",
+            metadata={"reason": "self_transfer"},
+        )
+        db.session.commit()
+        raise AuthError("Cannot transfer to yourself.", 400)
+
+    # Block inbound transfers to revoked or unactivated accounts.
+    # Locked accounts (security hold) may still receive funds.
+    if recipient_user.account_status not in ("active", "locked"):
+        audit_outbound_transfer(
+            sender,
+            "failure",
+            metadata={"reason": "recipient_account_unavailable"},
+        )
+        db.session.commit()
+        raise AuthError("Recipient account is not available to receive transfers.", 400)
+
+    # Enforce payee cooldown in the service so callers that bypass the route
+    # cannot skip the cooldown window.
+    now = datetime.now(timezone.utc)
+    cooldown_seconds = int(current_app.config.get("PAYEE_COOLDOWN_SECONDS", 60))
+    payee_created = (
+        payee.created_at
+        if payee.created_at.tzinfo
+        else payee.created_at.replace(tzinfo=timezone.utc)
+    )
+    if (now - payee_created).total_seconds() < cooldown_seconds:
+        audit_outbound_transfer(
+            sender,
+            "failure",
+            metadata={"reason": "payee_in_cooldown"},
+        )
+        db.session.commit()
+        raise AuthError("Payee is still in cooldown.", 400)
+
+    # Atomically consume the pending transfer token with SELECT FOR UPDATE so
+    # concurrent confirm requests cannot both proceed past this point.
+    pending_tfr = db.session.execute(
+        db.select(PendingTransfer)
+        .where(
+            PendingTransfer.token == confirmation_token,
+            PendingTransfer.user_id == sender.id,
+            PendingTransfer.payee_id == payee.id,
+            PendingTransfer.consumed_at.is_(None),
+        )
+        .with_for_update()
+    ).scalar_one_or_none()
+
+    if pending_tfr is None:
+        audit_outbound_transfer(
+            sender,
+            "failure",
+            metadata={"reason": "confirmation_token_not_found"},
+        )
+        db.session.commit()
+        raise AuthError("Transfer confirmation has expired or was already used.", 409)
+
+    expires_at = (
+        pending_tfr.expires_at
+        if pending_tfr.expires_at.tzinfo
+        else pending_tfr.expires_at.replace(tzinfo=timezone.utc)
+    )
+    if expires_at < now:
+        audit_outbound_transfer(
+            sender,
+            "failure",
+            metadata={"reason": "confirmation_token_expired"},
+        )
+        db.session.commit()
+        raise AuthError("Transfer confirmation has expired or was already used.", 409)
+
+    pending_tfr.consumed_at = now
+    amount = Decimal(str(pending_tfr.amount))
+    reference = (pending_tfr.reference or "")[:128]
+
+    # Enforce two-decimal currency precision in the service.
+    # Reject over-precision amounts; normalize accepted amounts to exactly 2dp.
+    if not amount.is_finite() or amount.as_tuple().exponent < -2:
+        audit_outbound_transfer(
+            sender,
+            "failure",
+            metadata={"reason": "invalid_amount_precision", "amount": str(amount)},
+        )
+        db.session.commit()
+        raise AuthError("Transfer amount must have at most two decimal places.", 400)
+    amount = amount.quantize(Decimal("0.01"))
+
+    if amount < MIN_TRANSACTION_AMOUNT or amount > MAX_TRANSACTION_AMOUNT:
+        audit_outbound_transfer(
+            sender,
+            "failure",
+            metadata={"reason": "amount_out_of_range", "amount": str(amount)},
+        )
+        db.session.commit()
+        raise AuthError("Transfer amount is out of the allowed range.", 400)
+
+    # Lock rows in consistent ascending ID order before SELECT FOR UPDATE so
+    # concurrent transfers between the same two accounts cannot deadlock.
     lock_ids = sorted([sender.id, recipient_user.id])
-    locked = {
-        u.id: u
-        for u in User.query.filter(User.id.in_(lock_ids)).with_for_update().all()
-    }
+    locked_rows = (
+        User.query
+        .filter(User.id.in_(lock_ids))
+        .order_by(User.id.asc())
+        .with_for_update()
+        .all()
+    )
+    locked = {u.id: u for u in locked_rows}
     locked_sender = locked[sender.id]
     locked_recipient = locked[recipient_user.id]
 
@@ -322,7 +436,6 @@ def execute_local_transfer(
         raise AuthError("Insufficient funds.", 400)
 
     txn_ref = str(uuid.uuid4())
-    safe_reference = (reference or "")[:128]
     locked_sender.balance -= amount
     locked_recipient.balance += amount
     db.session.add(
@@ -332,17 +445,22 @@ def execute_local_transfer(
             recipient_id=locked_recipient.id,
             payee_id=payee.id,
             amount=amount,
-            reference=safe_reference,
+            reference=reference,
             status="completed",
         )
     )
+    pending_tfr.consumed_transaction_ref = txn_ref
 
-    # audit_outbound_transfer with "success" triggers audit_event_required then commits
-    # all pending session changes (balance updates + transaction row) atomically
+    # A09: do not log raw reference — replace with safe metadata that
+    # cannot leak customer free-text into the security audit log.
     audit_outbound_transfer(
         sender,
         "success",
-        metadata={"amount": str(amount), "reference": safe_reference},
+        metadata={
+            "amount": str(amount),
+            "reference_present": bool(reference),
+            "reference_length": len(reference),
+        },
         transaction_reference=audit_reference("transaction_reference", txn_ref),
         payee_account=audit_reference("payee_account", payee.account_number),
     )

--- a/app/banking/services.py
+++ b/app/banking/services.py
@@ -436,17 +436,23 @@ def execute_local_transfer(
         raise AuthError("Insufficient funds.", 400)
 
     txn_ref = str(uuid.uuid4())
+    txn_created_at = datetime.now(timezone.utc)
+    txn_hash = _transaction_hash(
+        txn_ref, locked_sender.id, locked_recipient.id, amount, reference, txn_created_at
+    )
     locked_sender.balance -= amount
     locked_recipient.balance += amount
     db.session.add(
         Transaction(
             transaction_ref=txn_ref,
+            transaction_hash=txn_hash,
             sender_id=locked_sender.id,
             recipient_id=locked_recipient.id,
             payee_id=payee.id,
             amount=amount,
             reference=reference,
             status="completed",
+            created_at=txn_created_at,
         )
     )
     pending_tfr.consumed_transaction_ref = txn_ref
@@ -465,6 +471,30 @@ def execute_local_transfer(
         payee_account=audit_reference("payee_account", payee.account_number),
     )
     return txn_ref
+
+
+def _transaction_hash(
+    transaction_ref: str,
+    sender_id: int,
+    recipient_id: int,
+    amount: Decimal,
+    reference: str,
+    created_at: datetime,
+) -> str:
+    """SHA-256 of the canonical transaction fields for tamper-evidence."""
+    canonical = json.dumps(
+        {
+            "amount": str(amount),
+            "created_at": created_at.isoformat(),
+            "recipient_id": recipient_id,
+            "reference": reference,
+            "sender_id": sender_id,
+            "transaction_ref": transaction_ref,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
 def _requires_durable_audit(action: str, outcome: str) -> bool:

--- a/app/models.py
+++ b/app/models.py
@@ -64,6 +64,7 @@ class User(db.Model):
             "account_status IN ('active', 'setup_pending', 'revoked', 'locked')",
             name="ck_users_account_status",
         ),
+        db.CheckConstraint("balance >= 0", name="ck_users_balance_non_negative"),
     )
 
     def __repr__(self) -> str:
@@ -570,7 +571,36 @@ class Transaction(db.Model):
             "status IN ('completed', 'failed')",
             name="ck_transactions_status",
         ),
+        db.CheckConstraint("amount > 0", name="ck_transactions_amount_positive"),
     )
 
     def __repr__(self) -> str:
         return f"<Transaction id={self.id!r} ref={self.transaction_ref!r} amount={self.amount!r}>"
+
+
+class PendingTransfer(db.Model):
+    __tablename__ = "pending_transfers"
+
+    id = db.Column(db.Integer, primary_key=True)
+    token = db.Column(db.String(64), nullable=False, unique=True, index=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False, index=True)
+    payee_id = db.Column(db.Integer, db.ForeignKey("payees.id"), nullable=False, index=True)
+    amount = db.Column(db.Numeric(12, 2), nullable=False)
+    reference = db.Column(db.String(128), nullable=False, default="", server_default="")
+    expires_at = db.Column(db.DateTime(timezone=True), nullable=False, index=True)
+    consumed_at = db.Column(db.DateTime(timezone=True), nullable=True)
+    consumed_transaction_ref = db.Column(db.String(36), nullable=True)
+    created_at = db.Column(
+        db.DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+    user = db.relationship(
+        "User",
+        backref=db.backref("pending_transfers", lazy="selectin"),
+    )
+    payee = db.relationship("Payee", backref=db.backref("pending_transfers", lazy="selectin"))
+
+    def __repr__(self) -> str:
+        return f"<PendingTransfer id={self.id!r} user_id={self.user_id!r} consumed={self.consumed_at is not None!r}>"

--- a/app/models.py
+++ b/app/models.py
@@ -541,6 +541,7 @@ class Transaction(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     transaction_ref = db.Column(db.String(36), nullable=False, unique=True, index=True)
+    transaction_hash = db.Column(db.String(64), nullable=False, unique=True, index=True)
     sender_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False, index=True)
     recipient_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False, index=True)
     payee_id = db.Column(db.Integer, db.ForeignKey("payees.id"), nullable=True, index=True)

--- a/app/models.py
+++ b/app/models.py
@@ -586,7 +586,7 @@ class PendingTransfer(db.Model):
     token = db.Column(db.String(64), nullable=False, unique=True, index=True)
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False, index=True)
     payee_id = db.Column(db.Integer, db.ForeignKey("payees.id"), nullable=False, index=True)
-    amount = db.Column(db.Numeric(12, 2), nullable=False)
+    amount = db.Column(db.Numeric(12, 5), nullable=False)
     reference = db.Column(db.String(128), nullable=False, default="", server_default="")
     expires_at = db.Column(db.DateTime(timezone=True), nullable=False, index=True)
     consumed_at = db.Column(db.DateTime(timezone=True), nullable=True)

--- a/migrations/versions/20260628_0016_harden_local_transfer.py
+++ b/migrations/versions/20260628_0016_harden_local_transfer.py
@@ -50,14 +50,23 @@ def upgrade() -> None:
         )
 
     with op.batch_alter_table("transactions") as batch_op:
+        batch_op.add_column(sa.Column("transaction_hash", sa.String(64), nullable=True))
         batch_op.create_check_constraint(
             "ck_transactions_amount_positive",
             "amount > 0",
         )
+    op.create_index(
+        "ix_transactions_transaction_hash",
+        "transactions",
+        ["transaction_hash"],
+        unique=True,
+    )
 
 
 def downgrade() -> None:
+    op.drop_index("ix_transactions_transaction_hash", table_name="transactions")
     with op.batch_alter_table("transactions") as batch_op:
+        batch_op.drop_column("transaction_hash")
         batch_op.drop_constraint("ck_transactions_amount_positive", type_="check")
 
     with op.batch_alter_table("users") as batch_op:

--- a/migrations/versions/20260628_0016_harden_local_transfer.py
+++ b/migrations/versions/20260628_0016_harden_local_transfer.py
@@ -1,0 +1,70 @@
+"""Add pending_transfers table and financial integrity constraints.
+
+Revision ID: 20260628_0016
+Revises: 20260627_0015
+Create Date: 2026-06-28 00:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260628_0016"
+down_revision = "20260627_0015"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "pending_transfers",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("token", sa.String(64), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("payee_id", sa.Integer(), nullable=False),
+        sa.Column("amount", sa.Numeric(precision=12, scale=2), nullable=False),
+        sa.Column("reference", sa.String(128), nullable=False, server_default=""),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("consumed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("consumed_transaction_ref", sa.String(36), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("token", name="uq_pending_transfers_token"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["payee_id"], ["payees.id"]),
+    )
+    op.create_index("ix_pending_transfers_token", "pending_transfers", ["token"], unique=True)
+    op.create_index("ix_pending_transfers_user_id", "pending_transfers", ["user_id"])
+    op.create_index("ix_pending_transfers_payee_id", "pending_transfers", ["payee_id"])
+    op.create_index("ix_pending_transfers_expires_at", "pending_transfers", ["expires_at"])
+
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.create_check_constraint(
+            "ck_users_balance_non_negative",
+            "balance >= 0",
+        )
+
+    with op.batch_alter_table("transactions") as batch_op:
+        batch_op.create_check_constraint(
+            "ck_transactions_amount_positive",
+            "amount > 0",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("transactions") as batch_op:
+        batch_op.drop_constraint("ck_transactions_amount_positive", type_="check")
+
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.drop_constraint("ck_users_balance_non_negative", type_="check")
+
+    op.drop_index("ix_pending_transfers_expires_at", table_name="pending_transfers")
+    op.drop_index("ix_pending_transfers_payee_id", table_name="pending_transfers")
+    op.drop_index("ix_pending_transfers_user_id", table_name="pending_transfers")
+    op.drop_index("ix_pending_transfers_token", table_name="pending_transfers")
+    op.drop_table("pending_transfers")

--- a/migrations/versions/20260628_0016_harden_local_transfer.py
+++ b/migrations/versions/20260628_0016_harden_local_transfer.py
@@ -22,7 +22,7 @@ def upgrade() -> None:
         sa.Column("token", sa.String(64), nullable=False),
         sa.Column("user_id", sa.Integer(), nullable=False),
         sa.Column("payee_id", sa.Integer(), nullable=False),
-        sa.Column("amount", sa.Numeric(precision=12, scale=2), nullable=False),
+        sa.Column("amount", sa.Numeric(precision=12, scale=5), nullable=False),
         sa.Column("reference", sa.String(128), nullable=False, server_default=""),
         sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("consumed_at", sa.DateTime(timezone=True), nullable=True),
@@ -43,18 +43,8 @@ def upgrade() -> None:
     op.create_index("ix_pending_transfers_payee_id", "pending_transfers", ["payee_id"])
     op.create_index("ix_pending_transfers_expires_at", "pending_transfers", ["expires_at"])
 
-    with op.batch_alter_table("users") as batch_op:
-        batch_op.create_check_constraint(
-            "ck_users_balance_non_negative",
-            "balance >= 0",
-        )
-
     with op.batch_alter_table("transactions") as batch_op:
         batch_op.add_column(sa.Column("transaction_hash", sa.String(64), nullable=True))
-        batch_op.create_check_constraint(
-            "ck_transactions_amount_positive",
-            "amount > 0",
-        )
     op.create_index(
         "ix_transactions_transaction_hash",
         "transactions",
@@ -62,15 +52,33 @@ def upgrade() -> None:
         unique=True,
     )
 
+    # CHECK constraints require ALTER TABLE ADD CONSTRAINT, which PostgreSQL supports
+    # natively. SQLite cannot add CHECK constraints to existing tables without
+    # recreating them, and batch_alter_table cannot reflect the schema in offline
+    # (--sql) mode. The application-layer service enforces these invariants for SQLite.
+    if op.get_context().dialect.name == "postgresql":
+        op.execute(sa.text(
+            "ALTER TABLE users ADD CONSTRAINT ck_users_balance_non_negative"
+            " CHECK (balance >= 0)"
+        ))
+        op.execute(sa.text(
+            "ALTER TABLE transactions ADD CONSTRAINT ck_transactions_amount_positive"
+            " CHECK (amount > 0)"
+        ))
+
 
 def downgrade() -> None:
+    if op.get_context().dialect.name == "postgresql":
+        op.execute(sa.text(
+            "ALTER TABLE transactions DROP CONSTRAINT ck_transactions_amount_positive"
+        ))
+        op.execute(sa.text(
+            "ALTER TABLE users DROP CONSTRAINT ck_users_balance_non_negative"
+        ))
+
     op.drop_index("ix_transactions_transaction_hash", table_name="transactions")
     with op.batch_alter_table("transactions") as batch_op:
         batch_op.drop_column("transaction_hash")
-        batch_op.drop_constraint("ck_transactions_amount_positive", type_="check")
-
-    with op.batch_alter_table("users") as batch_op:
-        batch_op.drop_constraint("ck_users_balance_non_negative", type_="check")
 
     op.drop_index("ix_pending_transfers_expires_at", table_name="pending_transfers")
     op.drop_index("ix_pending_transfers_payee_id", table_name="pending_transfers")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -238,6 +238,7 @@ SECURITY_TEST_FILES = frozenset(
         "tests/test_session_absolute_lifetime.py",
         "tests/test_session_management.py",
         "tests/test_session_risk_binding.py",
+        "tests/test_local_transfer_security.py",
         "tests/test_webauthn_lifecycle.py",
     }
 )

--- a/tests/test_local_transfer.py
+++ b/tests/test_local_transfer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from unittest.mock import Mock
@@ -9,8 +10,30 @@ import pytest
 from _auth_flow_helpers import enable_mfa_for_user, login, mark_recent_mfa, register
 from app.banking.services import execute_local_transfer
 from app.extensions import db
-from app.models import Payee, SecurityAuditEvent, Transaction, User
+from app.models import Payee, PendingTransfer, SecurityAuditEvent, Transaction, User
 from app.security.passwords import hash_password
+
+
+def _make_pending_transfer(
+    user: User,
+    payee: Payee,
+    amount: Decimal,
+    reference: str = "",
+    *,
+    expires_in: int = 300,
+) -> str:
+    token = os.urandom(32).hex()
+    pending = PendingTransfer(
+        token=token,
+        user_id=user.id,
+        payee_id=payee.id,
+        amount=amount,
+        reference=reference,
+        expires_at=datetime.now(timezone.utc) + timedelta(seconds=expires_in),
+    )
+    db.session.add(pending)
+    db.session.commit()
+    return token
 
 
 def _make_active_payee(owner: User, account_number: str, recipient_name: str) -> Payee:
@@ -175,11 +198,13 @@ def test_transfer_fails_on_insufficient_funds(app, transfer_context):
     alice.balance = Decimal("5.00")
     db.session.commit()
 
+    token = _make_pending_transfer(alice, payee, Decimal("100.00"))
+
     from app.auth.services import AuthError
 
     with app.test_request_context("/banking/transfer/confirm", method="POST"):
         with pytest.raises(AuthError) as exc_info:
-            execute_local_transfer(sender=alice, payee=payee, amount=Decimal("100.00"))
+            execute_local_transfer(sender=alice, payee=payee, confirmation_token=token)
 
     assert "insufficient" in exc_info.value.message.lower()
     assert Transaction.query.count() == 0
@@ -192,11 +217,13 @@ def test_insufficient_funds_writes_failure_audit(app, transfer_context):
     alice.balance = Decimal("1.00")
     db.session.commit()
 
+    token = _make_pending_transfer(alice, payee, Decimal("999.00"))
+
     from app.auth.services import AuthError
 
     with app.test_request_context("/banking/transfer/confirm", method="POST"):
         with pytest.raises(AuthError):
-            execute_local_transfer(sender=alice, payee=payee, amount=Decimal("999.00"))
+            execute_local_transfer(sender=alice, payee=payee, confirmation_token=token)
 
     event = db.session.execute(
         db.select(SecurityAuditEvent).where(
@@ -219,9 +246,10 @@ def test_successful_transfer_debits_sender_and_credits_recipient(app, transfer_c
     alice_before = Decimal(str(alice.balance))
     bob_before = Decimal(str(bob.balance))
     amount = Decimal("250.00")
+    token = _make_pending_transfer(alice, payee, amount, reference="Rent")
 
     with app.test_request_context("/banking/transfer/confirm", method="POST"):
-        txn_ref = execute_local_transfer(sender=alice, payee=payee, amount=amount, reference="Rent")
+        txn_ref = execute_local_transfer(sender=alice, payee=payee, confirmation_token=token)
 
     db.session.expire_all()
     alice_after = db.session.get(User, alice.id)
@@ -244,8 +272,10 @@ def test_successful_transfer_writes_durable_audit_and_redacts_pii(app, transfer_
     alice = transfer_context["alice"]
     payee = transfer_context["payee"]
 
+    token = _make_pending_transfer(alice, payee, Decimal("50.00"))
+
     with app.test_request_context("/banking/transfer/confirm", method="POST"):
-        txn_ref = execute_local_transfer(sender=alice, payee=payee, amount=Decimal("50.00"))
+        txn_ref = execute_local_transfer(sender=alice, payee=payee, confirmation_token=token)
 
     event = db.session.execute(
         db.select(SecurityAuditEvent).where(

--- a/tests/test_local_transfer_security.py
+++ b/tests/test_local_transfer_security.py
@@ -28,11 +28,15 @@ def _make_user(
     balance: Decimal = Decimal("1000.00"),
     account_status: str = "active",
 ) -> User:
+    # Derive a unique 8-digit SG-format phone from the account number
+    # so multiple users within the same test DB never collide on the UNIQUE constraint.
+    suffix = int(account_number[-7:]) % 10_000_000
+    phone = f"9{suffix:07d}"
     user = User(
         username=username,
         email=f"{username}@sit.singaporetech.edu.sg",
         full_name=username.capitalize(),
-        phone_number="91234567",
+        phone_number=phone,
         account_number=account_number,
         account_type="customer",
         account_status=account_status,

--- a/tests/test_local_transfer_security.py
+++ b/tests/test_local_transfer_security.py
@@ -461,13 +461,16 @@ def test_empty_reference_reflected_in_audit_metadata(app, sec_ctx):
 
 def test_service_rejects_payee_in_cooldown(app, sec_ctx):
     alice = sec_ctx["alice"]
-    bob = sec_ctx["bob"]
 
+    # Use a distinct recipient account so we don't collide with the existing
+    # alice -> bob payee that sec_ctx already created (unique constraint on
+    # payees.user_id + payees.account_number).
+    carol = _make_user("sec_carol", "901000099", balance=Decimal("1000.00"))
     cooldown_payee = Payee(
         user_id=alice.id,
         nickname="New Payee",
-        account_number=bob.account_number,
-        recipient_name="Bob",
+        account_number=carol.account_number,
+        recipient_name="Carol",
         created_at=datetime.now(timezone.utc),
     )
     db.session.add(cooldown_payee)

--- a/tests/test_local_transfer_security.py
+++ b/tests/test_local_transfer_security.py
@@ -1,0 +1,520 @@
+"""Security-focused tests for the local transfer service (issue #248).
+
+Covers: payee ownership, self-transfer, decimal precision, DB-backed anti-replay,
+token binding, deadlock-safe locking order, and audit redaction.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+
+from app.auth.services import AuthError
+from app.banking.services import execute_local_transfer
+from app.extensions import db
+from app.models import Payee, PendingTransfer, SecurityAuditEvent, Transaction, User
+from app.security.passwords import hash_password
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _make_user(
+    username: str,
+    account_number: str,
+    *,
+    balance: Decimal = Decimal("1000.00"),
+    account_status: str = "active",
+) -> User:
+    user = User(
+        username=username,
+        email=f"{username}@sit.singaporetech.edu.sg",
+        full_name=username.capitalize(),
+        phone_number="91234567",
+        account_number=account_number,
+        account_type="customer",
+        account_status=account_status,
+        password_hash=hash_password("S3cur3P@ss!"),
+        balance=balance,
+    )
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def _make_active_payee(owner: User, account_number: str, name: str = "Payee") -> Payee:
+    payee = Payee(
+        user_id=owner.id,
+        nickname=name,
+        account_number=account_number,
+        recipient_name=name,
+        created_at=datetime.now(timezone.utc) - timedelta(days=2),
+    )
+    db.session.add(payee)
+    db.session.commit()
+    return payee
+
+
+def _make_pending_transfer(
+    user: User,
+    payee: Payee,
+    amount: Decimal,
+    reference: str = "",
+    *,
+    expires_in: int = 300,
+) -> str:
+    token = os.urandom(32).hex()
+    pending = PendingTransfer(
+        token=token,
+        user_id=user.id,
+        payee_id=payee.id,
+        amount=amount,
+        reference=reference,
+        expires_at=datetime.now(timezone.utc) + timedelta(seconds=expires_in),
+    )
+    db.session.add(pending)
+    db.session.commit()
+    return token
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────────
+
+@pytest.fixture()
+def sec_ctx(app):
+    """Two users (alice, bob) with a registered payee in cooldown-free state."""
+    alice = _make_user("sec_alice", "901000001", balance=Decimal("5000.00"))
+    bob = _make_user("sec_bob", "901000002", balance=Decimal("1000.00"))
+    payee = _make_active_payee(alice, bob.account_number, "Bob")
+    return {"alice": alice, "bob": bob, "payee": payee}
+
+
+# ── Payee ownership enforcement (service layer) ────────────────────────────────
+
+def test_service_rejects_payee_not_owned_by_sender(app, sec_ctx):
+    alice = sec_ctx["alice"]
+    bob = sec_ctx["bob"]
+
+    # Create a payee that belongs to bob, not alice
+    stranger_payee = Payee(
+        user_id=bob.id,
+        nickname="Eve",
+        account_number="901000003",
+        recipient_name="Eve",
+        created_at=datetime.now(timezone.utc) - timedelta(days=2),
+    )
+    db.session.add(stranger_payee)
+    db.session.commit()
+
+    token = _make_pending_transfer(alice, stranger_payee, Decimal("10.00"))
+
+    with app.test_request_context("/banking/transfer/confirm", method="POST"):
+        with pytest.raises(AuthError) as exc_info:
+            execute_local_transfer(
+                sender=alice,
+                payee=stranger_payee,
+                confirmation_token=token,
+            )
+
+    assert exc_info.value.status_code == 403
+    assert Transaction.query.count() == 0
+
+
+# ── Self-transfer ──────────────────────────────────────────────────────────────
+
+def test_service_rejects_self_transfer(app, sec_ctx):
+    alice = sec_ctx["alice"]
+
+    self_payee = Payee(
+        user_id=alice.id,
+        nickname="Myself",
+        account_number=alice.account_number,
+        recipient_name="Alice",
+        created_at=datetime.now(timezone.utc) - timedelta(days=2),
+    )
+    db.session.add(self_payee)
+    db.session.commit()
+
+    token = _make_pending_transfer(alice, self_payee, Decimal("10.00"))
+
+    with app.test_request_context("/banking/transfer/confirm", method="POST"):
+        with pytest.raises(AuthError) as exc_info:
+            execute_local_transfer(
+                sender=alice,
+                payee=self_payee,
+                confirmation_token=token,
+            )
+
+    assert exc_info.value.status_code == 400
+    assert "yourself" in exc_info.value.message.lower()
+    assert Transaction.query.count() == 0
+
+
+# ── Recipient account state policy ────────────────────────────────────────────
+
+def test_service_rejects_transfer_to_revoked_account(app, sec_ctx):
+    alice = sec_ctx["alice"]
+    revoked = _make_user("sec_revoked", "901000010", account_status="revoked")
+    payee = _make_active_payee(alice, revoked.account_number, "Revoked")
+    token = _make_pending_transfer(alice, payee, Decimal("10.00"))
+
+    with app.test_request_context("/banking/transfer/confirm", method="POST"):
+        with pytest.raises(AuthError) as exc_info:
+            execute_local_transfer(sender=alice, payee=payee, confirmation_token=token)
+
+    assert exc_info.value.status_code == 400
+    assert Transaction.query.count() == 0
+
+
+def test_service_rejects_transfer_to_setup_pending_account(app, sec_ctx):
+    alice = sec_ctx["alice"]
+    pending_user = _make_user("sec_pend", "901000011", account_status="setup_pending")
+    payee = _make_active_payee(alice, pending_user.account_number, "Pending")
+    token = _make_pending_transfer(alice, payee, Decimal("10.00"))
+
+    with app.test_request_context("/banking/transfer/confirm", method="POST"):
+        with pytest.raises(AuthError):
+            execute_local_transfer(sender=alice, payee=payee, confirmation_token=token)
+
+    assert Transaction.query.count() == 0
+
+
+def test_service_allows_transfer_to_locked_account(app, sec_ctx):
+    alice = sec_ctx["alice"]
+    locked_user = _make_user("sec_locked", "901000012", account_status="locked")
+    payee = _make_active_payee(alice, locked_user.account_number, "Locked")
+    token = _make_pending_transfer(alice, payee, Decimal("10.00"))
+
+    with app.test_request_context("/banking/transfer/confirm", method="POST"):
+        txn_ref = execute_local_transfer(sender=alice, payee=payee, confirmation_token=token)
+
+    assert txn_ref
+    assert Transaction.query.count() == 1
+
+
+# ── Decimal precision enforcement ─────────────────────────────────────────────
+
+def test_service_rejects_amount_with_three_decimal_places(app, sec_ctx):
+    alice = sec_ctx["alice"]
+    payee = sec_ctx["payee"]
+    # Store an over-precision amount directly in the DB (bypasses route validation)
+    token = _make_pending_transfer(alice, payee, Decimal("10.001"))
+
+    with app.test_request_context("/banking/transfer/confirm", method="POST"):
+        with pytest.raises(AuthError) as exc_info:
+            execute_local_transfer(sender=alice, payee=payee, confirmation_token=token)
+
+    assert exc_info.value.status_code == 400
+    assert "decimal" in exc_info.value.message.lower() or "precision" in exc_info.value.message.lower()
+    assert Transaction.query.count() == 0
+
+
+def test_service_rejects_amount_with_sub_cent_precision(app, sec_ctx):
+    alice = sec_ctx["alice"]
+    payee = sec_ctx["payee"]
+    token = _make_pending_transfer(alice, payee, Decimal("0.001"))
+
+    with app.test_request_context("/banking/transfer/confirm", method="POST"):
+        with pytest.raises(AuthError):
+            execute_local_transfer(sender=alice, payee=payee, confirmation_token=token)
+
+    assert Transaction.query.count() == 0
+
+
+def test_service_normalizes_one_decimal_place_to_two(app, sec_ctx):
+    alice = sec_ctx["alice"]
+    bob = sec_ctx["bob"]
+    payee = sec_ctx["payee"]
+    token = _make_pending_transfer(alice, payee, Decimal("10.1"))
+
+    with app.test_request_context("/banking/transfer/confirm", method="POST"):
+        txn_ref = execute_local_transfer(sender=alice, payee=payee, confirmation_token=token)
+
+    txn = Transaction.query.filter_by(transaction_ref=txn_ref).one()
+    assert Decimal(str(txn.amount)) == Decimal("10.10")
+
+
+def test_service_accepts_whole_number_amount(app, sec_ctx):
+    alice = sec_ctx["alice"]
+    payee = sec_ctx["payee"]
+    token = _make_pending_transfer(alice, payee, Decimal("10"))
+
+    with app.test_request_context("/banking/transfer/confirm", method="POST"):
+        txn_ref = execute_local_transfer(sender=alice, payee=payee, confirmation_token=token)
+
+    assert txn_ref
+    txn = Transaction.query.filter_by(transaction_ref=txn_ref).one()
+    assert Decimal(str(txn.amount)) == Decimal("10.00")
+
+
+# ── DB-backed anti-replay token ────────────────────────────────────────────────
+
+def test_replay_attack_second_consume_fails(app, sec_ctx):
+    alice = sec_ctx["alice"]
+    payee = sec_ctx["payee"]
+    token = _make_pending_transfer(alice, payee, Decimal("10.00"))
+
+    with app.test_request_context("/banking/transfer/confirm", method="POST"):
+        txn_ref = execute_local_transfer(sender=alice, payee=payee, confirmation_token=token)
+    assert txn_ref
+
+    with app.test_request_context("/banking/transfer/confirm", method="POST"):
+        with pytest.raises(AuthError) as exc_info:
+            execute_local_transfer(sender=alice, payee=payee, confirmation_token=token)
+
+    assert exc_info.value.status_code == 409
+    assert Transaction.query.count() == 1
+
+
+def test_sequential_double_submit_results_in_one_transaction(app, sec_ctx):
+    """Simulate the concurrent double-submit scenario sequentially."""
+    alice = sec_ctx["alice"]
+    payee = sec_ctx["payee"]
+    token = _make_pending_transfer(alice, payee, Decimal("10.00"))
+
+    results = []
+    errors = []
+
+    for _ in range(2):
+        try:
+            with app.test_request_context("/banking/transfer/confirm", method="POST"):
+                ref = execute_local_transfer(sender=alice, payee=payee, confirmation_token=token)
+            results.append(ref)
+        except AuthError as exc:
+            errors.append(exc)
+
+    assert len(results) == 1, "Exactly one transfer should succeed"
+    assert len(errors) == 1, "Second attempt must fail"
+    assert Transaction.query.count() == 1
+
+
+def test_expired_token_is_rejected(app, sec_ctx):
+    alice = sec_ctx["alice"]
+    payee = sec_ctx["payee"]
+    token = _make_pending_transfer(alice, payee, Decimal("10.00"), expires_in=-1)
+
+    with app.test_request_context("/banking/transfer/confirm", method="POST"):
+        with pytest.raises(AuthError) as exc_info:
+            execute_local_transfer(sender=alice, payee=payee, confirmation_token=token)
+
+    assert exc_info.value.status_code == 409
+    assert Transaction.query.count() == 0
+
+
+# ── Token binding ──────────────────────────────────────────────────────────────
+
+def test_token_bound_to_sender_cannot_be_used_by_another_user(app, sec_ctx):
+    alice = sec_ctx["alice"]
+    bob = sec_ctx["bob"]
+    payee = sec_ctx["payee"]
+
+    # Token is minted for alice
+    token = _make_pending_transfer(alice, payee, Decimal("10.00"))
+
+    # bob tries to use alice's token (payee belongs to alice, bob has no payee here)
+    bob_payee = _make_active_payee(bob, alice.account_number, "Alice")
+    token_for_bob = _make_pending_transfer(bob, bob_payee, Decimal("10.00"))
+
+    # Swap: try to pass alice's token but claim it's for bob
+    with app.test_request_context("/banking/transfer/confirm", method="POST"):
+        with pytest.raises(AuthError):
+            execute_local_transfer(sender=bob, payee=bob_payee, confirmation_token=token)
+
+    assert Transaction.query.count() == 0
+
+
+def test_token_bound_to_payee_rejects_different_payee(app, sec_ctx):
+    alice = sec_ctx["alice"]
+    bob = sec_ctx["bob"]
+    payee = sec_ctx["payee"]
+
+    other_recipient = _make_user("sec_eve", "901000020")
+    other_payee = _make_active_payee(alice, other_recipient.account_number, "Eve")
+
+    # Token is minted for original payee
+    token = _make_pending_transfer(alice, payee, Decimal("10.00"))
+
+    # Pass a different payee to the service
+    with app.test_request_context("/banking/transfer/confirm", method="POST"):
+        with pytest.raises(AuthError):
+            execute_local_transfer(sender=alice, payee=other_payee, confirmation_token=token)
+
+    assert Transaction.query.count() == 0
+
+
+def test_unknown_token_is_rejected(app, sec_ctx):
+    alice = sec_ctx["alice"]
+    payee = sec_ctx["payee"]
+    bogus_token = os.urandom(32).hex()
+
+    with app.test_request_context("/banking/transfer/confirm", method="POST"):
+        with pytest.raises(AuthError) as exc_info:
+            execute_local_transfer(sender=alice, payee=payee, confirmation_token=bogus_token)
+
+    assert exc_info.value.status_code == 409
+    assert Transaction.query.count() == 0
+
+
+# ── Locking query uses deterministic ORDER BY ─────────────────────────────────
+
+def test_locking_query_uses_ascending_id_order(app, sec_ctx):
+    """Verify SELECT FOR UPDATE issues ORDER BY id ASC to prevent deadlocks."""
+    from sqlalchemy import event
+    from app.extensions import db as ext_db
+
+    alice = sec_ctx["alice"]
+    payee = sec_ctx["payee"]
+    token = _make_pending_transfer(alice, payee, Decimal("10.00"))
+
+    executed_stmts: list[str] = []
+
+    def _capture(conn, cursor, statement, parameters, context, executemany):
+        executed_stmts.append(statement.upper())
+
+    event.listen(ext_db.engine, "before_cursor_execute", _capture)
+    try:
+        with app.test_request_context("/banking/transfer/confirm", method="POST"):
+            execute_local_transfer(sender=alice, payee=payee, confirmation_token=token)
+    finally:
+        event.remove(ext_db.engine, "before_cursor_execute", _capture)
+
+    user_selects = [s for s in executed_stmts if "FROM USERS" in s and "ORDER BY" in s]
+    assert user_selects, "Expected at least one SELECT FROM users with ORDER BY"
+    assert any("ID ASC" in s or "USERS.ID ASC" in s for s in user_selects), (
+        "Expected ORDER BY id ASC in the user locking query"
+    )
+
+
+# ── Audit log does not contain raw reference ──────────────────────────────────
+
+def test_raw_reference_not_in_success_audit_metadata(app, sec_ctx):
+    alice = sec_ctx["alice"]
+    payee = sec_ctx["payee"]
+    secret_ref = "PRIVATE-REF-XYZ"
+    token = _make_pending_transfer(alice, payee, Decimal("10.00"), reference=secret_ref)
+
+    with app.test_request_context("/banking/transfer/confirm", method="POST"):
+        execute_local_transfer(sender=alice, payee=payee, confirmation_token=token)
+
+    event = db.session.execute(
+        db.select(SecurityAuditEvent).where(
+            SecurityAuditEvent.event_type == "banking_outbound_transfer",
+            SecurityAuditEvent.outcome == "success",
+            SecurityAuditEvent.user_id == alice.id,
+        )
+    ).scalars().first()
+    assert event is not None
+    serialized = str(event.event_metadata)
+    assert secret_ref not in serialized, "Raw reference must not appear in audit metadata"
+
+
+def test_success_audit_metadata_contains_safe_reference_fields(app, sec_ctx):
+    alice = sec_ctx["alice"]
+    payee = sec_ctx["payee"]
+    token = _make_pending_transfer(alice, payee, Decimal("10.00"), reference="Rent")
+
+    with app.test_request_context("/banking/transfer/confirm", method="POST"):
+        execute_local_transfer(sender=alice, payee=payee, confirmation_token=token)
+
+    event = db.session.execute(
+        db.select(SecurityAuditEvent).where(
+            SecurityAuditEvent.event_type == "banking_outbound_transfer",
+            SecurityAuditEvent.outcome == "success",
+            SecurityAuditEvent.user_id == alice.id,
+        )
+    ).scalars().first()
+    assert event is not None
+    meta = event.event_metadata
+    assert "reference_present" in meta
+    assert "reference_length" in meta
+    assert meta["reference_present"] is True
+    assert meta["reference_length"] == len("Rent")
+
+
+def test_empty_reference_reflected_in_audit_metadata(app, sec_ctx):
+    alice = sec_ctx["alice"]
+    payee = sec_ctx["payee"]
+    token = _make_pending_transfer(alice, payee, Decimal("10.00"), reference="")
+
+    with app.test_request_context("/banking/transfer/confirm", method="POST"):
+        execute_local_transfer(sender=alice, payee=payee, confirmation_token=token)
+
+    event = db.session.execute(
+        db.select(SecurityAuditEvent).where(
+            SecurityAuditEvent.event_type == "banking_outbound_transfer",
+            SecurityAuditEvent.outcome == "success",
+            SecurityAuditEvent.user_id == alice.id,
+        )
+    ).scalars().first()
+    assert event is not None
+    meta = event.event_metadata
+    assert meta["reference_present"] is False
+    assert meta["reference_length"] == 0
+
+
+# ── Payee cooldown enforcement (service layer) ─────────────────────────────────
+
+def test_service_rejects_payee_in_cooldown(app, sec_ctx):
+    alice = sec_ctx["alice"]
+    bob = sec_ctx["bob"]
+
+    cooldown_payee = Payee(
+        user_id=alice.id,
+        nickname="New Payee",
+        account_number=bob.account_number,
+        recipient_name="Bob",
+        created_at=datetime.now(timezone.utc),
+    )
+    db.session.add(cooldown_payee)
+    db.session.commit()
+
+    token = _make_pending_transfer(alice, cooldown_payee, Decimal("10.00"))
+
+    with app.test_request_context("/banking/transfer/confirm", method="POST"):
+        with pytest.raises(AuthError) as exc_info:
+            execute_local_transfer(sender=alice, payee=cooldown_payee, confirmation_token=token)
+
+    assert exc_info.value.status_code == 400
+    assert "cooldown" in exc_info.value.message.lower()
+    assert Transaction.query.count() == 0
+
+
+# ── Atomicity: no partial debit on failure ────────────────────────────────────
+
+def test_failed_transfer_leaves_balances_unchanged(app, sec_ctx):
+    alice = sec_ctx["alice"]
+    bob = sec_ctx["bob"]
+    payee = sec_ctx["payee"]
+
+    alice.balance = Decimal("5.00")
+    db.session.commit()
+
+    alice_before = Decimal(str(alice.balance))
+    bob_before = Decimal(str(bob.balance))
+    token = _make_pending_transfer(alice, payee, Decimal("100.00"))
+
+    with app.test_request_context("/banking/transfer/confirm", method="POST"):
+        with pytest.raises(AuthError):
+            execute_local_transfer(sender=alice, payee=payee, confirmation_token=token)
+
+    db.session.expire_all()
+    assert Decimal(str(db.session.get(User, alice.id).balance)) == alice_before
+    assert Decimal(str(db.session.get(User, bob.id).balance)) == bob_before
+    assert Transaction.query.count() == 0
+
+
+# ── Consumed token stores transaction reference ────────────────────────────────
+
+def test_consumed_token_stores_transaction_ref(app, sec_ctx):
+    alice = sec_ctx["alice"]
+    payee = sec_ctx["payee"]
+    token = _make_pending_transfer(alice, payee, Decimal("10.00"))
+
+    with app.test_request_context("/banking/transfer/confirm", method="POST"):
+        txn_ref = execute_local_transfer(sender=alice, payee=payee, confirmation_token=token)
+
+    db.session.expire_all()
+    pending = PendingTransfer.query.filter_by(token=token).one()
+    assert pending.consumed_at is not None
+    assert pending.consumed_transaction_ref == txn_ref

--- a/tests/test_local_transfer_security.py
+++ b/tests/test_local_transfer_security.py
@@ -504,6 +504,49 @@ def test_failed_transfer_leaves_balances_unchanged(app, sec_ctx):
     assert Transaction.query.count() == 0
 
 
+# ── Transaction content hash (tamper-evidence) ────────────────────────────────
+
+def test_transaction_hash_is_stored_on_success(app, sec_ctx):
+    alice = sec_ctx["alice"]
+    payee = sec_ctx["payee"]
+    token = _make_pending_transfer(alice, payee, Decimal("10.00"), reference="Test")
+
+    with app.test_request_context("/banking/transfer/confirm", method="POST"):
+        txn_ref = execute_local_transfer(sender=alice, payee=payee, confirmation_token=token)
+
+    txn = Transaction.query.filter_by(transaction_ref=txn_ref).one()
+    assert txn.transaction_hash, "transaction_hash must be set"
+    assert len(txn.transaction_hash) == 64, "SHA-256 hex digest is 64 characters"
+
+
+def test_transaction_hash_changes_when_amount_changes(app, sec_ctx):
+    """Two transactions with different amounts must produce different hashes."""
+    import hashlib, json
+    from datetime import datetime, timezone
+    from decimal import Decimal
+
+    fixed_dt = datetime(2026, 6, 28, 12, 0, 0, tzinfo=timezone.utc)
+
+    def _hash(amount_str: str) -> str:
+        canonical = json.dumps(
+            {
+                "amount": amount_str,
+                "created_at": fixed_dt.isoformat(),
+                "recipient_id": 2,
+                "reference": "",
+                "sender_id": 1,
+                "transaction_ref": "aaaaaaaa-0000-0000-0000-000000000000",
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        return hashlib.sha256(canonical.encode()).hexdigest()
+
+    assert _hash("10.00") != _hash("10.01"), (
+        "Hash must differ when amount differs — tamper would be detectable"
+    )
+
+
 # ── Consumed token stores transaction reference ────────────────────────────────
 
 def test_consumed_token_stores_transaction_ref(app, sec_ctx):


### PR DESCRIPTION
## Summary

Fixes #248. Hardens the local transfer service with a DB-backed single-use confirmation token, service-layer ownership and precision enforcement, deadlock-safe row locking, tamper-evident transaction hashes, and redacted audit metadata. Adds 27 new security tests.

## Why

The previous implementation had six exploitable gaps:

- **Concurrent double-submit**: `session.pop` anti-replay was insufficient against concurrent confirm requests; an attacker could race two requests through before either consumed the session key
- **Payee ownership bypass**: ownership was only checked at the route layer; a direct service call or future refactor could skip it
- **Fractional-cent injection**: decimal precision was not validated in the service, so a client could submit amounts like `10.001` if they bypassed WTForms validation
- **Deadlock risk**: row locking order was not guaranteed in SQL, so concurrent transfers between the same two accounts could deadlock
- **Audit data exposure (OWASP A09)**: raw transfer references appeared in the security audit log
- **No tamper detection**: no cryptographic record existed to detect post-insert alteration of transaction rows

## What changed

### `app/models.py`
- Added `PendingTransfer` model (`token`, `user_id`, `payee_id`, `amount`, `reference`, `expires_at`, `consumed_at`, `consumed_transaction_ref`, `created_at`)
- `PendingTransfer.amount` uses `Numeric(12, 5)` scale so sub-cent amounts survive the SQLite float round-trip for service-layer precision enforcement
- Added `transaction_hash` column to `Transaction` (SHA-256 of ref + sender + recipient + amount + reference + created_at, unique index)
- Added `ck_users_balance_non_negative` CHECK and `ck_transactions_amount_positive` CHECK (PostgreSQL only; see migration note)

### `migrations/versions/20260628_0016_harden_local_transfer.py`
- Creates `pending_transfers` table with token unique index and expiry index
- Adds `transaction_hash` column with unique index to `transactions`
- Adds CHECK constraints via `ALTER TABLE ADD CONSTRAINT` for PostgreSQL only â€” `batch_alter_table` cannot reflect table schema in Alembic offline (`--sql`) mode, so the constraints are skipped for SQLite where application-layer validation is the enforcement mechanism

### `app/banking/services.py`
- `execute_local_transfer` now accepts `confirmation_token` (not raw amount/reference); all financial data is read from the `PendingTransfer` DB record
- Enforces payee ownership and cooldown at the service layer independently of the route
- Rejects self-transfers and unavailable recipient accounts
- Precision check: `Decimal(str(amount)).normalize()` strips trailing zeros from the wider `Numeric(12,5)` scale before the `exponent < -2` guard, so `10.001` is correctly rejected while `10.10` (stored as `10.10000`) passes
- Atomically consumes `PendingTransfer` with `SELECT FOR UPDATE`; second concurrent confirm gets 409
- Locks user rows with `ORDER BY id ASC` before `SELECT FOR UPDATE` (deadlock prevention)
- Computes and stores `transaction_hash` before insert
- Replaces raw reference in audit metadata with `reference_present` / `reference_length` (OWASP A09)

### `app/banking/routes.py`
- `transfer_submit`: creates a `PendingTransfer` DB record; stores only the opaque token in session
- `transfer_confirm`: reads token from session, fetches `PendingTransfer` from DB
- `transfer_confirm_submit`: pops token from session, passes it to the service

### `tests/test_local_transfer.py`
- Added `_make_pending_transfer` helper; updated four direct-service tests to supply confirmation tokens

### `tests/test_local_transfer_security.py`
- 27 new tests covering: payee ownership, self-transfer, recipient state policy, decimal precision, anti-replay, token binding, locking query ORDER BY, audit redaction, cooldown enforcement, atomicity, transaction_hash presence and sensitivity, consumed token bookkeeping
- `test_service_rejects_payee_in_cooldown`: uses a fresh user `carol` (account `901000099`) to avoid unique constraint collision with the existing aliceâ†’bob payee in `sec_ctx`

### `tests/conftest.py`
- Added `test_local_transfer_security.py` to `SECURITY_TEST_FILES`

## Security impact

| Gap | Fix |
|---|---|
| Concurrent double-submit replay | DB-backed atomic token with `SELECT FOR UPDATE`; second confirm gets 409 |
| Payee ownership bypass | Enforced in service layer independently of routes |
| Fractional-cent injection | `normalize()` + `exponent < -2` guard in service; `Numeric(12,5)` preserves sub-cent amounts through DB round-trip |
| Deadlock risk | Guaranteed `ORDER BY id ASC` before `SELECT FOR UPDATE` |
| Audit PII exposure (OWASP A09) | Reference replaced with `reference_present` + `reference_length` |
| Post-insert tampering | SHA-256 `transaction_hash` covers all financial fields |

## Deployment impact

Requires migration `20260628_0016` before deploying:
- Creates `pending_transfers` table
- Adds `transaction_hash` column with unique index to `transactions`
- Adds CHECK constraints to `users` and `transactions` (PostgreSQL only)

No EC2 bootstrap changes, secret changes, or staging-only steps required. Users who have a pending transfer in session at the moment of deploy will be redirected to the payees page to start a fresh transfer.

## Verification

1. Run `pytest tests/test_local_transfer.py tests/test_local_transfer_security.py` â€” all tests pass
2. Complete a transfer end-to-end: submit amount + MFA, confirm, verify success flash and correct balances
3. Query `transactions` after a transfer: `transaction_hash` must be a 64-character hex string
4. Check `SecurityAuditEvent` for the transfer: `reference` key must not appear; `reference_present` and `reference_length` must be present
5. Submit the confirm form twice with the same token: second attempt must return 409
