### PR TITLE
Stabilize admin invite TOTP tests

### DIFF
--- a/tests/test_admin_staff_invites.py
+++ b/tests/test_admin_staff_invites.py
@@ -79,10 +79,17 @@ def _login_admin(client, secret: str, email: str = ROOT_EMAIL, password: str = R
     assert password_response.status_code == 200
     verify_response = client.post(
         "/mfa/verify",
-        json={"totp_code": pyotp.TOTP(secret, digits=6, interval=30).now()},
+        json={"totp_code": _stable_totp(secret)},
     )
     assert verify_response.status_code == 200
     return verify_response
+
+
+def _stable_totp(secret: str) -> str:
+    seconds_into_step = time.time() % 30
+    if seconds_into_step > 20:
+        time.sleep(30 - seconds_into_step + 0.25)
+    return pyotp.TOTP(secret, digits=6, interval=30).now()
 
 
 def _create_invite(client, secret: str, **overrides):
@@ -90,7 +97,7 @@ def _create_invite(client, secret: str, **overrides):
         "personal_email": "staff.person@gmail.com",
         "workplace_email": "staff.person@sit.singaporetech.edu.sg",
         "role": "staff",
-        "totp_code": pyotp.TOTP(secret, digits=6, interval=30).now(),
+        "totp_code": _stable_totp(secret),
     }
     payload.update(overrides)
     return client.post("/invites", json=payload)
@@ -286,7 +293,7 @@ def test_staff_invite_acceptance_activates_only_after_workplace_code_and_totp(ad
         json={"workplace_email": staff_user.email, "password": STAFF_PASSWORD},
     )
     workplace_code = _latest_workplace_code()
-    totp_code = pyotp.TOTP(setup["manual_entry_secret"], digits=6, interval=30).now()
+    totp_code = _stable_totp(setup["manual_entry_secret"])
     verify = admin_client.post(
         f"/invites/accept/{token}/verify",
         json={"totp_code": totp_code, "workplace_verification_code": workplace_code},


### PR DESCRIPTION
## Summary
Stabilizes the admin staff-invite TOTP tests under parallel CI.

## Why
The merged `main` CI run failed because a test generated a TOTP code near the end of a 30-second step, then verified it through a zero-window admin MFA path after the step had rolled over.

## What changed
* Added a `_stable_totp` helper in `tests/test_admin_staff_invites.py`
* Reused that helper for admin login, invite creation step-up, and staff invite acceptance verification
* Kept production admin MFA behavior unchanged

## Security impact
No production security behavior changes. This only makes tests avoid boundary-expired TOTP codes while preserving zero-window admin step-up assertions.

## Deployment impact
No deployment action required for this test-only hotfix. After merge, the normal main CI should become green again.

## Verification
* `git diff --check`
* `.\.venv\Scripts\python.exe -m pytest -q -n auto tests/test_admin_staff_invites.py`
* `.\.venv\Scripts\python.exe -m pytest -q -n auto tests/test_admin_staff_invites.py tests/test_admin_dashboard_operations.py tests/test_admin_manual_recovery.py tests/test_admin_isolation.py tests/test_admin_bootstrap_root.py`
* `.\.venv\Scripts\python.exe -m pytest -q -n auto --durations=30 --durations-min=0.5`

## Notes
This PR addresses the post-merge CI failure from run `28326766670`. The earlier `curl` SSL error is an operator command issue: port `5002` on loopback is not serving TLS directly, so use HTTP against `127.0.0.1:5002` or test TLS through the public/Tailscale hostname.