### PR TITLE
Fix admin runtime database grants

### DIFF
--- a/app/ops/db_privileges.py
+++ b/app/ops/db_privileges.py
@@ -109,10 +109,20 @@ def apply_admin_runtime_database_privileges(
             connection.execute(
                 text(f"GRANT USAGE ON SCHEMA {qualified_schema} TO {quoted_admin_role}")
             )
+            qualified_audit_table = _qualified_table_name(schema, "security_audit_events")
             connection.execute(
                 text(
-                    f"GRANT SELECT, INSERT ON ALL TABLES IN SCHEMA {qualified_schema} "
+                    f"GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA {qualified_schema} "
                     f"TO {quoted_admin_role}"
+                )
+            )
+            connection.execute(
+                text(f"GRANT SELECT, INSERT ON TABLE {qualified_audit_table} TO {quoted_admin_role}")
+            )
+            connection.execute(
+                text(
+                    f"REVOKE UPDATE, DELETE, TRUNCATE ON TABLE {qualified_audit_table} "
+                    f"FROM {quoted_admin_role}"
                 )
             )
             connection.execute(
@@ -124,7 +134,7 @@ def apply_admin_runtime_database_privileges(
             connection.execute(
                 text(
                     f"ALTER DEFAULT PRIVILEGES FOR ROLE {quoted_migration_role} "
-                    f"IN SCHEMA {qualified_schema} GRANT SELECT, INSERT ON TABLES "
+                    f"IN SCHEMA {qualified_schema} GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES "
                     f"TO {quoted_admin_role}"
                 )
             )
@@ -155,6 +165,10 @@ def apply_admin_runtime_database_privileges(
                 raise RuntimeError(
                     "ADMIN_DATABASE_URL did not authenticate to the configured database"
                 )
+            _assert_admin_runtime_database_privileges(
+                admin_connection,
+                schema=schema,
+            )
     finally:
         admin_engine.dispose()
 
@@ -164,6 +178,69 @@ def apply_admin_runtime_database_privileges(
         database=database,
         schema=schema,
     )
+
+
+def _assert_admin_runtime_database_privileges(connection, *, schema: str) -> None:
+    required_table_privileges = {
+        "users": ("SELECT", "INSERT", "UPDATE"),
+        "staff_invites": ("SELECT", "INSERT", "UPDATE"),
+        "manual_recovery_requests": ("SELECT", "UPDATE"),
+        "auth_attempt_counters": ("SELECT", "INSERT", "UPDATE", "DELETE"),
+        "totp_replay_records": ("SELECT", "INSERT"),
+        "server_side_sessions": ("SELECT", "INSERT", "UPDATE", "DELETE"),
+        "security_audit_events": ("SELECT", "INSERT"),
+    }
+    for table_name, privileges in required_table_privileges.items():
+        qualified_table = f"{schema}.{table_name}"
+        for privilege in privileges:
+            has_privilege = bool(
+                connection.execute(
+                    text(
+                        "SELECT has_table_privilege("
+                        "current_user, :table_name, :privilege"
+                        ")"
+                    ),
+                    {"table_name": qualified_table, "privilege": privilege},
+                ).scalar_one()
+            )
+            if not has_privilege:
+                raise RuntimeError(
+                    f"ADMIN_DATABASE_URL role is missing {privilege} on {qualified_table}"
+                )
+
+    audit_table = f"{schema}.security_audit_events"
+    for privilege in ("UPDATE", "DELETE", "TRUNCATE"):
+        has_privilege = bool(
+            connection.execute(
+                text(
+                    "SELECT has_table_privilege("
+                    "current_user, :table_name, :privilege"
+                    ")"
+                ),
+                {"table_name": audit_table, "privilege": privilege},
+            ).scalar_one()
+        )
+        if has_privilege:
+            raise RuntimeError(
+                f"ADMIN_DATABASE_URL role must not have {privilege} on {audit_table}"
+            )
+
+    for sequence_name in ("users_id_seq", "security_audit_events_id_seq"):
+        qualified_sequence = f"{schema}.{sequence_name}"
+        has_usage = bool(
+            connection.execute(
+                text(
+                    "SELECT has_sequence_privilege("
+                    "current_user, :sequence_name, 'USAGE'"
+                    ")"
+                ),
+                {"sequence_name": qualified_sequence},
+            ).scalar_one()
+        )
+        if not has_usage:
+            raise RuntimeError(
+                f"ADMIN_DATABASE_URL role is missing USAGE on {qualified_sequence}"
+            )
 
 
 def apply_runtime_audit_table_privileges(

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -116,6 +116,46 @@ def _load_db_privileges_module():
     return module
 
 
+class _ScalarResult:
+    def __init__(self, value: bool):
+        self.value = value
+
+    def scalar_one(self) -> bool:
+        return self.value
+
+
+class _FakeAdminPrivilegeConnection:
+    def __init__(
+        self,
+        *,
+        missing_table_privileges: set[tuple[str, str]] | None = None,
+        audit_mutation_privileges: set[str] | None = None,
+        missing_sequences: set[str] | None = None,
+    ):
+        self.missing_table_privileges = missing_table_privileges or set()
+        self.audit_mutation_privileges = audit_mutation_privileges or set()
+        self.missing_sequences = missing_sequences or set()
+        self.table_checks: list[tuple[str, str]] = []
+        self.sequence_checks: list[str] = []
+
+    def execute(self, _statement, params):
+        if "table_name" in params:
+            table_name = str(params["table_name"])
+            privilege = str(params["privilege"])
+            self.table_checks.append((table_name, privilege))
+            if (
+                table_name == "public.security_audit_events"
+                and privilege in {"UPDATE", "DELETE", "TRUNCATE"}
+            ):
+                return _ScalarResult(privilege in self.audit_mutation_privileges)
+            return _ScalarResult((table_name, privilege) not in self.missing_table_privileges)
+        if "sequence_name" in params:
+            sequence_name = str(params["sequence_name"])
+            self.sequence_checks.append(sequence_name)
+            return _ScalarResult(sequence_name not in self.missing_sequences)
+        raise AssertionError(f"Unexpected privilege query params: {params!r}")
+
+
 def _load_create_dast_session_module():
     module_path = Path("ops/container/create_dast_session.py")
     spec = importlib.util.spec_from_file_location("_create_dast_session_under_test", module_path)
@@ -407,13 +447,78 @@ def test_runtime_privilege_verifier_quotes_create_probe_table_name():
     assert "ALTER ROLE" not in source
     assert "create_engine(admin_url)" in source
     assert "ADMIN_DATABASE_URL did not authenticate as the configured role" in source
-    assert "GRANT SELECT, INSERT ON ALL TABLES" in source
+    assert "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES" in source
     assert "ALTER DEFAULT PRIVILEGES FOR ROLE" in source
+    assert "_assert_admin_runtime_database_privileges" in source
+    assert "has_table_privilege" in source
+    assert "has_sequence_privilege" in source
+    assert '"users": ("SELECT", "INSERT", "UPDATE")' in source
+    assert '"auth_attempt_counters": ("SELECT", "INSERT", "UPDATE", "DELETE")' in source
+    assert '"server_side_sessions": ("SELECT", "INSERT", "UPDATE", "DELETE")' in source
+    assert '"security_audit_events": ("SELECT", "INSERT")' in source
+    assert 'for privilege in ("UPDATE", "DELETE", "TRUNCATE")' in source
     assert "REVOKE UPDATE, DELETE, TRUNCATE ON TABLE" in source
     assert "GRANT SELECT, INSERT ON TABLE" in source
+    assert "FROM {quoted_admin_role}" in source
     assert "previous_event_hash" in source
     assert "event_hash" in source
     assert "hash_algorithm" in source
+
+
+def test_admin_runtime_privilege_verifier_accepts_required_dml_without_audit_mutation():
+    db_privileges = _load_db_privileges_module()
+    connection = _FakeAdminPrivilegeConnection()
+
+    db_privileges._assert_admin_runtime_database_privileges(connection, schema="public")
+
+    assert ("public.users", "UPDATE") in connection.table_checks
+    assert ("public.auth_attempt_counters", "DELETE") in connection.table_checks
+    assert ("public.security_audit_events", "INSERT") in connection.table_checks
+    assert ("public.security_audit_events", "TRUNCATE") in connection.table_checks
+    assert "public.users_id_seq" in connection.sequence_checks
+    assert "public.security_audit_events_id_seq" in connection.sequence_checks
+
+
+def test_admin_runtime_privilege_verifier_rejects_missing_bootstrap_update():
+    db_privileges = _load_db_privileges_module()
+    connection = _FakeAdminPrivilegeConnection(
+        missing_table_privileges={("public.users", "UPDATE")},
+    )
+
+    with pytest.raises(RuntimeError, match=r"missing UPDATE on public\.users"):
+        db_privileges._assert_admin_runtime_database_privileges(
+            connection,
+            schema="public",
+        )
+
+
+def test_admin_runtime_privilege_verifier_rejects_audit_table_mutation():
+    db_privileges = _load_db_privileges_module()
+    connection = _FakeAdminPrivilegeConnection(
+        audit_mutation_privileges={"DELETE"},
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"must not have DELETE on public\.security_audit_events",
+    ):
+        db_privileges._assert_admin_runtime_database_privileges(
+            connection,
+            schema="public",
+        )
+
+
+def test_admin_runtime_privilege_verifier_requires_insert_sequences():
+    db_privileges = _load_db_privileges_module()
+    connection = _FakeAdminPrivilegeConnection(
+        missing_sequences={"public.users_id_seq"},
+    )
+
+    with pytest.raises(RuntimeError, match=r"missing USAGE on public\.users_id_seq"):
+        db_privileges._assert_admin_runtime_database_privileges(
+            connection,
+            schema="public",
+        )
 
 
 def test_dast_session_creator_requires_loopback_or_explicit_smoke_host():
@@ -3315,6 +3420,10 @@ def test_audit_operations_runbook_and_append_only_privileges_are_present():
     assert "REVOKE UPDATE, DELETE, TRUNCATE ON TABLE" in privileges
     assert "TRUNCATE security_audit_events" in privileges
     assert "GRANT SELECT, INSERT ON TABLE" in privileges
+    assert "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES" in privileges
+    assert "_assert_admin_runtime_database_privileges" in privileges
+    assert "has_table_privilege" in privileges
+    assert "has_sequence_privilege" in privileges
     assert "_assert_audit_append_only_triggers_installed" in privileges
     assert "pg_advisory_xact_lock" in privileges
     assert "previous_event_hash" in privileges


### PR DESCRIPTION
Summary

Fixes the admin runtime database privilege grant so the isolated admin app can perform the DML required for admin login, root-admin bootstrap, sessions, TOTP replay protection, staff invites, and manual recovery workflows.

Why

Production `flask admin bootstrap-root` failed with `permission denied for table users` from the admin container. The deployment helper authenticated the admin runtime role but only granted `SELECT, INSERT` on application tables, while bootstrap and normal admin flows need updates and selected deletes.

What changed

* Grants the admin runtime role `SELECT, INSERT, UPDATE, DELETE` on application tables during `apply-admin-runtime-db-privileges`.
* Explicitly keeps `security_audit_events` append-only for the admin runtime role by granting only `SELECT, INSERT` and revoking `UPDATE`, `DELETE`, and `TRUNCATE`.
* Adds post-grant verification for required admin runtime table and sequence privileges, including `users`, `staff_invites`, `auth_attempt_counters`, `totp_replay_records`, `server_side_sessions`, and `security_audit_events`.
* Updates deployment tests to pin the admin runtime privilege contract.

Security impact

Admin authentication, TOTP, root-admin allowlist checks, invite flow, session isolation, audit logging, Tailscale-only admin access, and public/customer boundaries are unchanged.

The admin database role remains separate from the customer runtime role and migration/schema-owner role. The admin role still does not receive DDL or ownership permissions, and audit rows remain protected from update/delete/truncate by both grants and existing append-only controls.

Deployment impact

This requires staging deployment and production deployment after merge so `apply-admin-runtime-db-privileges` reapplies the corrected grants on EC2.

Before retrying root-admin bootstrap, let the normal deployment complete successfully. No GitHub secret changes are required.

Verification

* `git diff --check`
* `.\.venv\Scripts\python.exe -m pytest -q tests/test_deployment.py::test_runtime_privilege_verifier_quotes_create_probe_table_name tests/test_deployment.py::test_audit_operations_runbook_and_append_only_privileges_are_present tests/test_admin_bootstrap_root.py`
* `.\.venv\Scripts\python.exe -m pytest -q tests/test_deployment.py`
* `.\.venv\Scripts\python.exe -m pytest -q tests/test_admin_bootstrap_root.py tests/test_admin_staff_invites.py tests/test_admin_dashboard_operations.py tests/test_admin_manual_recovery.py tests/test_admin_isolation.py`
* `.\.venv\Scripts\python.exe -m pytest -q`

Notes

After this PR is merged and deployed, rerun the root-admin bootstrap manually over SSH inside the admin container. Do not pass the password or TOTP setup output through GitHub Actions.