### PR TITLE
Relax privileged user contact fields

### DIFF
--- a/migrations/versions/20260629_0017_relax_privileged_user_contact_fields.py
+++ b/migrations/versions/20260629_0017_relax_privileged_user_contact_fields.py
@@ -1,0 +1,29 @@
+"""Relax customer-only contact fields for privileged users.
+
+Revision ID: 20260629_0017
+Revises: 20260628_0016
+Create Date: 2026-06-29 00:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260629_0017"
+down_revision = "20260628_0016"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    if op.get_context().dialect.name != "postgresql":
+        return
+
+    op.execute(sa.text("ALTER TABLE users ALTER COLUMN phone_number DROP NOT NULL"))
+    op.execute(sa.text("ALTER TABLE users ALTER COLUMN account_number DROP NOT NULL"))
+
+
+def downgrade() -> None:
+    # The intended model already allowed these fields to be nullable by the
+    # previous revision; this migration repairs production schema drift.
+    return

--- a/tests/test_admin_bootstrap_root.py
+++ b/tests/test_admin_bootstrap_root.py
@@ -106,6 +106,7 @@ def test_bootstrap_root_admin_cli_creates_allowlisted_active_totp_root(admin_app
     assert user.workplace_email_verified_at is not None
     assert user.mfa_enabled is True
     assert user.mfa_secret_ciphertext is not None
+    assert user.phone_number is None
     assert user.account_number is None
     assert db.session.query(User).filter_by(account_type="root_admin").count() == 1
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -572,6 +572,19 @@ def test_registration_field_migration_preserves_unknown_phones_and_randomizes_ac
     assert "SET full_name = username" in migration
 
 
+def test_privileged_user_contact_field_migration_repairs_production_schema_drift():
+    migration = Path(
+        "migrations/versions/20260629_0017_relax_privileged_user_contact_fields.py"
+    ).read_text(encoding="utf-8")
+
+    assert 'revision = "20260629_0017"' in migration
+    assert 'down_revision = "20260628_0016"' in migration
+    assert "ALTER TABLE users ALTER COLUMN phone_number DROP NOT NULL" in migration
+    assert "ALTER TABLE users ALTER COLUMN account_number DROP NOT NULL" in migration
+    assert "SET phone_number" not in migration
+    assert "SET account_number" not in migration
+
+
 def test_container_bundle_separates_secrets_from_non_secret_environment(monkeypatch):
     _set_deployment_values(monkeypatch)
 


### PR DESCRIPTION
Summary
---
Repairs production schema drift that blocks manual root admin bootstrap.

Why
---
The deployed production users table still has phone_number marked NOT NULL, but root admin bootstrap correctly creates a non-customer admin identity without customer phone/account fields. The INSERT fails before MFA setup can complete.

What changed
---
* Added migration 20260629_0017 to drop NOT NULL from users.phone_number and users.account_number on PostgreSQL.
* Added a deployment test that pins the repair migration and prevents synthetic phone/account backfills.
* Added a bootstrap test assertion that root_admin remains without customer-only phone data.

Security impact
---
Root admin allowlisting, MFA setup, admin login, invite roles, session isolation, and public exposure boundaries are unchanged. The migration does not generate or store fake customer identifiers.

Deployment impact
---
A normal production deployment is required because this PR includes a database migration. No EC2 bootstrap, GitHub Actions bootstrap workflow, or secret changes are required.

Verification
---
* git diff --check
* .\.venv\Scripts\python.exe -m pytest -q tests/test_deployment.py::test_privileged_user_contact_field_migration_repairs_production_schema_drift tests/test_deployment.py::test_migration_baseline_renders_offline_sql tests/test_deployment.py::test_existing_schema_matches_migration_baseline tests/test_admin_bootstrap_root.py
* .\.venv\Scripts\python.exe -m pytest -q tests/test_admin_staff_invites.py tests/test_admin_dashboard_operations.py tests/test_admin_manual_recovery.py tests/test_admin_isolation.py

Notes
---
Full .\.venv\Scripts\python.exe -m pytest -q was attempted but timed out after 10 minutes in the local shell before producing a result.