### PR TITLE
Complete local transfer hardening audit and documentation gaps

### DIFF
--- a/app/banking/services.py
+++ b/app/banking/services.py
@@ -299,6 +299,15 @@ def execute_local_transfer(
     # Defence-in-depth: service enforces payee ownership independently of the
     # route layer so direct callers and future refactors cannot bypass it.
     if payee.user_id != sender.id:
+        audit_outbound_transfer(
+            sender,
+            "failure",
+            metadata={
+                "reason": "payee_ownership_mismatch",
+                "payee_id_ref": audit_reference("payee_id", payee.id),
+            },
+        )
+        db.session.commit()
         raise AuthError("Transfer denied.", 403)
 
     recipient_user = User.query.filter_by(account_number=payee.account_number).first()

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -309,10 +309,20 @@ the mismatched anchor as incident evidence, run
 and investigate possible row tampering, chain rewind, or tail deletion before
 resuming routine deployments.
 
-The current banking implementation audits public transaction validation and
-TOTP-backed transaction authorization checks. There is no final ledger movement
-endpoint in this codebase, so final transfer execution is intentionally out of
-scope until such an endpoint exists.
+The current banking implementation audits public transaction validation,
+TOTP-backed transaction authorization checks, and local transfer execution.
+Local transfer performs final ledger movement: the sender balance is debited,
+the recipient balance is credited, and a `Transaction` record is created in a
+single atomic commit. The two-step transfer flow requires MFA step-up before a
+DB-backed `PendingTransfer` record is created; the single-use confirmation token
+is consumed atomically with `SELECT FOR UPDATE` to prevent concurrent
+double-submit replay. Row locks are acquired in ascending `id` order to prevent
+deadlocks. Payee ownership and cooldown are enforced at the service layer
+independently of the route layer. Transfer amounts are validated to at most two
+decimal places. Recipient account state is checked before funds move.
+Blocked authorization failures, including payee ownership mismatches, are
+audited safely using opaque references so raw account numbers, payee details,
+and pending transfer tokens do not appear in the audit log.
 
 The admin boundary audits root-admin-controlled staff invite onboarding,
 admin login success/failure, TOTP verification, admin step-up, admin data

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -3395,7 +3395,9 @@ def test_audit_operations_runbook_and_append_only_privileges_are_present():
         "10 or more `login` failures",
         "`auth_backoff`",
         "3 or more transaction failures",
-        "There is no final ledger",
+        "local transfer performs final ledger movement",
+        "single-use confirmation token",
+        "payee ownership mismatches",
         "Docker `local` log rotation",
     ):
         assert required in docs

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -3395,7 +3395,7 @@ def test_audit_operations_runbook_and_append_only_privileges_are_present():
         "10 or more `login` failures",
         "`auth_backoff`",
         "3 or more transaction failures",
-        "local transfer performs final ledger movement",
+        "Local transfer performs final ledger movement",
         "single-use confirmation token",
         "payee ownership mismatches",
         "Docker `local` log rotation",

--- a/tests/test_local_transfer_security.py
+++ b/tests/test_local_transfer_security.py
@@ -221,7 +221,7 @@ def test_ownership_mismatch_error_is_generic(app, sec_ctx):
 
 def test_docs_describe_local_transfer_execution():
     ops = (Path(__file__).parent.parent / "docs" / "OPERATIONS.md").read_text(encoding="utf-8")
-    assert "local transfer performs final ledger movement" in ops
+    assert "Local transfer performs final ledger movement" in ops
     assert "single-use confirmation token" in ops
     assert "payee ownership" in ops.lower()
     assert "There is no final ledger" not in ops

--- a/tests/test_local_transfer_security.py
+++ b/tests/test_local_transfer_security.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import os
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
+from pathlib import Path
 
 import pytest
 
@@ -123,6 +124,107 @@ def test_service_rejects_payee_not_owned_by_sender(app, sec_ctx):
 
     assert exc_info.value.status_code == 403
     assert Transaction.query.count() == 0
+
+
+def test_ownership_mismatch_is_audited(app, sec_ctx):
+    alice = sec_ctx["alice"]
+    bob = sec_ctx["bob"]
+
+    stranger_payee = Payee(
+        user_id=bob.id,
+        nickname="Eve",
+        account_number="901000004",
+        recipient_name="Eve",
+        created_at=datetime.now(timezone.utc) - timedelta(days=2),
+    )
+    db.session.add(stranger_payee)
+    db.session.commit()
+
+    token = _make_pending_transfer(alice, stranger_payee, Decimal("10.00"))
+    before_count = SecurityAuditEvent.query.count()
+
+    with app.test_request_context("/banking/transfer/confirm", method="POST"):
+        with pytest.raises(AuthError):
+            execute_local_transfer(sender=alice, payee=stranger_payee, confirmation_token=token)
+
+    events = SecurityAuditEvent.query.filter(
+        SecurityAuditEvent.id > before_count,
+        SecurityAuditEvent.event_type == "banking_outbound_transfer",
+        SecurityAuditEvent.outcome == "failure",
+    ).all()
+    assert len(events) == 1, "ownership mismatch must produce exactly one audit event"
+    meta = events[0].event_metadata
+    assert meta.get("reason") == "payee_ownership_mismatch"
+
+
+def test_ownership_mismatch_audit_uses_safe_metadata(app, sec_ctx):
+    alice = sec_ctx["alice"]
+    bob = sec_ctx["bob"]
+
+    stranger_payee = Payee(
+        user_id=bob.id,
+        nickname="Eve",
+        account_number="901000005",
+        recipient_name="Eve",
+        created_at=datetime.now(timezone.utc) - timedelta(days=2),
+    )
+    db.session.add(stranger_payee)
+    db.session.commit()
+
+    token = _make_pending_transfer(alice, stranger_payee, Decimal("10.00"))
+    before_count = SecurityAuditEvent.query.count()
+
+    with app.test_request_context("/banking/transfer/confirm", method="POST"):
+        with pytest.raises(AuthError):
+            execute_local_transfer(sender=alice, payee=stranger_payee, confirmation_token=token)
+
+    events = SecurityAuditEvent.query.filter(
+        SecurityAuditEvent.id > before_count,
+        SecurityAuditEvent.event_type == "banking_outbound_transfer",
+    ).all()
+    assert events, "expected at least one audit event"
+    for event in events:
+        meta = event.event_metadata
+        meta_str = str(meta)
+        # Raw sensitive values must not appear in audit metadata
+        assert stranger_payee.account_number not in meta_str, "raw account number must not be logged"
+        assert token not in meta_str, "raw pending transfer token must not be logged"
+        assert stranger_payee.recipient_name not in meta_str, "raw payee name must not be logged"
+        assert bob.email not in meta_str, "raw recipient email must not be logged"
+
+
+def test_ownership_mismatch_error_is_generic(app, sec_ctx):
+    alice = sec_ctx["alice"]
+    bob = sec_ctx["bob"]
+
+    stranger_payee = Payee(
+        user_id=bob.id,
+        nickname="Eve",
+        account_number="901000006",
+        recipient_name="Eve",
+        created_at=datetime.now(timezone.utc) - timedelta(days=2),
+    )
+    db.session.add(stranger_payee)
+    db.session.commit()
+
+    token = _make_pending_transfer(alice, stranger_payee, Decimal("10.00"))
+
+    with app.test_request_context("/banking/transfer/confirm", method="POST"):
+        with pytest.raises(AuthError) as exc_info:
+            execute_local_transfer(sender=alice, payee=stranger_payee, confirmation_token=token)
+
+    msg = exc_info.value.message.lower()
+    assert "payee" not in msg or "denied" in msg, "error must not expose IDOR detail"
+    assert stranger_payee.account_number not in msg
+    assert "901000006" not in msg
+
+
+def test_docs_describe_local_transfer_execution():
+    ops = (Path(__file__).parent.parent / "docs" / "OPERATIONS.md").read_text(encoding="utf-8")
+    assert "local transfer performs final ledger movement" in ops
+    assert "single-use confirmation token" in ops
+    assert "payee ownership" in ops.lower()
+    assert "There is no final ledger" not in ops
 
 
 # ── Self-transfer ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #259.

- Adds a safe `banking_outbound_transfer / failure` audit event when `execute_local_transfer` rejects a payee ownership mismatch, using only opaque references — no raw account numbers, payee names, tokens, or PII.
- Updates `docs/OPERATIONS.md` to accurately describe the implemented local transfer: final ledger movement, two-step MFA flow, DB-backed single-use confirmation token, SELECT FOR UPDATE replay protection, deadlock-safe row locking, service-layer ownership and cooldown enforcement, amount precision validation, recipient state policy, and safe audit redaction for blocked authorization failures.
- Removes the stale claim that final transfer execution was intentionally out of scope.

## What changed

### `app/banking/services.py`
- Before raising `AuthError("Transfer denied.", 403)` on ownership mismatch, calls `audit_outbound_transfer` with `reason: payee_ownership_mismatch` and a hashed opaque `payee_id_ref`.
- Error message remains generic — does not distinguish missing, unauthorized, or another customer's payee.

### `docs/OPERATIONS.md`
- Replaced stale paragraph claiming no final ledger movement endpoint existed with an accurate paragraph describing the full local transfer implementation and its security controls.

### `tests/test_local_transfer_security.py`
- `test_ownership_mismatch_is_audited` — verifies exactly one `banking_outbound_transfer / failure` event with `reason: payee_ownership_mismatch`.
- `test_ownership_mismatch_audit_uses_safe_metadata` — verifies raw account number, token, payee name, and recipient email are absent from event metadata.
- `test_ownership_mismatch_error_is_generic` — verifies error message does not expose IDOR detail or raw account number.
- `test_docs_describe_local_transfer_execution` — verifies OPERATIONS.md contains accurate transfer description and no longer contains the stale sentence about no final ledger movement.

### `tests/test_deployment.py`
- Replaced `"There is no final ledger"` assertion with three assertions matching the new accurate doc content.

## Security impact

| Gap | Fix |
|---|---|
| Payee ownership mismatch not audited | Safe `banking_outbound_transfer/failure` event with opaque `payee_id_ref`; no raw PII logged |
| Stale docs claiming no ledger movement | OPERATIONS.md now accurately describes full transfer flow and audit coverage |

## Deployment impact

- No migration required.
- No EC2 bootstrap changes.
- Staging deployment required for the services.py change.

## Verification

```powershell
python -m pytest -q -n auto tests/test_local_transfer_security.py
python -m pytest -q -n auto tests/test_deployment.py::test_audit_operations_runbook_and_append_only_privileges_are_present
python -m pytest -q -n auto
```
