### PR TITLE
Remediate SonarQube security hotspots

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.12.13-slim-trixie@sha256:d764629ce0ddd8c71fd371e9901efb324a95789d2315a47db7e4d27e78f1b0e9 AS builder
+# Keep the version tag for Dependabot tracking; the digest controls the content.
+FROM python:3.12.13-slim-trixie@sha256:6c4dd321d176d61ea848dc8c73a4f7dbae8f70e0ee48bb411ea2f045b599fa8e AS builder
 
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=1 \
@@ -10,7 +11,7 @@ RUN /opt/venv/bin/python -m pip install \
     --require-hashes \
     --requirement /tmp/requirements.lock
 
-FROM python:3.12.13-slim-trixie@sha256:d764629ce0ddd8c71fd371e9901efb324a95789d2315a47db7e4d27e78f1b0e9 AS runtime
+FROM python:3.12.13-slim-trixie@sha256:6c4dd321d176d61ea848dc8c73a4f7dbae8f70e0ee48bb411ea2f045b599fa8e AS runtime
 
 ARG VCS_REF=unknown
 ARG SOURCE_URL=unknown
@@ -36,13 +37,14 @@ RUN apt-get update \
     && groupadd --gid 10001 sitbank \
     && useradd --uid 10001 --gid 10001 --no-create-home \
         --home-dir /nonexistent --shell /usr/sbin/nologin sitbank \
-    && install -d -o 10001 -g 10001 -m 0750 /app
+    && install -d -o root -g 10001 -m 0750 /app
 
 COPY --from=builder /opt/venv /opt/venv
 WORKDIR /app
-COPY --chown=10001:10001 app ./app
-COPY --chown=10001:10001 migrations ./migrations
-COPY --chown=10001:10001 config.py wsgi.py admin_wsgi.py ./
+COPY --chown=0:0 app ./app
+COPY --chown=0:0 migrations ./migrations
+COPY --chown=0:0 config.py wsgi.py admin_wsgi.py ./
+RUN chmod -R a-w /app
 
 USER 10001:10001
 

--- a/app/admin/services.py
+++ b/app/admin/services.py
@@ -84,7 +84,7 @@ GENERIC_WORKPLACE_VERIFICATION_ERROR = "Workplace verification failed"
 ADMIN_AUTH_BACKOFF_ERROR = "Too many attempts. Please try again later."
 STAFF_USERNAME_RE = re.compile(r"^[A-Za-z0-9_.-]{3,64}$")
 FULL_NAME_RE = re.compile(r"^[^\x00-\x1f\x7f<>]{1,120}$")
-PHONE_RE = re.compile(r"^[89][0-9]{7}$")
+PHONE_RE = re.compile(r"^[89]\d{7}$", re.ASCII)
 EMAIL_RE = re.compile(
     r"^(?=\S{1,128}@\S{1,253}$)[^@\x00-\x1f\x7f]+@[^@\x00-\x1f\x7f]+$"
 )

--- a/app/security/alerts.py
+++ b/app/security/alerts.py
@@ -15,6 +15,7 @@ from flask import current_app, has_app_context
 
 from app.extensions import db
 from app.models import SecurityAlertDedupe, SecurityAuditEvent, User
+from app.security.sensitive_values import contains_sensitive_url
 from app.security.session_hmac import active_hmac_hex
 
 
@@ -126,14 +127,6 @@ DELIVERY_SENSITIVE_KEY_PARTS = (
     "token",
     "totp",
     "webhook",
-)
-DELIVERY_CREDENTIAL_URL_RE = re.compile(
-    r"\b(?:postgres(?:ql)?|redis)://[^\s/@]*:[^\s/@]*@",
-    re.IGNORECASE,
-)
-DELIVERY_WEBHOOK_URL_RE = re.compile(
-    r"https://(?:[^/\s]*hooks[^/\s]*|discord(?:app)?\.com)/(?:api/)?(?:webhooks|services)/\S+",
-    re.IGNORECASE,
 )
 DELIVERY_PRIVATE_KEY_RE = re.compile(
     r"BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY",
@@ -821,7 +814,10 @@ def _sanitize_delivery_value(value: Any, key_lower: str, *, depth: int) -> Any:
             for item in list(value)[:25]
         ]
 
-    text = _safe_text(value, 512)
+    raw_text = str(value)
+    if contains_sensitive_url(raw_text):
+        return REDACTED_VALUE
+    text = _safe_text(raw_text, 512)
     if _looks_like_sensitive_delivery_value(text):
         return REDACTED_VALUE
     return text
@@ -841,10 +837,6 @@ def _looks_like_sensitive_delivery_value(text: str) -> bool:
     if lowered == REDACTED_VALUE:
         return True
     if lowered.startswith(("bearer ", "basic ", "token ")):
-        return True
-    if DELIVERY_CREDENTIAL_URL_RE.search(text):
-        return True
-    if DELIVERY_WEBHOOK_URL_RE.search(text):
         return True
     if DELIVERY_PRIVATE_KEY_RE.search(text):
         return True

--- a/app/security/audit.py
+++ b/app/security/audit.py
@@ -17,6 +17,7 @@ from sqlalchemy import text
 
 from app.extensions import db
 from app.models import SecurityAuditEvent, User
+from app.security.sensitive_values import contains_sensitive_url
 from app.security.session_hmac import active_hmac_hex
 
 
@@ -61,14 +62,6 @@ ACCOUNT_KEY_PARTS = (
     "pan",
 )
 
-SENSITIVE_CREDENTIAL_URL_RE = re.compile(
-    r"\b(?:postgres(?:ql)?|redis)://[^\s/@]*:[^\s/@]*@",
-    re.IGNORECASE,
-)
-SENSITIVE_WEBHOOK_URL_RE = re.compile(
-    r"https://(?:[^/\s]*hooks[^/\s]*|discord(?:app)?\.com)/(?:api/)?(?:webhooks|services)/\S+",
-    re.IGNORECASE,
-)
 SENSITIVE_PRIVATE_KEY_RE = re.compile(
     r"BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY",
     re.IGNORECASE,
@@ -486,7 +479,10 @@ def _sanitize_metadata_value(value: Any, key_lower: str, *, depth: int) -> Any:
     if depth < 4 and isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
         return [_sanitize_metadata_value(item, key_lower, depth=depth + 1) for item in list(value)[:20]]
 
-    text = _clean_audit_text(value, 256)
+    raw_text = str(value)
+    if contains_sensitive_url(raw_text):
+        return REDACTED_VALUE
+    text = _clean_audit_text(raw_text, 256)
     if _looks_like_sensitive_value(text) or _looks_like_account_value(key_lower, text):
         return REDACTED_VALUE
     return text
@@ -510,10 +506,6 @@ def _is_sensitive_key(key_lower: str) -> bool:
 def _looks_like_sensitive_value(text: str) -> bool:
     lowered = text.casefold()
     if lowered.startswith(("bearer ", "basic ", "token ")):
-        return True
-    if SENSITIVE_CREDENTIAL_URL_RE.search(text):
-        return True
-    if SENSITIVE_WEBHOOK_URL_RE.search(text):
         return True
     if SENSITIVE_PRIVATE_KEY_RE.search(text):
         return True

--- a/app/security/passwords.py
+++ b/app/security/passwords.py
@@ -137,7 +137,7 @@ def _is_password_pwned_by_hibp(password: str) -> bool:
             count = int(count_text.strip())
             if hmac.compare_digest(candidate_suffix.strip().upper(), hash_suffix) and count > 0:
                 return True
-    except (UnicodeDecodeError, ValueError) as exc:
+    except ValueError as exc:
         raise LivePasswordCheckUnavailable("HIBP response could not be parsed") from exc
 
     return False

--- a/app/security/sensitive_values.py
+++ b/app/security/sensitive_values.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+
+_CREDENTIAL_SCHEMES = ("postgres://", "postgresql://", "redis://")
+_WEBHOOK_SCHEME = "https://"
+_WEBHOOK_HOSTS = frozenset({"discord.com", "discordapp.com"})
+_WEBHOOK_PATH_PREFIXES = ("webhooks/", "services/")
+_ASCII_LOWER_TRANSLATION = str.maketrans(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    "abcdefghijklmnopqrstuvwxyz",
+)
+
+
+def contains_sensitive_url(text: str) -> bool:
+    """Return whether text contains a credential-bearing or webhook URL."""
+    return contains_credential_url(text) or contains_webhook_url(text)
+
+
+def contains_credential_url(text: str) -> bool:
+    """Detect supported credential URLs with a deterministic linear scan."""
+    folded = text.translate(_ASCII_LOWER_TRANSLATION)
+    for scheme in _CREDENTIAL_SCHEMES:
+        cursor = 0
+        while True:
+            scheme_index = folded.find(scheme, cursor)
+            if scheme_index < 0:
+                break
+            cursor = scheme_index + 1
+            if scheme_index and _is_word_character(text[scheme_index - 1]):
+                continue
+            if _authority_contains_password(text, scheme_index + len(scheme)):
+                return True
+    return False
+
+
+def contains_webhook_url(text: str) -> bool:
+    """Detect supported webhook URLs without regex backtracking."""
+    folded = text.translate(_ASCII_LOWER_TRANSLATION)
+    cursor = 0
+    while True:
+        scheme_index = folded.find(_WEBHOOK_SCHEME, cursor)
+        if scheme_index < 0:
+            return False
+        cursor = scheme_index + 1
+        authority_start = scheme_index + len(_WEBHOOK_SCHEME)
+        path_start = _path_start(text, authority_start)
+        if path_start < 0:
+            continue
+        host = folded[authority_start : path_start - 1]
+        if _is_webhook_host(host) and _has_webhook_path(text, folded, path_start):
+            return True
+
+
+def _authority_contains_password(text: str, authority_start: int) -> bool:
+    has_userinfo_separator = False
+    for char in text[authority_start:]:
+        if char.isspace() or char == "/":
+            return False
+        if char == "@":
+            return has_userinfo_separator
+        if char == ":":
+            has_userinfo_separator = True
+    return False
+
+
+def _path_start(text: str, authority_start: int) -> int:
+    for index in range(authority_start, len(text)):
+        char = text[index]
+        if char.isspace():
+            return -1
+        if char == "/":
+            return index + 1
+    return -1
+
+
+def _is_webhook_host(host: str) -> bool:
+    return "hooks" in host or host in _WEBHOOK_HOSTS
+
+
+def _has_webhook_path(text: str, folded: str, path_start: int) -> bool:
+    if folded.startswith("api/", path_start):
+        path_start += len("api/")
+    for prefix in _WEBHOOK_PATH_PREFIXES:
+        if folded.startswith(prefix, path_start):
+            secret_start = path_start + len(prefix)
+            return secret_start < len(text) and not text[secret_start].isspace()
+    return False
+
+
+def _is_word_character(char: str) -> bool:
+    return char == "_" or char.isalnum()

--- a/docs/security/sonarqube.md
+++ b/docs/security/sonarqube.md
@@ -141,6 +141,13 @@ that no reusable credential value is committed. HTTP used solely between
 ephemeral containers on an isolated smoke-test network is also a reviewed
 false positive; production and external traffic remain HTTPS-only.
 
+The Python base image intentionally retains both its specific version tag and
+its immutable digest. Docker resolves the image by digest, while the tag keeps
+the intended `3.12.13-slim-trixie` release line visible to Dependabot. A
+maintainability finding that asks for only one of those identifiers should be
+accepted with this rationale rather than removing reproducible pinning or
+automated version tracking.
+
 Four cognitive-complexity findings are accepted maintainability debt in
 central registration and security-boundary functions:
 

--- a/docs/security/test-automation-and-dependencies.md
+++ b/docs/security/test-automation-and-dependencies.md
@@ -11,7 +11,7 @@ and test evidence found in the repository.
 | `requirements.lock` | Runtime Python lockfile | Generated with hashes and consumed by `pip-audit --require-hashes` |
 | `requirements-dev.in` | Development/test dependencies | Includes `-r requirements.in`, `pytest`, `pytest-cov`, `pytest-xdist`, `pip-audit`, `bandit`, and `pip-tools` |
 | `requirements-dev.lock` | Development/test lockfile | Generated with hashes and audited separately |
-| `Dockerfile` | Runtime image | Uses pinned Python base image digest and creates non-root UID/GID `10001:10001` |
+| `Dockerfile` | Runtime image | Uses a version tag plus immutable Python base-image digest for Dependabot tracking and reproducible builds, keeps application code root-owned and read-only, and runs as non-root UID/GID `10001:10001` |
 | `compose.prod.yml` | Production deployment model | Uses Docker secrets, read-only app containers, loopback bindings, and separate customer/admin secret sets |
 | `compose.staging.yml` | Staging deployment model | Uses separate staging secrets and database roles |
 | `docker-compose.test.yml` | Test/CI compose model | Used by container smoke and validation flows |

--- a/tests/test_admin_service_edge_coverage.py
+++ b/tests/test_admin_service_edge_coverage.py
@@ -20,6 +20,13 @@ def test_email_normalizers_reject_malformed_and_aliased_addresses(app):
             services.normalize_personal_email("not-an-email")
 
 
+def test_phone_validation_remains_ascii_only():
+    assert services.validate_phone_number("91234567") == "91234567"
+
+    with pytest.raises(AuthError, match="Invalid phone number"):
+        services.validate_phone_number("9１２３４５６７")
+
+
 def test_invalid_invite_token_records_audited_failure(app, monkeypatch):
     reasons: list[tuple[str, bool]] = []
     monkeypatch.setattr(

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -43,8 +43,9 @@ KNOWN_NODE20_ACTION_USES = {
     "actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48",
     "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02",
 }
-PYTHON_SLIM_TRIXIE_DIGEST_RE = re.compile(
-    r"python:3\.12(?:\.\d+)?-slim-trixie@sha256:[0-9a-f]{64}"
+PYTHON_SLIM_TRIXIE_IMAGE = (
+    "python:3.12.13-slim-trixie@sha256:"
+    "6c4dd321d176d61ea848dc8c73a4f7dbae8f70e0ee48bb411ea2f045b599fa8e"
 )
 
 ROOT_ADMIN_EMAILS_VALUE = ",".join(
@@ -1195,12 +1196,14 @@ def test_dockerfile_and_compose_enforce_hardened_runtime():
     stage_images = _dockerfile_stage_images(dockerfile)
     assert set(stage_images) == {"builder", "runtime"}
     assert stage_images["builder"] == stage_images["runtime"]
-    assert PYTHON_SLIM_TRIXIE_DIGEST_RE.fullmatch(stage_images["runtime"]), (
-        "Dockerfile must use a Python 3.12 slim-trixie base image pinned by "
-        f"sha256 digest, got {stage_images['runtime']}"
-    )
+    assert stage_images["runtime"] == PYTHON_SLIM_TRIXIE_IMAGE
+    assert "Keep the version tag for Dependabot tracking" in dockerfile
     assert 'org.opencontainers.image.title="SITBank banking application"' in dockerfile
     assert "USER 10001:10001" in dockerfile
+    assert "install -d -o root -g 10001 -m 0750 /app" in dockerfile
+    assert dockerfile.count("COPY --chown=0:0") == 3
+    assert "--chown=10001:10001" not in dockerfile
+    assert "RUN chmod -R a-w /app" in dockerfile
     assert "--require-hashes" in dockerfile
     assert "/health/ready" in dockerfile
     assert "admin_wsgi.py" in dockerfile

--- a/tests/test_sensitive_values.py
+++ b/tests/test_sensitive_values.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from app.security.alerts import _sanitize_alert_for_delivery
+from app.security.audit import _sanitize_metadata
+from app.security.sensitive_values import (
+    contains_credential_url,
+    contains_sensitive_url,
+    contains_webhook_url,
+)
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        "postgresql://user:password@db/sitbank",
+        "prefix redis://:password@redis:6379/0 suffix",
+        "POSTGRES://service:secret@db/sitbank",
+        "Straße POSTGRESQL://service:secret@db/sitbank",
+    ),
+)
+def test_credential_url_scanner_detects_supported_urls(value):
+    assert contains_credential_url(value)
+    assert contains_sensitive_url(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        "xpostgresql://user:password@db/sitbank",
+        "postgresql://user@db/sitbank",
+        "postgresql://user:password/db@sitbank",
+        "redis://cache:6379/0",
+    ),
+)
+def test_credential_url_scanner_rejects_noncredential_text(value):
+    assert not contains_credential_url(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        "https://hooks.example.test/services/webhook-secret",
+        "https://discord.com/api/webhooks/1234567890/webhook-secret",
+        "HTTPS://DISCORDAPP.COM/SERVICES/webhook-secret",
+        "Straße HTTPS://HOOKS.EXAMPLE.TEST/SERVICES/webhook-secret",
+    ),
+)
+def test_webhook_url_scanner_detects_supported_urls(value):
+    assert contains_webhook_url(value)
+    assert contains_sensitive_url(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        "http://hooks.example.test/services/webhook-secret",
+        "https://discord.example.test/api/webhooks/123/secret",
+        "https://example.test/services/webhook-secret",
+        "https://hooks.example.test/services/",
+        "https://hooks.example.test bad/services/webhook-secret",
+        "https://hooks.example.test/not-a-webhook/secret",
+    ),
+)
+def test_webhook_url_scanner_rejects_unrelated_urls(value):
+    assert not contains_webhook_url(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        "postgresql://user:" + ("a:" * 50_000),
+        "https://" + ("hookshooks" * 10_000),
+    ),
+    ids=("credential", "webhook"),
+)
+def test_sensitive_url_scanner_rejects_long_attack_text_quickly(value):
+    started = time.perf_counter()
+
+    assert not contains_sensitive_url(value)
+
+    assert time.perf_counter() - started < 0.5
+
+
+@pytest.mark.parametrize(
+    ("sanitize", "limit"),
+    (
+        (_sanitize_metadata, 256),
+        (_sanitize_alert_for_delivery, 512),
+    ),
+)
+def test_sanitizers_scan_full_values_before_applying_output_limits(sanitize, limit):
+    credential_url = "postgresql://user:" + ("p" * (limit * 2)) + "@db/sitbank"
+    webhook_url = "https://hooks.example.test/services/" + ("s" * (limit * 2))
+
+    assert sanitize({"reason": credential_url})["reason"] == "[redacted]"
+    assert sanitize({"reason": webhook_url})["reason"] == "[redacted]"
+
+
+@pytest.mark.parametrize(
+    ("sanitize", "limit"),
+    (
+        (_sanitize_metadata, 256),
+        (_sanitize_alert_for_delivery, 512),
+    ),
+)
+def test_sanitizers_bound_long_nonsensitive_output(sanitize, limit):
+    sanitized = sanitize({"reason": "a" * (limit * 2)})
+
+    assert sanitized["reason"] == "a" * limit

--- a/tests/test_sonarqube_workflow.py
+++ b/tests/test_sonarqube_workflow.py
@@ -214,6 +214,9 @@ def test_sonarqube_docs_record_cloud_private_repo_and_nonblocking_policy():
         assert required in normalized
     assert "SONAR_HOST_URL" in normalized
     assert "sonar.qualitygate.wait=false" in normalized
+    assert "specific version tag" in normalized
+    assert "immutable digest" in normalized
+    assert "visible to Dependabot" in normalized
 
 
 def test_active_docs_do_not_claim_sonarqube_is_missing():


### PR DESCRIPTION
## Summary

Remediates SonarQube security hotspot and maintainability findings on `codex/sonarqube-security-hotspots-maintainability`, and updates the Docker base image pinning and runtime filesystem permissions.

This replaces vulnerable regex URL detection with deterministic URL scanning, improves sanitizer behavior so complete values are inspected before truncation, removes redundant exception handling, reviews safe TOTP hotspots, updates the Dockerfile to a verified base-image digest, and makes `/app` root-owned and read-only for the runtime UID.

## Why

SonarQube reported security hotspot and maintainability findings that should either be remediated, explicitly reviewed, or documented before the scan output can be treated as clean review evidence.

The regex findings were worth fixing because URL scanning in sensitive-value handling should be deterministic and avoid vulnerable regular-expression behavior.

The sanitizer changes ensure audit and alert paths inspect full values before output shortening, reducing the chance that sensitive content is hidden by truncation before detection.

The Dockerfile update improves image reproducibility and runtime hardening by keeping the base image pinned with a verified digest and preventing UID `10001` from modifying application code.

## What changed

* Created `codex/sonarqube-security-hotspots-maintainability`.
* Replaced four vulnerable regexes in `app/security/sensitive_values.py` with deterministic URL scanning.
* Updated audit sanitization to inspect complete values before truncation.
* Updated alert sanitization to inspect complete values before truncation.
* Preserved ASCII-only phone validation using `\d` with `re.ASCII`.
* Removed the redundant `UnicodeDecodeError` catch.
* Reviewed both HMAC-SHA1 TOTP security hotspots as safe in SonarQube.
* Updated `Dockerfile` to use the new verified digest:

  * `sha256:6c4dd3…599fa8e`
* Kept the `tag@digest` base-image format.
* Documented the rationale for accepting the Sonar finding:

  * the digest provides reproducibility
  * the tag supports Dependabot’s tag-based update tracking
* Made `/app` root-owned and read-only.
* Preserved UID `10001` read/execute access.
* Prevented UID `10001` from modifying application code.
* Generated `coverage.xml`.
* Preserved existing quality rules, thresholds, and dependency posture.

## Security impact

This improves sensitive-value scanning, sanitizer correctness, Docker image reproducibility, and runtime filesystem hardening.

Replacing vulnerable URL regexes with deterministic scanning reduces regex-related risk in security-sensitive sanitization code.

Inspecting complete audit and alert values before truncation improves the chance that sensitive material is detected before sanitized output is shortened.

Making `/app` root-owned and read-only limits the non-root runtime user’s ability to modify application code inside the container.

The TOTP HMAC-SHA1 hotspots were reviewed as safe because HMAC-SHA1 is part of the standard TOTP construction and is not being used as a general-purpose password hashing or collision-resistant signature primitive.

No application secrets, tokens, private keys, or production credentials were added.

## Deployment impact

This PR requires:

* staging deployment
* production deployment

This PR does not require:

* EC2 bootstrap
* database migration
* secret changes

The Docker image must be rebuilt and redeployed for the updated base-image digest and `/app` permission hardening to take effect.

## Verification

* Docker image:

  * Builds successfully
* Runtime permissions:

  * Verified
* Full suite:

  * `736 passed, 2 skipped`
* Local coverage:

  * `81.44%`
  * Baseline: `79.6%`
* New scanner coverage:

  * `100%`
* `coverage.xml`

  * Generated
* Bandit:

  * Passed
* Compilation:

  * Passed
* `git diff --check`

  * Passed
* Current SonarQube state:

  * Quality gate passed
  * TOTP hotspots: `2` reviewed safe
  * Regex hotspots: `4` awaiting branch CI analysis
  * Maintainability issues: `2` awaiting branch CI analysis

## Notes

SonarQube branch CI still needs to reanalyze this branch before the regex hotspot and maintainability issue state updates remotely.

The TOTP hotspots were reviewed as safe rather than changed because the existing HMAC-SHA1 use is appropriate for TOTP.

The Docker base image intentionally keeps `tag@digest`: the digest provides reproducibility, while the tag keeps Dependabot tracking practical.
