### PR TITLE
Add admin browser login MFA flow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,27 @@
-## Summary
+Summary
+---
 
 Briefly describe what this PR improves or fixes.
 
-## Why
+Why
+---
 
 Explain the problem, risk, or reason this change is needed.
 
-## What changed
+What changed
+---
 
 *
 *
 *
 
-## Security impact
+Security impact
+---
 
 Explain how this affects security controls, secrets, permissions, auth, CI/CD, deployment safety, or runtime behavior.
 
-## Deployment impact
+Deployment impact
+---
 
 Explain whether this PR requires:
 
@@ -27,12 +32,14 @@ Explain whether this PR requires:
 * secret changes
 * no deployment action
 
-## Verification
+Verification
+---
 
 *
 *
 *
 
-## Notes
+Notes
+---
 
 Add any follow-up work, limitations, or operator instructions.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SITBank
+﻿# SITBank
 
 Secure Internet Banking Application for O$P$ Bank.
 
@@ -6,7 +6,7 @@ SITBank is a student cybersecurity project and demonstration site. Do not enter 
 
 ## Overview
 
-SITBank is a Flask/Gunicorn application deployed as hardened Docker containers behind host-managed Nginx, TLS, and PostgreSQL. Production customer traffic runs at `https://sitbank.duckdns.org`; operators use the private Tailscale Serve URL `https://sitbank-ec2.tailca101b.ts.net/` with a separate admin app, cookie, session keys, database role, root-admin-controlled staff invites, and mandatory TOTP. Staging runs separately at `https://staging-sitbank.pp.ua`.
+SITBank is a Flask/Gunicorn application deployed as hardened Docker containers behind host-managed Nginx, TLS, and PostgreSQL. Production customer traffic runs at `https://sitbank.duckdns.org`; operators use the private Tailscale Serve URL `https://admin-sitbank.tailca101b.ts.net/` with a separate admin app, browser login at `/login`, cookie, session keys, database role, manual root-admin bootstrap, root-admin-controlled staff invites, and mandatory TOTP. Staging runs separately at `https://staging-sitbank.pp.ua`.
 
 Security-critical state is stored in application-owned PostgreSQL tables. Server-side sessions, authentication failure counters, TOTP replay markers, registration OTP challenges, password-reset transactions, security-alert dedupe windows, and breached-password circuit-breaker state are stored in dedicated tables. Browser cookies keep only opaque identifiers; lookup hashes are HMAC-derived with `SESSION_LOOKUP_HMAC_KEY` or `ADMIN_SESSION_LOOKUP_HMAC_KEY`, and stored session payloads remain signed with the session HMAC keyring.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
-# SITBank Security Operations
+﻿# SITBank Security Operations
 
 ## Reporting
 
@@ -67,10 +67,15 @@ session cookie, session-signing material, session-lookup HMAC key, and database
 runtime role. The admin role must be distinct from both `sitbank_app` and
 `sitbank_owner`; it must not use migration/schema-owner credentials. Admin
 access is private operator access only through Tailscale Serve at
-`https://sitbank-ec2.tailca101b.ts.net/`; do not enable Tailscale Funnel and
+`https://admin-sitbank.tailca101b.ts.net/`; do not enable Tailscale Funnel and
 do not expose admin through the customer app or any public admin Nginx route.
 The Flask admin app still uses a separate cookie, session HMAC keyring,
-database role, root-admin-controlled staff invites, and mandatory TOTP.
+database role, manual root-admin bootstrap, browser password login, TOTP
+verification, root-admin-controlled staff invites, and mandatory TOTP.
+Bootstrapped root admins open `https://admin-sitbank.tailca101b.ts.net/login`,
+authenticate with the existing admin password and TOTP flow, and then reach the
+private dashboard at `https://admin-sitbank.tailca101b.ts.net/`. Customer
+accounts cannot authenticate to the admin runtime.
 
 Staging access is protected by Cloudflare Access before Nginx/Flask and by
 Cloudflare Authenticated Origin Pulls at the staging Nginx origin. Direct

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -19,6 +19,7 @@ from app.security.production_guard import (
 from app.security.rate_limits import request_principal
 
 from .services import (
+    ADMIN_INDEX_ENDPOINT,
     AuthError,
     admin_navigation_for,
     admin_dashboard_context,
@@ -50,7 +51,6 @@ admin_bp = Blueprint("admin", __name__)
 _TOTP_PATTERN = r"^[0-9]{6}$"
 _MFA_CODE_ERROR = "MFA code must be exactly 6 digits"
 _JSON_MIME_TYPE = "application/json"
-_ADMIN_INDEX_ENDPOINT = "admin.index"
 _STAFF_ACCOUNTS_ENDPOINT = "admin.staff_accounts"
 _ADMIN_LOGIN_TEMPLATE = "admin/login.html"
 _ADMIN_MFA_VERIFY_TEMPLATE = "admin/mfa_verify.html"
@@ -246,7 +246,7 @@ def index():
 @admin_bp.get("/login")
 def login_form():
     if getattr(g, "current_user", None) is not None:
-        return redirect(url_for(_ADMIN_INDEX_ENDPOINT))
+        return redirect(url_for(ADMIN_INDEX_ENDPOINT))
     if request.args.get("session_expired"):
         flash("Your admin session expired. Please log in again.", "warning")
     return _render_login_form()[0]
@@ -288,7 +288,7 @@ def login():
 @admin_bp.get("/mfa/verify")
 def mfa_verify_form():
     if getattr(g, "current_user", None) is not None:
-        return redirect(url_for(_ADMIN_INDEX_ENDPOINT))
+        return redirect(url_for(ADMIN_INDEX_ENDPOINT))
     if not session.get("pending_mfa_user_id"):
         if _wants_json():
             return jsonify({"error": "No pending MFA challenge"}), 401
@@ -320,7 +320,7 @@ def mfa_verify():
         return _render_mfa_form(form, status_code=exc.status_code)
 
     flash("Login successful.", "success")
-    return redirect(url_for(_ADMIN_INDEX_ENDPOINT)), 303
+    return redirect(url_for(ADMIN_INDEX_ENDPOINT)), 303
 
 
 @admin_bp.post("/logout")

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
-from flask import Blueprint, current_app, flash, jsonify, redirect, render_template, request, url_for
+from flask import Blueprint, current_app, flash, g, jsonify, redirect, render_template, request, session, url_for
 from flask_limiter.util import get_remote_address
+from flask_wtf import FlaskForm
 from flask_wtf.csrf import generate_csrf
 from marshmallow import Schema, ValidationError, fields, validate, validates_schema
 from sqlalchemy import text
+from wtforms import PasswordField, StringField
+from wtforms.validators import Email, InputRequired, Length, Regexp
 
 from app.extensions import db, limiter
 from app.security.alerts import build_security_alert_report
@@ -48,6 +51,8 @@ _TOTP_PATTERN = r"^[0-9]{6}$"
 _MFA_CODE_ERROR = "MFA code must be exactly 6 digits"
 _JSON_MIME_TYPE = "application/json"
 _STAFF_ACCOUNTS_ENDPOINT = "admin.staff_accounts"
+_ADMIN_LOGIN_TEMPLATE = "admin/login.html"
+_ADMIN_MFA_VERIFY_TEMPLATE = "admin/mfa_verify.html"
 
 
 class AdminLoginSchema(Schema):
@@ -60,6 +65,24 @@ class AdminTotpSchema(Schema):
         required=True,
         load_only=True,
         validate=validate.Regexp(_TOTP_PATTERN, error=_MFA_CODE_ERROR),
+    )
+
+
+class AdminLoginForm(FlaskForm):
+    workplace_email = StringField(
+        "Workplace email",
+        validators=[InputRequired(), Email(), Length(max=255)],
+    )
+    password = PasswordField("Password", validators=[InputRequired()])
+
+
+class AdminTotpForm(FlaskForm):
+    totp_code = StringField(
+        "Authenticator code",
+        validators=[
+            InputRequired(),
+            Regexp(_TOTP_PATTERN, message=_MFA_CODE_ERROR),
+        ],
     )
 
 
@@ -155,7 +178,9 @@ def handle_validation_error(_error: ValidationError):
 def _payload(schema: Schema) -> dict:
     if request.is_json:
         return schema.load(request.get_json(silent=False) or {})
-    return schema.load(dict(request.form))
+    payload = dict(request.form)
+    payload.pop("csrf_token", None)
+    return schema.load(payload)
 
 
 def _request_fields() -> set[str]:
@@ -172,6 +197,14 @@ def _wants_json() -> bool:
     return best == _JSON_MIME_TYPE and (
         request.accept_mimetypes[_JSON_MIME_TYPE] >= request.accept_mimetypes["text/html"]
     )
+
+
+def _render_login_form(form: AdminLoginForm | None = None, *, status_code: int = 200):
+    return render_template(_ADMIN_LOGIN_TEMPLATE, form=form or AdminLoginForm()), status_code
+
+
+def _render_mfa_form(form: AdminTotpForm | None = None, *, status_code: int = 200):
+    return render_template(_ADMIN_MFA_VERIFY_TEMPLATE, form=form or AdminTotpForm()), status_code
 
 
 @admin_bp.get("/health/live")
@@ -209,22 +242,84 @@ def index():
     return render_template("admin/dashboard.html", **admin_dashboard_context(user))
 
 
+@admin_bp.get("/login")
+def login_form():
+    if getattr(g, "current_user", None) is not None:
+        return redirect(url_for("admin.index"))
+    if request.args.get("session_expired"):
+        flash("Your admin session expired. Please log in again.", "warning")
+    return _render_login_form()[0]
+
+
 @admin_bp.post("/login")
 @limiter.limit("50 per day", key_func=get_remote_address)
 @limiter.limit("50 per day", key_func=request_principal)
 @limiter.limit("5 per minute", key_func=get_remote_address)
 @limiter.limit("5 per minute", key_func=request_principal)
 def login():
-    data = _payload(AdminLoginSchema())
-    return jsonify(authenticate_admin_primary(data["workplace_email"], data["password"]))
+    if _wants_json():
+        data = _payload(AdminLoginSchema())
+        return jsonify(authenticate_admin_primary(data["workplace_email"], data["password"]))
+
+    form = AdminLoginForm()
+    if not form.validate_on_submit():
+        return _render_login_form(form, status_code=400)
+
+    try:
+        data = AdminLoginSchema().load(
+            {
+                "workplace_email": form.workplace_email.data,
+                "password": form.password.data,
+            }
+        )
+        authenticate_admin_primary(data["workplace_email"], data["password"])
+    except ValidationError:
+        flash("Invalid request", "error")
+        return _render_login_form(form, status_code=400)
+    except AuthError as exc:
+        flash(exc.message, "error")
+        return _render_login_form(form, status_code=exc.status_code)
+
+    flash("Enter your authenticator code to finish signing in.", "info")
+    return redirect(url_for("admin.mfa_verify_form")), 303
+
+
+@admin_bp.get("/mfa/verify")
+def mfa_verify_form():
+    if getattr(g, "current_user", None) is not None:
+        return redirect(url_for("admin.index"))
+    if not session.get("pending_mfa_user_id"):
+        if _wants_json():
+            return jsonify({"error": "No pending MFA challenge"}), 401
+        flash("Please log in first.", "warning")
+        return redirect(url_for("admin.login_form")), 303
+    return _render_mfa_form()[0]
 
 
 @admin_bp.post("/mfa/verify")
 @limiter.limit("5 per 5 minutes", key_func=get_remote_address)
 @limiter.limit("5 per 5 minutes", key_func=request_principal)
 def mfa_verify():
-    data = _payload(AdminTotpSchema())
-    return jsonify(complete_admin_mfa_login(data["totp_code"]))
+    if _wants_json():
+        data = _payload(AdminTotpSchema())
+        return jsonify(complete_admin_mfa_login(data["totp_code"]))
+
+    if not session.get("pending_mfa_user_id"):
+        flash("Please log in first.", "warning")
+        return redirect(url_for("admin.login_form")), 303
+
+    form = AdminTotpForm()
+    if not form.validate_on_submit():
+        return _render_mfa_form(form, status_code=400)
+
+    try:
+        complete_admin_mfa_login(form.totp_code.data)
+    except AuthError as exc:
+        flash(exc.message, "error")
+        return _render_mfa_form(form, status_code=exc.status_code)
+
+    flash("Login successful.", "success")
+    return redirect(url_for("admin.index")), 303
 
 
 @admin_bp.post("/logout")

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -50,6 +50,7 @@ admin_bp = Blueprint("admin", __name__)
 _TOTP_PATTERN = r"^[0-9]{6}$"
 _MFA_CODE_ERROR = "MFA code must be exactly 6 digits"
 _JSON_MIME_TYPE = "application/json"
+_ADMIN_INDEX_ENDPOINT = "admin.index"
 _STAFF_ACCOUNTS_ENDPOINT = "admin.staff_accounts"
 _ADMIN_LOGIN_TEMPLATE = "admin/login.html"
 _ADMIN_MFA_VERIFY_TEMPLATE = "admin/mfa_verify.html"
@@ -245,7 +246,7 @@ def index():
 @admin_bp.get("/login")
 def login_form():
     if getattr(g, "current_user", None) is not None:
-        return redirect(url_for("admin.index"))
+        return redirect(url_for(_ADMIN_INDEX_ENDPOINT))
     if request.args.get("session_expired"):
         flash("Your admin session expired. Please log in again.", "warning")
     return _render_login_form()[0]
@@ -287,7 +288,7 @@ def login():
 @admin_bp.get("/mfa/verify")
 def mfa_verify_form():
     if getattr(g, "current_user", None) is not None:
-        return redirect(url_for("admin.index"))
+        return redirect(url_for(_ADMIN_INDEX_ENDPOINT))
     if not session.get("pending_mfa_user_id"):
         if _wants_json():
             return jsonify({"error": "No pending MFA challenge"}), 401
@@ -319,7 +320,7 @@ def mfa_verify():
         return _render_mfa_form(form, status_code=exc.status_code)
 
     flash("Login successful.", "success")
-    return redirect(url_for("admin.index")), 303
+    return redirect(url_for(_ADMIN_INDEX_ENDPOINT)), 303
 
 
 @admin_bp.post("/logout")

--- a/app/templates/admin/login.html
+++ b/app/templates/admin/login.html
@@ -1,0 +1,38 @@
+{% extends "admin/base.html" %}
+
+{% block title %}Admin Login | SITBank{% endblock %}
+
+{% block content %}
+<section class="auth-shell">
+  <div class="auth-intro">
+    <p class="eyebrow">Private admin access</p>
+    <h1>SITBank Admin</h1>
+    <p class="lede">Sign in with your SIT workplace account.</p>
+  </div>
+
+  <div class="auth-card">
+    <div class="page-heading">
+      <p class="eyebrow">Staff authentication</p>
+      <h2>Log in</h2>
+    </div>
+
+    <form method="post" action="{{ url_for('admin.login') }}" novalidate>
+      {{ form.hidden_tag() }}
+
+      <div class="form-group">
+        <label for="{{ form.workplace_email.id }}">Workplace email</label>
+        {{ form.workplace_email(autocomplete="username", maxlength="255") }}
+        {% for error in form.workplace_email.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
+      </div>
+
+      <div class="form-group">
+        <label for="{{ form.password.id }}">Password</label>
+        {{ form.password(autocomplete="current-password") }}
+        {% for error in form.password.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
+      </div>
+
+      <button class="button full" type="submit">Continue</button>
+    </form>
+  </div>
+</section>
+{% endblock %}

--- a/app/templates/admin/mfa_verify.html
+++ b/app/templates/admin/mfa_verify.html
@@ -1,0 +1,26 @@
+{% extends "admin/base.html" %}
+
+{% block title %}Admin MFA Verification | SITBank{% endblock %}
+
+{% block content %}
+<section class="auth-card narrow">
+  <div class="page-heading">
+    <p class="eyebrow">Second step</p>
+    <h1>Authenticator code</h1>
+    <p class="muted">Enter the current six-digit code for this admin account.</p>
+  </div>
+
+  <form method="post" action="{{ url_for('admin.mfa_verify') }}" novalidate>
+    {{ form.hidden_tag() }}
+
+    <div class="form-group">
+      <label for="{{ form.totp_code.id }}">Authenticator code</label>
+      {{ form.totp_code(autocomplete="one-time-code", inputmode="numeric", maxlength="6") }}
+      {% for error in form.totp_code.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
+    </div>
+
+    <button class="button full" type="submit">Verify</button>
+  </form>
+  <p class="switch-link"><a href="{{ url_for('admin.login_form') }}">Back to login</a></p>
+</section>
+{% endblock %}

--- a/docs/CONTRIBUTION_MESSAGE_POLICY.md
+++ b/docs/CONTRIBUTION_MESSAGE_POLICY.md
@@ -60,8 +60,17 @@ release notes, and reduce ambiguity during incident response or rollback.
 
 ## PR Description Requirements
 
-Pull requests must also fill in the repository PR template. The description
-must include these sections, either as plain headings or Markdown headings:
+Pull requests must also fill in the repository PR template. Use Setext-style
+Markdown headings so each section name is followed by a `---` underline, for
+example:
+
+```markdown
+Summary
+---
+Adds the change in one short paragraph.
+```
+
+The description must include these sections:
 
 - `Summary`
 - `Why`

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,11 +1,11 @@
-# Deployment
+﻿# Deployment
 
 ## Current Architecture
 
 Only Flask/Gunicorn runs in the SITBank container. Nginx, TLS, PostgreSQL, and backups remain host-managed on EC2. Sessions, authentication counters, OTP/reset state, alert dedupe, and breached-password circuit state live in application-owned PostgreSQL tables.
 
 - Production public host: `sitbank.duckdns.org`
-- Production private admin URL: `https://sitbank-ec2.tailca101b.ts.net/`
+- Production private admin URL: `https://admin-sitbank.tailca101b.ts.net/`
 - Staging public host: `staging-sitbank.pp.ua`
 - Staging Cloudflare Access host: `staging-sitbank.pp.ua`
 - Production customer access: public HTTPS
@@ -163,9 +163,13 @@ can enforce the fixed root-admin group. Root-admin bootstrap remains manual
 over SSH inside the admin container; it is not a GitHub Actions workflow.
 
 Production admin does not use a public DNS hostname. Keep admin access on the
-private Tailscale Serve URL `https://sitbank-ec2.tailca101b.ts.net/` and do
-not enable Tailscale Funnel. Production still requires root-managed admin
-secret files under `/etc/sitbank/secrets`: `admin_secret_key`,
+private Tailscale Serve URL `https://admin-sitbank.tailca101b.ts.net/` and do
+not enable Tailscale Funnel. Bootstrapped root admins open
+`https://admin-sitbank.tailca101b.ts.net/login`, authenticate with the existing
+admin password and TOTP flow, and are redirected to the private dashboard at
+`https://admin-sitbank.tailca101b.ts.net/`. Customer accounts cannot access the
+admin runtime. Production still requires root-managed admin secret files under
+`/etc/sitbank/secrets`: `admin_secret_key`,
 `admin_wtf_csrf_secret_key`, `admin_session_hmac_keys_json`,
 `admin_session_lookup_hmac_key`, `admin_database_url`, and
 `admin_password_pepper_b64`.
@@ -423,9 +427,10 @@ The reviewed production bootstrap installs and enables the production edge from 
   enable Tailscale Funnel or expose the admin app through the customer host.
 - Cloudflare or AWS WAF should sit in front of Nginx for managed common, SQL injection, XSS, bot, and protocol anomaly rules.
 - Cloudflare or AWS WAF rules and security-group allowlists are still infrastructure state and must be checked manually.
-- Flask admin auth is implemented only for root-admin-controlled invite
-  onboarding with mandatory TOTP, separate admin sessions, and no
-  password-only administrator login.
+- Flask admin auth supports manual root-admin bootstrap plus
+  root-admin-controlled staff invite onboarding with mandatory password and
+  TOTP login, separate admin sessions, and no password-only administrator
+  login.
 
 Verification:
 
@@ -457,7 +462,7 @@ admin routes publicly. The staging admin service must bind only to localhost
 and use a separate loopback port from production admin when both environments
 share one EC2 host. Production admin owns `127.0.0.1:5002`; staging admin owns
 `127.0.0.1:5003`. Operators use Tailscale VPN before opening the private
-production admin URL `https://sitbank-ec2.tailca101b.ts.net/`; staging admin
+production admin URL `https://admin-sitbank.tailca101b.ts.net/`; staging admin
 must use the same private-network pattern through an approved tailnet path. Do
 not enable Tailscale Funnel and do not add a public staging admin Nginx server
 block. Staging admin secrets must be root-managed under

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,4 +1,4 @@
-# Operations
+﻿# Operations
 
 Security owner roles, milestone/release review cadence, accepted-risk handling,
 and off-repo evidence expectations are defined in
@@ -56,8 +56,15 @@ SITBank uses a hybrid private-access model:
 - Staging is protected by Cloudflare Access and Cloudflare Authenticated Origin
   Pulls at `staging-sitbank.pp.ua`.
 - Admin is protected by Tailscale/private operator access at
-  `https://sitbank-ec2.tailca101b.ts.net/`.
+  `https://admin-sitbank.tailca101b.ts.net/`.
 - The production customer site `sitbank.duckdns.org` remains public.
+
+Bootstrapped root admins browse to
+`https://admin-sitbank.tailca101b.ts.net/login`, sign in with the existing
+admin workplace email and password, complete TOTP, and are redirected to the
+private dashboard at `https://admin-sitbank.tailca101b.ts.net/`. Customer
+accounts cannot authenticate to the admin app, and admin access remains
+Tailscale-only.
 
 The Access application, narrow approved-operator policy, session duration, and
 proxied staging DNS desired state are managed by
@@ -85,7 +92,7 @@ curl --fail --resolve staging-sitbank.pp.ua:443:127.0.0.1 \
 curl -I --resolve staging-sitbank.pp.ua:443:<EC2_PUBLIC_IP> \
   https://staging-sitbank.pp.ua/
 sudo tailscale serve status
-curl -I https://sitbank-ec2.tailca101b.ts.net/
+curl -I https://admin-sitbank.tailca101b.ts.net/login
 ```
 
 The origin-pull verifier is an offline host check. It rejects missing,
@@ -181,6 +188,9 @@ that output into logs, tickets, chat, shell history, or committed files. The
 bootstrap stores only the protected password hash and envelope-encrypted TOTP
 secret, sets the account active, marks the workplace email verified, and records
 a safe `root_admin_bootstrap` audit event without the password or TOTP secret.
+After bootstrap, open `https://admin-sitbank.tailca101b.ts.net/login` from an
+approved tailnet device and use that workplace email, password, and TOTP code to
+enter the private dashboard.
 
 ## EC2 SSH And Deployment Access Operations
 
@@ -456,7 +466,7 @@ the release or change record. Do not run a public-endpoint scan from ordinary
 pull requests.
 
 The normal public TLS scan deliberately excludes the private Tailscale admin hostname
-`sitbank-ec2.tailca101b.ts.net`; a GitHub-hosted public runner cannot reach it
+`admin-sitbank.tailca101b.ts.net`; a GitHub-hosted public runner cannot reach it
 unless a separate protected job joins the tailnet or uses a tailnet self-hosted
 runner. Do not make staging or admin verification pass by switching Cloudflare
 to Flexible SSL, disabling TLS verification, disabling the Cloudflare proxy,

--- a/docs/security/access-control.md
+++ b/docs/security/access-control.md
@@ -1,4 +1,4 @@
-# Access Control
+﻿# Access Control
 
 This document records the access-control model implemented in the SITBank
 repository. It distinguishes implemented runtime enforcement from test
@@ -107,8 +107,9 @@ remains in `tests/test_payee_management_security.py`.
 
 ## Admin And Staff Controls
 
-Admin/staff access is invite-only and uses the admin runtime. The implemented
-role hierarchy is:
+Admin/staff access uses the isolated admin runtime. Root admins are created or
+rotated only by the manual allowlisted bootstrap command; staff and admin users
+are invite-only after that. The implemented role hierarchy is:
 
 ```text
 root_admin > admin > staff > customer
@@ -123,7 +124,7 @@ admin runtime authorization checks.
 | Control | Implementation evidence | Test evidence |
 | --- | --- | --- |
 | Generated admin route authorization inventory | `app/admin/routes.py`; explicit policy entries in `tests/test_admin_route_inventory_security.py` | `tests/test_admin_route_inventory_security.py::test_admin_route_inventory_matches_registered_flask_routes`, `tests/test_admin_route_inventory_security.py::test_admin_route_inventory_has_complete_security_decisions` |
-| Staff/admin login requires workplace email, password, active account, verified workplace email, and TOTP | `app/admin/services.py::authenticate_staff_primary()` and `complete_staff_mfa()` | `tests/test_admin_staff_invites.py::test_admin_login_creates_only_admin_session_cookie` |
+| Staff/admin browser and JSON login requires workplace email, password, active account, verified workplace email, and TOTP | `app/admin/routes.py`, `app/admin/services.py::authenticate_admin_primary()` and `complete_admin_mfa_login()` | `tests/test_admin_dashboard_operations.py::test_admin_browser_login_and_mfa_reaches_dashboard`, `tests/test_admin_dashboard_operations.py::test_admin_json_login_contract_remains_compatible` |
 | Root admin is configured by role and email allowlist | `app/admin/services.py::is_root_admin()` and `config.py` `ROOT_ADMIN_EMAILS` | `tests/test_admin_staff_invites.py::test_only_root_admin_with_totp_stepup_can_create_invites` |
 | Root admin can invite only `staff` or `admin`, not `root_admin` | `StaffInvite` role constraint in `app/models.py`; role validation in `app/admin/services.py` | `tests/test_admin_staff_invites.py::test_invite_creation_validates_server_side_email_and_role_policy` |
 | Invite acceptance rejects forged privileged fields | `_reject_forged_invite_fields()` in `app/admin/services.py` | `tests/test_admin_staff_invites.py` |
@@ -135,14 +136,12 @@ admin runtime authorization checks.
 | Staff/customer self-action guard | `app/admin/separation.py::assert_not_self_customer_action()` | `tests/test_admin_staff_invites.py::test_separation_guard_blocks_linked_staff_acting_on_own_customer` |
 | Admin session context drift | Any detected coarse-network, browser-family, or detailed User-Agent drift revokes the admin session and requires full login | `app/security/sessions.py`, `tests/test_session_risk_binding.py::test_admin_context_change_revokes_session_under_stricter_policy` |
 
-Production Nginx currently defines an admin hostname in
-`ops/nginx/sitbank-production.conf` but denies public access to the primary
-admin paths with `deny all` or explicit `403` responses. This keeps the public
-admin hostname limited to denied root, health, and app responses. The actual
-admin application access path is the Tailscale Serve URL
-`https://sitbank-ec2.tailca101b.ts.net/`, followed by the normal Flask admin
-login and TOTP controls.
-Do not enable Tailscale Funnel or expose admin through the customer app.
+Production Nginx does not publish the admin app. The admin application access
+path is the Tailscale Serve URL `https://admin-sitbank.tailca101b.ts.net/`;
+operators open `/login`, complete the normal Flask admin password and TOTP
+controls, and then reach the dashboard. Do not enable Tailscale Funnel or
+expose admin through the customer app. Customer accounts cannot authenticate to
+the admin runtime.
 
 Manual recovery operator review is exposed only by the isolated admin app.
 `GET /manual-recovery/requests` lists public-safe request summaries for root
@@ -206,7 +205,7 @@ Network boundaries complement, but do not replace, Flask authorization:
 | --- | --- | --- |
 | Production customer | Public HTTPS at `sitbank.duckdns.org` | Customer login, MFA onboarding, CSRF, route inventory, rate limiting |
 | Staging customer | Cloudflare Access before Nginx, Cloudflare Authenticated Origin Pull at Nginx, staging Basic Auth | Customer login, MFA, CSRF, route inventory, rate limiting |
-| Production admin | Tailscale Serve at `https://sitbank-ec2.tailca101b.ts.net/`; public admin app routes denied | Staff/root-admin login, mandatory TOTP, CSRF, admin route inventory, admin rate limiting |
+| Production admin | Tailscale Serve at `https://admin-sitbank.tailca101b.ts.net/`; public admin app routes denied | Staff/root-admin login, mandatory TOTP, CSRF, admin route inventory, admin rate limiting |
 | Staging admin | Tailscale/private operator access to `127.0.0.1:5003`; no public admin host | Staff/root-admin login, mandatory TOTP, CSRF, admin route inventory, admin rate limiting |
 
 The staging Nginx config uses Cloudflare Authenticated Origin Pulls so direct

--- a/docs/security/admin-and-staging-zero-trust-access.md
+++ b/docs/security/admin-and-staging-zero-trust-access.md
@@ -1,4 +1,4 @@
-# Admin And Staging Zero-Trust Access
+﻿# Admin And Staging Zero-Trust Access
 
 SITBank uses a hybrid zero-trust access model:
 
@@ -51,7 +51,7 @@ References:
 | --- | --- | --- | --- |
 | Production customer | `https://sitbank.duckdns.org` | Public HTTPS edge, Flask customer login and MFA | Public |
 | Staging customer | `https://staging-sitbank.pp.ua` | Cloudflare Access, Cloudflare Authenticated Origin Pull, origin JWT validation, staging Basic Auth, Flask login and MFA | Not directly public at the origin |
-| Production admin app | `https://sitbank-ec2.tailca101b.ts.net/` through Tailscale Serve | Tailscale ACLs, approved devices, Flask admin login and TOTP | Private tailnet only |
+| Production admin app | `https://admin-sitbank.tailca101b.ts.net/` through Tailscale Serve | Tailscale ACLs, approved devices, Flask admin login and TOTP | Private tailnet only |
 | Staging admin app | Approved Tailscale/private operator path to `127.0.0.1:5003` | Tailscale ACLs, approved devices, Flask admin login and TOTP | Private tailnet only |
 
 The customer production site remains public. The admin app is not exposed
@@ -173,11 +173,13 @@ sudo tailscale serve status
 ```
 
 Admins connect to the Tailscale VPN first, then open
-`https://sitbank-ec2.tailca101b.ts.net/`. The `tailscale serve` command exposes
-the local admin service inside the tailnet. It must not be paired with
+`https://admin-sitbank.tailca101b.ts.net/login`. The `tailscale serve` command
+exposes the local admin service inside the tailnet. It must not be paired with
 `tailscale funnel`; Funnel would publish the service to the public internet and
 is not approved for SITBank admin. Flask admin login and TOTP remain mandatory
-after the private network boundary is satisfied.
+after the private network boundary is satisfied. Successful browser login
+redirects the operator to the private dashboard at
+`https://admin-sitbank.tailca101b.ts.net/`.
 
 If Tailscale Serve is unavailable, use a separate reviewed private operator
 path rather than exposing the admin app publicly. In all cases, the Flask
@@ -281,10 +283,10 @@ live checks manually:
 
 Live Tailscale admin checks:
 
-1. An approved operator reaches `https://sitbank-ec2.tailca101b.ts.net/` only from an approved tailnet device.
+1. An approved operator reaches `https://admin-sitbank.tailca101b.ts.net/` only from an approved tailnet device.
 2. A non-tailnet network cannot reach the admin app.
 3. A removed user or deleted device loses access.
-4. Admin Flask login and TOTP are still required after Tailscale access.
+4. Admin browser login with workplace password and TOTP reaches the dashboard.
 5. Admin readiness endpoints remain private or restricted.
 6. No public admin hostname is required or scanned.
 7. `https://sitbank.duckdns.org` remains public.

--- a/ops/security/validate_pr_body.py
+++ b/ops/security/validate_pr_body.py
@@ -45,6 +45,7 @@ HEADING_RE = re.compile(
     r"\s*:?\s*$",
     re.IGNORECASE,
 )
+SETEXT_UNDERLINE_RE = re.compile(r"^\s{0,3}(?:-{3,}|={3,})\s*$")
 
 
 @dataclass(frozen=True)
@@ -86,6 +87,8 @@ def parse_sections(body: str) -> dict[str, str]:
         if heading:
             current = _canonical_section_name(heading.group(1))
             sections.setdefault(current, [])
+            continue
+        if current is not None and SETEXT_UNDERLINE_RE.match(line):
             continue
         if current is not None:
             sections[current].append(line)
@@ -144,26 +147,33 @@ def print_examples() -> None:
     print(
         """Valid PR description example:
 Summary
+---
 Adds server-side Payee management required for Local Transfer.
 
 Why
+---
 Local Transfer needs trusted recipient records before transfer creation.
 
 What changed
+---
 * Added Payee model and routes
 * Added server-side validation
 * Added tests for invalid recipient input
 
 Security impact
+---
 Recipient names are loaded from the database and are not accepted from client input.
 
 Deployment impact
+---
 No deployment action required.
 
 Verification
+---
 * python -m pytest tests/test_payees.py
 
 Notes
+---
 No follow-up required.
 """.rstrip()
     )

--- a/tests/test_admin_dashboard_operations.py
+++ b/tests/test_admin_dashboard_operations.py
@@ -9,7 +9,7 @@ import pyotp
 import pytest
 
 from app.extensions import db
-from app.models import SecurityAuditEvent, User
+from app.models import SecurityAuditEvent, StaffInvite, User
 from app.security.crypto import encrypt_mfa_secret
 from app.security.passwords import hash_password
 from conftest import TestConfig
@@ -133,6 +133,51 @@ def test_admin_browser_login_and_mfa_reaches_dashboard(admin_app, admin_client):
     assert ROOT_EMAIL in dashboard.get_data(as_text=True)
 
 
+def test_admin_browser_login_pages_redirect_authenticated_admin(admin_client):
+    _root, root_secret = _create_staff_identity(
+        username="root-admin",
+        email=ROOT_EMAIL,
+        account_type="root_admin",
+        phone_number="91234567",
+    )
+    _login_admin(admin_client, root_secret)
+
+    login_page = admin_client.get("/login", follow_redirects=False)
+    mfa_page = admin_client.get("/mfa/verify", follow_redirects=False)
+
+    assert login_page.status_code == 302
+    assert login_page.headers["Location"].endswith("/")
+    assert mfa_page.status_code == 302
+    assert mfa_page.headers["Location"].endswith("/")
+
+
+def test_admin_login_form_renders_session_expired_message(admin_client):
+    response = admin_client.get("/login?session_expired=1")
+
+    assert response.status_code == 200
+    assert "Your admin session expired. Please log in again." in response.get_data(as_text=True)
+
+
+def test_admin_browser_login_rejects_invalid_form_and_schema(monkeypatch, admin_client):
+    invalid_form = admin_client.post("/login", data={})
+
+    def reject_schema(_self, _payload):
+        from marshmallow import ValidationError
+
+        raise ValidationError("forced schema rejection")
+
+    monkeypatch.setattr("app.admin.routes.AdminLoginSchema.load", reject_schema)
+    schema_rejected = admin_client.post(
+        "/login",
+        data={"workplace_email": ROOT_EMAIL, "password": ROOT_PASSWORD},
+    )
+
+    assert invalid_form.status_code == 400
+    assert "This field is required" in invalid_form.get_data(as_text=True)
+    assert schema_rejected.status_code == 400
+    assert "Invalid request" in schema_rejected.get_data(as_text=True)
+
+
 def test_admin_json_login_contract_remains_compatible(admin_client):
     _root, root_secret = _create_staff_identity(
         username="root-admin",
@@ -167,6 +212,69 @@ def test_admin_mfa_form_requires_pending_browser_challenge(admin_client):
     assert browser_response.headers["Location"].endswith("/login")
     assert json_response.status_code == 401
     assert json_response.get_json() == {"error": "No pending MFA challenge"}
+
+
+def test_admin_browser_mfa_post_requires_pending_challenge(admin_client):
+    response = admin_client.post(
+        "/mfa/verify",
+        data={"totp_code": "123456"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["Location"].endswith("/login")
+
+
+def test_admin_browser_mfa_rejects_invalid_form_and_bad_code(admin_client):
+    _root, root_secret = _create_staff_identity(
+        username="root-admin",
+        email=ROOT_EMAIL,
+        account_type="root_admin",
+        phone_number="91234567",
+    )
+    primary = admin_client.post(
+        "/login",
+        data={"workplace_email": ROOT_EMAIL, "password": ROOT_PASSWORD},
+    )
+
+    invalid_form = admin_client.post("/mfa/verify", data={"totp_code": "abc"})
+    bad_code = "000000"
+    if bad_code == _totp(root_secret):
+        bad_code = "111111"
+    bad_mfa = admin_client.post("/mfa/verify", data={"totp_code": bad_code})
+
+    assert primary.status_code == 303
+    assert invalid_form.status_code == 400
+    assert "MFA code must be exactly 6 digits" in invalid_form.get_data(as_text=True)
+    assert bad_mfa.status_code == 401
+    assert "Invalid workplace email, password, or authentication code" in bad_mfa.get_data(as_text=True)
+
+
+def test_admin_browser_form_payload_strips_csrf_token_for_invites(admin_client):
+    _root, root_secret = _create_staff_identity(
+        username="root-admin",
+        email=ROOT_EMAIL,
+        account_type="root_admin",
+        phone_number="91234567",
+    )
+    _login_admin(admin_client, root_secret)
+
+    response = admin_client.post(
+        "/invites",
+        data={
+            "personal_email": "staff.person@gmail.com",
+            "workplace_email": "staff.person@sit.singaporetech.edu.sg",
+            "role": "staff",
+            "totp_code": _totp(root_secret),
+            "csrf_token": "browser-form-token",
+        },
+        follow_redirects=False,
+    )
+    invite = db.session.execute(db.select(StaffInvite)).scalar_one()
+
+    assert response.status_code == 303
+    assert response.headers["Location"].endswith("/invites")
+    assert invite.workplace_email_normalized == "staff.person@sit.singaporetech.edu.sg"
 
 
 def test_admin_browser_login_rejects_customer_accounts_with_generic_error(admin_client):

--- a/tests/test_admin_dashboard_operations.py
+++ b/tests/test_admin_dashboard_operations.py
@@ -84,6 +84,126 @@ def _totp(secret: str) -> str:
     return pyotp.TOTP(secret, digits=6, interval=30).now()
 
 
+def test_admin_browser_login_and_mfa_reaches_dashboard(admin_app, admin_client):
+    _root, root_secret = _create_staff_identity(
+        username="root-admin",
+        email=ROOT_EMAIL,
+        account_type="root_admin",
+        phone_number="91234567",
+    )
+
+    login_page = admin_client.get("/login")
+    primary = admin_client.post(
+        "/login",
+        data={"workplace_email": ROOT_EMAIL, "password": ROOT_PASSWORD},
+        follow_redirects=False,
+    )
+
+    with admin_client.session_transaction() as sess:
+        pending_user_id = sess.get("pending_mfa_user_id")
+
+    mfa_page = admin_client.get("/mfa/verify")
+    verify = admin_client.post(
+        "/mfa/verify",
+        data={"totp_code": _totp(root_secret)},
+        follow_redirects=False,
+    )
+    dashboard = admin_client.get("/")
+    verify_cookies = verify.headers.getlist("Set-Cookie")
+
+    assert login_page.status_code == 200
+    login_body = login_page.get_data(as_text=True)
+    assert 'action="/login"' in login_body
+    assert 'name="workplace_email"' in login_body
+    assert 'name="password"' in login_body
+    assert primary.status_code == 303
+    assert primary.headers["Location"].endswith("/mfa/verify")
+    assert pending_user_id is not None
+    assert mfa_page.status_code == 200
+    assert 'name="totp_code"' in mfa_page.get_data(as_text=True)
+    assert verify.status_code == 303
+    assert verify.headers["Location"].endswith("/")
+    assert any(
+        cookie.startswith(f"{admin_app.config['SESSION_COOKIE_NAME']}=")
+        and not cookie.startswith(f"{admin_app.config['SESSION_COOKIE_NAME']}=;")
+        for cookie in verify_cookies
+    )
+    assert not any(cookie.startswith("__Host-sitbank_session=") for cookie in verify_cookies)
+    assert dashboard.status_code == 200
+    assert ROOT_EMAIL in dashboard.get_data(as_text=True)
+
+
+def test_admin_json_login_contract_remains_compatible(admin_client):
+    _root, root_secret = _create_staff_identity(
+        username="root-admin",
+        email=ROOT_EMAIL,
+        account_type="root_admin",
+        phone_number="91234567",
+    )
+
+    primary = admin_client.post(
+        "/login",
+        json={"workplace_email": ROOT_EMAIL, "password": ROOT_PASSWORD},
+    )
+    verify = admin_client.post(
+        "/mfa/verify",
+        json={"totp_code": _totp(root_secret)},
+    )
+
+    assert primary.status_code == 200
+    assert primary.get_json() == {"message": "MFA verification required", "mfa_required": True}
+    assert verify.status_code == 200
+    verify_payload = verify.get_json()
+    assert verify_payload["message"] == "Login successful"
+    assert verify_payload["session_ref"]
+    assert verify_payload["user"]["email"] == ROOT_EMAIL
+
+
+def test_admin_mfa_form_requires_pending_browser_challenge(admin_client):
+    browser_response = admin_client.get("/mfa/verify", follow_redirects=False)
+    json_response = admin_client.get("/mfa/verify", headers={"Accept": "application/json"})
+
+    assert browser_response.status_code == 303
+    assert browser_response.headers["Location"].endswith("/login")
+    assert json_response.status_code == 401
+    assert json_response.get_json() == {"error": "No pending MFA challenge"}
+
+
+def test_admin_browser_login_rejects_customer_accounts_with_generic_error(admin_client):
+    db.session.add(
+        User(
+            username="customer-admin-try",
+            email="customer.admin@sit.singaporetech.edu.sg",
+            password_hash=hash_password(ROOT_PASSWORD),
+            account_type="customer",
+            account_status="active",
+            full_name="Customer Admin Try",
+            phone_number="91234567",
+            account_number="100000001",
+            mfa_enabled=True,
+        )
+    )
+    db.session.commit()
+
+    response = admin_client.post(
+        "/login",
+        data={
+            "workplace_email": "customer.admin@sit.singaporetech.edu.sg",
+            "password": ROOT_PASSWORD,
+        },
+    )
+
+    with admin_client.session_transaction() as sess:
+        pending_user_id = sess.get("pending_mfa_user_id")
+        authenticated_user_id = sess.get("user_id")
+
+    body = response.get_data(as_text=True)
+    assert response.status_code == 401
+    assert "Invalid workplace email, password, or authentication code" in body
+    assert pending_user_id is None
+    assert authenticated_user_id is None
+
+
 def test_dashboard_renders_role_navigation_and_audits_access(admin_client):
     _staff, staff_secret = _create_staff_identity(
         username="bank-staff",

--- a/tests/test_admin_route_inventory_security.py
+++ b/tests/test_admin_route_inventory_security.py
@@ -94,6 +94,20 @@ ADMIN_ROUTE_SECURITY_INVENTORY = {
         "expected_guard": "require_staff_session",
         "public_justification": "",
     },
+    "admin.login_form": {
+        "endpoint": "admin.login_form",
+        "rule": "/login",
+        "methods": {"GET"},
+        "access": "public",
+        "role": "none",
+        "classification": "login",
+        "csrf": "not_applicable",
+        "rate_limit": "edge_admin",
+        "step_up": "not_required",
+        "state_changing": False,
+        "expected_guard": "none",
+        "public_justification": "Admin login form must be reachable before a staff session exists.",
+    },
     "admin.login": {
         "endpoint": "admin.login",
         "rule": "/login",
@@ -107,6 +121,20 @@ ADMIN_ROUTE_SECURITY_INVENTORY = {
         "state_changing": True,
         "expected_guard": "none",
         "public_justification": "Primary admin authentication must be reachable before a staff session exists.",
+    },
+    "admin.mfa_verify_form": {
+        "endpoint": "admin.mfa_verify_form",
+        "rule": "/mfa/verify",
+        "methods": {"GET"},
+        "access": "public",
+        "role": "none",
+        "classification": "mfa",
+        "csrf": "not_applicable",
+        "rate_limit": "edge_admin",
+        "step_up": "pending_admin_mfa",
+        "state_changing": False,
+        "expected_guard": "pending_admin_mfa_session",
+        "public_justification": "Admin MFA form is reachable only with a pending admin MFA challenge.",
     },
     "admin.mfa_verify": {
         "endpoint": "admin.mfa_verify",
@@ -471,7 +499,9 @@ def test_admin_route_inventory_has_complete_security_decisions():
         if entry["expected_guard"] == "require_root_admin_session":
             assert "require_root_admin_session" in source, f"{endpoint} must call require_root_admin_session"
         if entry["expected_guard"] == "pending_admin_mfa_session":
-            assert "complete_admin_mfa_login" in source, f"{endpoint} must complete pending admin MFA only"
+            assert (
+                "complete_admin_mfa_login" in source or "pending_mfa_user_id" in source
+            ), f"{endpoint} must require pending admin MFA state"
         if entry["expected_guard"] == "invite_token_validation":
             assert "<token>" in entry["rule"]
             assert any(

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
 import ast
 import os
@@ -2420,7 +2420,7 @@ def test_live_tls_scan_workflow_collects_evidence_without_running_on_pull_reques
     assert '$items[]\n                    | select(type == "object")' in workflow_text
     assert '$items[]\n                  | select(type == "object")' in workflow_text
     assert "secrets." not in workflow_text
-    assert "sitbank-ec2.tailca101b.ts.net" not in workflow_text
+    assert "admin-sitbank.tailca101b.ts.net" not in workflow_text
 
     upload_steps = [
         step for step in scan["steps"]
@@ -2461,12 +2461,12 @@ def test_live_tls_scan_workflow_collects_evidence_without_running_on_pull_reques
         assert "SSL Labs" in docs
         assert re.search(r"HIGH,\s+CRITICAL,\s+or FATAL", docs)
     for docs in (deployment_docs, operations_docs):
-        assert "https://sitbank-ec2.tailca101b.ts.net/" in docs
+        assert "https://admin-sitbank.tailca101b.ts.net/" in docs
     assert "staging_host" in deployment_docs
     assert "staging_host" in operations_docs
     assert "retired DuckDNS staging hostname" in deployment_docs
     assert "retired DuckDNS staging hostname" in operations_docs
-    assert "sitbank-ec2.tailca101b.ts.net" in operations_docs
+    assert "admin-sitbank.tailca101b.ts.net" in operations_docs
     assert "private Tailscale admin hostname" in operations_docs
     assert "testssl.sh --warnings batch --color 0" in deployment_docs
     assert "tls-scan-staging-sitbank" in deployment_docs
@@ -3177,7 +3177,7 @@ def test_production_edge_runbook_documents_network_waf_and_verification_steps():
         "Nginx terminates TLS, redirects production customer HTTP to HTTPS",
         "Gunicorn binds only to `127.0.0.1:5000`",
         "Admin Gunicorn binds only to `127.0.0.1:5002`",
-        "Flask admin auth is implemented only for root-admin-controlled invite",
+        "Flask admin auth supports manual root-admin bootstrap plus",
         "compose.prod.yml` publishes no",
         "`/health/ready` is for local deployment and load-balancer checks",
         "Cloudflare or AWS WAF should sit in front of Nginx",
@@ -3248,7 +3248,7 @@ def test_staging_edge_runbook_documents_operator_verification_steps():
         "ops/deploy/bootstrap-container-ec2",
         "staging-sitbank.pp.ua",
         "retired DuckDNS staging hostname",
-        "https://sitbank-ec2.tailca101b.ts.net/",
+        "https://admin-sitbank.tailca101b.ts.net/",
         "private Tailscale admin hostname",
         "Nginx proxy header snippet",
         "Cloudflare origin-pull CA file",

--- a/tests/test_pr_body_policy.py
+++ b/tests/test_pr_body_policy.py
@@ -8,26 +8,33 @@ from ops.security.validate_pr_body import load_body_from_event, validate_body
 
 
 VALID_BODY = """Summary
+---
 Adds server-side Payee management required for Local Transfer.
 
 Why
+---
 Local Transfer needs trusted recipient records before transfer creation.
 
 What changed
+---
 * Added Payee model and routes
 * Added server-side validation
 * Added tests for invalid recipient input
 
 Security impact
+---
 Recipient names are loaded from the database and are not accepted from client input.
 
 Deployment impact
+---
 No deployment action required.
 
 Verification
+---
 * python -m pytest tests/test_payees.py
 
 Notes
+---
 No follow-up required.
 """
 
@@ -36,12 +43,18 @@ def _messages(body: str) -> list[str]:
     return [error.message for error in validate_body(body)]
 
 
-def test_valid_pr_body_passes_with_plain_headings():
+def test_valid_pr_body_passes_with_setext_headings():
     assert validate_body(VALID_BODY) == []
 
 
+def test_valid_pr_body_still_accepts_plain_headings():
+    body = VALID_BODY.replace("---\n", "")
+
+    assert validate_body(body) == []
+
+
 def test_valid_pr_body_passes_with_markdown_headings_and_notes_none():
-    body = VALID_BODY.replace("Summary", "## Summary", 1).replace("Notes\nNo follow-up required.", "### Notes\nN/A")
+    body = VALID_BODY.replace("Summary\n---", "## Summary", 1).replace("Notes\n---\nNo follow-up required.", "### Notes\nN/A")
 
     assert validate_body(body) == []
 
@@ -51,7 +64,7 @@ def test_empty_pr_body_fails():
 
 
 def test_missing_required_section_fails():
-    body = VALID_BODY.replace("Why\nLocal Transfer needs trusted recipient records before transfer creation.\n\n", "")
+    body = VALID_BODY.replace("Why\n---\nLocal Transfer needs trusted recipient records before transfer creation.\n\n", "")
 
     assert "Missing required PR description section: Why." in _messages(body)
 
@@ -60,17 +73,22 @@ def test_placeholder_template_left_below_custom_paragraph_fails():
     body = """Introduces the Payee feature as a prerequisite for Local Transfer.
 
 Summary
+---
 Briefly describe what this PR improves or fixes.
 
 Why
+---
 Explain the problem, risk, or reason this change is needed.
 
 What changed
+---
 
 Security impact
+---
 Explain how this affects security controls, secrets, permissions, auth, CI/CD, deployment safety, or runtime behavior.
 
 Deployment impact
+---
 Explain whether this PR requires:
 
 EC2 bootstrap
@@ -81,8 +99,10 @@ secret changes
 no deployment action
 
 Verification
+---
 
 Notes
+---
 Add any follow-up work, limitations, or operator instructions.
 """
 
@@ -103,6 +123,15 @@ def test_verification_requires_meaningful_content():
     body = VALID_BODY.replace("* python -m pytest tests/test_payees.py", "*\n*\n*")
 
     assert "PR description section 'Verification' must contain meaningful content." in _messages(body)
+
+
+def test_setext_underline_alone_does_not_make_section_meaningful():
+    body = VALID_BODY.replace(
+        "* Added Payee model and routes\n* Added server-side validation\n* Added tests for invalid recipient input",
+        "",
+    )
+
+    assert "PR description section 'What changed' must contain meaningful content." in _messages(body)
 
 
 def test_event_payload_body_is_loaded(tmp_path):

--- a/tests/test_security_docs_issue_links.py
+++ b/tests/test_security_docs_issue_links.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
 from pathlib import Path
 
@@ -75,7 +75,7 @@ def test_zero_trust_docs_use_current_architecture_and_issue_set():
     assert "SITBank uses a hybrid zero-trust access model" in docs
     for issue_ref in ("#198", "#199", "#200", "#210", "#211", "#215", "#218"):
         assert issue_ref in docs
-    assert "https://sitbank-ec2.tailca101b.ts.net/" in docs
+    assert "https://admin-sitbank.tailca101b.ts.net/" in docs
     assert "Admins connect to the Tailscale VPN first, then open" in docs
     assert "Funnel would publish the service to the public internet" in docs
     assert "admin login, TOTP, CSRF, route authorization, and audit logging" in docs
@@ -102,8 +102,24 @@ def test_public_tls_docs_exclude_private_tailscale_admin_hostname_from_normal_sc
 
     assert "normal public TLS scan deliberately excludes the private Tailscale admin hostname" in operations
     assert "job joins the tailnet or uses a tailnet self-hosted runner" in normalized_operations
-    assert "sitbank-ec2.tailca101b.ts.net" not in workflow
+    assert "admin-sitbank.tailca101b.ts.net" not in workflow
     assert "Do not add the private Tailscale admin URL to public GitHub-hosted TLS scans." in normalized_deployment
+
+
+def test_active_docs_tests_and_workflows_use_current_private_admin_hostname():
+    current_admin_host = "admin-sitbank.tailca101b.ts.net"
+    retired_ec2_host = "sitbank-ec2" + ".tailca101b.ts.net"
+    retired_admin_host = "sitbank-admin" + ".tailca101b.ts.net"
+    paths = [Path("README.md"), Path("SECURITY.md")]
+    paths.extend(path for path in sorted(Path("docs").rglob("*.md")) if "archive" not in path.parts)
+    paths.extend(sorted(Path("tests").glob("*.py")))
+    paths.extend(sorted(Path(".github/workflows").glob("*.yml")))
+
+    combined = "\n".join(path.read_text(encoding="utf-8") for path in paths)
+
+    assert current_admin_host in combined
+    assert retired_ec2_host not in combined
+    assert retired_admin_host not in combined
 
 
 def test_current_open_gap_rows_have_tracking_state():

--- a/tests/test_zero_trust_access_boundary.py
+++ b/tests/test_zero_trust_access_boundary.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
 import re
 import subprocess
@@ -64,7 +64,7 @@ def test_hybrid_cloudflare_staging_and_tailscale_admin_design_is_documented():
         "This intentionally uses both products because the surfaces have different",
         "Production customer | `https://sitbank.duckdns.org`",
         "Staging customer | `https://staging-sitbank.pp.ua`",
-        "Production admin app | `https://sitbank-ec2.tailca101b.ts.net/` through Tailscale Serve",
+        "Production admin app | `https://admin-sitbank.tailca101b.ts.net/` through Tailscale Serve",
         "The customer production site remains public.",
         "self-hosted Access application",
         "Cloudflare Authenticated Origin Pulls",
@@ -77,7 +77,7 @@ def test_hybrid_cloudflare_staging_and_tailscale_admin_design_is_documented():
         "Cloudflare Access and Tailscale decide whether a request may reach",
         "retired DuckDNS staging hostname is no longer",
         "Admins connect to the Tailscale VPN first, then open",
-        "https://sitbank-ec2.tailca101b.ts.net/",
+        "https://admin-sitbank.tailca101b.ts.net/",
         "old public admin verification",
         "page has been removed from the edge bootstrap",
         "No public admin hostname is required or scanned.",
@@ -182,7 +182,7 @@ def test_admin_public_surface_is_absent_and_private_access_is_tailscale_only():
     assert "proxy_pass http://127.0.0.1:5002;" not in production_nginx
 
     assert "Tailscale/private operator access" in docs
-    assert "https://sitbank-ec2.tailca101b.ts.net/" in docs
+    assert "https://admin-sitbank.tailca101b.ts.net/" in docs
     assert "Do not enable Tailscale Funnel" in docs
     assert "old public admin verification" in docs
     assert "page has been removed from the edge bootstrap" in docs


### PR DESCRIPTION
Summary
---
Adds browser-accessible admin login and MFA pages for the private admin app while preserving JSON API clients.

Why
---
Active administrators need a browser login flow for the private admin app without changing existing API-style authentication behavior.

What changed
---
* Added browser login and MFA templates/routes for admin auth.
* Preserved JSON login and MFA behavior for API clients.
* Stripped browser CSRF form fields before admin schema validation.
* Added focused admin browser flow tests and route inventory coverage.
* Replaced duplicated `admin.index` literal with an endpoint constant.

Security impact
---
Admin credentials and MFA codes still use the existing server-side validation path. Form-only CSRF metadata is removed before schema validation, and invalid browser authentication attempts render generic errors.

Deployment impact
---
No deployment action required.

Verification
---
* python -m pytest -q tests/test_admin_dashboard_operations.py tests/test_admin_route_inventory_security.py
* python -m pytest -q -n auto
* python -m pytest -q -n auto --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term --durations=30 --durations-min=0.5
* Changed executable lines in app/admin/routes.py: 100.0% covered locally from coverage.xml

Notes
---
Future PR descriptions should use these Setext-style headings with `---` under each heading and must be saved without a UTF-8 BOM.