### PR TITLE
Enforce separate customer and admin identities

### DIFF
--- a/app/admin/bootstrap_root.py
+++ b/app/admin/bootstrap_root.py
@@ -13,6 +13,7 @@ from app.auth.services import AuthError
 from app.models import User
 from app.security.audit import audit_reference, audit_system_event
 from app.security.crypto import encrypt_mfa_secret
+from app.security.identity_policy import is_admin_workplace_email, root_admin_emails
 from app.security.passwords import PasswordPolicyError, hash_password, validate_password_policy
 
 from .services import (
@@ -133,10 +134,12 @@ def _require_admin_runtime() -> None:
 
 
 def _require_allowlisted_root_email(email: str) -> None:
-    root_emails = frozenset(str(item).casefold() for item in current_app.config["ROOT_ADMIN_EMAILS"])
-    if email.casefold() not in root_emails:
+    if email.casefold() not in root_admin_emails():
         _audit_bootstrap("blocked", email, reason="email_not_allowlisted")
         raise RootAdminBootstrapError("Root admin email is not listed in ROOT_ADMIN_EMAILS")
+    if not is_admin_workplace_email(email):
+        _audit_bootstrap("blocked", email, reason="email_domain_not_allowed")
+        raise RootAdminBootstrapError("Root admin email must use an approved admin workplace domain")
 
 
 def _validate_username(username: str) -> str:

--- a/app/admin/services.py
+++ b/app/admin/services.py
@@ -31,6 +31,15 @@ from app.models import ManualRecoveryRequest, SecurityAuditEvent, StaffInvite, U
 from app.security.audit import audit_event, audit_event_required, audit_reference, principal_reference
 from app.security.crypto import encrypt_mfa_secret
 from app.security.email import send_security_email
+from app.security.identity_policy import (
+    IdentityPolicyError,
+    admin_allowed_email_domains,
+    is_admin_workplace_email,
+    normalize_identity_email,
+    require_admin_workplace_email,
+    root_admin_emails,
+    staff_personal_email_policy_violation,
+)
 from app.security.passwords import (
     PasswordPolicyError,
     hash_password,
@@ -135,13 +144,21 @@ def is_staff_user(user: User | None) -> bool:
 
 
 def is_active_staff_user(user: User | None) -> bool:
-    return bool(is_staff_user(user) and user.account_status == "active" and user.mfa_enabled)
+    return bool(
+        is_staff_user(user)
+        and user.account_status == "active"
+        and user.mfa_enabled
+        and is_admin_workplace_email(str(user.email or ""))
+    )
 
 
 def is_root_admin(user: User | None) -> bool:
     if user is None or user.account_type != ACCOUNT_ROOT_ADMIN:
         return False
-    return _normalize_email(user.email).casefold() in _root_admin_emails()
+    return (
+        is_admin_workplace_email(str(user.email or ""))
+        and _normalize_email(user.email).casefold() in _root_admin_emails()
+    )
 
 
 def require_staff_session() -> User:
@@ -769,7 +786,25 @@ def _like_escape(value: str) -> str:
 
 
 def authenticate_admin_primary(workplace_email: str, password: str) -> dict[str, Any]:
-    normalized_email = normalize_workplace_email(workplace_email)
+    try:
+        normalized_email = normalize_workplace_email(workplace_email)
+    except AuthError as exc:
+        normalized_email = _normalize_email(workplace_email)
+        principal = _auth_principal(normalized_email)
+        _enforce_auth_backoff("admin_login", principal)
+        if is_password_raw_length_safe(password):
+            verify_password(password, _dummy_password_hash())
+        audit_event(
+            "admin_login",
+            "failure",
+            metadata={
+                "known_user": False,
+                "reason": "invalid_workplace_email",
+                "principal_ref": principal_reference(normalized_email),
+            },
+        )
+        record_failure("admin_login", principal)
+        raise AuthError(GENERIC_ADMIN_LOGIN_ERROR, 401) from exc
     principal = _auth_principal(normalized_email)
     _enforce_auth_backoff("admin_login", principal)
 
@@ -791,6 +826,7 @@ def authenticate_admin_primary(workplace_email: str, password: str) -> dict[str,
             user=user,
             metadata={
                 "known_user": user is not None,
+                "reason": "invalid_credentials_or_ineligible_staff",
                 "principal_ref": principal_reference(normalized_email),
             },
         )
@@ -857,8 +893,16 @@ def create_staff_invite(
         audit_event("staff_invite_create", "failure", user=actor, metadata={"reason": "missing_totp_step_up"})
         raise AuthError(FRESH_MFA_REQUIRED_ERROR, 403)
 
-    normalized_personal = normalize_personal_email(personal_email)
-    normalized_workplace = normalize_workplace_email(workplace_email)
+    try:
+        normalized_workplace = normalize_workplace_email(workplace_email)
+        normalized_personal = normalize_personal_email(personal_email)
+    except AuthError:
+        audit_event("staff_invite_create", "blocked", user=actor, metadata={"reason": "email_policy"})
+        raise
+    personal_policy_reason = staff_personal_email_policy_violation(normalized_personal, normalized_workplace)
+    if personal_policy_reason:
+        audit_event("staff_invite_create", "blocked", user=actor, metadata={"reason": personal_policy_reason})
+        raise AuthError(INVALID_PERSONAL_EMAIL_ERROR, 400)
     normalized_role = str(role or "").strip().casefold()
     if normalized_role not in INVITABLE_ROLES:
         audit_event("staff_invite_create", "failure", user=actor, metadata={"reason": "invalid_role"})
@@ -988,6 +1032,7 @@ def transition_manual_recovery_request_as_admin(
         )
         raise AuthError(FRESH_MFA_REQUIRED_ERROR, 403)
 
+    _assert_not_self_manual_recovery_action(actor, request_id, "manual_recovery_transition")
     result = transition_manual_recovery_request(request_id, normalized_status, reason=clean_reason)
     audit_event(
         "manual_recovery_admin_transition",
@@ -1021,6 +1066,7 @@ def complete_manual_recovery_request_as_admin(
         )
         raise AuthError(FRESH_MFA_REQUIRED_ERROR, 403)
 
+    _assert_not_self_manual_recovery_action(actor, request_id, "manual_recovery_complete")
     result = complete_manual_recovery_request(request_id, reason=clean_reason)
     audit_event(
         "manual_recovery_admin_complete",
@@ -1037,6 +1083,7 @@ def complete_manual_recovery_request_as_admin(
 
 def invite_info(token: str) -> dict[str, Any]:
     invite = _active_invite_by_token(token, audit_failures=True)
+    _ensure_invite_identity_policy(invite, "staff_invite_info")
     return {
         "message": "Invite found",
         "invite": {
@@ -1066,6 +1113,7 @@ def start_invite_acceptance(
         raise AuthError(INVITE_ACCEPTANCE_ERROR, 400) from exc
 
     invite = _active_invite_by_token(token, lock=True, audit_failures=True)
+    _ensure_invite_identity_policy(invite, "staff_invite_accept")
     name = validate_full_name(full_name)
     phone = validate_phone_number(phone_number)
     if password != confirm_password:
@@ -1148,6 +1196,7 @@ def verify_invite_acceptance(
 ) -> dict[str, Any]:
     _reject_forged_invite_fields(request_fields)
     invite = _active_invite_by_token(token, lock=True, audit_failures=True)
+    _ensure_invite_identity_policy(invite, "staff_invite_accept")
     user = db.session.get(User, invite.setup_user_id) if invite.setup_user_id else None
     if user is None or user.account_status != "setup_pending" or user.account_type != invite.role:
         audit_event("staff_invite_accept", "failure", metadata={"reason": "setup_missing"})
@@ -1226,28 +1275,30 @@ def public_manual_recovery_request(request_record: ManualRecoveryRequest) -> dic
 
 
 def normalize_workplace_email(email: str) -> str:
-    normalized = _normalize_email(email)
-    local, separator, domain = normalized.partition("@")
-    if not _valid_email_parts(local, separator, domain):
-        raise AuthError(INVALID_WORKPLACE_EMAIL_ERROR, 400)
-    if domain.casefold() not in _workplace_domains():
-        raise AuthError(INVALID_WORKPLACE_EMAIL_ERROR, 400)
+    try:
+        normalized = require_admin_workplace_email(email)
+    except IdentityPolicyError as exc:
+        raise AuthError(INVALID_WORKPLACE_EMAIL_ERROR, 400) from exc
+    local = normalized.partition("@")[0]
     if _contains_alias_separator(local):
         raise AuthError(INVALID_WORKPLACE_EMAIL_ERROR, 400)
-    return f"{local}@{domain.casefold()}"
+    return normalized
 
 
 def normalize_personal_email(email: str) -> str:
-    normalized = _normalize_email(email)
+    try:
+        normalized = normalize_identity_email(email)
+    except IdentityPolicyError as exc:
+        raise AuthError(INVALID_PERSONAL_EMAIL_ERROR, 400) from exc
     local, separator, domain = normalized.partition("@")
     if not _valid_email_parts(local, separator, domain):
         raise AuthError(INVALID_PERSONAL_EMAIL_ERROR, 400)
     domain_lower = domain.casefold()
-    if domain_lower in _workplace_domains() or domain_lower not in _personal_domains():
+    if staff_personal_email_policy_violation(normalized) or domain_lower not in _personal_domains():
         raise AuthError(INVALID_PERSONAL_EMAIL_ERROR, 400)
     if _contains_alias_separator(local):
         raise AuthError(INVALID_PERSONAL_EMAIL_ERROR, 400)
-    return f"{local}@{domain_lower}"
+    return normalized
 
 
 def validate_full_name(full_name: str) -> str:
@@ -1314,6 +1365,19 @@ def _audit_invalid_invite_attempt(reason: str, *, enabled: bool) -> None:
             "failure",
             metadata={"reason": reason},
         )
+
+
+def _ensure_invite_identity_policy(invite: StaffInvite, event_type: str) -> None:
+    try:
+        normalized_workplace = normalize_workplace_email(invite.workplace_email_normalized)
+        normalized_personal = normalize_personal_email(invite.personal_email_normalized)
+    except AuthError:
+        audit_event(event_type, "blocked", metadata={**_invite_audit_metadata(invite), "reason": "email_policy"})
+        raise AuthError(GENERIC_INVITE_ERROR, 401)
+    policy_reason = staff_personal_email_policy_violation(normalized_personal, normalized_workplace)
+    if policy_reason:
+        audit_event(event_type, "blocked", metadata={**_invite_audit_metadata(invite), "reason": policy_reason})
+        raise AuthError(GENERIC_INVITE_ERROR, 401)
 
 
 def _send_invite_email(invite: StaffInvite, invite_url: str) -> None:
@@ -1386,6 +1450,18 @@ def _require_manual_recovery_reason(reason: str, event_type: str, actor: User) -
         audit_event(event_type, "failure", user=actor, metadata={"reason": "reason_too_long"})
         raise AuthError("Reason is too long", 400)
     return text
+
+
+def _assert_not_self_manual_recovery_action(actor: User, request_id: int, action_type: str) -> None:
+    from app.admin.separation import assert_not_self_customer_action
+
+    request_record = db.session.get(ManualRecoveryRequest, int(request_id))
+    if request_record is None or request_record.user_id is None:
+        return
+    target_customer = db.session.get(User, request_record.user_id)
+    if target_customer is None:
+        return
+    assert_not_self_customer_action(actor, target_customer, action_type)
 
 
 def _reject_existing_staff_identity(workplace_email: str) -> None:
@@ -1526,7 +1602,7 @@ def _contains_alias_separator(local: str) -> bool:
 
 
 def _workplace_domains() -> frozenset[str]:
-    return frozenset(str(item).casefold() for item in current_app.config["SIT_WORKPLACE_EMAIL_DOMAINS"])
+    return admin_allowed_email_domains()
 
 
 def _personal_domains() -> frozenset[str]:
@@ -1534,7 +1610,7 @@ def _personal_domains() -> frozenset[str]:
 
 
 def _root_admin_emails() -> frozenset[str]:
-    return frozenset(str(item).casefold() for item in current_app.config["ROOT_ADMIN_EMAILS"])
+    return root_admin_emails()
 
 
 def _utcnow() -> datetime:

--- a/app/auth/forms.py
+++ b/app/auth/forms.py
@@ -101,7 +101,7 @@ class RegisterDetailsForm(FlaskForm):
 
 
 class RegistrationOtpRequestForm(FlaskForm):
-    email = StringField("SIT email", validators=[InputRequired(), Email(), Length(max=255)])
+    email = StringField("Customer email", validators=[InputRequired(), Email(), Length(max=255)])
 
 
 class RegistrationOtpCodeForm(FlaskForm):
@@ -115,7 +115,7 @@ class RegistrationOtpCodeForm(FlaskForm):
 
 
 class RegistrationOtpVerifyForm(FlaskForm):
-    email = StringField("SIT email", validators=[InputRequired(), Email(), Length(max=255)])
+    email = StringField("Customer email", validators=[InputRequired(), Email(), Length(max=255)])
     otp_code = StringField(
         "Verification code",
         validators=[

--- a/app/auth/registration_otp.py
+++ b/app/auth/registration_otp.py
@@ -13,17 +13,18 @@ from app.extensions import db
 from app.models import RegistrationOtpChallenge, User
 from app.security.audit import audit_event, audit_reference
 from app.security.email import send_security_email
+from app.security.identity_policy import (
+    IdentityPolicyError,
+    customer_email_policy_violation,
+    require_customer_email,
+)
 from app.security.session_hmac import active_hmac_hex
 
 
-APPROVED_REGISTRATION_EMAIL_DOMAINS = frozenset(
-    {
-        "sit.singaporetech.edu.sg",
-        "singaporetech.edu.sg",
-    }
-)
 GENERIC_OTP_SENT_MESSAGE = "If the email is eligible, a verification code has been sent."
 GENERIC_OTP_ERROR = "Verification code expired or invalid. Please request a new code."
+GENERIC_REGISTRATION_EMAIL_ERROR = "Registration could not be started for that email."
+VERIFY_CUSTOMER_EMAIL_MESSAGE = "Verify your customer email before creating an account."
 REGISTRATION_OTP_TTL_SECONDS = 5 * 60
 REGISTRATION_OTP_RESEND_COOLDOWN_SECONDS = 60
 REGISTRATION_OTP_MAX_ATTEMPTS = 5
@@ -46,21 +47,22 @@ def normalize_registration_email(email: str) -> str:
 
 
 def is_approved_registration_email(email: str) -> bool:
-    normalized = normalize_registration_email(email)
-    local, separator, domain = normalized.partition("@")
-    return bool(local and separator and domain in APPROVED_REGISTRATION_EMAIL_DOMAINS)
+    return customer_email_policy_violation(email) is None
 
 
 def request_registration_otp(email: str) -> dict[str, str]:
-    normalized_email = normalize_registration_email(email)
-    email_ref = audit_reference("registration_email", normalized_email)
-    if not is_approved_registration_email(normalized_email):
+    try:
+        normalized_email = require_customer_email(email)
+    except IdentityPolicyError as exc:
+        normalized_email = normalize_registration_email(email)
+        email_ref = audit_reference("registration_email", normalized_email)
         audit_event(
             "registration_otp",
-            "failed",
-            metadata={"reason": "invalid_domain", "email_ref": email_ref},
+            "blocked",
+            metadata={"reason": exc.reason, "email_ref": email_ref},
         )
-        raise RegistrationOtpError("Use your SIT email address to register.", 400)
+        raise RegistrationOtpError(GENERIC_REGISTRATION_EMAIL_ERROR, 400) from exc
+    email_ref = audit_reference("registration_email", normalized_email)
 
     existing_user = _user_by_email(normalized_email)
     if existing_user is not None:
@@ -130,15 +132,18 @@ def request_registration_otp(email: str) -> dict[str, str]:
 
 
 def verify_registration_otp(email: str, otp_code: str) -> dict[str, str]:
-    normalized_email = normalize_registration_email(email)
-    email_ref = audit_reference("registration_email", normalized_email)
-    if not is_approved_registration_email(normalized_email):
+    try:
+        normalized_email = require_customer_email(email)
+    except IdentityPolicyError as exc:
+        normalized_email = normalize_registration_email(email)
+        email_ref = audit_reference("registration_email", normalized_email)
         audit_event(
             "registration_otp",
-            "failed",
-            metadata={"reason": "invalid_domain", "email_ref": email_ref},
+            "blocked",
+            metadata={"reason": exc.reason, "email_ref": email_ref},
         )
-        raise RegistrationOtpError(GENERIC_OTP_ERROR, 400)
+        raise RegistrationOtpError(GENERIC_OTP_ERROR, 400) from exc
+    email_ref = audit_reference("registration_email", normalized_email)
 
     challenge = _load_otp_challenge(normalized_email)
     if challenge is None:
@@ -185,7 +190,11 @@ def pending_registration_email() -> str | None:
 def current_verified_registration_email() -> str | None:
     verified_email = normalize_registration_email(str(session.get(REGISTRATION_OTP_VERIFIED_EMAIL_KEY) or ""))
     verified_at = int(session.get(REGISTRATION_OTP_VERIFIED_AT_KEY) or 0)
-    if not verified_email or int(time.time()) - verified_at > REGISTRATION_OTP_TTL_SECONDS:
+    if (
+        not verified_email
+        or customer_email_policy_violation(verified_email)
+        or int(time.time()) - verified_at > REGISTRATION_OTP_TTL_SECONDS
+    ):
         if verified_email:
             _clear_registration_session_state()
         return None
@@ -196,12 +205,24 @@ def require_current_verified_registration_email() -> str:
     verified_email = current_verified_registration_email()
     if not verified_email:
         audit_event("registration", "failure", metadata={"reason": "email_otp_required"})
-        raise RegistrationOtpError("Verify your SIT email before creating an account.", 400)
+        raise RegistrationOtpError(VERIFY_CUSTOMER_EMAIL_MESSAGE, 400)
     return verified_email
 
 
 def require_verified_registration_email(email: str) -> str:
-    normalized_email = normalize_registration_email(email)
+    try:
+        normalized_email = require_customer_email(email)
+    except IdentityPolicyError as exc:
+        normalized_email = normalize_registration_email(email)
+        audit_event(
+            "registration",
+            "blocked",
+            metadata={
+                "reason": exc.reason,
+                "email_ref": audit_reference("registration_email", normalized_email),
+            },
+        )
+        raise RegistrationOtpError(VERIFY_CUSTOMER_EMAIL_MESSAGE, 400) from exc
     verified_email = current_verified_registration_email()
     if not verified_email or verified_email != normalized_email:
         audit_event(
@@ -212,7 +233,7 @@ def require_verified_registration_email(email: str) -> str:
                 "email_ref": audit_reference("registration_email", normalized_email),
             },
         )
-        raise RegistrationOtpError("Verify your SIT email before creating an account.", 400)
+        raise RegistrationOtpError(VERIFY_CUSTOMER_EMAIL_MESSAGE, 400)
     return normalized_email
 
 

--- a/app/auth/services.py
+++ b/app/auth/services.py
@@ -32,6 +32,7 @@ from app.auth.mfa_policy import (
 )
 from app.security.audit import audit_event, audit_event_required, principal_reference
 from app.security.crypto import decrypt_mfa_secret, encrypt_mfa_secret
+from app.security.identity_policy import IdentityPolicyError, require_customer_email
 from app.security.passwords import (
     PasswordPolicyError,
     hash_password,
@@ -260,6 +261,7 @@ def authenticate_primary(identifier: str, password: str) -> dict[str, Any]:
     principal = _auth_principal(identifier)
     user = _find_user_by_identifier(identifier)
     _enforce_auth_backoff("login", principal)
+    failure_reason = "invalid_credentials"
 
     password_ok = False
     if is_password_raw_length_safe(password):
@@ -268,6 +270,7 @@ def authenticate_primary(identifier: str, password: str) -> dict[str, Any]:
 
     if user is not None and getattr(user, "account_type", "customer") != "customer":
         password_ok = False
+        failure_reason = "not_customer_identity"
 
     if user is None or not password_ok:
         audit_event(
@@ -276,6 +279,7 @@ def authenticate_primary(identifier: str, password: str) -> dict[str, Any]:
             user=user,
             metadata={
                 "known_user": user is not None,
+                "reason": failure_reason,
                 "principal_ref": principal_reference(identifier),
             },
         )
@@ -574,7 +578,16 @@ def update_profile_details(
 ) -> bool:
     normalized_username = username.strip()
     username_lookup = _normalize(normalized_username)
-    normalized_email = email.strip().lower()
+    submitted_email = email.strip().lower()
+    email_changed = submitted_email != _normalize(user.email)
+    if email_changed:
+        try:
+            normalized_email = require_customer_email(email)
+        except IdentityPolicyError as exc:
+            audit_event("profile_update", "blocked", user=user, metadata={"reason": exc.reason})
+            raise AuthError("Profile could not be updated with those details", 400) from exc
+    else:
+        normalized_email = submitted_email
     normalized_preference = _normalize_step_up_preference(mfa_step_up_preference)
     if (
         username_lookup == _normalize(user.username)

--- a/app/security/identity_policy.py
+++ b/app/security/identity_policy.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+from flask import current_app
+
+
+EMAIL_RE = re.compile(r"^(?=\S{1,128}@\S{1,253}$)[^@\x00-\x1f\x7f]+@[^@\x00-\x1f\x7f]+$")
+
+
+class IdentityPolicyError(ValueError):
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+def normalize_identity_email(email: str) -> str:
+    text = str(email or "").strip()
+    if "\x00" in text or "\r" in text or "\n" in text or len(text) > 255:
+        raise IdentityPolicyError("invalid_email")
+    local, separator, domain = text.partition("@")
+    if not _valid_email_parts(local, separator, domain):
+        raise IdentityPolicyError("invalid_email")
+    return f"{local.casefold()}@{domain.strip().casefold()}"
+
+
+def admin_allowed_email_domains() -> frozenset[str]:
+    return _config_set("ADMIN_ALLOWED_EMAIL_DOMAINS", fallback_name="SIT_WORKPLACE_EMAIL_DOMAINS")
+
+
+def root_admin_emails() -> frozenset[str]:
+    return _config_set("ROOT_ADMIN_EMAILS")
+
+
+def is_admin_workplace_email(email: str) -> bool:
+    try:
+        normalized = normalize_identity_email(email)
+    except IdentityPolicyError:
+        return False
+    return _email_domain(normalized) in admin_allowed_email_domains()
+
+
+def customer_email_policy_violation(email: str) -> str | None:
+    try:
+        normalized = normalize_identity_email(email)
+    except IdentityPolicyError:
+        return "invalid_email"
+    if normalized in root_admin_emails():
+        return "root_admin_allowlisted_email"
+    if _email_domain(normalized) in admin_allowed_email_domains():
+        return "admin_email_domain"
+    return None
+
+
+def require_customer_email(email: str) -> str:
+    reason = customer_email_policy_violation(email)
+    if reason:
+        raise IdentityPolicyError(reason)
+    return normalize_identity_email(email)
+
+
+def require_admin_workplace_email(email: str) -> str:
+    normalized = normalize_identity_email(email)
+    if _email_domain(normalized) not in admin_allowed_email_domains():
+        raise IdentityPolicyError("admin_email_domain_not_allowed")
+    return normalized
+
+
+def staff_personal_email_policy_violation(personal_email: str, workplace_email: str | None = None) -> str | None:
+    try:
+        normalized = normalize_identity_email(personal_email)
+    except IdentityPolicyError:
+        return "invalid_email"
+    if normalized in root_admin_emails():
+        return "root_admin_allowlisted_email"
+    if _email_domain(normalized) in admin_allowed_email_domains():
+        return "admin_email_domain"
+    if workplace_email:
+        try:
+            normalized_workplace = normalize_identity_email(workplace_email)
+        except IdentityPolicyError:
+            normalized_workplace = ""
+        if normalized_workplace and normalized == normalized_workplace:
+            return "personal_matches_workplace"
+    return None
+
+
+def _config_set(name: str, *, fallback_name: str | None = None) -> frozenset[str]:
+    value = current_app.config.get(name)
+    if value is None and fallback_name:
+        value = current_app.config.get(fallback_name)
+    return frozenset(_iter_config_values(value))
+
+
+def _iter_config_values(value: object) -> Iterable[str]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return tuple(item.strip().casefold() for item in value.split(",") if item.strip())
+    return tuple(str(item).strip().casefold() for item in value if str(item).strip())
+
+
+def _valid_email_parts(local: str, separator: str, domain: str) -> bool:
+    domain = domain.strip()
+    if separator != "@" or not local or not domain:
+        return False
+    if not EMAIL_RE.fullmatch(f"{local}@{domain}"):
+        return False
+    labels = domain.split(".")
+    return all(label and not label.startswith("-") and not label.endswith("-") for label in labels)
+
+
+def _email_domain(email: str) -> str:
+    return email.rpartition("@")[2].casefold()

--- a/app/security/production_guard.py
+++ b/app/security/production_guard.py
@@ -54,6 +54,19 @@ class ProductionStartupSecurityError(RuntimeError):
     """Raised only when a production WSGI process is unsafe to start."""
 
 
+def _email_domain(value: object) -> str:
+    _local, separator, domain = str(value or "").strip().partition("@")
+    return domain.casefold() if separator else ""
+
+
+def _config_values(value: object) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return tuple(item.strip().casefold() for item in value.split(",") if item.strip())
+    return tuple(str(item).strip().casefold() for item in value if str(item).strip())
+
+
 def is_production_app(app: Flask) -> bool:
     return str(app.config.get("APP_ENV") or "").strip().casefold() == "production"
 
@@ -142,8 +155,17 @@ def _validate_mode_and_route_isolation(
         if not str(app.config.get("RATELIMIT_KEY_PREFIX") or "").startswith("ospbank:admin:"):
             result.failures.append("Admin rate-limit key prefix must be isolated")
         root_admin_emails = app.config.get("ROOT_ADMIN_EMAILS") or set()
-        if not isinstance(root_admin_emails, (set, frozenset, list, tuple)) or len(root_admin_emails) != 7:
+        root_admin_collection = isinstance(root_admin_emails, (set, frozenset, list, tuple))
+        if not root_admin_collection or len(root_admin_emails) != 7:
             result.failures.append("ROOT_ADMIN_EMAILS must configure exactly 7 root administrators")
+        admin_domains = set(
+            _config_values(
+                app.config.get("ADMIN_ALLOWED_EMAIL_DOMAINS")
+                or app.config.get("SIT_WORKPLACE_EMAIL_DOMAINS")
+            )
+        )
+        if root_admin_collection and any(_email_domain(item) not in admin_domains for item in root_admin_emails):
+            result.failures.append("ROOT_ADMIN_EMAILS must use approved admin workplace domains")
         if any(endpoint.startswith(("auth.", "web.", "banking.", "main.")) for endpoint in endpoints):
             result.failures.append("Admin runtime must not register customer routes")
     else:

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -7,12 +7,12 @@
   <div class="auth-intro">
     <p class="eyebrow">New customer profile</p>
     <h1>Create your online banking profile</h1>
-    <p class="lede">Use your SIT email address to verify your registration before creating a secure banking portal profile.</p>
+    <p class="lede">Use a personal customer email address to verify your registration before creating a secure banking portal profile.</p>
     <div class="notice">
       <span class="notice-icon" aria-hidden="true">
         <svg class="icon" focusable="false"><use href="#icon-info"></use></svg>
       </span>
-      <p class="muted">Registration is limited to sit.singaporetech.edu.sg and singaporetech.edu.sg email addresses. This simulated banking portal must not be used with real banking credentials.</p>
+      <p class="muted">SIT workplace email addresses are reserved for staff and admin access. This simulated banking portal must not be used with real banking credentials.</p>
     </div>
   </div>
 
@@ -85,13 +85,13 @@
     <div class="stacked-panel">
       <div class="page-heading compact">
         <p class="eyebrow">Step 1 of 2</p>
-        <h3>Verify your SIT email</h3>
+        <h3>Verify your customer email</h3>
       </div>
       <form method="post" action="{{ url_for('web.register_otp_request') }}" novalidate>
         {{ otp_request_form.hidden_tag() }}
         <div class="form-group">
-          <label for="otp_request_email">SIT email</label>
-          {{ otp_request_form.email(id="otp_request_email", autocomplete="email", maxlength="255", placeholder="name@sit.singaporetech.edu.sg") }}
+          <label for="otp_request_email">Customer email</label>
+          {{ otp_request_form.email(id="otp_request_email", autocomplete="email", maxlength="255", placeholder="name@example.com") }}
           {% for error in otp_request_form.email.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
         </div>
         <button class="button secondary full" type="submit">Send verification code</button>

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -44,6 +44,7 @@ from app.auth.mfa_policy import has_enrolled_mfa_method
 from app.auth.registration_otp import (
     GENERIC_OTP_ERROR,
     RegistrationOtpError,
+    VERIFY_CUSTOMER_EMAIL_MESSAGE,
     current_verified_registration_email,
     pending_registration_email,
     request_registration_otp,
@@ -246,7 +247,7 @@ def register_submit():
 
     verified_email = current_verified_registration_email()
     if not verified_email:
-        flash("Verify your SIT email before creating an account.", "error")
+        flash(VERIFY_CUSTOMER_EMAIL_MESSAGE, "error")
         return _render_register_email_form(), 400
 
     form = RegisterDetailsForm()

--- a/config.py
+++ b/config.py
@@ -332,6 +332,15 @@ def _csv_env_set(name: str, *, default: str) -> frozenset[str]:
     return values
 
 
+def _email_domain(value: str) -> str:
+    _local, separator, domain = str(value or "").strip().partition("@")
+    return domain.casefold() if separator else ""
+
+
+def _all_email_domains_allowed(emails: frozenset[str], allowed_domains: frozenset[str]) -> bool:
+    return all(_email_domain(item) in allowed_domains for item in emails)
+
+
 def _optional_turnstile_secret() -> str | None:
     direct_value = os.getenv("TURNSTILE_SECRET_KEY")
     file_value = os.getenv("TURNSTILE_SECRET_KEY_FILE")
@@ -1089,10 +1098,14 @@ class Config:
         min_production_seconds=MIN_PRODUCTION_PAYEE_COOLDOWN_SECONDS,
     )
 
-    SIT_WORKPLACE_EMAIL_DOMAINS = _csv_env_set(
-        "SIT_WORKPLACE_EMAIL_DOMAINS",
-        default="sit.singaporetech.edu.sg,singaporetech.edu.sg",
+    ADMIN_ALLOWED_EMAIL_DOMAINS = _csv_env_set(
+        "ADMIN_ALLOWED_EMAIL_DOMAINS",
+        default=os.getenv(
+            "SIT_WORKPLACE_EMAIL_DOMAINS",
+            "sit.singaporetech.edu.sg,singaporetech.edu.sg",
+        ),
     )
+    SIT_WORKPLACE_EMAIL_DOMAINS = ADMIN_ALLOWED_EMAIL_DOMAINS
     STAFF_INVITE_PERSONAL_EMAIL_DOMAINS = _csv_env_set(
         "STAFF_INVITE_PERSONAL_EMAIL_DOMAINS",
         default="gmail.com,outlook.com,hotmail.com,yahoo.com,icloud.com,proton.me,protonmail.com",
@@ -1116,6 +1129,8 @@ class Config:
     )
     if len(ROOT_ADMIN_EMAILS) != 7:
         raise RuntimeError("ROOT_ADMIN_EMAILS must contain exactly 7 workplace email addresses")
+    if not _all_email_domains_allowed(ROOT_ADMIN_EMAILS, ADMIN_ALLOWED_EMAIL_DOMAINS):
+        raise RuntimeError("ROOT_ADMIN_EMAILS must contain only approved admin workplace email addresses")
     STAFF_INVITE_TTL_SECONDS = _int_env(
         "STAFF_INVITE_TTL_SECONDS",
         default=str(24 * 60 * 60),

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -55,9 +55,10 @@ matching GitHub environment. For both `staging` and `production`, set:
 
 `ROOT_ADMIN_EMAILS` is scoped by GitHub environment rather than prefix: set it
 separately in both the `staging` and `production` environments. It must be a
-comma-separated list of exactly 7 SIT workplace email addresses. The deployment
-workflow maps it into the prefixed renderer input for the target environment
-and writes `ROOT_ADMIN_EMAILS` into the signed runtime `container.env`.
+comma-separated list of exactly 7 workplace email addresses from
+`ADMIN_ALLOWED_EMAIL_DOMAINS`. The deployment workflow maps it into the
+prefixed renderer input for the target environment and writes
+`ROOT_ADMIN_EMAILS` into the signed runtime `container.env`.
 
 For production only, also set:
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -260,11 +260,12 @@ Provider automation and origin assertion details are in
 ## Root Admin Bootstrap
 
 Root admins remain a fixed allowlisted group. `ROOT_ADMIN_EMAILS` must contain
-exactly 7 approved SIT workplace email addresses before any database user can
-become `root_admin`; normal customer registration and staff invites must not
-create `root_admin` accounts. Configure `ROOT_ADMIN_EMAILS` as a protected
-GitHub environment variable in both `staging` and `production` before deploying
-this command. Do not commit the allowlist to the repository.
+exactly 7 approved admin workplace email addresses from
+`ADMIN_ALLOWED_EMAIL_DOMAINS` before any database user can become `root_admin`;
+normal customer registration and staff invites must not create `root_admin`
+accounts. Configure `ROOT_ADMIN_EMAILS` as a protected GitHub environment
+variable in both `staging` and `production` before deploying this command. Do
+not commit the allowlist to the repository.
 
 After deployment, verify the admin container received the allowlist:
 
@@ -728,9 +729,12 @@ Manual recovery operator workflow:
 - Public account-recovery submission never unlocks, mutates, or completes an
   account by itself.
 
-## SIT Email OTP Registration Operations
+## Customer Email OTP Registration Operations
 
-Customer self-registration is limited to exact normalized SIT email domains:
+Customer self-registration uses personal/customer email addresses. The exact
+normalized domains in `ADMIN_ALLOWED_EMAIL_DOMAINS` are reserved for
+staff/admin/root-admin workplace identities and are blocked from customer
+registration:
 
 - `sit.singaporetech.edu.sg`
 - `singaporetech.edu.sg`
@@ -756,11 +760,11 @@ settings as password reset email:
 
 Operational checks:
 
-- Verify SMTP settings with a controlled staging registration using a test SIT
-  email address.
+- Verify SMTP settings with a controlled staging registration using a test
+  personal customer email address.
 - Investigate `registration_otp` audit events by outcome
-  (`requested`, `verified`, `failed`, `expired`, or `locked`) without expecting
-  raw email addresses or codes in event metadata.
+  (`requested`, `verified`, `blocked`, `failed`, `expired`, or `locked`)
+  without expecting raw email addresses or codes in event metadata.
 - If registration email delivery fails, the request fails closed and the
   PostgreSQL OTP challenge row is deleted.
 - Existing-account requests intentionally return the same generic response as

--- a/docs/security/access-control.md
+++ b/docs/security/access-control.md
@@ -28,9 +28,11 @@ Customer and admin functionality are separated at application-factory level:
 | Admin app | `admin_wsgi.py` / `create_app(app_mode="admin")` | Admin routes only | `app/__init__.py`, `app/admin/routes.py` |
 
 The customer app rejects staff/admin account types during customer login in
-`app/auth/services.py`. The admin app accepts only staff account types with
-active status, verified workplace email, password authentication, and TOTP in
-`app/admin/services.py`.
+`app/auth/services.py`. Customer registration and customer profile email
+changes also reject the configured admin workplace domains through
+`app/security/identity_policy.py`. The admin app accepts only staff account
+types with active status, an approved admin workplace email domain, verified
+workplace email, password authentication, and TOTP in `app/admin/services.py`.
 
 Tests:
 
@@ -143,8 +145,8 @@ changes.
 | Control | Implementation evidence | Test evidence |
 | --- | --- | --- |
 | Generated admin route authorization inventory | `app/admin/routes.py`; explicit policy entries in `tests/test_admin_route_inventory_security.py` | `tests/test_admin_route_inventory_security.py::test_admin_route_inventory_matches_registered_flask_routes`, `tests/test_admin_route_inventory_security.py::test_admin_route_inventory_has_complete_security_decisions` |
-| Staff/admin browser and JSON login requires workplace email, password, active account, verified workplace email, and TOTP | `app/admin/routes.py`, `app/admin/services.py::authenticate_admin_primary()` and `complete_admin_mfa_login()` | `tests/test_admin_dashboard_operations.py::test_admin_browser_login_and_mfa_reaches_dashboard`, `tests/test_admin_dashboard_operations.py::test_admin_json_login_contract_remains_compatible` |
-| Root admin is configured by role and email allowlist | `app/admin/services.py::is_root_admin()` and `config.py` `ROOT_ADMIN_EMAILS` | `tests/test_admin_staff_invites.py::test_only_root_admin_with_totp_stepup_can_create_invites` |
+| Staff/admin browser and JSON login requires workplace email, password, active account, approved admin email domain, verified workplace email, and TOTP | `app/admin/routes.py`, `app/admin/services.py::authenticate_admin_primary()` and `complete_admin_mfa_login()` | `tests/test_admin_dashboard_operations.py::test_admin_browser_login_and_mfa_reaches_dashboard`, `tests/test_admin_dashboard_operations.py::test_admin_json_login_contract_remains_compatible`, `tests/test_admin_dashboard_operations.py::test_admin_browser_login_rejects_staff_outside_admin_email_domains` |
+| Root admin is configured by role, approved admin email domain, and email allowlist | `app/admin/services.py::is_root_admin()`, `app/security/identity_policy.py`, and `config.py` `ROOT_ADMIN_EMAILS` | `tests/test_admin_staff_invites.py::test_only_root_admin_with_totp_stepup_can_create_invites`, `tests/test_admin_bootstrap_root.py::test_bootstrap_root_admin_cli_rejects_non_admin_domain_allowlist_entry` |
 | Root admin can invite only `staff` or `admin`, not `root_admin` | `StaffInvite` role constraint in `app/models.py`; role validation in `app/admin/services.py` | `tests/test_admin_staff_invites.py::test_invite_creation_validates_server_side_email_and_role_policy` |
 | Invite acceptance rejects forged privileged fields | `_reject_forged_invite_fields()` in `app/admin/services.py` | `tests/test_admin_staff_invites.py` |
 | Staff invite acceptance activates only after workplace verification and TOTP setup | `start_invite_acceptance()` and `verify_invite_acceptance()` | `tests/test_admin_staff_invites.py::test_staff_invite_acceptance_activates_only_after_workplace_code_and_totp` |
@@ -152,7 +154,7 @@ changes.
 | Admin/root audit viewer supports bounded filters, safe field search, sorting, pagination, and redacted detail display | `app/admin/routes.py::audit_logs()`, `app/admin/services.py::query_audit_events_for_admin()` | `tests/test_admin_dashboard_operations.py::test_audit_viewer_filters_bounds_and_redacts_detail_metadata`, `tests/test_admin_audit_viewer.py` |
 | Admin/root alert review uses the existing report path without sending alerts | `app/admin/routes.py::alerts()`, `app/security/alerts.py::build_security_alert_report()` | `tests/test_admin_dashboard_operations.py::test_alert_review_is_admin_only_and_does_not_send_alerts` |
 | Root-admin staff/admin lifecycle actions require TOTP and audit logging | `app/admin/routes.py`, `app/admin/services.py::transition_staff_account_as_root_admin()` | `tests/test_admin_dashboard_operations.py::test_root_manages_staff_lifecycle_with_totp_and_safe_audit` |
-| Staff/customer self-action guard | `app/admin/separation.py::assert_not_self_customer_action()` | `tests/test_admin_staff_invites.py::test_separation_guard_blocks_linked_staff_acting_on_own_customer` |
+| Staff/customer self-action guard | `app/admin/separation.py::assert_not_self_customer_action()` | `tests/test_admin_staff_invites.py::test_separation_guard_blocks_linked_staff_acting_on_own_customer`, `tests/test_admin_manual_recovery.py::test_root_admin_cannot_transition_own_customer_manual_recovery` |
 | Admin session context drift | Any detected coarse-network, browser-family, or detailed User-Agent drift revokes the admin session and requires full login | `app/security/sessions.py`, `tests/test_session_risk_binding.py::test_admin_context_change_revokes_session_under_stricter_policy` |
 
 Production Nginx does not publish the admin app. The admin application access

--- a/docs/security/cryptography-and-authentication.md
+++ b/docs/security/cryptography-and-authentication.md
@@ -222,9 +222,13 @@ and `tests/test_password_reset.py::test_recovery_codes_are_hashed_single_use_res
 
 ### Customer Authentication
 
-Customer registration requires a verified SIT email OTP before `register_user`
-creates a customer account. Evidence: `app/auth/registration_otp.py`,
-`app/auth/services.py`, `app/auth/routes.py`, and `app/web/routes.py`.
+Customer registration requires a verified personal/customer email OTP before
+`register_user` creates a customer account. `app/security/identity_policy.py`
+reserves configured admin workplace domains and root-admin allowlisted emails
+for staff/admin/root-admin identities, so they cannot be used for customer
+registration or customer profile email changes. Evidence:
+`app/auth/registration_otp.py`, `app/auth/services.py`,
+`app/auth/routes.py`, and `app/web/routes.py`.
 
 Customer login uses username or email plus password. `authenticate_primary()`
 uses a dummy password hash for unknown users to reduce user-enumeration timing
@@ -276,7 +280,8 @@ and `tests/test_password_reset.py::test_admin_like_customer_domain_reset_fails_c
 The admin runtime is a separate Flask app mode selected by `admin_wsgi.py` and
 `create_app(app_mode="admin")`. Admin/staff users use workplace email,
 password, and mandatory TOTP. Active staff users must have `account_status`
-`active`, an allowed staff account type, `mfa_enabled`, and
+`active`, an allowed staff account type, an email domain in
+`ADMIN_ALLOWED_EMAIL_DOMAINS`, `mfa_enabled`, and
 `workplace_email_verified_at`.
 
 Staff onboarding is invite-based. Root admins create invites for `staff` or

--- a/docs/security/privacy-and-pdpa.md
+++ b/docs/security/privacy-and-pdpa.md
@@ -10,7 +10,7 @@ protected personal data.
 | Data category | Purpose | Minimization and handling |
 | --- | --- | --- |
 | Customer name | Account display, support, audit context | Required at registration; do not copy into alert payloads unless needed for a reviewed support workflow |
-| Customer email | SIT email verification, login identifier, reset/recovery email | Exact SIT domains only for registration; audit metadata uses references where possible |
+| Customer email | Customer email verification, login identifier, reset/recovery email | Staff/admin workplace domains are blocked for customer registration; audit metadata uses references where possible |
 | Customer phone | Registration contact metadata | Singapore phone format only; optional for preserved legacy rows; do not use as an authenticator |
 | Account identifiers | Customer account routing, payee setup, display | Generated server-side; UI masks account numbers where possible; audit events use references |
 | Payee records | Customer-managed payment recipients | Scoped to owner; recipient lookup occurs only after TOTP step-up; do not expose payee ownership across users |

--- a/docs/security/secure-coding.md
+++ b/docs/security/secure-coding.md
@@ -18,7 +18,7 @@ fields are ignored or rejected rather than trusted from client payloads.
 | --- | --- | --- |
 | Customer registration and login | `app/auth/forms.py`, `app/auth/schemas.py`, `app/auth/services.py` | `tests/test_auth_registration_login.py` |
 | Password policy and length limits | `app/security/passwords.py` | `tests/test_passwords.py`, `tests/test_auth_registration_login.py::test_oversized_registration_password_rejected_before_policy_processing` |
-| SIT email OTP registration | `app/auth/registration_otp.py` | `tests/test_auth_registration_login.py::test_registration_otp_rejects_non_sit_email_domain`, `tests/test_auth_registration_login.py::test_registration_otp_rejects_suffix_lookalike_domain` |
+| Customer email OTP registration with admin-domain exclusion | `app/auth/registration_otp.py`, `app/security/identity_policy.py` | `tests/test_auth_registration_login.py::test_registration_otp_rejects_admin_and_root_allowlist_emails`, `tests/test_auth_registration_login.py::test_registration_service_rechecks_customer_email_policy` |
 | Admin invite acceptance | `app/admin/routes.py`, `app/admin/services.py` | `tests/test_admin_staff_invites.py` |
 | Banking and transaction payloads | `app/banking/forms.py`, `app/banking/schemas.py`, `app/banking/services.py` | `tests/test_banking_transaction_security.py` |
 | Open redirect and URL-like mass assignment | `app/auth/routes.py`, `app/web/routes.py` | `tests/test_owasp_regressions.py::test_external_next_parameter_cannot_create_an_open_redirect`, `tests/test_owasp_regressions.py::test_url_like_mass_assignment_field_is_rejected` |

--- a/tests/_auth_flow_helpers.py
+++ b/tests/_auth_flow_helpers.py
@@ -40,7 +40,7 @@ def _latest_registration_otp() -> str:
     return match.group(1)
 
 
-def verify_registration_email(client, email="alice@sit.singaporetech.edu.sg"):
+def verify_registration_email(client, email="alice@example.com"):
     normalized_email = normalize_registration_email(email)
     with client.session_transaction() as sess:
         already_verified = (
@@ -62,7 +62,7 @@ def verify_registration_email(client, email="alice@sit.singaporetech.edu.sg"):
     return request_response, verify_response
 
 
-def register(client, username="alice01", email="alice@sit.singaporetech.edu.sg", password="correct horse battery staple",
+def register(client, username="alice01", email="alice@example.com", password="correct horse battery staple",
              full_name="Alice Test", phone_number="91234567", verify_email=True):
     if verify_email:
         verify_registration_email(client, email)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,9 +176,10 @@ class TestConfig:
     FRESH_MFA_SECONDS = 5 * 60
     TOTP_LOGIN_VALID_WINDOW = 1
     TOTP_HIGH_RISK_VALID_WINDOW = 0
-    SIT_WORKPLACE_EMAIL_DOMAINS = frozenset(
+    ADMIN_ALLOWED_EMAIL_DOMAINS = frozenset(
         {"sit.singaporetech.edu.sg", "singaporetech.edu.sg"}
     )
+    SIT_WORKPLACE_EMAIL_DOMAINS = ADMIN_ALLOWED_EMAIL_DOMAINS
     STAFF_INVITE_PERSONAL_EMAIL_DOMAINS = frozenset(
         {"gmail.com", "outlook.com", "hotmail.com", "yahoo.com", "icloud.com", "proton.me", "protonmail.com"}
     )

--- a/tests/test_account_security_actions.py
+++ b/tests/test_account_security_actions.py
@@ -96,7 +96,7 @@ def test_authenticated_user_can_open_own_edit_profile_page(client):
     assert response.status_code == 200
     assert b"Edit profile" in response.data
     assert b"alice01" in response.data
-    assert b"alice@sit.singaporetech.edu.sg" in response.data
+    assert b"alice@example.com" in response.data
     assert 'name="username"' in markup
     assert 'name="email"' in markup
     assert "Update profile details" in markup
@@ -342,7 +342,7 @@ def test_profile_email_update_rejects_passkey_stepup_token(client):
 
     assert response.status_code == 403
     assert session_after_update == session_before_update
-    assert user.email == "alice@sit.singaporetech.edu.sg"
+    assert user.email == "alice@example.com"
     assert b"Enter an authenticator code to verify this action" in response.data
 
 def test_profile_email_update_accepts_totp_stepup_without_passkey(client):
@@ -376,7 +376,7 @@ def test_profile_preference_rejects_passkey_when_not_enrolled(client):
         "/profile",
         data={
             "username": "alice01",
-            "email": "alice@sit.singaporetech.edu.sg",
+            "email": "alice@example.com",
             "mfa_step_up_preference": "passkey",
             "totp_code": pyotp.TOTP(secret, digits=6, interval=30).now(),
         },
@@ -409,7 +409,7 @@ def test_legacy_passkey_does_not_unlock_profile_without_totp(client):
 
     assert response.status_code == 302
     assert response.headers["Location"].endswith("/mfa/setup")
-    assert user.email == "alice@sit.singaporetech.edu.sg"
+    assert user.email == "alice@example.com"
     assert user.mfa_step_up_preference == "passkey"
 
 
@@ -426,7 +426,34 @@ def test_profile_update_rejects_invalid_email(client):
     db.session.refresh(user)
 
     assert response.status_code == 400
-    assert user.email == "alice@sit.singaporetech.edu.sg"
+    assert user.email == "alice@example.com"
+
+
+def test_profile_update_rejects_admin_domain_customer_email(client):
+    register(client)
+    login(client)
+    user = db.session.execute(db.select(User).where(User.username == "alice01")).scalar_one()
+    mark_recent_mfa(client, user)
+
+    response = client.post(
+        "/profile",
+        data={
+            "username": "alice01",
+            "email": "alice@sit.singaporetech.edu.sg",
+            "mfa_step_up_preference": "totp",
+        },
+    )
+    db.session.refresh(user)
+    event = (
+        db.session.query(SecurityAuditEvent)
+        .filter_by(event_type="profile_update", outcome="blocked")
+        .one()
+    )
+
+    assert response.status_code == 400
+    assert user.email == "alice@example.com"
+    assert event.event_metadata["reason"] == "admin_email_domain"
+
 
 def test_profile_update_rejects_invalid_username(client):
     register(client)
@@ -435,7 +462,7 @@ def test_profile_update_rejects_invalid_username(client):
 
     response = client.post(
         "/profile",
-        data={"username": "bad user", "email": "alice@sit.singaporetech.edu.sg", "mfa_step_up_preference": "totp"},
+        data={"username": "bad user", "email": "alice@example.com", "mfa_step_up_preference": "totp"},
     )
     db.session.refresh(user)
 
@@ -444,13 +471,13 @@ def test_profile_update_rejects_invalid_username(client):
 
 def test_profile_update_rejects_duplicate_username(client):
     register(client)
-    register(client, username="bob02", email="bob@sit.singaporetech.edu.sg", full_name="Bob Test", phone_number="81234567")
+    register(client, username="bob02", email="bob@example.com", full_name="Bob Test", phone_number="81234567")
     login(client)
     user, _secret = enable_mfa_for_user()
 
     response = client.post(
         "/profile",
-        data={"username": "BOB02", "email": "alice@sit.singaporetech.edu.sg", "mfa_step_up_preference": "totp"},
+        data={"username": "BOB02", "email": "alice@example.com", "mfa_step_up_preference": "totp"},
     )
     db.session.refresh(user)
 
@@ -460,19 +487,19 @@ def test_profile_update_rejects_duplicate_username(client):
 
 def test_profile_update_rejects_duplicate_email(client):
     register(client)
-    register(client, username="bob02", email="bob@sit.singaporetech.edu.sg", full_name="Bob Test", phone_number="81234567")
+    register(client, username="bob02", email="bob@example.com", full_name="Bob Test", phone_number="81234567")
     login(client)
     user = db.session.execute(db.select(User).where(User.username == "alice01")).scalar_one()
     mark_recent_mfa(client, user)
 
     response = client.post(
         "/profile",
-        data={"username": "alice01", "email": "bob@sit.singaporetech.edu.sg", "mfa_step_up_preference": "totp"},
+        data={"username": "alice01", "email": "bob@example.com", "mfa_step_up_preference": "totp"},
     )
     db.session.refresh(user)
 
     assert response.status_code == 400
-    assert user.email == "alice@sit.singaporetech.edu.sg"
+    assert user.email == "alice@example.com"
     assert db.session.query(SecurityAuditEvent).filter_by(event_type="profile_update", outcome="failure").count() == 1
 
 def test_profile_post_requires_csrf_when_enabled(app, client):
@@ -518,7 +545,7 @@ def test_json_auth_post_requires_global_csrf_header_when_enabled(app, client):
 
 def test_profile_submission_cannot_modify_privileged_fields(client):
     register(client)
-    register(client, username="bob02", email="bob@sit.singaporetech.edu.sg", full_name="Bob Test", phone_number="81234567")
+    register(client, username="bob02", email="bob@example.com", full_name="Bob Test", phone_number="81234567")
     login(client)
     user, secret = enable_mfa_for_user()
     other_user = db.session.execute(db.select(User).where(User.username == "bob02")).scalar_one()
@@ -548,7 +575,7 @@ def test_profile_submission_cannot_modify_privileged_fields(client):
     assert user.is_frozen is False
     assert user.password_hash == original_password_hash
     assert other_user.username == "bob02"
-    assert other_user.email == "bob@sit.singaporetech.edu.sg"
+    assert other_user.email == "bob@example.com"
 
 def test_high_risk_stepup_token_is_rejected(client):
     register(client)
@@ -568,7 +595,7 @@ def test_high_risk_stepup_token_is_rejected(client):
     db.session.refresh(user)
 
     assert response.status_code == 403
-    assert user.email == "alice@sit.singaporetech.edu.sg"
+    assert user.email == "alice@example.com"
     event = db.session.query(SecurityAuditEvent).filter_by(event_type="profile_update", outcome="failure").first()
     assert event is not None
     assert event.event_metadata["reason"] == "passkey_step_up_disabled"
@@ -683,5 +710,5 @@ def test_session_risk_drift_requires_reauth_before_sensitive_action(client):
 
     assert response.status_code == 401
     assert b"Session verification required. Please sign in again." in response.data
-    assert user.email == "alice@sit.singaporetech.edu.sg"
+    assert user.email == "alice@example.com"
     assert db.session.query(SecurityAuditEvent).filter_by(event_type="session_risk", outcome="step_up_required").count() == 1

--- a/tests/test_admin_bootstrap_root.py
+++ b/tests/test_admin_bootstrap_root.py
@@ -133,6 +133,26 @@ def test_bootstrap_root_admin_cli_requires_root_admin_allowlist(admin_app):
     assert db.session.query(User).count() == 0
 
 
+def test_bootstrap_root_admin_cli_rejects_non_admin_domain_allowlist_entry(admin_app):
+    root_emails = {
+        "root1@example.com",
+        "root2@sit.singaporetech.edu.sg",
+        "root3@sit.singaporetech.edu.sg",
+        "root4@sit.singaporetech.edu.sg",
+        "root5@sit.singaporetech.edu.sg",
+        "root6@sit.singaporetech.edu.sg",
+        "root7@sit.singaporetech.edu.sg",
+    }
+    admin_app.config["ROOT_ADMIN_EMAILS"] = frozenset(root_emails)
+    command_input = _command_input().replace(ROOT_EMAIL, "root1@example.com", 1)
+
+    result = admin_app.test_cli_runner().invoke(args=["admin", "bootstrap-root"], input=command_input)
+
+    assert result.exit_code != 0
+    assert "Invalid workplace email" in result.output
+    assert db.session.query(User).count() == 0
+
+
 def test_bootstrap_root_admin_cli_refuses_customer_account_conversion(admin_app):
     credential = _credential_input("Primary")
     customer = User(

--- a/tests/test_admin_dashboard_operations.py
+++ b/tests/test_admin_dashboard_operations.py
@@ -321,6 +321,33 @@ def test_admin_browser_login_rejects_customer_accounts_with_generic_error(admin_
     assert authenticated_user_id is None
 
 
+def test_admin_browser_login_rejects_staff_outside_admin_email_domains(admin_client):
+    _staff, _secret = _create_staff_identity(
+        username="external-staff",
+        email="external.staff@example.com",
+        account_type="staff",
+        phone_number="91234567",
+    )
+
+    response = admin_client.post(
+        "/login",
+        data={
+            "workplace_email": "external.staff@example.com",
+            "password": ROOT_PASSWORD,
+        },
+    )
+
+    with admin_client.session_transaction() as sess:
+        pending_user_id = sess.get("pending_mfa_user_id")
+        authenticated_user_id = sess.get("user_id")
+
+    body = response.get_data(as_text=True)
+    assert response.status_code == 401
+    assert "Invalid workplace email, password, or authentication code" in body
+    assert pending_user_id is None
+    assert authenticated_user_id is None
+
+
 def test_dashboard_renders_role_navigation_and_audits_access(admin_client):
     _staff, staff_secret = _create_staff_identity(
         username="bank-staff",

--- a/tests/test_admin_manual_recovery.py
+++ b/tests/test_admin_manual_recovery.py
@@ -257,6 +257,35 @@ def test_root_admin_transition_requires_totp_and_preserves_status(admin_client):
     assert request_record.status == "pending"
 
 
+def test_root_admin_cannot_transition_own_customer_manual_recovery(admin_client):
+    root, root_secret = _create_staff_identity(
+        username="root-admin",
+        email=ROOT_EMAIL,
+        account_type="root_admin",
+        phone_number="91234567",
+    )
+    customer, _customer_secret = _create_customer("recover-self-root")
+    root.staff_personal_email = customer.email
+    request_record = _create_manual_recovery_request(customer)
+    db.session.commit()
+    _login_admin(admin_client, root_secret)
+
+    response = admin_client.post(
+        f"/manual-recovery/requests/{request_record.id}/transition",
+        json={"status": "under_review", "reason": "identity review", "totp_code": _totp(root_secret)},
+    )
+    db.session.refresh(request_record)
+    event = db.session.query(SecurityAuditEvent).filter_by(
+        event_type="staff_self_customer_action_blocked",
+        outcome="blocked",
+    ).one()
+
+    assert response.status_code == 403
+    assert request_record.status == "pending"
+    assert event.user_id == root.id
+    assert event.event_metadata["action_type"] == "manual_recovery_transition"
+
+
 def test_root_admin_can_transition_manual_recovery_to_review_and_approval(admin_client):
     _root, root_secret = _create_staff_identity(
         username="root-admin",

--- a/tests/test_admin_staff_invites.py
+++ b/tests/test_admin_staff_invites.py
@@ -188,12 +188,33 @@ def test_invite_creation_validates_server_side_email_and_role_policy(admin_clien
         {"workplace_email": "staff@gmail.com"},
         {"personal_email": "staff+tag@gmail.com"},
         {"personal_email": "staff@sit.singaporetech.edu.sg"},
+        {"personal_email": ROOT_EMAIL},
         {"role": "root_admin"},
     ]
     responses = [_create_invite(admin_client, secret, **case) for case in cases]
 
-    assert [response.status_code for response in responses] == [400, 400, 400, 400, 400]
+    assert [response.status_code for response in responses] == [400, 400, 400, 400, 400, 400]
     assert db.session.query(StaffInvite).count() == 0
+
+
+def test_invite_creation_accepts_configured_admin_email_domains(admin_client):
+    _root, secret = _create_staff_identity(
+        username="root-admin",
+        email=ROOT_EMAIL,
+        account_type="root_admin",
+        phone_number="91234567",
+    )
+    _login_admin(admin_client, secret)
+
+    response = _create_invite(
+        admin_client,
+        secret,
+        personal_email="staff.second-domain@gmail.com",
+        workplace_email="staff.second-domain@singaporetech.edu.sg",
+    )
+
+    assert response.status_code == 201
+    assert response.get_json()["invite"]["workplace_email"] == "staff.second-domain@singaporetech.edu.sg"
 
 
 def test_invite_acceptance_requires_turnstile_when_enabled(admin_app, admin_client, monkeypatch):

--- a/tests/test_auth_registration_login.py
+++ b/tests/test_auth_registration_login.py
@@ -24,7 +24,7 @@ def test_registration_uses_local_fallback_when_live_password_check_is_unavailabl
         "/register",
         data={
             "username": "alice01",
-            "email": "alice@sit.singaporetech.edu.sg",
+            "email": "alice@example.com",
             "full_name": "Alice Test",
             "phone_number": "91234567",
             "password": "correct horse battery staple",
@@ -46,11 +46,11 @@ def test_registration_rejects_live_breached_password(client, monkeypatch):
     assert db.session.query(User).count() == 0
     assert b"Password is too common. Please try again" in response.data
 
-def test_register_requires_verified_sit_email(client):
+def test_register_requires_verified_customer_email(client):
     response = register(client, verify_email=False)
 
     assert response.status_code == 400
-    assert b"Verify your SIT email before creating an account" in response.data
+    assert b"Verify your customer email before creating an account" in response.data
     assert db.session.query(User).count() == 0
 
 
@@ -66,7 +66,7 @@ def test_registration_step_one_has_single_email_input(client):
 
 
 def test_registration_step_two_uses_verified_email_text_not_input(client):
-    verify_registration_email(client, "verified@sit.singaporetech.edu.sg")
+    verify_registration_email(client, "verified@example.com")
 
     response = client.get("/register")
     html = response.data.decode("utf-8")
@@ -74,19 +74,19 @@ def test_registration_step_two_uses_verified_email_text_not_input(client):
     assert response.status_code == 200
     assert "Step 2 of 2" in html
     assert "Verified email" in html
-    assert "verified@sit.singaporetech.edu.sg" in html
+    assert "verified@example.com" in html
     assert 'name="email"' not in html
     assert "data-password-strength" in html
 
 
 def test_registration_ignores_forged_step_two_email_field(client):
-    verify_registration_email(client, "verified@sit.singaporetech.edu.sg")
+    verify_registration_email(client, "verified@example.com")
 
     response = client.post(
         "/register",
         data={
             "username": "verified01",
-            "email": "attacker@sit.singaporetech.edu.sg",
+            "email": "attacker@example.com",
             "email_verified": "true",
             "full_name": "Verified User",
             "phone_number": "91234567",
@@ -97,11 +97,11 @@ def test_registration_ignores_forged_step_two_email_field(client):
     user = db.session.execute(db.select(User).where(User.username == "verified01")).scalar_one()
 
     assert response.status_code == 302
-    assert user.email == "verified@sit.singaporetech.edu.sg"
+    assert user.email == "verified@example.com"
 
 
 def test_registration_consumes_verified_email_after_success(client):
-    verify_registration_email(client, "consume@sit.singaporetech.edu.sg")
+    verify_registration_email(client, "consume@example.com")
 
     created = client.post(
         "/register",
@@ -126,33 +126,80 @@ def test_registration_consumes_verified_email_after_success(client):
 
     assert created.status_code == 302
     assert reused.status_code == 400
-    assert b"Verify your SIT email before creating an account" in reused.data
+    assert b"Verify your customer email before creating an account" in reused.data
     assert db.session.query(User).count() == 1
 
 
-def test_registration_otp_rejects_non_sit_email_domain(client):
+def test_registration_otp_allows_personal_customer_email(client):
     response = client.post("/auth/register/otp/request", json={"email": "alice@example.com"})
 
-    assert response.status_code == 400
-    assert response.get_json() == {"error": "Use your SIT email address to register."}
+    assert response.status_code == 200
+    assert response.get_json() == {"message": "If the email is eligible, a verification code has been sent."}
     assert db.session.query(User).count() == 0
 
 
-def test_registration_otp_rejects_suffix_lookalike_domain(client):
+def test_registration_otp_rejects_admin_and_root_allowlist_emails(client):
+    cases = [
+        ("staff@sit.singaporetech.edu.sg", "admin_email_domain"),
+        ("staff@singaporetech.edu.sg", "admin_email_domain"),
+        ("root1@sit.singaporetech.edu.sg", "root_admin_allowlisted_email"),
+    ]
+    responses = [
+        client.post("/auth/register/otp/request", json={"email": email})
+        for email, _reason in cases
+    ]
+    events = db.session.query(SecurityAuditEvent).filter_by(event_type="registration_otp").all()
+
+    assert [response.status_code for response in responses] == [400, 400, 400]
+    assert [response.get_json() for response in responses] == [
+        {"error": "Registration could not be started for that email."},
+        {"error": "Registration could not be started for that email."},
+        {"error": "Registration could not be started for that email."},
+    ]
+    assert [event.outcome for event in events] == ["blocked", "blocked", "blocked"]
+    assert {event.event_metadata["reason"] for event in events} == {reason for _email, reason in cases}
+
+
+def test_registration_otp_uses_exact_admin_domain_matching(client):
     response = client.post(
         "/auth/register/otp/request",
         json={"email": "alice@sit.singaporetech.edu.sg.example.com"},
     )
 
+    assert response.status_code == 200
+    assert response.get_json() == {"message": "If the email is eligible, a verification code has been sent."}
+
+
+def test_registration_service_rechecks_customer_email_policy(client):
+    with client.session_transaction() as sess:
+        sess[REGISTRATION_OTP_VERIFIED_EMAIL_KEY] = "root1@sit.singaporetech.edu.sg"
+        sess[REGISTRATION_OTP_VERIFIED_AT_KEY] = int(time.time())
+
+    response = client.post(
+        "/auth/register",
+        json={
+            "username": "root-as-customer",
+            "email": "root1@sit.singaporetech.edu.sg",
+            "full_name": "Root As Customer",
+            "phone_number": "91234567",
+            "password": "correct horse battery staple",
+            "confirm_password": "correct horse battery staple",
+        },
+    )
+    events = db.session.query(SecurityAuditEvent).filter_by(event_type="registration").all()
+
     assert response.status_code == 400
-    assert response.get_json() == {"error": "Use your SIT email address to register."}
+    assert response.get_json() == {"error": "Verify your customer email before creating an account."}
+    assert db.session.query(User).count() == 0
+    assert events[-1].outcome == "blocked"
+    assert events[-1].event_metadata["reason"] == "root_admin_allowlisted_email"
 
 
 def test_registration_otp_hashes_code_and_verifies_email(client):
     from app.security.email import password_reset_outbox
     from app.models import RegistrationOtpChallenge
 
-    email = "alice@sit.singaporetech.edu.sg"
+    email = "alice@example.com"
     request_response = client.post("/auth/register/otp/request", json={"email": email})
     raw_code = re.search(r"\b([0-9]{6})\b", password_reset_outbox()[-1]["body"]).group(1)
     stored_values = [
@@ -163,7 +210,7 @@ def test_registration_otp_hashes_code_and_verifies_email(client):
 
     assert request_response.status_code == 200
     assert verify_response.status_code == 200
-    assert password_reset_outbox()[-1]["to"] == "alice@sit.singaporetech.edu.sg"
+    assert password_reset_outbox()[-1]["to"] == "alice@example.com"
     assert password_reset_outbox()[-1]["subject"] == "SITBank registration verification code"
     assert stored_values
     assert all(raw_code not in str(value) for value in stored_values)
@@ -172,7 +219,7 @@ def test_registration_otp_hashes_code_and_verifies_email(client):
 def test_registration_otp_resend_invalidates_previous_code(client, monkeypatch):
     from app.security.email import password_reset_outbox
 
-    email = "alice@sit.singaporetech.edu.sg"
+    email = "alice@example.com"
     first = client.post("/auth/register/otp/request", json={"email": email})
     first_code = re.search(r"\b([0-9]{6})\b", password_reset_outbox()[-1]["body"]).group(1)
     resend_time = int(time.time()) + 61
@@ -192,7 +239,7 @@ def test_registration_otp_resend_invalidates_previous_code(client, monkeypatch):
 def test_registration_otp_attempt_limit_invalidates_code(client):
     from app.security.email import password_reset_outbox
 
-    email = "alice@sit.singaporetech.edu.sg"
+    email = "alice@example.com"
     client.post("/auth/register/otp/request", json={"email": email})
     code = re.search(r"\b([0-9]{6})\b", password_reset_outbox()[-1]["body"]).group(1)
     failures = [
@@ -213,7 +260,7 @@ def test_registration_otp_existing_account_response_is_generic(client):
     second_client = current_app.test_client()
     response = second_client.post(
         "/auth/register/otp/request",
-        json={"email": "alice@sit.singaporetech.edu.sg"},
+        json={"email": "alice@example.com"},
     )
 
     assert created.status_code == 302
@@ -232,7 +279,7 @@ def test_registration_otp_email_failure_fails_closed_without_code(client, monkey
 
     response = client.post(
         "/auth/register/otp/request",
-        json={"email": "alice@sit.singaporetech.edu.sg"},
+        json={"email": "alice@example.com"},
     )
 
     assert response.status_code == 503
@@ -284,8 +331,8 @@ def test_registration_hashes_password_with_pbkdf2(client):
     assert user.password_hash.startswith(f"{PBKDF2_PREFIX}$v1$i=600000$")
 
 def test_short_password_registration_retry_can_login(client):
-    rejected = register(client, username="retry01", email="retry@sit.singaporetech.edu.sg", password="short")
-    created = register(client, username="retry01", email="retry@sit.singaporetech.edu.sg")
+    rejected = register(client, username="retry01", email="retry@example.com", password="short")
+    created = register(client, username="retry01", email="retry@example.com")
     login_response = login(client, identifier="retry01")
     dashboard_response = client.get("/dashboard")
 
@@ -327,7 +374,7 @@ def test_long_unicode_password_can_register_login_and_change(client, monkeypatch
     assert verify_password(new_password, user.password_hash)
 
 def test_password_templates_do_not_truncate_and_show_max_length_guidance(client):
-    verify_registration_email(client, "template@sit.singaporetech.edu.sg")
+    verify_registration_email(client, "template@example.com")
     register_response = client.get("/register")
     login_response = client.get("/login")
     register(client)
@@ -368,7 +415,7 @@ def test_password_at_minimum_length_can_register_and_login(client):
 
 def test_browser_registration_uses_configured_password_minimum(app, client):
     app.config["PASSWORD_MIN_LENGTH"] = 12
-    verify_registration_email(client, "minimum@sit.singaporetech.edu.sg")
+    verify_registration_email(client, "minimum@example.com")
 
     too_short = client.post(
         "/register",
@@ -405,13 +452,13 @@ def test_browser_registration_uses_configured_password_minimum(app, client):
 
 def test_api_registration_uses_configured_password_minimum(app, client):
     app.config["PASSWORD_MIN_LENGTH"] = 12
-    verify_registration_email(client, "minimum-api@sit.singaporetech.edu.sg")
+    verify_registration_email(client, "minimum-api@example.com")
 
     too_short = client.post(
         "/auth/register",
         json={
             "username": "minapi01",
-            "email": "minimum-api@sit.singaporetech.edu.sg",
+            "email": "minimum-api@example.com",
             "full_name": "Minimum Api",
             "phone_number": "91234567",
             "password": "Abcdef12345",
@@ -428,7 +475,7 @@ def test_api_registration_uses_configured_password_minimum(app, client):
         "/auth/register",
         json={
             "username": "minapi01",
-            "email": "minimum-api@sit.singaporetech.edu.sg",
+            "email": "minimum-api@example.com",
             "full_name": "Minimum Api",
             "phone_number": "91234567",
             "password": accepted_password,
@@ -474,7 +521,7 @@ def test_oversized_api_registration_password_rejected_cleanly(client, monkeypatc
         "/auth/register",
         json={
             "username": "oversized01",
-            "email": "oversized@sit.singaporetech.edu.sg",
+            "email": "oversized@example.com",
             "full_name": "Oversized Test",
             "phone_number": "91234567",
             "password": password,
@@ -539,7 +586,7 @@ def test_registration_requires_matching_confirm_password(client):
         "/register",
         data={
             "username": "alice01",
-            "email": "alice@sit.singaporetech.edu.sg",
+            "email": "alice@example.com",
             "full_name": "Alice Test",
             "phone_number": "91234567",
             "password": "correct horse battery staple",
@@ -556,7 +603,7 @@ def test_registration_requires_full_name_and_valid_phone_number(client):
         "/register",
         data={
             "username": "alice01",
-            "email": "alice@sit.singaporetech.edu.sg",
+            "email": "alice@example.com",
             "phone_number": "91234567",
             "password": "correct horse battery staple",
             "confirm_password": "correct horse battery staple",
@@ -566,7 +613,7 @@ def test_registration_requires_full_name_and_valid_phone_number(client):
         "/register",
         data={
             "username": "alice01",
-            "email": "alice@sit.singaporetech.edu.sg",
+            "email": "alice@example.com",
             "full_name": "Alice Test",
             "phone_number": "71234567",
             "password": "correct horse battery staple",
@@ -604,7 +651,7 @@ def test_registration_rejects_duplicate_phone_with_generic_error(client):
     duplicate_phone = register(
         client,
         username="bob02",
-        email="bob@sit.singaporetech.edu.sg",
+        email="bob@example.com",
         full_name="Bob Test",
         phone_number="91234567",
     )
@@ -619,7 +666,7 @@ def test_api_registration_rejects_client_supplied_account_number(client):
         "/auth/register",
         json={
             "username": "alice01",
-            "email": "alice@sit.singaporetech.edu.sg",
+            "email": "alice@example.com",
             "full_name": "Alice Test",
             "phone_number": "91234567",
             "account_number": "999999999",

--- a/tests/test_authenticated_portal_ui.py
+++ b/tests/test_authenticated_portal_ui.py
@@ -178,7 +178,7 @@ def test_public_layout_does_not_expose_authenticated_account_actions(client):
     assert 'action="/logout"' not in markup
 
 def test_authentication_pages_have_password_helpers_and_mfa_back_link(client):
-    verify_registration_email(client, "helpers@sit.singaporetech.edu.sg")
+    verify_registration_email(client, "helpers@example.com")
     register_page = client.get("/register")
     login_page = client.get("/login")
     register(client)
@@ -196,12 +196,12 @@ def test_authentication_pages_have_password_helpers_and_mfa_back_link(client):
     assert "Back to login" in mfa_page.data.decode("utf-8")
 
 def test_flash_messages_are_dismissible(client):
-    verify_registration_email(client, "flash@sit.singaporetech.edu.sg")
+    verify_registration_email(client, "flash@example.com")
     response = client.post(
         "/register",
         data={
             "username": "flash01",
-            "email": "flash@sit.singaporetech.edu.sg",
+            "email": "flash@example.com",
             "full_name": "Flash Test",
             "phone_number": "91234567",
             "password": "correct horse battery staple",

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -11,7 +11,7 @@ from app.models import User
 
 # ── Helpers ────────────────────────────────────────────────────────────────────
 
-def register(client, username="alice01", email="alice@sit.singaporetech.edu.sg",
+def register(client, username="alice01", email="alice@example.com",
              password="correct horse battery staple",
              full_name="Alice Test", phone_number="91234567"):
     verify_registration_email(client, email)

--- a/tests/test_local_transfer.py
+++ b/tests/test_local_transfer.py
@@ -72,14 +72,14 @@ def transfer_context(app, client):
     register(
         client,
         username="alice01",
-        email="alice@sit.singaporetech.edu.sg",
+        email="alice@example.com",
         full_name="Alice Sender",
         phone_number="91234567",
     )
     register(
         bob_client,
         username="bob02",
-        email="bob@sit.singaporetech.edu.sg",
+        email="bob@example.com",
         full_name="Bob Recipient",
         phone_number="81234567",
     )
@@ -139,7 +139,7 @@ def test_transfer_submit_blocked_during_cooldown(client, transfer_context):
 def test_transfer_page_returns_404_for_other_users_payee(app, client, transfer_context):
     carol = User(
         username="carol03",
-        email="carol@sit.singaporetech.edu.sg",
+        email="carol@example.com",
         full_name="Carol Other",
         phone_number="71234567",
         account_number="555555555",
@@ -165,7 +165,7 @@ def test_transfer_submit_idor_check_runs_before_mfa(app, client, transfer_contex
 
     carol = User(
         username="carol04",
-        email="carol04@sit.singaporetech.edu.sg",
+        email="carol04@example.com",
         full_name="Carol Other",
         phone_number="61234567",
         account_number="777777777",

--- a/tests/test_local_transfer_security.py
+++ b/tests/test_local_transfer_security.py
@@ -35,7 +35,7 @@ def _make_user(
     phone = f"9{suffix:07d}"
     user = User(
         username=username,
-        email=f"{username}@sit.singaporetech.edu.sg",
+        email=f"{username}@example.com",
         full_name=username.capitalize(),
         phone_number=phone,
         account_number=account_number,

--- a/tests/test_mfa_lifecycle.py
+++ b/tests/test_mfa_lifecycle.py
@@ -349,7 +349,7 @@ def test_mfa_setup_warns_when_recovery_codes_are_low_and_dashboard_stays_quiet(c
 def test_mfa_setup_generates_independent_user_secrets(app, client):
     second_client = app.test_client()
     register(client)
-    register(second_client, username="bob02", email="bob@sit.singaporetech.edu.sg", full_name="Bob Test", phone_number="81234567")
+    register(second_client, username="bob02", email="bob@example.com", full_name="Bob Test", phone_number="81234567")
     login(client)
     login(second_client, identifier="bob02")
 
@@ -371,7 +371,7 @@ def test_mfa_code_verifies_only_for_own_enrolled_secret(app, client, monkeypatch
 
     second_client = app.test_client()
     register(client)
-    register(second_client, username="bob02", email="bob@sit.singaporetech.edu.sg", full_name="Bob Test", phone_number="81234567")
+    register(second_client, username="bob02", email="bob@example.com", full_name="Bob Test", phone_number="81234567")
     login(client)
     login(second_client, identifier="bob02")
 

--- a/tests/test_owasp_regressions.py
+++ b/tests/test_owasp_regressions.py
@@ -36,12 +36,12 @@ def test_public_homepage_exposes_verification_and_student_disclaimer(client):
 
 
 def test_external_next_parameter_cannot_create_an_open_redirect(client):
-    verify_registration_email(client, "redirect@sit.singaporetech.edu.sg")
+    verify_registration_email(client, "redirect@example.com")
     register = client.post(
         "/register",
         data={
             "username": "redirect01",
-            "email": "redirect@sit.singaporetech.edu.sg",
+            "email": "redirect@example.com",
             "full_name": "Redirect User",
             "phone_number": "91234567",
             "password": VALID_PASSWORD,

--- a/tests/test_payee_idor.py
+++ b/tests/test_payee_idor.py
@@ -16,14 +16,14 @@ def payee_idor_context(app, client):
     register(
         client,
         username="alice01",
-        email="alice@sit.singaporetech.edu.sg",
+        email="alice@example.com",
         full_name="Alice Customer",
         phone_number="91234567",
     )
     register(
         bob_client,
         username="bob02",
-        email="bob@sit.singaporetech.edu.sg",
+        email="bob@example.com",
         full_name="Bob Customer",
         phone_number="81234567",
     )

--- a/tests/test_payee_management_security.py
+++ b/tests/test_payee_management_security.py
@@ -88,14 +88,14 @@ def test_payee_lookup_does_not_reveal_recipient_before_totp(app, client):
     _register_customer(
         client,
         username="alice01",
-        email="alice@sit.singaporetech.edu.sg",
+        email="alice@example.com",
         phone="91234567",
         account="012345678",
     )
     bob = _register_customer(
         bob_client,
         username="bob02",
-        email="bob@sit.singaporetech.edu.sg",
+        email="bob@example.com",
         phone="81234567",
         account="012555999",
     )
@@ -121,14 +121,14 @@ def test_payee_lookup_requires_totp_before_confirmation(app, client):
     _register_customer(
         client,
         username="alice01",
-        email="alice@sit.singaporetech.edu.sg",
+        email="alice@example.com",
         phone="91234567",
         account="012345678",
     )
     bob = _register_customer(
         bob_client,
         username="bob02",
-        email="bob@sit.singaporetech.edu.sg",
+        email="bob@example.com",
         phone="81234567",
         account="012555999",
     )
@@ -160,14 +160,14 @@ def test_payee_add_rejects_passkey_stepup_token(app, client):
     _register_customer(
         client,
         username="alice01",
-        email="alice@sit.singaporetech.edu.sg",
+        email="alice@example.com",
         phone="91234567",
         account="012345678",
     )
     bob = _register_customer(
         bob_client,
         username="bob02",
-        email="bob@sit.singaporetech.edu.sg",
+        email="bob@example.com",
         phone="81234567",
         account="012555999",
     )
@@ -193,7 +193,7 @@ def test_invalid_payee_lookup_is_generic_and_audited(client):
     _register_customer(
         client,
         username="alice01",
-        email="alice@sit.singaporetech.edu.sg",
+        email="alice@example.com",
         phone="91234567",
         account="012345678",
     )
@@ -220,14 +220,14 @@ def test_self_and_duplicate_payee_are_rejected_before_pending_state(app, client)
     alice = _register_customer(
         client,
         username="alice01",
-        email="alice@sit.singaporetech.edu.sg",
+        email="alice@example.com",
         phone="91234567",
         account="012345678",
     )
     bob = _register_customer(
         bob_client,
         username="bob02",
-        email="bob@sit.singaporetech.edu.sg",
+        email="bob@example.com",
         phone="81234567",
         account="012555999",
     )
@@ -255,14 +255,14 @@ def test_pending_payee_confirmation_expires(app, client):
     _register_customer(
         client,
         username="alice01",
-        email="alice@sit.singaporetech.edu.sg",
+        email="alice@example.com",
         phone="91234567",
         account="012345678",
     )
     bob = _register_customer(
         bob_client,
         username="bob02",
-        email="bob@sit.singaporetech.edu.sg",
+        email="bob@example.com",
         phone="81234567",
         account="012555999",
     )
@@ -289,14 +289,14 @@ def test_payee_removal_enforces_ownership_and_totp(app, client):
     alice = _register_customer(
         client,
         username="alice01",
-        email="alice@sit.singaporetech.edu.sg",
+        email="alice@example.com",
         phone="91234567",
         account="012345678",
     )
     bob = _register_customer(
         bob_client,
         username="bob02",
-        email="bob@sit.singaporetech.edu.sg",
+        email="bob@example.com",
         phone="81234567",
         account="012555999",
     )
@@ -320,7 +320,7 @@ def test_payee_routes_cover_missing_expired_and_unauthorized_pending_state(clien
     alice = _register_customer(
         client,
         username="alice01",
-        email="alice@sit.singaporetech.edu.sg",
+        email="alice@example.com",
         phone="91234567",
         account="012345678",
     )
@@ -381,14 +381,14 @@ def test_payee_confirmation_handles_missing_duplicate_and_removal_paths(
     alice = _register_customer(
         client,
         username="alice01",
-        email="alice@sit.singaporetech.edu.sg",
+        email="alice@example.com",
         phone="91234567",
         account="012345678",
     )
     bob = _register_customer(
         bob_client,
         username="bob02",
-        email="bob@sit.singaporetech.edu.sg",
+        email="bob@example.com",
         phone="81234567",
         account="012555999",
     )

--- a/tests/test_pentest_auth_bypass.py
+++ b/tests/test_pentest_auth_bypass.py
@@ -305,10 +305,10 @@ class TestRegistrationBypass:
 
     def test_register_with_extra_privileged_fields(self, app, client):
         """ATTACK: Submit extra fields during registration to gain privileges."""
-        verify_registration_email(client, "hacker@sit.singaporetech.edu.sg")
+        verify_registration_email(client, "hacker@example.com")
         response = client.post("/auth/register", json={
             "username": "hacker01",
-            "email": "hacker@sit.singaporetech.edu.sg",
+            "email": "hacker@example.com",
             "full_name": "Hacker Test",
             "phone_number": "91234567",
             "password": "correct horse battery staple",
@@ -330,10 +330,10 @@ class TestRegistrationBypass:
     def test_register_unicode_homoglyph_username(self, app, client):
         """ATTACK: Register with a username that looks visually identical using Unicode."""
 
-        verify_registration_email(client, "admin@sit.singaporetech.edu.sg")
+        verify_registration_email(client, "admin@example.com")
         client.post("/auth/register", json={
             "username": "admin",
-            "email": "admin@sit.singaporetech.edu.sg",
+            "email": "admin@example.com",
             "full_name": "Admin Test",
             "phone_number": "91234567",
             "password": "correct horse battery staple",
@@ -352,20 +352,20 @@ class TestRegistrationBypass:
 
     def test_register_case_insensitive_duplicate(self, app, client):
         """ATTACK: Register with uppercase variant of existing username."""
-        verify_registration_email(client, "alice@sit.singaporetech.edu.sg")
+        verify_registration_email(client, "alice@example.com")
         client.post("/auth/register", json={
             "username": "alice01",
-            "email": "alice@sit.singaporetech.edu.sg",
+            "email": "alice@example.com",
             "full_name": "Alice User",
             "phone_number": "91234567",
             "password": "correct horse battery staple",
             "confirm_password": "correct horse battery staple",
         })
 
-        verify_registration_email(client, "alice2@sit.singaporetech.edu.sg")
+        verify_registration_email(client, "alice2@example.com")
         response = client.post("/auth/register", json={
             "username": "ALICE01",
-            "email": "alice2@sit.singaporetech.edu.sg",
+            "email": "alice2@example.com",
             "full_name": "Alice User Two",
             "phone_number": "91234568",
             "password": "correct horse battery staple",
@@ -379,7 +379,7 @@ class TestRegistrationBypass:
         """ATTACK: SQL injection via username field."""
         response = client.post("/auth/register", json={
             "username": "'; DROP TABLE users; --",
-            "email": "sqli@sit.singaporetech.edu.sg",
+            "email": "sqli@example.com",
             "full_name": "SQL Injection Test",
             "phone_number": "91234567",
             "password": "correct horse battery staple",
@@ -562,22 +562,22 @@ class TestInfoLeakage:
 
     def test_registration_does_not_reveal_existing_users(self, app, client):
         """Check that registration errors don't reveal which final field already exists."""
-        create_user(app, "alice", "alice@sit.singaporetech.edu.sg")
+        create_user(app, "alice", "alice@example.com")
 
-        verify_registration_email(client, "other@sit.singaporetech.edu.sg")
+        verify_registration_email(client, "other@example.com")
         response1 = client.post("/auth/register", json={
             "username": "alice",
-            "email": "other@sit.singaporetech.edu.sg",
+            "email": "other@example.com",
             "full_name": "Alice Duplicate Test",
             "phone_number": "91234567",
             "password": "correct horse battery staple",
             "confirm_password": "correct horse battery staple",
         })
 
-        verify_registration_email(client, "other2@sit.singaporetech.edu.sg")
+        verify_registration_email(client, "other2@example.com")
         response2 = client.post("/auth/register", json={
             "username": "other_user",
-            "email": "other2@sit.singaporetech.edu.sg",
+            "email": "other2@example.com",
             "full_name": "Other User Test",
             "phone_number": "91234567",
             "password": "correct horse battery staple",
@@ -586,7 +586,7 @@ class TestInfoLeakage:
 
         existing_email_otp = client.post(
             "/auth/register/otp/request",
-            json={"email": "alice@sit.singaporetech.edu.sg"},
+            json={"email": "alice@example.com"},
         )
 
         msg1 = response1.get_json()["error"]

--- a/tests/test_production_guard.py
+++ b/tests/test_production_guard.py
@@ -109,6 +109,25 @@ def test_admin_validator_enforces_admin_isolation(monkeypatch):
     assert "Admin authentication must be enabled" in result.failures
 
 
+def test_admin_validator_rejects_root_admin_allowlist_outside_admin_domains(monkeypatch):
+    app = _production_app(monkeypatch, app_mode="admin")
+    app.config["ROOT_ADMIN_EMAILS"] = frozenset(
+        {
+            "root1@example.com",
+            "root2@sit.singaporetech.edu.sg",
+            "root3@sit.singaporetech.edu.sg",
+            "root4@sit.singaporetech.edu.sg",
+            "root5@sit.singaporetech.edu.sg",
+            "root6@sit.singaporetech.edu.sg",
+            "root7@sit.singaporetech.edu.sg",
+        }
+    )
+
+    result = validate_production_security_prerequisites(app, app_mode="admin")
+
+    assert "ROOT_ADMIN_EMAILS must use approved admin workplace domains" in result.failures
+
+
 def test_startup_guard_is_inactive_outside_production(monkeypatch):
     from app import create_app
 

--- a/tests/test_route_inventory_security.py
+++ b/tests/test_route_inventory_security.py
@@ -98,7 +98,7 @@ ROUTE_SECURITY_INVENTORY = {
         "csrf": "required",
         "rate_limit": "per_route",
         "step_up": "not_required",
-        "public_justification": "Account creation must be reachable before authentication but requires a verified SIT email OTP.",
+        "public_justification": "Account creation must be reachable before authentication but requires a verified customer email OTP.",
     },
     "auth.register_otp_request": {
         "endpoint": "auth.register_otp_request",
@@ -109,7 +109,7 @@ ROUTE_SECURITY_INVENTORY = {
         "csrf": "required",
         "rate_limit": "per_route",
         "step_up": "not_required",
-        "public_justification": "Registration OTP requests must be reachable before account creation and are constrained to approved SIT email domains.",
+        "public_justification": "Registration OTP requests must be reachable before account creation and block configured admin workplace email domains.",
     },
     "auth.register_otp_verify": {
         "endpoint": "auth.register_otp_verify",
@@ -120,7 +120,7 @@ ROUTE_SECURITY_INVENTORY = {
         "csrf": "required",
         "rate_limit": "per_route",
         "step_up": "not_required",
-        "public_justification": "Registration OTP verification binds the approved SIT email to the caller's pre-authentication session.",
+        "public_justification": "Registration OTP verification binds the approved customer email to the caller's pre-authentication session.",
     },
     "auth.login": {
         "endpoint": "auth.login",
@@ -505,7 +505,7 @@ ROUTE_SECURITY_INVENTORY = {
         "csrf": "required",
         "rate_limit": "per_route",
         "step_up": "not_required",
-        "public_justification": "Account creation must be reachable before authentication but requires a verified SIT email OTP.",
+        "public_justification": "Account creation must be reachable before authentication but requires a verified customer email OTP.",
     },
     "web.login": {
         "endpoint": "web.login",
@@ -1050,4 +1050,4 @@ def test_login_and_registration_have_method_level_security_decisions(app):
     assert ROUTE_SECURITY_INVENTORY["web.register_form"]["csrf"] == "not_applicable"
     assert ROUTE_SECURITY_INVENTORY["web.register_submit"]["csrf"] == "required"
     assert ROUTE_SECURITY_INVENTORY["web.register_submit"]["rate_limit"] == "per_route"
-    assert "verified SIT email OTP" in ROUTE_SECURITY_INVENTORY["web.register_submit"]["public_justification"]
+    assert "verified customer email OTP" in ROUTE_SECURITY_INVENTORY["web.register_submit"]["public_justification"]

--- a/tests/test_session_management.py
+++ b/tests/test_session_management.py
@@ -255,7 +255,7 @@ def test_past_sessions_are_scoped_to_current_user(app, client):
     alice, _alice_secret = enable_mfa_for_user()
     mark_recent_mfa(client, alice)
 
-    register(second_client, username="bob02", email="bob@sit.singaporetech.edu.sg", full_name="Bob Test", phone_number="81234567")
+    register(second_client, username="bob02", email="bob@example.com", full_name="Bob Test", phone_number="81234567")
     login(second_client, identifier="bob02")
     bob, _bob_secret = enable_mfa_for_user("bob02")
     mark_recent_mfa(second_client, bob)

--- a/tests/test_session_risk_binding.py
+++ b/tests/test_session_risk_binding.py
@@ -294,7 +294,7 @@ def test_suspicious_customer_context_requires_reauth_for_sensitive_action(
 
     assert safe_response.status_code == 200
     assert sensitive_response.status_code == 401
-    assert user.email == "alice@sit.singaporetech.edu.sg"
+    assert user.email == "alice@example.com"
     events = db.session.query(SecurityAuditEvent).filter_by(
         event_type="session_risk",
         outcome="reauth_required",

--- a/tests/test_web_route_dispatch_coverage.py
+++ b/tests/test_web_route_dispatch_coverage.py
@@ -16,7 +16,7 @@ class _StubForm:
         self.stepup_token = SimpleNamespace(data="")
         self.identifier = SimpleNamespace(data="alice01")
         self.password = SimpleNamespace(data="old-password")
-        self.email = SimpleNamespace(data="alice@sit.singaporetech.edu.sg")
+        self.email = SimpleNamespace(data="alice@example.com")
         self.current_password = SimpleNamespace(data="old-password")
         self.new_password = SimpleNamespace(data="new-password")
         self.confirm_new_password = SimpleNamespace(data="new-password")


### PR DESCRIPTION
Summary
---

- Closes #270.
- Enforces separated customer and staff/admin/root-admin identity email policy.
- Keeps this PR focused on issue #270 only.

Why
---

- Customer self-registration was still tied to SIT workplace domains.
- Staff/admin/root-admin identities need SIT workplace email domains, while customer identities need personal/customer email addresses.
- Root-admin allowlisted emails and admin workplace domains must not be usable as customer identities.

What changed
---

- Added a centralized identity email policy in `app/security/identity_policy.py`.
- Added `ADMIN_ALLOWED_EMAIL_DOMAINS` as the central admin-domain config while preserving `SIT_WORKPLACE_EMAIL_DOMAINS` as a compatibility alias.
- Blocked configured admin workplace domains and root-admin allowlisted emails from customer registration OTP, final registration, and customer profile email changes.
- Required admin/staff/root-admin login/session eligibility and root-admin checks to use approved admin workplace email domains.
- Rechecked stored staff invite identities before invite info, setup, and activation.
- Added manual recovery self-customer protection before root-admin recovery mutation.
- Strengthened root-admin bootstrap and production readiness validation for admin-domain allowlist rules.
- Updated customer registration UI copy, operations docs, security docs, privacy docs, GitHub Actions docs, and route-inventory documentation checks.
- Updated customer test fixtures from SIT workplace addresses to personal/customer addresses where appropriate.

Security impact
---

- Tightens identity separation between customer and privileged admin domains.
- Preserves generic login and registration failure messages for sensitive paths.
- Adds safe audit reason codes and audit references without logging raw secrets, tokens, TOTP seeds, QR codes, provisioning URIs, session cookies, CSRF tokens, OAuth secrets, Cloudflare credentials, Tailscale auth keys, or deployment credentials.
- Does not weaken existing security controls, MFA requirements, CSRF protections, route isolation, or quality gates.

Deployment impact
---

No deployment action required for database migrations or secret changes.

- `ADMIN_ALLOWED_EMAIL_DOMAINS` defaults to the current SIT workplace domains and falls back from existing `SIT_WORKPLACE_EMAIL_DOMAINS` environment configuration for compatibility.
- Operators should ensure `ROOT_ADMIN_EMAILS` contains exactly seven addresses from `ADMIN_ALLOWED_EMAIL_DOMAINS`.

Verification
---

- `git diff --check`
- `git status --short --branch`
- `./.venv/Scripts/python.exe -m pytest -q -n auto` - 813 passed, 2 skipped, 6 warnings.
- Focused suites covering registration, customer profile updates, admin login, staff invites, manual recovery, root bootstrap, production guard, route inventory, and privacy docs also passed.
- Coverage/SonarCloud expectations are satisfied by added and updated tests for new and changed behavior. This PR does not change CI coverage generation, test structure, or Sonar source path configuration, so no local `coverage.xml` was generated; CI should continue to generate coverage for SonarCloud import.

Notes
---

- Documentation was updated so fixed behavior is not described as still requiring customer SIT email registration.
- Implementation started from `main` commit `3cc592f` while main deployment run `28393875490` was still in progress, per request.
- No blockers are known.