### PR TITLE
Update repository owner and SonarCloud references

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,22 +1,22 @@
 # Default owner for application and documentation changes.
-* @WenJiangg
+* @TL0024
 
 # Production supply-chain and deployment controls require explicit ownership.
-/.github/workflows/ @WenJiangg
-/.github/dependabot.yml @WenJiangg
-/Dockerfile @WenJiangg
-/compose.prod.yml @WenJiangg
-/compose.staging.yml @WenJiangg
-/requirements.in @WenJiangg
-/requirements-dev.in @WenJiangg
-/requirements.lock @WenJiangg
-/requirements-dev.lock @WenJiangg
-/ops/container/ @WenJiangg
-/ops/cloudflare/ @WenJiangg
-/ops/deploy/ @WenJiangg
-/ops/nginx/ @WenJiangg
-/ops/nginx-proxy-headers.conf @WenJiangg
-/ops/security/ @WenJiangg
-/ops/sudoers/ @WenJiangg
-/ops/systemd/ @WenJiangg
-/migrations/ @WenJiangg
+/.github/workflows/ @TL0024
+/.github/dependabot.yml @TL0024
+/Dockerfile @TL0024
+/compose.prod.yml @TL0024
+/compose.staging.yml @TL0024
+/requirements.in @TL0024
+/requirements-dev.in @TL0024
+/requirements.lock @TL0024
+/requirements-dev.lock @TL0024
+/ops/container/ @TL0024
+/ops/cloudflare/ @TL0024
+/ops/deploy/ @TL0024
+/ops/nginx/ @TL0024
+/ops/nginx-proxy-headers.conf @TL0024
+/ops/security/ @TL0024
+/ops/sudoers/ @TL0024
+/ops/systemd/ @TL0024
+/migrations/ @TL0024

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -20,7 +20,7 @@ condition = "AND"
 targetRules = ["generic-api-key"]
 regexTarget = "line"
 paths = ['''^sonar-project\.properties$''']
-regexes = ['''^sonar\.projectKey=TL0024_SITBank$''']
+regexes = ['''^sonar\.projectKey=WenJiangg_SITBank$''']
 
 [[allowlists]]
 description = "Historical synthetic accepted-password test fixture"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -23,6 +23,15 @@ paths = ['''^sonar-project\.properties$''']
 regexes = ['''^sonar\.projectKey=WenJiangg_SITBank$''']
 
 [[allowlists]]
+description = "Historical public SonarQube Cloud project key metadata"
+condition = "AND"
+targetRules = ["generic-api-key"]
+regexTarget = "line"
+commits = ["f29d15f476d975d4b8e3c9e1b529a855a12776db"]
+paths = ['''^sonar-project\.properties$''']
+regexes = ['''^sonar\.projectKey=TL0024_SITBank$''']
+
+[[allowlists]]
 description = "Historical synthetic accepted-password test fixture"
 condition = "AND"
 targetRules = ["generic-api-key"]

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ customer domain.
 
 ## Deployment Snapshot
 
-Images are published as immutable signed digests under `ghcr.io/wenjiangg/sitbank@sha256:<digest>` from the `WenJiangg/SITBank` repository. The workflow derives the package path from `GITHUB_REPOSITORY` so future owner changes need only docs, CODEOWNERS, EC2 deploy config, and bootstrap inputs updated. Production uses `/etc/sitbank`, `/opt/sitbank`, `sitbank-container.service`, `sitbank_db`, `sitbank_owner`, `sitbank_app`, and a distinct admin runtime DB role such as `sitbank_admin`. Staging uses separate `/etc/sitbank-staging`, `/opt/sitbank-staging`, isolated Compose services, and isolated Docker volumes.
+Images are published as immutable signed digests under `ghcr.io/tl0024/sitbank@sha256:<digest>` from the `TL0024/SITBank` repository. The workflow derives the package path from `GITHUB_REPOSITORY` so future owner changes need only docs, CODEOWNERS, EC2 deploy config, and bootstrap inputs updated. Production uses `/etc/sitbank`, `/opt/sitbank`, `sitbank-container.service`, `sitbank_db`, `sitbank_owner`, `sitbank_app`, and a distinct admin runtime DB role such as `sitbank_admin`. Staging uses separate `/etc/sitbank-staging`, `/opt/sitbank-staging`, isolated Compose services, and isolated Docker volumes.
 
 Database migrations use Alembic. Existing databases that predate Alembic must first pass `verify-migration-baseline`, then be stamped with `db stamp 20260610_0001`. Do not run `db.create_all()` in deployment.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -528,7 +528,7 @@ The current restricted SSH deployment remains supported. The preferred next
 step is GitHub OIDC federation to a narrowly scoped AWS IAM role and Systems
 Manager Run Command:
 
-- trust only `repo:WenJiangg/SITBank:environment:production`;
+- trust only `repo:TL0024/SITBank:environment:production`;
 - require the GitHub OIDC audience `sts.amazonaws.com`;
 - allow commands only on the tagged SITBank instance and approved SSM
   document;

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -12,8 +12,8 @@ Only Flask/Gunicorn runs in the SITBank container. Nginx, TLS, PostgreSQL, and b
 - Staging access boundary: Cloudflare Access plus Authenticated Origin Pull
   plus origin-side Access JWT validation
 - Admin access boundary: Tailscale/private operator access only
-- Production image form: `ghcr.io/wenjiangg/sitbank@sha256:<digest>`
-- Repository identity: `WenJiangg/SITBank`
+- Production image form: `ghcr.io/tl0024/sitbank@sha256:<digest>`
+- Repository identity: `TL0024/SITBank`
 - Production config root: `/etc/sitbank`
 - Production compose dir: `/opt/sitbank`
 - Production service: `sitbank-container.service`
@@ -709,7 +709,7 @@ sudo /usr/local/sbin/verify-certbot-host-state staging
 sudo /usr/local/sbin/verify-certbot-host-state --renewal-dry-run staging
 ```
 
-Then run `ops/deploy/bootstrap-container-ec2 staging WenJiangg/SITBank staging-sitbank.pp.ua`. The bootstrap installs the Nginx proxy header snippet, TLS policy snippet, rate-limit include, and staging Nginx server block for `staging-sitbank.pp.ua`; verifies the staging Basic Auth file and the pinned Cloudflare origin-pull CA; then runs `sudo nginx -t` before `sudo systemctl reload nginx`. This edge setup is separate from application deployment.
+Then run `ops/deploy/bootstrap-container-ec2 staging TL0024/SITBank staging-sitbank.pp.ua`. The bootstrap installs the Nginx proxy header snippet, TLS policy snippet, rate-limit include, and staging Nginx server block for `staging-sitbank.pp.ua`; verifies the staging Basic Auth file and the pinned Cloudflare origin-pull CA; then runs `sudo nginx -t` before `sudo systemctl reload nginx`. This edge setup is separate from application deployment.
 
 Staging verification:
 

--- a/docs/security/assurance/sonarqube.md
+++ b/docs/security/assurance/sonarqube.md
@@ -22,7 +22,7 @@ allows Free-plan analysis of private projects up to 50,000 private lines of
 code across the organization. Tests, comments, blank lines, excluded files,
 and unsupported languages do not count toward that limit. A repository-side
 count found about 11,600 nonblank/noncomment Python lines under `app`, so this
-project is within the per-organization ceiling if the `tl0024` SonarQube
+project is within the per-organization ceiling if the `wenjiangg` SonarQube
 Cloud organization has enough unused private LOC and no more than five
 members. The plan and usage must be confirmed in the SonarQube Cloud
 organization during project import because limits and organization-wide usage
@@ -42,8 +42,8 @@ a reviewed follow-up instead.
 ## One-Time Setup And Secrets
 
 1. Import or rebind the private `TL0024/SITBank` GitHub repository into the
-   `tl0024` SonarQube Cloud organization and confirm the project key is
-   `TL0024_SITBank`.
+   `wenjiangg` SonarQube Cloud organization and confirm the project key is
+   `WenJiangg_SITBank`.
 2. Confirm current private LOC usage, member limits, plan terms, repository
    binding, and access permissions in SonarQube Cloud.
 3. Generate a narrowly scoped project analysis token.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
-sonar.projectKey=TL0024_SITBank
-sonar.organization=tl0024
+sonar.projectKey=WenJiangg_SITBank
+sonar.organization=wenjiangg
 sonar.projectName=SITBank
 sonar.sources=app,ops,config.py,wsgi.py,admin_wsgi.py
 sonar.tests=tests

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -2329,7 +2329,12 @@ def test_dependabot_tracks_docker_base_images_without_automerge():
 def test_codeowners_and_codeql_cover_security_sensitive_changes():
     codeowners = Path(".github/CODEOWNERS").read_text(encoding="utf-8")
     codeql = Path(".github/workflows/codeql.yml").read_text(encoding="utf-8")
+    stale_owner = "@Wen" + "Jiangg"
+    stale_typo_owner = "@Wen" + "Jiangggg"
 
+    assert "@TL0024" in codeowners
+    assert stale_owner not in codeowners
+    assert stale_typo_owner not in codeowners
     for protected_path in (
         "/.github/workflows/",
         "/Dockerfile",
@@ -3447,8 +3452,8 @@ def test_migration_baseline_and_existing_database_runbook_are_present():
     assert "verify-migration-baseline" in docs
     assert "db stamp 20260610_0001" in docs
     assert "Do not run `db.create_all()`" in docs
-    assert "WenJiangg/SITBank" in docs
-    assert "ghcr.io/wenjiangg/sitbank@sha256:<digest>" in docs
+    assert "TL0024/SITBank" in docs
+    assert "ghcr.io/tl0024/sitbank@sha256:<digest>" in docs
     assert "sitbank_db" in docs
     assert "sitbank_owner" in docs
     assert "sitbank_app" in docs

--- a/tests/test_gitleaks_workflow.py
+++ b/tests/test_gitleaks_workflow.py
@@ -134,7 +134,7 @@ def test_gitleaks_configuration_keeps_defaults_and_has_no_broad_allowlist():
         "targetRules": ["generic-api-key"],
         "regexTarget": "line",
         "paths": [r"^sonar-project\.properties$"],
-        "regexes": [r"^sonar\.projectKey=TL0024_SITBank$"],
+        "regexes": [r"^sonar\.projectKey=WenJiangg_SITBank$"],
     }
 
 

--- a/tests/test_gitleaks_workflow.py
+++ b/tests/test_gitleaks_workflow.py
@@ -94,10 +94,11 @@ def test_gitleaks_configuration_keeps_defaults_and_has_no_broad_allowlist():
     assert config["title"] == "SITBank Gitleaks configuration"
     assert config["extend"] == {"useDefault": True}
     allowlists = config["allowlists"]
-    assert len(allowlists) == 5
+    assert len(allowlists) == 6
     assert {entry["description"] for entry in allowlists} == {
         "Public SHA-256 checksum pinned by the Tailscale installer",
         "Public SonarQube Cloud project key metadata",
+        "Historical public SonarQube Cloud project key metadata",
         "Historical synthetic accepted-password test fixture",
         "Historical mappings from secret environment names to config field names",
         "Historical shell cases that reject private-key PEM headers",
@@ -135,6 +136,21 @@ def test_gitleaks_configuration_keeps_defaults_and_has_no_broad_allowlist():
         "regexTarget": "line",
         "paths": [r"^sonar-project\.properties$"],
         "regexes": [r"^sonar\.projectKey=WenJiangg_SITBank$"],
+    }
+    historical_sonar_project_key = next(
+        entry
+        for entry in allowlists
+        if entry["description"]
+        == "Historical public SonarQube Cloud project key metadata"
+    )
+    assert historical_sonar_project_key == {
+        "description": "Historical public SonarQube Cloud project key metadata",
+        "condition": "AND",
+        "targetRules": ["generic-api-key"],
+        "regexTarget": "line",
+        "commits": ["f29d15f476d975d4b8e3c9e1b529a855a12776db"],
+        "paths": [r"^sonar-project\.properties$"],
+        "regexes": [r"^sonar\.projectKey=TL0024_SITBank$"],
     }
 
 

--- a/tests/test_sonarqube_workflow.py
+++ b/tests/test_sonarqube_workflow.py
@@ -170,8 +170,8 @@ def test_sonarqube_properties_define_scope_coverage_and_reporting_policy():
     properties = _properties()
     gitignore = Path(".gitignore").read_text(encoding="utf-8").splitlines()
 
-    assert properties["sonar.projectKey"] == "TL0024_SITBank"
-    assert properties["sonar.organization"] == "tl0024"
+    assert properties["sonar.projectKey"] == "WenJiangg_SITBank"
+    assert properties["sonar.organization"] == "wenjiangg"
     assert properties["sonar.sources"].split(",") == [
         "app",
         "ops",
@@ -210,8 +210,8 @@ def test_sonarqube_docs_record_cloud_private_repo_and_nonblocking_policy():
         "Semgrep",
         "false positive",
         "coverage.xml",
-        "TL0024_SITBank",
-        "tl0024",
+        "WenJiangg_SITBank",
+        "wenjiangg",
     ):
         assert required in normalized
     assert "SONAR_HOST_URL" in normalized

--- a/tests/test_zero_trust_access_boundary.py
+++ b/tests/test_zero_trust_access_boundary.py
@@ -358,8 +358,8 @@ def test_repository_identity_ghcr_cosign_and_bootstrap_references_are_consistent
         assert old_owner not in lowered, path
         assert old_repo not in lowered, path
 
-    assert "Repository identity: `WenJiangg/SITBank`" in docs
-    assert "Production image form: `ghcr.io/wenjiangg/sitbank@sha256:<digest>`" in docs
+    assert "Repository identity: `TL0024/SITBank`" in docs
+    assert "Production image form: `ghcr.io/tl0024/sitbank@sha256:<digest>`" in docs
     assert 'repository="ghcr.io/${GITHUB_REPOSITORY,,}"' in workflow
     assert "GITHUB_REPOSITORY=${github_repository}" in bootstrap
     assert "GHCR_REPOSITORY=ghcr.io/${repository_lower}" in bootstrap


### PR DESCRIPTION
Summary
---

- Updates repository ownership references after the move to `TL0024/SITBank`.
- Routes CODEOWNERS review ownership to `@TL0024`.
- Keeps SonarCloud analysis under the existing Wenjiang SonarCloud organization while the GitHub repository remains under `TL0024/SITBank`.

Why
---

- The GitHub repository owner changed from the old owner to `TL0024`.
- Active CODEOWNERS review routing and deployment identity documentation should match the current GitHub repository owner.
- SonarCloud is still hosted under Wenjiang's existing SonarCloud organization, so `sonar.organization=tl0024` fails with `Organization key 'tl0024' does not exist.`
- Stale owner references can route reviews, deployment setup, or scanner configuration to the wrong account.

What changed
---

- Replaced `.github/CODEOWNERS` owners with `@TL0024` while preserving the existing protected-path coverage.
- Updated active GHCR, repository identity, staging bootstrap, and AWS OIDC repository-claim examples to `TL0024/SITBank`.
- Updated `sonar-project.properties` to use SonarCloud organization `wenjiangg` and project key `WenJiangg_SITBank`.
- Updated SonarCloud docs/tests to explain that the GitHub repo is `TL0024/SITBank` while the SonarCloud org/project remains under `wenjiangg` / `WenJiangg_SITBank`.
- Updated Gitleaks allowlists narrowly for exact public SonarCloud project-key metadata lines, including the historical merged `TL0024_SITBank` line from `f29d15f`.
- Updated regression tests so CODEOWNERS, deployment docs, SonarCloud properties, and Gitleaks allowlists reject stale or broad configuration.

Security impact
---

- Preserves CODEOWNERS intent and security-sensitive path ownership coverage.
- Does not weaken branch protection, review routing, deployment checks, SonarCloud analysis, coverage upload, PR analysis, secret scanning, or security ownership.
- Does not touch secrets, credentials, tokens, deployment keys, or `SONAR_TOKEN` values.

Deployment impact
---

- Documentation now points operators to `ghcr.io/tl0024/sitbank` and `TL0024/SITBank` bootstrap inputs.
- External deployment systems that still trust the old repository claim must be updated outside the repo before an OIDC/SSM migration uses that claim.
- SonarCloud still requires an external ALM binding/import update so project `WenJiangg_SITBank` under organization `wenjiangg` is bound to GitHub repo `TL0024/SITBank` and can find PRs in that repo.
- No application runtime, workflow, migration, or secret change is included.

Verification
---

- Confirmed `TL0024` is a GitHub user and has `admin` permission on `TL0024/SITBank`, so `@TL0024` is a valid CODEOWNERS owner target.
- GitHub CODEOWNERS API returned no errors for `repo-owner-codeowners-tl0024`.
- Public SonarCloud organization lookup confirmed organization key `wenjiangg` exists.
- Prior CI log from PR #287 confirmed scanner access to project key `WenJiangg_SITBank` and ALM binding checks for that project.
- `git diff --check` passed.
- `.\.venv\Scripts\python.exe -m pytest -q tests\test_sonarqube_workflow.py tests\test_gitleaks_workflow.py -n auto` passed: 13 passed.
- `.\.venv\Scripts\python.exe -m pytest -q tests\test_github_actions_workflows.py tests\test_deployment.py -n auto` passed: 68 passed, 6 warnings.
- `.\.venv\Scripts\python.exe -m pytest -q tests\test_zero_trust_access_boundary.py::test_repository_identity_ghcr_cosign_and_bootstrap_references_are_consistent -n auto` passed: 1 passed.
- `git grep -n "WenJiangg\|WenJiangggg\|ghcr.io/wenjiangg" -- .github docs README.md SECURITY.md sonar-project.properties tests` returned no active owner-routing matches after CODEOWNERS/docs updates.
- CI `Full-history secret scan` passed after the exact historical Sonar project-key allowlist.
- CI `test` and `image-test` passed on run 28453584927.

Notes
---

- SonarCloud now runs with project key `WenJiangg_SITBank` instead of failing on missing organization `tl0024`.
- SonarCloud still fails before quality-gate and new-code coverage results because project `WenJiangg_SITBank` cannot fetch pull request `289`; this points to SonarCloud ALM binding/import still targeting the old GitHub repository identity.
- Required manual action: in SonarCloud, bind or re-import project `WenJiangg_SITBank` in organization `wenjiangg` to GitHub repository `TL0024/SITBank`, then verify the current `SONAR_TOKEN` can access that project.
- SonarCloud new-code coverage, new issues, and security hotspot results are unavailable until the ALM binding can find this repository's pull requests.