### PR TITLE
Fix staging readiness body comparison

### DIFF
--- a/ops/deploy/sitbank-container-deploy
+++ b/ops/deploy/sitbank-container-deploy
@@ -530,6 +530,9 @@ wait_for_ready_response() {
         )"; then
             status="${response##*$'\n'}"
             body="${response%$'\n'*}"
+            body="${body%$'\r'}"
+            body="${body%$'\n'}"
+
             if [[ "${status}" == "200" && "${body}" == "${expected_body}" ]]; then
                 return
             fi


### PR DESCRIPTION
## Summary

Fixes the staging deployment readiness check so it accepts Flask `jsonify()` readiness responses that include a trailing newline.

## Why

Staging deployment rolls back even though the app and admin containers are healthy.

The deploy wrapper currently compares the readiness body byte-for-byte against `{"status":"ready"}`. Flask `jsonify()` returns the expected JSON with a trailing newline, so the wrapper rejects a valid HTTP 200 readiness response.

## What changed

* Trim trailing CR/LF characters from the readiness response body before comparing it with the expected JSON payload.
* Preserve the strict HTTP 200 requirement.
* Preserve the strict expected JSON body check.
* Keep staging readiness on the approved local loopback/Nginx path instead of using public `/health/ready`.

## Security impact

This does not expose public staging readiness and does not weaken Cloudflare Access or Authenticated Origin Pull boundaries.

The fix only normalizes harmless trailing line endings from Flask `jsonify()` responses. It does not accept arbitrary response bodies, redirects, non-200 responses, or public staging readiness.

## Deployment impact

EC2 staging bootstrap is required because this changes the root-owned deploy wrapper `ops/deploy/sitbank-container-deploy`.

After bootstrap, rerun staging deployment. No production deployment, database migration, secret change, or provider setting change is expected.

## Verification

* `git diff --check`
* `.\.venv\Scripts\python.exe -m pytest -q -n auto`
* Confirmed direct app readiness returns HTTP 200 with the expected JSON plus trailing newline:
  * `curl --silent --show-error --max-redirs 0 --write-out $'\nHTTP=%{http_code}\n' --header "Host: staging-sitbank.pp.ua" --header "X-Forwarded-For: 127.0.0.1" --header "X-Forwarded-Proto: https" http://127.0.0.1:5001/health/ready | cat -A`
* Confirmed local Nginx staging readiness returns HTTP 200:
  * `curl --silent --show-error --max-redirs 0 --write-out $'\nHTTP=%{http_code}\n' http://127.0.0.1:8081/health/ready | cat -A`

## Notes

Rerun the trusted staging bootstrap before retrying staging deployment so the EC2 host uses the updated root-owned deployment wrapper.