### PR TITLE
Security: harden bootstrap and normalize CI workflow names

### DIFF
--- a/.github/workflows/bootstrap-ec2.yml
+++ b/.github/workflows/bootstrap-ec2.yml
@@ -83,6 +83,8 @@ jobs:
         env:
           SSH_PRIVATE_KEY_B64: ${{ secrets.STAGING_EC2_SSH_PRIVATE_KEY_B64 }}
           SSH_KNOWN_HOSTS: ${{ secrets.STAGING_EC2_KNOWN_HOSTS }}
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
         shell: bash
         run: |
           required=(
@@ -91,6 +93,8 @@ jobs:
             REMOTE_USER
             SSH_PRIVATE_KEY_B64
             SSH_KNOWN_HOSTS
+            TS_OAUTH_CLIENT_ID
+            TS_OAUTH_SECRET
           )
           missing=0
           for name in "${required[@]}"; do
@@ -121,6 +125,14 @@ jobs:
           cosign sign-blob --yes \
             --bundle "${archive}.sigstore.json" \
             "${archive}"
+
+      - name: Join the staging bootstrap tailnet
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:github-ci-staging-deploy
+          ping: ${{ vars.STAGING_EC2_HOST }}
 
       - name: Configure verified SSH
         env:
@@ -212,6 +224,11 @@ jobs:
             "bootstrap-${TARGET}-${TRUSTED_SHA}.tar.gz" \
             "bootstrap-${TARGET}-${TRUSTED_SHA}.tar.gz.sigstore.json"
 
+      - name: Disconnect staging bootstrap tailnet
+        if: ${{ always() }}
+        shell: bash
+        run: sudo tailscale logout > /dev/null 2>&1 || true
+
   bootstrap-production:
     if: inputs.target_environment == 'production'
     needs: validate-request
@@ -241,6 +258,8 @@ jobs:
         env:
           SSH_PRIVATE_KEY_B64: ${{ secrets.PROD_EC2_SSH_PRIVATE_KEY_B64 }}
           SSH_KNOWN_HOSTS: ${{ secrets.PROD_EC2_KNOWN_HOSTS }}
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
         shell: bash
         run: |
           required=(
@@ -249,6 +268,8 @@ jobs:
             REMOTE_USER
             SSH_PRIVATE_KEY_B64
             SSH_KNOWN_HOSTS
+            TS_OAUTH_CLIENT_ID
+            TS_OAUTH_SECRET
           )
           missing=0
           for name in "${required[@]}"; do
@@ -279,6 +300,14 @@ jobs:
           cosign sign-blob --yes \
             --bundle "${archive}.sigstore.json" \
             "${archive}"
+
+      - name: Join the production bootstrap tailnet
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:github-ci-prod-deploy
+          ping: ${{ vars.PROD_EC2_HOST }}
 
       - name: Configure verified SSH
         env:
@@ -369,3 +398,8 @@ jobs:
             ~/.ssh/bootstrap_key \
             "bootstrap-${TARGET}-${TRUSTED_SHA}.tar.gz" \
             "bootstrap-${TARGET}-${TRUSTED_SHA}.tar.gz.sigstore.json"
+
+      - name: Disconnect production bootstrap tailnet
+        if: ${{ always() }}
+        shell: bash
+        run: sudo tailscale logout > /dev/null 2>&1 || true

--- a/.github/workflows/bootstrap-ec2.yml
+++ b/.github/workflows/bootstrap-ec2.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   validate-request:
+    name: Validate bootstrap request
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -37,6 +38,7 @@ jobs:
           fi
 
   bootstrap-staging:
+    name: Bootstrap staging EC2
     if: inputs.target_environment == 'staging'
     needs: validate-request
     runs-on: ubuntu-latest
@@ -230,6 +232,7 @@ jobs:
         run: sudo tailscale logout > /dev/null 2>&1 || true
 
   bootstrap-production:
+    name: Bootstrap production EC2
     if: inputs.target_environment == 'production'
     needs: validate-request
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -283,6 +283,7 @@ jobs:
           retention-days: 1
 
   sonarqube:
+    name: SonarQube analysis
     if: github.event_name != 'schedule'
     needs: [test, resolve-source]
     permissions:
@@ -295,6 +296,7 @@ jobs:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   sonarqube-comment:
+    name: SonarQube PR comment
     if: >-
       needs.sonarqube.result == 'success' &&
       github.event_name == 'pull_request' &&
@@ -516,6 +518,7 @@ jobs:
           fi
 
   publish:
+    name: Publish container image
     if: >-
       github.event_name != 'pull_request' &&
       github.ref == 'refs/heads/main' &&
@@ -595,6 +598,7 @@ jobs:
           cache-to: type=gha,mode=max
 
   release-verify:
+    name: Release verification
     if: >-
       github.event_name != 'pull_request' &&
       github.ref == 'refs/heads/main' &&
@@ -738,6 +742,7 @@ jobs:
             "${IMAGE}" >/dev/null
 
   deploy-staging:
+    name: Deploy staging
     if: >-
       github.event_name != 'pull_request' &&
       needs.release-verify.result == 'success' &&
@@ -998,6 +1003,7 @@ jobs:
           sudo tailscale logout > /dev/null 2>&1 || true
 
   verify-staging-tls:
+    name: Verify staging TLS
     if: >-
       always() &&
       needs.deploy-staging.result == 'success'
@@ -1008,6 +1014,7 @@ jobs:
       staging_host: ${{ vars['STAGING_PUBLIC_HOST'] || 'staging-sitbank.pp.ua' }}
 
   deploy-production:
+    name: Deploy production
     if: >-
       always() &&
       needs.release-verify.result == 'success' &&
@@ -1258,6 +1265,7 @@ jobs:
           sudo tailscale logout > /dev/null 2>&1 || true
 
   verify-production-tls:
+    name: Verify production TLS
     if: >-
       always() &&
       needs.deploy-production.result == 'success'
@@ -1268,7 +1276,7 @@ jobs:
       production_host: ${{ vars['PROD_PUBLIC_HOST'] || 'sitbank.pp.ua' }}
 
   verify-private-admin-tailnet:
-    name: Required private admin post-deploy gate
+    name: Verify private admin tailnet
     if: >-
       always() &&
       needs.deploy-production.result == 'success' &&
@@ -1343,7 +1351,7 @@ jobs:
           fi
 
           {
-            echo "## Private-tailnet verification"
+            echo "## Private admin tailnet verification"
             echo
             echo "- Protected runner joined the approved tailnet."
             echo "- Private admin HTTPS login entrypoint returned the documented unauthenticated response."

--- a/.github/workflows/cloudflare-access-verify.yml
+++ b/.github/workflows/cloudflare-access-verify.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   verify:
+    name: Verify staging Cloudflare Access
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   label:
+    name: Label issue
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   label:
+    name: Label pull request
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/retag-labels.yml
+++ b/.github/workflows/retag-labels.yml
@@ -45,6 +45,7 @@ concurrency:
 
 jobs:
   retag:
+    name: Retag issue and pull request labels
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -20,6 +20,7 @@ permissions: {}
 
 jobs:
   analyze:
+    name: SonarQube analysis
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/tailscale-private-admin-verify.yml
+++ b/.github/workflows/tailscale-private-admin-verify.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   verify:
-    name: Private-tailnet verification
+    name: Verify private admin tailnet
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
@@ -60,7 +60,7 @@ jobs:
           fi
 
           {
-            echo "## Private-tailnet verification"
+            echo "## Private admin tailnet verification"
             echo
             echo "- Private admin is not reachable from the public runner context."
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -176,6 +176,11 @@ Production deployment runs from the trusted `main` workflow only after release
 verification, staging deployment, and the post-deployment staging TLS scan all
 succeed. A successful production deployment is followed by public production
 TLS verification and then the required protected private-admin tailnet gate.
+The visible Actions checks for those gates are `Release verification`,
+`Deploy staging`, `Verify staging TLS`, `Deploy production`,
+`Verify production TLS`, and `Verify private admin tailnet`. Their stable
+kebab-case job IDs remain in workflow `needs:` expressions and are not display
+labels.
 Production deployment is environment-approved automatic after successful
 staging gates. GitHub Environment approval pauses that automatic `main` flow;
 there is no direct manual production dispatch target.
@@ -194,7 +199,7 @@ appropriate:
 
 | Variable | Safe behavior when unset | Workflow consumer |
 | --- | --- | --- |
-| `ENABLE_GITHUB_CODE_SECURITY` | Defaults to `false`; private-repository dependency review runs only when the value is exactly `true` | `dependency-review` in `.github/workflows/ci-deploy.yml` |
+| `ENABLE_GITHUB_CODE_SECURITY` | Defaults to `false`; private-repository dependency review runs only when the value is exactly `true` | `Dependency review` (`dependency-review` job ID) in `.github/workflows/ci-deploy.yml` |
 | `STAGING_PUBLIC_HOST` | Defaults to the reviewed staging hostname `staging-sitbank.pp.ua` | Staging deployment URL/configuration and post-deployment staging TLS verification |
 | `PROD_PUBLIC_HOST` | Defaults to the reviewed production hostname `sitbank.pp.ua` | Production deployment URL/configuration and post-deployment production TLS verification |
 | `STAGING_EC2_HOST` | Required private Tailscale MagicDNS name or `100.x.y.z` address | Staging OpenSSH deployment target |
@@ -262,7 +267,8 @@ change, and remove it immediately after recovery.
 The manual `.github/workflows/tailscale-private-admin-verify.yml` workflow
 uses a GitHub-hosted runner that temporarily joins the tailnet. The
 `.github/workflows/ci-deploy.yml` production workflow implements the same
-check directly after `deploy-production` and `verify-production-tls` succeed.
+visible `Verify private admin tailnet` check directly after the internal
+`deploy-production` and `verify-production-tls` jobs succeed.
 The direct job is necessary because the previous reusable-workflow call did
 not receive the protected environment secrets. Create a GitHub
 Environment named `admin-tailscale`, require manual approval by trusted

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -221,9 +221,11 @@ only `tag:github-ci-staging-deploy`; the production client may advertise only
 `tag:github-ci-prod-deploy`. Regenerate `STAGING_EC2_KNOWN_HOSTS` and
 `PROD_EC2_KNOWN_HOSTS` for their private Tailscale targets and verify the SSH
 fingerprints out of band. Keep the existing OpenSSH private keys and strict
-host-key checking. Do not enable Tailscale SSH or Funnel. After both private
-deployments are proven, remove public SSH exposure from the EC2 firewall and
-security group.
+host-key checking. Both the deployment and trusted-main bootstrap workflows
+join with the matching environment OAuth client before any SSH or SCP to the
+private host and always log out afterward. Do not enable Tailscale SSH or
+Funnel. After both private deployment and bootstrap paths are proven, remove
+public SSH exposure from the EC2 firewall and security group.
 
 ### Tailscale Deployment Rollout
 
@@ -247,6 +249,13 @@ its protected environment. Remove public port `22` only after both private
 paths pass. Committed files and tests do not prove live Tailscale, GitHub
 Environment, security-group, or host-firewall state; retain sanitized operator
 evidence separately.
+
+Once `STAGING_EC2_HOST` and `PROD_EC2_HOST` use a Tailscale IP or MagicDNS
+name, both bootstrap and deployment require the private tailnet path; public
+SSH is not a workflow fallback. Retain an approved host-recovery path such as
+AWS console or SSM access. A temporary security-group exception is break-glass
+only: authorize it explicitly, restrict its source and lifetime, record the
+change, and remove it immediately after recovery.
 
 ### Protected Private-Admin Verification Environment
 

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -52,8 +52,9 @@ Manual pre-merge staging:
 
 Feature-branch workflow and deployment scripts are never executed with environment secrets. The only accepted migration mode for existing EC2 deployment files is `adopt-existing`, and it must still pass wrapper hash validation before app deployment.
 
-The SSH deployment jobs join Tailscale before any `ssh` or `scp` command.
-Staging uses `tag:github-ci-staging-deploy` and production uses
+The SSH deployment jobs and trusted-main EC2 bootstrap jobs join Tailscale
+before any `ssh` or `scp` command and always log out afterward. Staging uses
+`tag:github-ci-staging-deploy` and production uses
 `tag:github-ci-prod-deploy`; each protected environment stores its own
 `TS_OAUTH_CLIENT_ID` and `TS_OAUTH_SECRET`. OpenSSH still requires the
 environment-specific deploy key, pinned known-hosts entry, and
@@ -87,10 +88,13 @@ prefixed renderer input for the target environment and writes
 
 `STAGING_PUBLIC_HOST` and `PROD_PUBLIC_HOST` are public HTTPS verification
 names. `STAGING_EC2_HOST` and `PROD_EC2_HOST` are private Tailscale MagicDNS
-names or `100.x.y.z` addresses used only for deployment SSH. Regenerate the
-matching `*_EC2_KNOWN_HOSTS` value for that private target and verify its
-fingerprint out of band before saving it. After private deployment succeeds,
-remove public port `22` exposure from the EC2 security group and host firewall.
+names or `100.x.y.z` addresses used only for deployment and bootstrap OpenSSH.
+Regenerate the matching `*_EC2_KNOWN_HOSTS` value for that private target and
+verify its fingerprint out of band before saving it. After both private paths
+succeed, remove public port `22` exposure from the EC2 security group and host
+firewall. Public SSH is not a workflow fallback; retain approved AWS
+console/SSM access or a tightly scoped, time-limited security-group break-glass
+procedure for host recovery.
 
 For production only, also set:
 

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -5,11 +5,50 @@
 The normal release path is:
 
 ```text
-main push -> publish -> release-verify -> staging -> production
-  -> production public TLS -> protected private admin tailnet gate
+main push -> Publish container image -> Release verification -> Deploy staging
+  -> Verify staging TLS -> Deploy production -> Verify production TLS
+  -> Verify private admin tailnet
 ```
 
 The tested, scanned, signed, and deployed digest must be identical. Deployments never use `latest`.
+
+## Workflow And Check Display Names
+
+Every workflow job and visible step has an explicit human-readable display
+name. Internal job IDs remain stable kebab-case keys because `needs:`
+dependencies, expressions, and repository tests refer to them. The Actions UI
+and status checks use the display names:
+
+| Internal job ID | Visible job/check name |
+| --- | --- |
+| `resolve-source` | `Resolve source` |
+| `workflow-security` | `Workflow security` |
+| `dependency-review` | `Dependency review` |
+| `test` | `Test and security checks` |
+| `sonarqube` | `SonarQube analysis` |
+| `sonarqube-comment` | `SonarQube PR comment` |
+| `image-test` | `Container image test` |
+| `deployment-preflight` | `Deployment preflight` |
+| `publish` | `Publish container image` |
+| `release-verify` | `Release verification` |
+| `deploy-staging` | `Deploy staging` |
+| `verify-staging-tls` | `Verify staging TLS` |
+| `deploy-production` | `Deploy production` |
+| `verify-production-tls` | `Verify production TLS` |
+| `verify-private-admin-tailnet` | `Verify private admin tailnet` |
+
+Bootstrap, Cloudflare verification, label automation, reusable SonarQube, and
+manual private-tailnet jobs follow the same explicit naming policy.
+`tests/test_workflow_display_names.py` enforces the policy across every
+`.github/workflows/*.yml` file while allowing the intentional TLS matrix name
+`Scan ${{ matrix.target.label }}`.
+
+Changing a job display name can change its required status-check context even
+when the internal ID is unchanged. Repository files do not update GitHub
+rulesets. After merging a display-name change, let the new check complete,
+update any affected required context in GitHub settings, and only then remove
+the old context, following
+`docs/security/governance/github-branch-protection-evidence.md`.
 
 Production never skips disabled, skipped, or failed staging. It runs only after
 release verification and staging deployment both succeed on `main`, with
@@ -33,7 +72,8 @@ dependency review, dependency audit, lockfile checks, tests, scanners, and
 manual maintainer review; no `pull_request_target`, write token, or secret is
 introduced for that exception.
 
-The `dependency-review` job is PR-only. Public PRs targeting `main` are
+The `Dependency review` check (internal job ID `dependency-review`) is PR-only.
+Public PRs targeting `main` are
 eligible without `ENABLE_GITHUB_CODE_SECURITY`. A private repository must set
 that variable to `true`; pushes, schedules, and manual deployment runs
 intentionally skip the comparison-only job. If it is unexpectedly skipped,
@@ -177,12 +217,12 @@ deployment.
 
 `.github/workflows/tailscale-private-admin-verify.yml` is manual-runnable.
 The trusted production workflow implements the same protected check directly
-as its required final gate after both `deploy-production` and
-`verify-production-tls` succeed. A direct environment-bound job is required
-because GitHub did not expose `admin-tailscale` environment secrets to the
-previous reusable-workflow call, even though the manual environment job could
-use them. Pull requests, forks, Dependabot, staging, and the public TLS
-workflow do not join the tailnet.
+as its required `Verify private admin tailnet` gate after the internal
+`deploy-production` and `verify-production-tls` jobs succeed. A direct
+environment-bound job is required because GitHub did not expose
+`admin-tailscale` environment secrets to the previous reusable-workflow call,
+even though the manual environment job could use them. Pull requests, forks,
+Dependabot, staging, and the public TLS workflow do not join the tailnet.
 
 Its `admin-tailscale` environment must require trusted maintainer approval and
 permit only `main`. The production caller explicitly uses `auth_mode: oauth`;
@@ -316,14 +356,15 @@ appears in logs, summaries, or artifacts.
 
 ## SonarQube Cloud
 
-The `test` job in `.github/workflows/ci-deploy.yml` runs the complete pytest
-suite once with `pytest-cov`, writes `coverage.xml`, and uploads that file as a
-short-lived artifact. After the test job succeeds on pull requests, pushes to
-`main`, and manual runs, the downstream `sonarqube` job calls the reusable
-`.github/workflows/sonarqube.yml`. That job checks out the same immutable
-source commit, downloads `coverage.xml`, and invokes only the SHA-pinned
-official SonarQube scanner; it does not install dependencies, rerun pytest, or
-hold any write permission.
+The `Test and security checks` job (internal ID `test`) in
+`.github/workflows/ci-deploy.yml` runs the complete pytest suite once with
+`pytest-cov`, writes `coverage.xml`, and uploads that file as a short-lived
+artifact. After it succeeds on pull requests, pushes to `main`, and manual
+runs, the downstream `SonarQube analysis` job (internal ID `sonarqube`) calls
+the reusable `.github/workflows/sonarqube.yml`. That job checks out the same
+immutable source commit, downloads `coverage.xml`, and invokes only the
+SHA-pinned official SonarQube scanner; it does not install dependencies, rerun
+pytest, or hold any write permission.
 
 The reusable scanner job has only `contents: read`. It requires the GitHub
 Actions secret `SONAR_TOKEN`; it does not use production environments,
@@ -333,7 +374,8 @@ SonarQube job. Coverage retrieval uses the SHA-pinned
 
 The initial SonarQube quality gate is reporting-only and is not a release or
 deployment dependency. After a successful trusted internal pull-request scan,
-the separate `sonarqube-comment` job uses SHA-pinned, Node.js 24
+the separate `SonarQube PR comment` job (internal ID `sonarqube-comment`) uses
+SHA-pinned, Node.js 24
 `actions/github-script` to create or update one informational summary with
 workflow and dashboard links. The comment job has only `contents: read` and
 `pull-requests: write`; the scanner never receives that write capability. A

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -216,11 +216,13 @@ evidence; the protected GitHub workflow below separately supplies
 tailnet-client reachability evidence. Operators must still retain live ACL,
 tag, device-approval, membership, and offboarding evidence.
 
-The staging and production deployment jobs and the protected private-admin
-verification jobs are the only GitHub-hosted jobs approved to join the
-tailnet. Deployment uses separate `tag:github-ci-staging-deploy` and
-`tag:github-ci-prod-deploy` identities with access only to the matching EC2
-host on port `22`. The direct production admin-verification job runs after
+The staging and production deployment and trusted-main bootstrap jobs, plus
+the protected private-admin verification jobs, are the only GitHub-hosted jobs
+approved to join the tailnet. Deployment and bootstrap use separate
+`tag:github-ci-staging-deploy` and `tag:github-ci-prod-deploy` identities with
+access only to the matching EC2 host on port `22`; each joins before its first
+SSH/SCP command and logs out even after failure. The direct production
+admin-verification job runs after
 deployment and public production TLS verification because a reusable-workflow
 call did not receive the protected environment secrets. That direct job and
 the manual verification workflow use the protected `admin-tailscale`
@@ -340,10 +342,14 @@ enter the private dashboard.
 
 ## EC2 SSH And Deployment Access Operations
 
-GitHub Actions deployment SSH uses protected, environment-specific Tailscale
-OAuth identities and private EC2 targets. After staging and production deploy
-successfully through those paths, remove public TCP `22` from the AWS security
-group and host firewall and retain sanitized provider evidence.
+GitHub Actions deployment and bootstrap SSH use protected,
+environment-specific Tailscale OAuth identities and private EC2 targets. After
+staging and production deploy and bootstrap successfully through those paths,
+remove public TCP `22` from the AWS security group and host firewall and retain
+sanitized provider evidence. Public SSH is not a fallback once the environment
+host variable points to a Tailscale IP or MagicDNS name. Keep approved AWS
+console/SSM recovery or a documented, source-restricted and time-limited
+security-group break-glass procedure.
 
 OpenSSH daemon and UFW hardening automation remains deferred. There is no
 repository OpenSSH drop-in or UFW rollout, so do not claim root SSH, password

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -42,6 +42,14 @@ DNS, certificate, and edge change is reviewed. The complete variable table and
 secret-placement boundary are in `docs/DEPLOYMENT.md`; never copy credentials
 or application secrets into repository variables.
 
+GitHub Actions displays explicit human-readable job names such as
+`Test and security checks`, `SonarQube analysis`, `Deploy staging`, and
+`Verify private admin tailnet`. Stable kebab-case job IDs remain only for
+workflow dependencies and expressions. If a renamed display name is a required
+status check, update the GitHub ruleset manually only after the new context has
+completed successfully; repository commits cannot mutate or prove that
+provider-side setting.
+
 MFA/TOTP seed encryption uses envelope encryption. Keep old KEKs in `mfa_kek_keys_json` until `rewrap-mfa-deks` has moved stored records to the new active KEK. Then update `MFA_KEK_ACTIVE_ID` and the root-managed keyring together.
 
 ## Disposable Registration Data Reset

--- a/docs/security/architecture/admin-and-staging-zero-trust-access.md
+++ b/docs/security/architecture/admin-and-staging-zero-trust-access.md
@@ -50,13 +50,13 @@ Category: [Security architecture](../README.md#architecture).
 
 ## Protected GitHub CI Tailnet Verification
 
-The staging and production deployment jobs, the manual **Verify private
-Tailscale admin access** workflow, and the direct production post-deploy gate
-temporarily join a GitHub-hosted runner to the tailnet. The project accepts
-this narrow credential exposure because no trusted self-hosted tailnet runner
-is available. This exception applies only to protected environment jobs. It
-does not put pull-request CI, scheduled public TLS scans, or other
-GitHub-hosted jobs inside the tailnet.
+The staging and production deployment and trusted-main bootstrap jobs, the
+manual **Verify private Tailscale admin access** workflow, and the direct
+production post-deploy gate temporarily join a GitHub-hosted runner to the
+tailnet. The project accepts this narrow credential exposure because no
+trusted self-hosted tailnet runner is available. This exception applies only
+to protected environment jobs. It does not put pull-request CI, scheduled
+public TLS scans, or other GitHub-hosted jobs inside the tailnet.
 
 `workflow_dispatch` supports on-demand checks. The trusted production workflow
 defines a direct required gate after `deploy-production` and
@@ -73,9 +73,13 @@ Auth Keys > Write**; an auth key must be short-lived, one-off where possible,
 ephemeral, tagged, and pre-approved when required. Both modes are restricted
 to `tag:github-ci-admin-verify`, which may reach only
 `tag:admin-sitbank:443` and cannot administer the tailnet or use broad SSH.
-Each run selects exactly one mode. Staging and production deployment use
-separate OAuth clients and source tags that can reach only the matching EC2
-destination tag on port `22`.
+Each run selects exactly one mode. Staging and production deployment and
+bootstrap use separate OAuth clients and source tags that can reach only the
+matching EC2 destination tag on port `22`. Bootstrap joins before any remote
+OpenSSH operation and logs out on every completion path, matching deployment.
+Public SSH is not a fallback once the EC2 host variables select private
+Tailscale targets; approved AWS console/SSM or a narrowly authorized temporary
+security-group exception remains the host-recovery boundary.
 
 Each approved run:
 

--- a/docs/security/architecture/admin-and-staging-zero-trust-access.md
+++ b/docs/security/architecture/admin-and-staging-zero-trust-access.md
@@ -59,8 +59,9 @@ to protected environment jobs. It does not put pull-request CI, scheduled
 public TLS scans, or other GitHub-hosted jobs inside the tailnet.
 
 `workflow_dispatch` supports on-demand checks. The trusted production workflow
-defines a direct required gate after `deploy-production` and
-`verify-production-tls` both succeed. This avoids the observed reusable-call
+defines a direct required `Verify private admin tailnet` gate after the
+internal `deploy-production` and `verify-production-tls` jobs both succeed.
+This avoids the observed reusable-call
 behavior where the called job received empty OAuth inputs despite the same
 environment secrets working in a manual run. Both jobs use the protected
 `admin-tailscale` GitHub Environment. Configure that environment to require
@@ -108,8 +109,10 @@ covers only `staging-sitbank.pp.ua` and `sitbank.pp.ua`. Operators separately
 verify that `www.sitbank.pp.ua` redirects to the canonical production host. It must not
 depend on or include the private Tailscale hostname.
 
-After a trusted production deployment, the release order is
-`deploy-production` -> `verify-production-tls` ->
+After a trusted production deployment, the visible release order is
+`Deploy production` -> `Verify production TLS` ->
+`Verify private admin tailnet`. The stable internal IDs remain
+`deploy-production`, `verify-production-tls`, and
 `verify-private-admin-tailnet`. A private-gate failure fails the completed
 deployment workflow and clearly requires post-deploy investigation; it does
 not roll back or redeploy automatically. Manual dispatch remains available for

--- a/docs/security/assurance/sonarqube.md
+++ b/docs/security/assurance/sonarqube.md
@@ -105,10 +105,13 @@ fall back to a legacy owner or project. Scanner evidence is valid only when the
 same run imports both `coverage.xml` and `coverage/lcov.info` for the resolved
 source commit.
 
-The reviewed main-branch cleartext-protocol findings in
-`ops/container/smoke-test.sh` are false positives: those URLs address only
-named containers on an isolated ephemeral Docker smoke network, while public
-and production traffic remains HTTPS-only. CodeQL findings for the mandated
+The reviewed main-branch cleartext-protocol finding in
+`ops/container/smoke-test.sh` is an intentional private-only exception: the
+URL and its ZAP baseline sink address only a named container on the isolated
+ephemeral Docker smoke network and carry narrow line-scoped dispositions.
+Public, staging, production, admin, deployment, and observability traffic
+remain HTTPS/TLS or private OpenSSH-over-Tailscale as applicable. CodeQL
+findings for the mandated
 HIBP SHA-1 range lookup, keyed HMAC/PBKDF2 constructions, a non-verifier
 configuration fingerprint, and exact trusted static-document assertions are
 also alert-specific false positives. Each provider disposition carries its

--- a/docs/security/assurance/sonarqube.md
+++ b/docs/security/assurance/sonarqube.md
@@ -64,8 +64,9 @@ that both the cloud scan and PR comment were skipped.
 
 ## Coverage, Scope, And Evidence
 
-The `test` job in `.github/workflows/ci-deploy.yml` installs
-`requirements-dev.lock` with hashes and runs the full suite once:
+The visible `Test and security checks` job (internal ID `test`) in
+`.github/workflows/ci-deploy.yml` installs `requirements-dev.lock` with hashes
+and runs the full suite once:
 
 ```text
 python -m pytest -q -n auto --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term --durations=30 --durations-min=0.5
@@ -73,14 +74,15 @@ node tests/js/collect-browser-coverage.mjs
 ```
 
 After all test and security checks pass, that job uploads `coverage.xml` and
-`coverage/lcov.info`
-as a one-day artifact. Its downstream `sonarqube` job calls the reusable
+`coverage/lcov.info` as a one-day artifact. Its downstream visible
+`SonarQube analysis` job (internal ID `sonarqube`) calls the reusable
 `.github/workflows/sonarqube.yml`, checks out the same resolved source commit,
 downloads the coverage artifact, and runs the scanner without rerunning pytest.
 This keeps the authoritative test result and SonarQube coverage input in the
 same workflow run. The test and reusable scanner jobs remain read-only; a
-separate trusted-PR-only comment job holds the narrowly scoped
-`pull-requests: write` permission.
+separate trusted-PR-only `SonarQube PR comment` job (internal ID
+`sonarqube-comment`) holds the narrowly scoped `pull-requests: write`
+permission.
 
 `sonar-project.properties` sends `app`, deployment/security material under
 `ops`, and `config.py`, `wsgi.py`, and `admin_wsgi.py` as sources.

--- a/docs/security/governance/github-branch-protection-evidence.md
+++ b/docs/security/governance/github-branch-protection-evidence.md
@@ -14,7 +14,7 @@ two checks would otherwise collide.
 - Require the branch to be up to date and require these stable PR checks:
   - `CI, publish, and deploy / Workflow security`
   - `CI, publish, and deploy / Test and security checks`
-  - `CI, publish, and deploy / Dependency review (PR only)`
+  - `CI, publish, and deploy / Dependency review`
   - `ShellCheck / Repository shell scripts`
   - `Hadolint / Repository Dockerfiles`
   - `Semgrep / High-severity SAST`
@@ -43,3 +43,8 @@ least quarterly.
 Roll out a renamed required check by first allowing the new workflow to complete
 successfully, updating the GitHub ruleset to the exact new check name, and only
 then removing the old name. This avoids an unmergeable branch-protection gap.
+This repository change does not update GitHub settings automatically. Review
+the active ruleset after merge for any former raw contexts such as
+`deploy-staging`, `verify-staging-tls`, `sonarqube`, or `sonarqube-comment`.
+Post-merge deployment and reporting-only jobs should remain non-required unless
+a separate reviewed policy change explicitly promotes them.

--- a/ops/container/smoke-test.sh
+++ b/ops/container/smoke-test.sh
@@ -498,7 +498,7 @@ if [[ "${RUN_ZAP_BASELINE:-false}" == "true" ]]; then
 -config replacer.full_list(0).matchtype=REQ_HEADER \
 -config replacer.full_list(0).matchstr=X-Forwarded-Proto \
 -config replacer.full_list(0).replacement=https" \
-            -t "${zap_baseline_target}"
+            -t "${zap_baseline_target}"  # NOSONAR - isolated ephemeral Docker network
 fi
 
 if [[ "${RUN_ZAP_DAST:-false}" == "true" ]]; then

--- a/tests/test_dast_workflows.py
+++ b/tests/test_dast_workflows.py
@@ -34,7 +34,10 @@ def test_pr_dast_smoke_is_local_automatic_and_time_bounded():
         'zap_baseline_target="http://${app_container}:5000/"  '
         "# NOSONAR - isolated ephemeral Docker network"
     ) in helper
-    assert '-t "${zap_baseline_target}" # NOSONAR' not in helper
+    assert (
+        '-t "${zap_baseline_target}"  '
+        "# NOSONAR - isolated ephemeral Docker network"
+    ) in helper
     for required_runtime_setting in (
         "--env PASSWORD_RESET_ENABLED=true",
         "--env PASSWORD_RESET_EMAIL_BACKEND=smtp",

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -2422,9 +2422,22 @@ def test_private_deploy_docs_separate_public_https_from_private_ssh_targets():
         "tag:sitbank-prod-ec2:22",
         "Tailscale SSH remains disabled",
         "remove public port `22`",
+        "public SSH is not a workflow fallback",
+        "both bootstrap and deployment require the private tailnet path",
+        "AWS console or SSM",
         "do not prove live Tailscale",
     ):
         assert required in docs
+    for path in (
+        Path("docs/GITHUB_ACTIONS.md"),
+        Path("docs/DEPLOYMENT.md"),
+        Path("docs/OPERATIONS.md"),
+        Path("docs/security/architecture/admin-and-staging-zero-trust-access.md"),
+    ):
+        document = path.read_text(encoding="utf-8")
+        assert "bootstrap" in document.lower()
+        assert "tag:github-ci-staging-deploy" in document
+        assert "tag:github-ci-prod-deploy" in document
     assert not re.search(r"tag:github-ci(?!-)", docs)
     assert "18.188.152.24" not in Path(
         "docs/security/architecture/cloudflare-staging-access.md"
@@ -2495,6 +2508,58 @@ def test_manual_bootstrap_workflow_uses_only_signed_trusted_main_sources():
         assert checkout["with"]["ref"] == "${{ github.workflow_sha }}"
         assert checkout["with"]["persist-credentials"] is False
         assert checkout["with"]["fetch-depth"] == 0
+        configuration_step = next(
+            step
+            for step in job["steps"]
+            if step["name"] == f"Verify {target} bootstrap configuration"
+        )
+        assert configuration_step["env"]["TS_OAUTH_CLIENT_ID"] == (
+            "${{ secrets.TS_OAUTH_CLIENT_ID }}"
+        )
+        assert configuration_step["env"]["TS_OAUTH_SECRET"] == (
+            "${{ secrets.TS_OAUTH_SECRET }}"
+        )
+        assert "TS_OAUTH_CLIENT_ID" in configuration_step["run"]
+        assert "TS_OAUTH_SECRET" in configuration_step["run"]
+        tailnet_step = next(
+            step
+            for step in job["steps"]
+            if step["name"] == f"Join the {target} bootstrap tailnet"
+        )
+        deploy_workflow = yaml.safe_load(
+            Path(".github/workflows/ci-deploy.yml").read_text(encoding="utf-8")
+        )
+        deploy_tailnet_step = next(
+            step
+            for step in deploy_workflow["jobs"][f"deploy-{target}"]["steps"]
+            if step["name"] == f"Join the {target} deploy tailnet"
+        )
+        assert tailnet_step["uses"] == deploy_tailnet_step["uses"]
+        assert tailnet_step["with"] == {
+            "oauth-client-id": "${{ secrets.TS_OAUTH_CLIENT_ID }}",
+            "oauth-secret": "${{ secrets.TS_OAUTH_SECRET }}",
+            "tags": (
+                "tag:github-ci-staging-deploy"
+                if target == "staging"
+                else "tag:github-ci-prod-deploy"
+            ),
+            "ping": f"${{{{ vars.{prefix}_EC2_HOST }}}}",
+        }
+        tailnet_index = job["steps"].index(tailnet_step)
+        remote_command_indexes = [
+            index
+            for index, step in enumerate(job["steps"])
+            if "REMOTE_HOST" in str(step.get("run", ""))
+            and re.search(r"\b(?:ssh|scp)\b", str(step.get("run", "")))
+        ]
+        assert remote_command_indexes
+        assert all(tailnet_index < index for index in remote_command_indexes)
+        cleanup_step = job["steps"][-1]
+        assert cleanup_step["name"] == f"Disconnect {target} bootstrap tailnet"
+        assert cleanup_step["if"] == "${{ always() }}"
+        assert cleanup_step["run"] == (
+            "sudo tailscale logout > /dev/null 2>&1 || true"
+        )
         step_text = "\n".join(
             str(step.get("run", "")) for step in job["steps"]
         )
@@ -2529,6 +2594,7 @@ def test_manual_bootstrap_workflow_uses_only_signed_trusted_main_sources():
     assert "PROD_EC2_SSH_PRIVATE_KEY_B64" in workflow_text
     assert "STAGING_EC2_KNOWN_HOSTS" in workflow_text
     assert "PROD_EC2_KNOWN_HOSTS" in workflow_text
+    assert "tag:github-ci-admin-verify" not in workflow_text
 
 
 def test_root_bootstrap_wrapper_authenticates_and_limits_privileged_updates():

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1958,7 +1958,7 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
             "${{ vars['PROD_PUBLIC_HOST'] || 'sitbank.pp.ua' }}"
         ),
     }
-    assert private_admin["name"] == "Required private admin post-deploy gate"
+    assert private_admin["name"] == "Verify private admin tailnet"
     assert private_admin["needs"] == [
         "deploy-production",
         "verify-production-tls",
@@ -2362,7 +2362,15 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     assert "source_ref = candidate branch, tag, or SHA" in docs
     assert "resolve immutable source_sha" in docs
     assert "deploy staging using trusted main scripts" in docs
-    assert "main push -> publish -> release-verify -> staging -> production" in docs
+    assert (
+        "main push -> Publish container image -> Release verification "
+        "-> Deploy staging"
+        in docs
+    )
+    assert (
+        "Verify staging TLS -> Deploy production -> Verify production TLS"
+        in docs
+    )
     assert "manual production dispatch -> publish -> release-verify -> production" not in docs
     assert "Production deployment is manual-only." not in docs
     production_policy = (

--- a/tests/test_github_branch_protection_evidence.py
+++ b/tests/test_github_branch_protection_evidence.py
@@ -8,6 +8,18 @@ def test_branch_protection_evidence_matches_workflow_display_names():
         "docs/security/governance/github-branch-protection-evidence.md"
     ).read_text(encoding="utf-8")
     expected = {
+        "CI, publish, and deploy / Workflow security": (
+            "ci-deploy.yml",
+            "workflow-security",
+        ),
+        "CI, publish, and deploy / Test and security checks": (
+            "ci-deploy.yml",
+            "test",
+        ),
+        "CI, publish, and deploy / Dependency review": (
+            "ci-deploy.yml",
+            "dependency-review",
+        ),
         "ShellCheck / Repository shell scripts": ("shellcheck.yml", "scan"),
         "Hadolint / Repository Dockerfiles": ("hadolint.yml", "scan"),
         "Semgrep / High-severity SAST": ("semgrep.yml", "scan"),

--- a/tests/test_tailscale_ci_tailnet_workflow.py
+++ b/tests/test_tailscale_ci_tailnet_workflow.py
@@ -169,7 +169,7 @@ def test_production_workflow_requires_private_gate_after_deploy_and_public_tls()
     ci = yaml.load(ci_text, Loader=yaml.BaseLoader)
     gate = ci["jobs"]["verify-private-admin-tailnet"]
 
-    assert gate["name"] == "Required private admin post-deploy gate"
+    assert gate["name"] == "Verify private admin tailnet"
     assert gate["needs"] == ["deploy-production", "verify-production-tls"]
     assert "needs.deploy-production.result == 'success'" in gate["if"]
     assert "needs.verify-production-tls.result == 'success'" in gate["if"]

--- a/tests/test_workflow_display_names.py
+++ b/tests/test_workflow_display_names.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+
+WORKFLOW_DIR = Path(".github/workflows")
+CI_WORKFLOW = WORKFLOW_DIR / "ci-deploy.yml"
+BOOTSTRAP_WORKFLOW = WORKFLOW_DIR / "bootstrap-ec2.yml"
+RAW_SLUG = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)+")
+TEMPLATE_FRAGMENT = re.compile(r"\$\{\{.*?\}\}")
+ALLOWED_DYNAMIC_JOB_NAMES = {
+    ("tls-scan.yml", "scan"): "Scan ${{ matrix.target.label }}",
+}
+EXPECTED_CI_NAMES = {
+    "resolve-source": "Resolve source",
+    "workflow-security": "Workflow security",
+    "dependency-review": "Dependency review",
+    "test": "Test and security checks",
+    "sonarqube": "SonarQube analysis",
+    "sonarqube-comment": "SonarQube PR comment",
+    "image-test": "Container image test",
+    "deployment-preflight": "Deployment preflight",
+    "publish": "Publish container image",
+    "release-verify": "Release verification",
+    "deploy-staging": "Deploy staging",
+    "verify-staging-tls": "Verify staging TLS",
+    "deploy-production": "Deploy production",
+    "verify-production-tls": "Verify production TLS",
+    "verify-private-admin-tailnet": "Verify private admin tailnet",
+}
+
+
+def _load_workflow(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _assert_human_readable_name(name: object, context: str) -> str:
+    assert isinstance(name, str) and name.strip(), (
+        f"{context} needs an explicit name"
+    )
+    assert name == name.strip(), f"{context} name has surrounding whitespace"
+    assert name[0].isupper(), f"{context} name must start with a capital letter"
+    assert not RAW_SLUG.fullmatch(name), f"{context} exposes a raw slug"
+    return name
+
+
+def test_every_workflow_job_and_visible_step_has_a_human_readable_name():
+    workflow_paths = sorted(WORKFLOW_DIR.glob("*.yml"))
+
+    assert workflow_paths
+    for path in workflow_paths:
+        workflow = _load_workflow(path)
+        _assert_human_readable_name(workflow.get("name"), f"{path} workflow")
+
+        jobs = workflow.get("jobs")
+        assert isinstance(jobs, dict) and jobs, f"{path} must define jobs"
+        for job_id, job in jobs.items():
+            context = f"{path} job {job_id}"
+            display_name = _assert_human_readable_name(job.get("name"), context)
+            assert display_name != job_id, f"{context} exposes its internal ID"
+
+            expected_dynamic_name = ALLOWED_DYNAMIC_JOB_NAMES.get(
+                (path.name, job_id)
+            )
+            if expected_dynamic_name is None:
+                assert not TEMPLATE_FRAGMENT.search(display_name), (
+                    f"{context} has an unexpected template fragment"
+                )
+            else:
+                assert display_name == expected_dynamic_name
+
+            for index, step in enumerate(job.get("steps", []), start=1):
+                step_context = f"{context} step {index}"
+                step_name = _assert_human_readable_name(
+                    step.get("name"), step_context
+                )
+                assert not TEMPLATE_FRAGMENT.search(step_name), (
+                    f"{step_context} has an unresolved template fragment"
+                )
+
+
+def test_release_display_names_preserve_security_boundaries_and_ordering():
+    ci = _load_workflow(CI_WORKFLOW)
+    bootstrap = _load_workflow(BOOTSTRAP_WORKFLOW)
+
+    assert {
+        job_id: job["name"] for job_id, job in ci["jobs"].items()
+    } == EXPECTED_CI_NAMES
+    assert {
+        job_id: job["name"] for job_id, job in bootstrap["jobs"].items()
+    } == {
+        "validate-request": "Validate bootstrap request",
+        "bootstrap-staging": "Bootstrap staging EC2",
+        "bootstrap-production": "Bootstrap production EC2",
+    }
+
+    assert ci["jobs"]["deploy-production"]["needs"] == [
+        "release-verify",
+        "deploy-staging",
+        "verify-staging-tls",
+    ]
+    private_admin = ci["jobs"]["verify-private-admin-tailnet"]
+    assert private_admin["needs"] == [
+        "deploy-production",
+        "verify-production-tls",
+    ]
+    assert private_admin["environment"] == {"name": "admin-tailscale"}
+    assert "tag:github-ci-admin-verify" in str(private_admin)
+
+    for target, expected_tag in (
+        ("staging", "tag:github-ci-staging-deploy"),
+        ("production", "tag:github-ci-prod-deploy"),
+    ):
+        job = ci["jobs"][f"deploy-{target}"]
+        prefix = "STAGING" if target == "staging" else "PROD"
+        tailnet_step = next(
+            step
+            for step in job["steps"]
+            if step["name"] == f"Join the {target} deploy tailnet"
+        )
+        assert tailnet_step["with"]["tags"] == expected_tag
+        assert "StrictHostKeyChecking=yes" in str(job)
+        assert "BatchMode=yes" in str(job)
+        assert "IdentitiesOnly=yes" in str(job)
+        assert f"{prefix}_EC2_KNOWN_HOSTS" in str(job)
+        assert f"{prefix}_EC2_SSH_PRIVATE_KEY_B64" in str(job)
+        assert "tailscale logout" in job["steps"][-1]["run"]
+        assert job["steps"][-1]["if"] == "${{ always() }}"
+
+
+def test_workflow_display_name_documentation_matches_the_ci_workflow():
+    github_actions = Path("docs/GITHUB_ACTIONS.md").read_text(encoding="utf-8")
+    deployment = Path("docs/DEPLOYMENT.md").read_text(encoding="utf-8")
+    operations = Path("docs/OPERATIONS.md").read_text(encoding="utf-8")
+    sonar = Path("docs/security/assurance/sonarqube.md").read_text(
+        encoding="utf-8"
+    )
+    combined = "\n".join((github_actions, deployment, operations, sonar))
+
+    for job_id, display_name in EXPECTED_CI_NAMES.items():
+        assert f"`{job_id}`" in combined
+        assert f"`{display_name}`" in combined
+    assert "Internal job IDs remain stable kebab-case keys" in github_actions
+    normalized_github_actions = re.sub(r"\s+", " ", github_actions)
+    assert (
+        "Repository files do not update GitHub rulesets"
+        in normalized_github_actions
+    )


### PR DESCRIPTION
Summary
---

Hardens trusted-main EC2 bootstrap over least-privilege Tailscale, resolves the remaining SonarCloud clear-text finding with a bounded private-network disposition, and gives every GitHub Actions job and visible step an explicit human-readable display name.

Closes #330
Closes #331

Why
---

Bootstrap attempted OpenSSH against private Tailscale targets before the GitHub runner joined the tailnet. SonarCloud separately reported the isolated ZAP baseline sink. The Actions UI also exposed raw internal job IDs, making security and deployment checks harder to read consistently.

What changed
---

- Validate environment-scoped Tailscale OAuth credentials, join with reviewed staging/production tags before remote SSH/SCP, ping the target, and always log out.
- Preserve pinned known-host verification, restricted bootstrap wrapper checks, Cosign signing, protected environments, and the separate private-admin identity.
- Place the narrow `NOSONAR` disposition on the exact isolated ZAP sink reported by `shell:S5332`, with tests and assurance documentation for the private-only boundary.
- Add explicit display names to every previously unnamed workflow job while keeping all internal IDs and dependency expressions stable.
- Add repository-wide policy tests for workflow, job, and step names plus existing Tailscale, SSH, environment, and release-order guardrails.
- Document visible check names, stable internal IDs, and the manual GitHub ruleset migration procedure.

Security impact
---

Bootstrap reaches EC2 only through the matching least-privilege tailnet grant while retaining normal OpenSSH, `StrictHostKeyChecking=yes`, environment-specific keys, and fail-closed wrapper authorization. Tailscale SSH and Funnel remain disabled. Public HTTPS/TLS boundaries and SonarQube quality-gate behavior are unchanged. Workflow naming changes do not alter permissions, environments, conditions, secrets, or deployment ordering.

Deployment impact
---

No database migration, application secret, EC2 bootstrap, or application deployment is required to merge these repository changes. Protected `staging` and `production` environments must retain their separate Tailscale OAuth credentials and source-tag restrictions. After merge, maintainers must review the active GitHub ruleset for any required contexts that used old raw job names; allow the new context to succeed before removing an old one. Repository files do not mutate or prove provider-side branch protection.

Verification
---

- `git diff --check`
- `.\.venv\Scripts\python.exe -m pytest -q -n auto` — 1,099 passed, 2 skipped
- Focused workflow, deployment, SonarQube, Tailscale, and branch-protection tests — 42 passed
- Workflow naming audit — 17 workflows, zero unnamed jobs or visible steps
- `coverage.xml` — 90.06% Python line coverage
- `node tests/js/collect-browser-coverage.mjs` — 98.8% browser line coverage

Notes
---

The PR remains draft pending provider-side runs proving staging and production bootstrap can join the live tailnet, reach their private EC2 port 22 targets, and clean up sessions after success or failure. The next SonarCloud analysis must confirm Security Rating A and removal of the `shell:S5332` issue without lowering the quality gate. Maintainers should also confirm the new human-readable check contexts in the Actions and ruleset UIs after merge.