### PR TITLE
Repair bootstrap and release smoke regressions

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -533,7 +533,10 @@ Release verification runs `ops/container/smoke-test.sh` against the exact image
 digest that will be deployed. When authenticated DAST is enabled, the helper
 creates only synthetic customer identities, restricts the target to loopback or
 the explicit smoke container host, and keeps real customer, staff, and admin
-credentials out of the scan path.
+credentials out of the scan path. Its synthetic login submits Cloudflare's
+documented public dummy token only with the official always-pass Turnstile test
+keys configured by the isolated smoke harness; deployed environments continue
+to use their protected real Turnstile credentials.
 
 DAST cookie handling is intentionally file-based. `auth-cookie` and
 `zap-replacer.properties` are created under `umask 077`, written as `0600`
@@ -685,7 +688,7 @@ served through DNS and the deployed edge.
 
 ## Production Edge and Network Hardening
 
-The reviewed production bootstrap installs and enables the production edge from `ops/nginx/sitbank-default.conf`, `ops/nginx/sitbank-production.conf`, `ops/nginx/sitbank-production-rate-limits.conf`, `ops/nginx-proxy-headers.conf`, and `ops/nginx/sitbank-tls-policy.conf`. `PUBLIC_BIND_ADDRESS` in root-owned `deploy.conf` must be the exact public/VPC IPv4 address assigned to Nginx; loopback, Tailscale `100.64.0.0/10`, wildcard, and malformed values fail bootstrap. During the first transition from a deploy config without this key, bootstrap derives the kernel's default-route source IPv4, validates it under the same policy, and persists it for subsequent deployments; operators with multiple egress interfaces must pass the intended address explicitly. The bootstrap renders every public port `80`/`443` listener onto that address, while Tailscale Serve owns its private HTTPS listener. The shared default config owns unknown-host rejection without wildcard public listeners. Any change to these files or `PUBLIC_BIND_ADDRESS` requires a target bootstrap after merge.
+The reviewed production bootstrap installs and enables the production edge from `ops/nginx/sitbank-default.conf`, `ops/nginx/sitbank-production.conf`, `ops/nginx/sitbank-production-rate-limits.conf`, `ops/nginx-proxy-headers.conf`, and `ops/nginx/sitbank-tls-policy.conf`. `PUBLIC_BIND_ADDRESS` in root-owned `deploy.conf` must be the exact public/VPC IPv4 address assigned to Nginx; loopback, Tailscale `100.64.0.0/10`, wildcard, and malformed values fail bootstrap. During the first transition from a deploy config without this key, bootstrap derives the kernel's default-route source IPv4, validates it under the same policy, and persists it for subsequent deployments. If route lookup does not return a valid source IPv4, bootstrap fails before changing Nginx; operators with multiple egress interfaces must pass the intended address explicitly. The bootstrap renders every public port `80`/`443` listener onto that address, while Tailscale Serve owns its private HTTPS listener. The shared default config owns unknown-host rejection without wildcard public listeners. Any change to these files or `PUBLIC_BIND_ADDRESS` requires a target bootstrap after merge.
 
 Production bootstrap also installs
 `/usr/local/sbin/verify-production-nginx-boundary`. Bootstrap runs it after

--- a/ops/container/create_dast_session.py
+++ b/ops/container/create_dast_session.py
@@ -15,6 +15,7 @@ from sqlalchemy.exc import IntegrityError
 
 
 DAST_COOKIE_RE = re.compile(r"^__Host-sitbank_session=[A-Za-z0-9._~-]+$")
+TURNSTILE_TEST_TOKEN = "XXXX.DUMMY.TOKEN.XXXX"
 
 
 class DastClient:
@@ -127,7 +128,11 @@ def create_authenticated_cookie(
     client.request(
         "POST",
         "/auth/login",
-        payload={"identifier": username, "password": password},
+        payload={
+            "identifier": username,
+            "password": password,
+            "cf-turnstile-response": TURNSTILE_TEST_TOKEN,
+        },
         csrf_token=csrf_token,
         expected_status=200,
     )

--- a/ops/deploy/bootstrap-container-ec2
+++ b/ops/deploy/bootstrap-container-ec2
@@ -97,7 +97,7 @@ fi
 if [[ -z "${public_bind_address}" ]]; then
     public_bind_address="$(
         ip -4 route get 1.1.1.1 \
-            | awk '{ for (index = 1; index <= NF; index++) if ($index == "src") { print $(index + 1); exit } }'
+            | awk '{ for (field_index = 1; field_index <= NF; field_index++) if ($field_index == "src") { print $(field_index + 1); exit } }'
     )"
 fi
 if ! python3 - "${public_bind_address}" <<'PY'

--- a/tests/test_dast_helper_security.py
+++ b/tests/test_dast_helper_security.py
@@ -327,6 +327,12 @@ def test_create_authenticated_cookie_runs_login_and_mfa_sequence(monkeypatch):
         "/auth/mfa/setup",
         "/auth/mfa/setup/verify",
     ]
+    assert calls[1][2]["payload"] == {
+        "identifier": "zapabc123",
+        "password": "DAST-fake-random-A9!",
+        "cf-turnstile-response": module.TURNSTILE_TEST_TOKEN,
+    }
+    assert module.TURNSTILE_TEST_TOKEN == "XXXX.DUMMY.TOKEN.XXXX"
     assert calls[-1][2]["payload"] == {"totp_code": "123456"}
 
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -3356,6 +3356,31 @@ def test_nginx_default_server_is_shared_for_same_host_production_and_staging():
     assert "server_name staging-sitbank.pp.ua;" in combined
 
 
+def test_bootstrap_default_route_source_parser_is_valid_awk():
+    bootstrap = Path("ops/deploy/bootstrap-container-ec2").read_text(
+        encoding="utf-8"
+    )
+    parser = re.search(
+        r"ip -4 route get 1\.1\.1\.1 \\\n\s+\| awk '([^']+)'",
+        bootstrap,
+    )
+    assert parser
+
+    try:
+        result = subprocess.run(
+            ["awk", parser.group(1)],
+            input="1.1.1.1 via 10.0.1.1 dev eth0 src 10.0.1.25 uid 0\n",
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        pytest.skip("awk is not installed")
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "10.0.1.25\n"
+
+
 def test_nginx_tls_policy_pins_strong_suites_curves_and_session_hardening():
     tls_policy_path = Path("ops/nginx/sitbank-tls-policy.conf")
     tls_policy = tls_policy_path.read_text(encoding="utf-8")


### PR DESCRIPTION
Summary
---
Repairs the trusted EC2 bootstrap and authenticated release-smoke regressions observed after the latest main merge.

Why
---
GNU awk rejects `index` as a loop variable because it is a built-in function name, causing bootstrap to fail while deriving `PUBLIC_BIND_ADDRESS`. The production-like smoke runtime also enabled fail-closed Turnstile with official test keys, but its non-browser DAST login omitted Cloudflare's required public dummy token.

What changed
---

- Renamed the awk route-field iterator and added a regression that executes the embedded parser against representative `ip route` output.
- Added Cloudflare's documented public dummy token to the isolated synthetic DAST login and asserted the complete login payload in the helper sequence test.
- Documented route-lookup failure behavior and the smoke-only Turnstile test-key contract.

Security impact
---
Fail-closed bootstrap address validation and deployed Turnstile enforcement remain intact. The dummy token is public test material and is submitted only by the isolated smoke helper with Cloudflare's official test keys; no production credential, provider setting, or authentication bypass was added.

Deployment impact
---
No database migration, secret change, or provider-setting change is required. After merge, rerun the failed trusted staging bootstrap from `main`; production bootstrap and deployment remain staging-first and subject to the existing release-verification and environment gates.

Verification
---

- `git diff --check`
- `C:\Program Files\Git\bin\bash.exe -n ops/deploy/bootstrap-container-ec2`
- `.\.venv\Scripts\python.exe -m pytest -q tests/test_dast_helper_security.py tests/test_deployment.py::test_dast_session_creator_matches_registration_contract` (16 passed)
- `.\.venv\Scripts\python.exe -m pytest -q -n 4 --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term` (1,275 passed, 6 skipped, 90% total coverage)
- Built `sitbank:codex-smoke` and ran `RUN_ZAP_DAST=true ops/container/smoke-test.sh sitbank:codex-smoke`; authenticated session creation passed and ZAP reported 0 new/in-progress failures with 137 passing checks.

Notes
---
The four ZAP warnings remain report-only under the existing policy. Live staging bootstrap and GitHub-hosted release verification must be rerun after merge because they depend on trusted `main` and external host/provider state.