### PR TITLE
Wire Turnstile secret into admin runtimes

### DIFF
--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -172,6 +172,7 @@ services:
       SECURITY_ALERT_WEBHOOK_URL_FILE: /run/secrets/security_alert_webhook_url
       SMTP_USERNAME_FILE: /run/secrets/smtp_username
       SMTP_PASSWORD_FILE: /run/secrets/smtp_password
+      TURNSTILE_SECRET_KEY_FILE: /run/secrets/turnstile_secret_key
     secrets:
       - source: admin_secret_key
         target: admin_secret_key
@@ -197,6 +198,8 @@ services:
         target: smtp_username
       - source: smtp_password
         target: smtp_password
+      - source: turnstile_secret_key
+        target: turnstile_secret_key
     volumes:
       - type: bind
         source: /etc/sitbank/common-passwords.txt

--- a/compose.staging.yml
+++ b/compose.staging.yml
@@ -224,6 +224,7 @@ services:
       SECURITY_ALERT_WEBHOOK_URL_FILE: /run/secrets/security_alert_webhook_url
       SMTP_USERNAME_FILE: /run/secrets/smtp_username
       SMTP_PASSWORD_FILE: /run/secrets/smtp_password
+      TURNSTILE_SECRET_KEY_FILE: /run/secrets/turnstile_secret_key
     secrets:
       - source: admin_secret_key
         target: admin_secret_key
@@ -249,6 +250,8 @@ services:
         target: smtp_username
       - source: smtp_password
         target: smtp_password
+      - source: turnstile_secret_key
+        target: turnstile_secret_key
     volumes:
       - type: bind
         source: /etc/sitbank-staging/common-passwords.txt

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -167,7 +167,9 @@ the production widget covers `sitbank.pp.ua` and `www.sitbank.pp.ua`, while the
 staging widget covers `staging-sitbank.pp.ua`. Store server credentials only as
 the `PROD_TURNSTILE_SECRET_KEY` and `STAGING_TURNSTILE_SECRET_KEY` GitHub
 Environment secrets. The trusted deployment installs each credential as
-`/etc/sitbank*/secrets/turnstile_secret_key`; Compose exposes only
+`/etc/sitbank*/secrets/turnstile_secret_key`; Compose mounts that
+environment-specific credential read-only into both the customer and admin
+runtimes and exposes only
 `TURNSTILE_SECRET_KEY_FILE=/run/secrets/turnstile_secret_key`.
 
 Production-like readiness fails closed unless Turnstile, the site and secret
@@ -772,7 +774,10 @@ production admin URL `https://admin-sitbank.tailca101b.ts.net/`; staging admin
 must use the same private-network pattern through an approved tailnet path. Do
 not enable Tailscale Funnel and do not add a public staging admin Nginx server
 block. Staging admin secrets must be root-managed under
-`/etc/sitbank-staging/secrets` and must not reuse customer runtime secrets.
+`/etc/sitbank-staging/secrets`. Admin Flask, session, password-pepper, and
+database secrets must not reuse customer runtime secrets; only the
+environment-specific Turnstile server credential is shared because both
+runtimes enforce their configured public-auth challenges.
 
 ## Staging Edge Setup
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1000,6 +1000,7 @@ def test_compose_secret_mounts_match_runtime_contract():
         "SECURITY_ALERT_WEBHOOK_URL_FILE": "/run/secrets/security_alert_webhook_url",
         "SMTP_USERNAME_FILE": "/run/secrets/smtp_username",
         "SMTP_PASSWORD_FILE": "/run/secrets/smtp_password",
+        "TURNSTILE_SECRET_KEY_FILE": "/run/secrets/turnstile_secret_key",
     }
     expected_admin_secrets = {
         **{name: name for name in ADMIN_SECRET_FILES},
@@ -1007,6 +1008,7 @@ def test_compose_secret_mounts_match_runtime_contract():
         "security_alert_webhook_url": "security_alert_webhook_url",
         "smtp_username": "smtp_username",
         "smtp_password": "smtp_password",
+        "turnstile_secret_key": "turnstile_secret_key",
     }
     for path, secret_root, base_extra_secrets in (
         (


### PR DESCRIPTION
Summary
---
Mounts the existing environment-specific Turnstile server credential into the production and staging admin services so mandatory admin public-auth readiness checks can pass.

Why
---
The failed staging deployment completed migration, runtime privilege application, negative privilege probes, and customer readiness successfully. The actual failure was the admin production check reporting `TURNSTILE_SECRET_KEY must be configured`: both Compose models mounted the protected credential into the customer service but omitted it from the admin service while admin login and invite Turnstile flags are mandatory.

What changed
---

- Added `TURNSTILE_SECRET_KEY_FILE=/run/secrets/turnstile_secret_key` to both admin services.
- Mounted the already-defined `turnstile_secret_key` Compose secret read-only into both admin services.
- Extended the exact Compose secret-contract test and documented the intentionally shared environment credential.

Security impact
---
Turnstile remains fail closed for production-like customer and admin routes. The credential stays in the existing root-managed secret file and is not written to `container.env`; admin Flask, session, password-pepper, and database secrets remain isolated from customer runtime secrets.

Deployment impact
---
No EC2 bootstrap, database migration, new secret, or provider-setting change is required. After merge, rerun the staging deployment; production deployment remains staging-first and subject to the existing release, environment, and verification gates.

Verification
---

- `git diff --check`
- `.\.venv\Scripts\python.exe -m pytest -q tests/test_deployment.py::test_compose_secret_mounts_match_runtime_contract` (1 passed)
- `C:\Program Files\Git\bin\bash.exe ops/container/validate-compose.sh sitbank:admin-turnstile-test`
- `.\.venv\Scripts\python.exe -m pytest -q tests/test_deployment.py -k "compose_secret_mounts_match_runtime_contract or dockerfile_and_compose_enforce_hardened_runtime or production_nginx_edge_config_enforces_network_boundary_and_limits or staging_nginx_enforces_https_auth_health_and_rate_limits"` (4 passed, 69 deselected)
- `.\.venv\Scripts\python.exe -m pytest -q -n 4 --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term` (1,275 passed, 6 skipped, 90% total coverage)

Notes
---
The PostgreSQL permission-denied diagnostics in the failed run are expected evidence that the runtime role cannot mutate audit records, own schema objects, or create extensions; the workflow reported those privilege checks as passed before the separate admin readiness failure.