### PR TITLE
Add private Grafana Loki verification

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,6 +18,7 @@ ops/deploy/verify-staging-edge-boundary text eol=lf
 ops/deploy/verify-tailscale-admin-access text eol=lf
 ops/deploy/verify-production-nginx-boundary text eol=lf
 ops/tailscale/* text eol=lf
+ops/observability/* text eol=lf
 ops/backups/* text eol=lf
 ops/sudoers/* text eol=lf
 scripts/ci-local text eol=lf

--- a/.github/workflows/observability-private-verify.yml
+++ b/.github/workflows/observability-private-verify.yml
@@ -1,0 +1,112 @@
+name: Verify private Grafana Loki observability
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_environment:
+        description: Environment whose private observability stack should be verified.
+        required: true
+        default: staging
+        type: choice
+        options:
+          - staging
+          - production
+
+permissions: {}
+
+concurrency:
+  group: private-observability-verification-${{ inputs.target_environment }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: Verify private Grafana Loki observability
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    environment:
+      name: observability-${{ inputs.target_environment }}
+    env:
+      OBSERVABILITY_TARGET_ENV: ${{ inputs.target_environment }}
+      GRAFANA_PRIVATE_URL: ${{ vars.GRAFANA_PRIVATE_URL }}
+      OBSERVABILITY_PUBLIC_PROBE_URLS: ${{ vars.OBSERVABILITY_PUBLIC_PROBE_URLS }}
+      GRAFANA_HEALTH_TOKEN: ${{ secrets.GRAFANA_HEALTH_TOKEN }}
+
+    steps:
+      - name: Check out trusted repository state
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+
+      - name: Validate private observability target
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${GRAFANA_PRIVATE_URL}" =~ ^https://([^/@]+)\.ts\.net/?$ ]]; then
+            :
+          else
+            echo "::error::GRAFANA_PRIVATE_URL must be a private https Tailscale URL from the protected observability environment."
+            exit 1
+          fi
+          if [[ "${GRAFANA_PRIVATE_URL,,}" == *"sitbank.pp.ua"* ]]; then
+            echo "::error::GRAFANA_PRIVATE_URL must not be a public SITBank hostname."
+            exit 1
+          fi
+          if [[ -z "${GRAFANA_HEALTH_TOKEN}" ]]; then
+            echo "::error::GRAFANA_HEALTH_TOKEN is required in the protected observability environment."
+            exit 1
+          fi
+          if curl --silent --show-error --max-time 8 \
+            --output /dev/null "${GRAFANA_PRIVATE_URL%/}/api/health"; then
+            echo "::error::Private Grafana responded before the protected runner joined the tailnet."
+            exit 1
+          fi
+
+      - name: Join the approved observability tailnet
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:github-ci-observability-verify
+
+      - name: Verify private Grafana and public Loki denial
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "$(tailscale status --json | jq -r '.BackendState')" != "Running" ]]; then
+            echo "::error::The protected runner did not establish a running tailnet session."
+            exit 1
+          fi
+
+          python ops/observability/verify-private-observability \
+            --target-environment "${OBSERVABILITY_TARGET_ENV}" \
+            --grafana-url "${GRAFANA_PRIVATE_URL}" \
+            --evidence-file "observability-evidence/private-observability.json"
+
+          {
+            echo "## Private Grafana/Loki verification"
+            echo
+            echo "- Target environment: \`${OBSERVABILITY_TARGET_ENV}\`"
+            echo "- Evidence: \`observability-evidence/private-observability.json\`"
+            echo "- Private Grafana, Grafana anonymous denial, Loki datasource health, least-privilege verifier role, and public observability route denial checks passed."
+            echo "- No operator password, browser session, cookie, MFA value, raw log, or API response body is retained."
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload sanitized private observability evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: private-observability-verification-${{ inputs.target_environment }}
+          path: observability-evidence/private-observability.json
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Disconnect observability tailnet session
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          sudo tailscale logout > /dev/null 2>&1 || true

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,12 @@ appendonly.aof*
 *.pem
 *.pdf
 cloudflare-access-evidence*.json
+observability-evidence/
+private-observability*.json
+grafana-*.json
+loki-*.json
+storage-state*.json
+*.har
 .vscode/
 compose.dev.yml
 docker-compose.dev.yml

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -39,7 +39,10 @@ and status checks use the display names:
 | `verify-private-admin-tailnet` | `Verify private admin tailnet` |
 
 Bootstrap, Cloudflare verification, label automation, reusable SonarQube, and
-manual private-tailnet jobs follow the same explicit naming policy.
+manual private-tailnet jobs follow the same explicit naming policy. The
+manual **Verify private Grafana Loki observability** workflow is a protected
+post-deployment evidence workflow for the private observability stack, not a
+pull-request or public TLS check.
 `tests/test_workflow_display_names.py` enforces the policy across every
 `.github/workflows/*.yml` file while allowing the intentional TLS matrix name
 `Scan ${{ matrix.target.label }}`.
@@ -309,6 +312,30 @@ used by workflows.
 The separate `ops/tailscale/` host automation installs Tailscale and configures
 the production Serve mapping only after explicit operator confirmation. It is
 never called by either verification job, pull requests, or normal CI.
+
+## Private Observability Verification
+
+`.github/workflows/observability-private-verify.yml` is manual-only,
+`main`-only, read-only, and protected by either `observability-staging` or
+`observability-production`. It verifies the private Grafana/Loki deployment
+after observability bootstrap, Grafana provisioning, Tailscale ACL/DNS changes,
+or operator credential rotation. It is intentionally separate from PR-safe
+static tests and from public TLS evidence because Grafana is a private operator
+tool and Loki is not Internet-facing.
+
+Configure each protected environment with `GRAFANA_PRIVATE_URL`,
+optional `OBSERVABILITY_PUBLIC_PROBE_URLS`, `GRAFANA_HEALTH_TOKEN`,
+`TS_OAUTH_CLIENT_ID`, and `TS_OAUTH_SECRET`. The Tailscale OAuth client should
+be restricted to `tag:github-ci-observability-verify`, and the Grafana token
+must be a least-privilege non-admin health token. Do not store operator
+passwords, browser sessions, cookies, MFA values, raw Loki logs, datasource
+credentials, or Grafana admin credentials in GitHub.
+
+The workflow checks that private Grafana is unreachable before joining the
+tailnet, joins Tailscale, verifies Grafana API health, anonymous API denial,
+non-admin verifier role, Loki datasource health, and public denial probes for
+`/grafana`, `/loki`, `/logs`, and `/metrics`. It uploads only sanitized JSON
+evidence for 30 days and logs out of Tailscale at completion.
 
 ## Gitleaks
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -342,6 +342,17 @@ operator verification steps are in
 Provider automation and origin assertion details are in
 `docs/security/architecture/cloudflare-staging-access.md`.
 
+Run the manual **Verify private Grafana Loki observability** workflow from
+`main` after private observability bootstrap, Grafana datasource changes,
+Tailscale ACL/DNS changes, or token rotation. The workflow uses the protected
+`observability-staging` or `observability-production` environment, joins
+Tailscale with `tag:github-ci-observability-verify`, verifies private Grafana
+health, anonymous denial, non-admin verifier role, Loki datasource health, and
+public denial probes, then uploads only sanitized evidence. It must not run on
+pull requests or public TLS jobs and must not receive operator passwords,
+browser sessions, cookies, MFA values, raw logs, datasource credentials, or
+Grafana admin credentials.
+
 ## Production Cloudflare Origin Operations
 
 Production requires Cloudflare Authenticated Origin Pull in addition to
@@ -854,7 +865,9 @@ The `pp.ua` DNS-01 migration and DuckDNS retirement are complete. Keep retired
 names out of active Nginx, Certbot, workflow, and TLS-scan configuration. Use
 `docs/runbooks/private-observability-grafana-loki.md` for the private
 Grafana/Loki/Alloy stack; Grafana remains private and is not exposed through
-the SITBank admin app.
+the SITBank admin app. Live Grafana/Loki evidence is collected only by the
+protected private observability workflow, never by public GitHub-hosted TLS
+scan jobs.
 
 The normal public TLS scan deliberately excludes the private Tailscale admin hostname
 `admin-sitbank.tailca101b.ts.net`; a GitHub-hosted public runner cannot reach

--- a/docs/runbooks/global-verification.md
+++ b/docs/runbooks/global-verification.md
@@ -288,7 +288,16 @@ Expected safe success indicators: Grafana listens only on `127.0.0.1:3000`,
 Loki listens only on `127.0.0.1:3100`, Alloy publishes no host listener, and
 public SITBank Nginx routes do not proxy observability services. Grafana
 credentials, datasource credentials, Loki credentials, broad log-reader
-credentials, and raw log exports are never safe to print.
+credentials, raw logs, cookies, sessions, Access assertions, and provider
+exports are not safe to print.
+
+After bootstrap or private-access changes, run the manual protected
+`.github/workflows/observability-private-verify.yml` workflow from `main`
+against `observability-staging` or `observability-production`. The retained
+artifact is `observability-evidence/private-observability.json` and contains
+only sanitized pass/fail evidence for private Grafana health, anonymous API
+denial, non-admin verifier role, Loki datasource health, and public
+Grafana/Loki route denial.
 
 ### Emergency And Break-Glass Checks
 

--- a/docs/runbooks/private-observability-grafana-loki.md
+++ b/docs/runbooks/private-observability-grafana-loki.md
@@ -59,6 +59,44 @@ Do not print the secret file contents.
 
 ## Verification
 
+### Protected Live Workflow
+
+Run **Verify private Grafana Loki observability** from `main` after the private
+observability stack, Tailscale DNS/ACLs, Grafana credentials, or datasource
+provisioning changes. Select `staging` or `production`; the job uses the
+matching protected GitHub Environment `observability-staging` or
+`observability-production`.
+
+Each environment must require trusted maintainer approval and restrict
+deployment branches to `main`. Configure:
+
+- `GRAFANA_PRIVATE_URL` as the private Tailscale HTTPS URL, for example
+  `https://grafana-sitbank.tailca101b.ts.net/`;
+- optional `OBSERVABILITY_PUBLIC_PROBE_URLS` as newline-separated public
+  denial probes for `/grafana`, `/loki`, `/logs`, and `/metrics`;
+- `TS_OAUTH_CLIENT_ID` and `TS_OAUTH_SECRET` for a narrowly scoped Tailscale
+  OAuth client tagged `tag:github-ci-observability-verify`;
+- `GRAFANA_HEALTH_TOKEN` as a least-privilege Grafana service account token
+  that can read `/api/health`, its own `/api/user` role, datasources, and
+  datasource health.
+
+Do not store operator passwords, browser sessions, cookies, MFA values,
+Grafana admin credentials, Loki credentials, datasource passwords, raw logs, or
+provider exports in GitHub secrets or artifacts. The token must not have
+Grafana admin privileges. The workflow first confirms the private URL is not
+reachable from the public runner, then joins Tailscale, verifies Grafana API
+health, verifies anonymous API denial, checks the verifier role is not admin,
+checks Loki datasource health through Grafana, and verifies public SITBank
+paths do not expose Grafana or Loki. It uploads only
+`observability-evidence/private-observability.json`, a sanitized summary with
+HTTP status codes and check names, not raw API responses.
+
+The protected workflow is live network-path evidence. It is not a pull-request
+check and must never run on forks, untrusted branches, or public GitHub-hosted
+TLS jobs.
+
+### Host Checks
+
 ```bash
 sudo docker compose --env-file /etc/sitbank-observability/observability.env -f /etc/sitbank-observability/compose.yml ps
 sudo ss -ltnp | grep -E ':(3000|3100)([[:space:]]|$)'

--- a/docs/security/assurance/operational-observability.md
+++ b/docs/security/assurance/operational-observability.md
@@ -41,6 +41,15 @@ Normal access uses a private Tailscale URL such as
 `https://grafana-sitbank.tailca101b.ts.net/` mapped to local Grafana. SSH local
 port forwarding is bootstrap or break-glass only, not the normal access model.
 
+Live Grafana/Loki evidence is collected only by
+`.github/workflows/observability-private-verify.yml`, a manually dispatched
+`main`-only workflow protected by `observability-staging` or
+`observability-production`. It joins Tailscale with the
+`tag:github-ci-observability-verify` identity, uses a least-privilege Grafana
+health token, and uploads only sanitized pass/fail evidence. Pull requests,
+forks, public TLS scans, and untrusted branches do not receive Tailscale or
+Grafana/Loki credentials.
+
 Do not expose Grafana publicly through production, staging, customer, admin, or
 unknown-host Nginx routes. Do not proxy, iframe, embed, or link authenticated
 Grafana sessions through Flask or the admin runtime.
@@ -58,6 +67,9 @@ from `/etc/sitbank-observability/secrets/*` and provisions Loki as a datasource
 without committed datasource credentials. Do not commit Grafana admin
 passwords, Loki tokens, API keys, datasource passwords, webhook URLs, cookies,
 session values, or provider exports.
+The protected live verifier's service account token is allowed only as a
+GitHub Environment secret and must be least-privilege, non-admin, rotated on
+operator offboarding, and excluded from artifacts and job summaries.
 
 ## Collection Guidance
 

--- a/ops/observability/verify-private-observability
+++ b/ops/observability/verify-private-observability
@@ -100,7 +100,11 @@ def _validate_public_probe_url(url: str) -> str:
         raise VerificationError("Public probe URLs must be https URLs without credentials")
     if parsed.hostname.casefold().endswith(".ts.net"):
         raise VerificationError("Public probes must not target private Tailscale hostnames")
-    if not any((parsed.path or "/").startswith(path) for path in PUBLIC_EXPOSURE_PATHS):
+    path = parsed.path or "/"
+    if not any(
+        path == allowed or path.startswith(f"{allowed}/")
+        for allowed in PUBLIC_EXPOSURE_PATHS
+    ):
         raise VerificationError("Public probes must target reviewed observability-denial paths")
     return url
 

--- a/ops/observability/verify-private-observability
+++ b/ops/observability/verify-private-observability
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Verify private Grafana/Loki posture and write sanitized evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess  # nosec B404
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Sequence
+from urllib.parse import urlparse
+
+
+DEFAULT_PUBLIC_PROBES = (
+    "https://sitbank.pp.ua/grafana",
+    "https://sitbank.pp.ua/loki",
+    "https://sitbank.pp.ua/logs",
+    "https://sitbank.pp.ua/metrics",
+    "https://www.sitbank.pp.ua/grafana",
+    "https://www.sitbank.pp.ua/loki",
+    "https://staging-sitbank.pp.ua/grafana",
+    "https://staging-sitbank.pp.ua/loki",
+    "https://staging-sitbank.pp.ua/logs",
+    "https://staging-sitbank.pp.ua/metrics",
+)
+SECRET_MARKERS = (
+    "authorization:",
+    "cookie:",
+    "cf-access-jwt-assertion",
+    "grafana_session",
+    "x-grafana-org-id",
+)
+PUBLIC_EXPOSURE_PATHS = ("/grafana", "/loki", "/logs", "/metrics")
+
+
+class VerificationError(RuntimeError):
+    """Raised when a required observability assertion fails."""
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+Runner = Callable[[Sequence[str]], CommandResult]
+
+
+def run_command(arguments: Sequence[str]) -> CommandResult:
+    executable = shutil.which(arguments[0])
+    if executable is None:
+        raise VerificationError(f"required command is not installed: {arguments[0]}")
+    try:
+        completed = subprocess.run(  # nosec B603
+            [executable, *arguments[1:]],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise VerificationError(f"could not run required command: {arguments[0]}") from exc
+    return CommandResult(completed.returncode, completed.stdout, completed.stderr)
+
+
+def _safe_json_load(raw: str, description: str) -> Any:
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise VerificationError(f"{description} did not return valid JSON") from exc
+
+
+def _safe_url_label(url: str) -> str:
+    parsed = urlparse(url)
+    return f"{parsed.hostname or '<invalid>'}{parsed.path or '/'}"
+
+
+def _validate_private_grafana_url(url: str) -> str:
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or not parsed.hostname or parsed.username or parsed.password:
+        raise VerificationError("GRAFANA_PRIVATE_URL must be an https URL without credentials")
+    hostname = parsed.hostname.casefold()
+    if hostname in {"sitbank.pp.ua", "www.sitbank.pp.ua", "staging-sitbank.pp.ua"}:
+        raise VerificationError("GRAFANA_PRIVATE_URL must not be a public SITBank hostname")
+    if not hostname.endswith(".ts.net"):
+        raise VerificationError("GRAFANA_PRIVATE_URL must use a private Tailscale DNS hostname")
+    return url.rstrip("/")
+
+
+def _validate_public_probe_url(url: str) -> str:
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or not parsed.hostname or parsed.username or parsed.password:
+        raise VerificationError("Public probe URLs must be https URLs without credentials")
+    if parsed.hostname.casefold().endswith(".ts.net"):
+        raise VerificationError("Public probes must not target private Tailscale hostnames")
+    if not any((parsed.path or "/").startswith(path) for path in PUBLIC_EXPOSURE_PATHS):
+        raise VerificationError("Public probes must target reviewed observability-denial paths")
+    return url
+
+
+def _public_probe_urls(raw: str | None) -> list[str]:
+    values = [
+        value.strip()
+        for value in (raw.splitlines() if raw else DEFAULT_PUBLIC_PROBES)
+        if value.strip()
+    ]
+    if not values:
+        raise VerificationError("At least one public observability probe URL is required")
+    return [_validate_public_probe_url(value) for value in values]
+
+
+def _curl(
+    runner: Runner,
+    url: str,
+    *,
+    token: str | None = None,
+) -> tuple[int, str]:
+    command = [
+        "curl",
+        "--silent",
+        "--show-error",
+        "--location",
+        "--max-time",
+        "15",
+        "--header",
+        "Accept: application/json",
+    ]
+    if token:
+        command.extend(["--header", f"Authorization: Bearer {token}"])
+    command.append(url)
+    result = runner(tuple(command))
+    if result.returncode != 0:
+        raise VerificationError(f"request failed for {_safe_url_label(url)}")
+    return result.returncode, result.stdout
+
+
+def _curl_status_headers(runner: Runner, url: str) -> tuple[str, str]:
+    result = runner(
+        (
+            "curl",
+            "--silent",
+            "--show-error",
+            "--location-trusted",
+            "--max-redirs",
+            "0",
+            "--max-time",
+            "15",
+            "--output",
+            "/dev/null",
+            "--dump-header",
+            "-",
+            "--write-out",
+            "\nSITBANK_HTTP_CODE:%{http_code}\n",
+            url,
+        )
+    )
+    if result.returncode not in {0, 22, 47}:
+        return "000", ""
+    status = "000"
+    for line in result.stdout.splitlines():
+        if line.startswith("SITBANK_HTTP_CODE:"):
+            status = line.split(":", 1)[1].strip()
+    return status, result.stdout
+
+
+def verify_private_grafana(
+    runner: Runner,
+    grafana_url: str,
+    token: str,
+) -> list[dict[str, str]]:
+    checks: list[dict[str, str]] = []
+    if not token:
+        raise VerificationError("GRAFANA_HEALTH_TOKEN is required for private API verification")
+
+    _curl(runner, f"{grafana_url}/api/health", token=token)
+    checks.append({"name": "grafana_api_health", "result": "pass"})
+
+    anonymous_status, _headers = _curl_status_headers(runner, f"{grafana_url}/api/user")
+    if anonymous_status not in {"401", "403"}:
+        raise VerificationError("Grafana anonymous API access is not denied")
+    checks.append(
+        {
+            "name": "grafana_anonymous_disabled",
+            "result": "pass",
+            "http_status": anonymous_status,
+        }
+    )
+
+    _code, user_raw = _curl(runner, f"{grafana_url}/api/user", token=token)
+    user = _safe_json_load(user_raw, "Grafana authenticated user API")
+    if isinstance(user, dict) and (
+        user.get("isGrafanaAdmin") is True or str(user.get("orgRole", "")).casefold() == "admin"
+    ):
+        raise VerificationError("Grafana verification token has administrative privileges")
+    checks.append({"name": "grafana_verifier_role_least_privilege", "result": "pass"})
+
+    _code, datasources_raw = _curl(runner, f"{grafana_url}/api/datasources", token=token)
+    datasources = _safe_json_load(datasources_raw, "Grafana datasource API")
+    if not isinstance(datasources, list):
+        raise VerificationError("Grafana datasource API returned an unexpected schema")
+    loki_sources = [
+        source for source in datasources
+        if isinstance(source, dict) and str(source.get("type", "")).casefold() == "loki"
+    ]
+    if not loki_sources:
+        raise VerificationError("Grafana has no Loki datasource to verify")
+    for source in loki_sources:
+        uid = source.get("uid")
+        if not isinstance(uid, str) or not re.fullmatch(r"[A-Za-z0-9_-]{1,128}", uid):
+            raise VerificationError("Grafana Loki datasource UID is missing or unsafe")
+        _curl(runner, f"{grafana_url}/api/datasources/uid/{uid}/health", token=token)
+    checks.append(
+        {
+            "name": "loki_datasource_health",
+            "result": "pass",
+            "datasource_count": str(len(loki_sources)),
+        }
+    )
+    return checks
+
+
+def verify_public_denials(
+    runner: Runner,
+    public_urls: Sequence[str],
+) -> list[dict[str, str]]:
+    checks: list[dict[str, str]] = []
+    failures: list[str] = []
+    for url in public_urls:
+        status, headers = _curl_status_headers(runner, url)
+        header_text = headers.casefold()
+        if status == "200" or "location:" in header_text and re.search(r"/(?:grafana|loki)(?:/|$)", header_text):
+            failures.append(f"{_safe_url_label(url)} returned public observability access evidence")
+        if any(marker in header_text for marker in SECRET_MARKERS):
+            failures.append(f"{_safe_url_label(url)} returned sensitive observability headers")
+        checks.append(
+            {
+                "name": "public_observability_denial",
+                "result": "pass" if not failures else "fail",
+                "target": _safe_url_label(url),
+                "http_status": status,
+            }
+        )
+    if failures:
+        raise VerificationError("\n".join(failures))
+    return checks
+
+
+def _write_evidence(
+    path: Path,
+    *,
+    target_environment: str,
+    grafana_url: str,
+    checks: Sequence[dict[str, str]],
+    token: str,
+) -> None:
+    parsed = urlparse(grafana_url)
+    evidence = {
+        "schema": 1,
+        "result": "pass",
+        "verification": "private-grafana-loki",
+        "target_environment": target_environment,
+        "workflow_trigger": "manual_protected",
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "private_grafana_host": parsed.hostname,
+        "checks": list(checks),
+        "sanitization": {
+            "raw_http_bodies_retained": False,
+            "credentials_retained": False,
+            "cookies_retained": False,
+            "access_assertions_retained": False,
+        },
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(evidence, indent=2, sort_keys=True) + "\n"
+    if token and token in text:
+        raise VerificationError("sanitized evidence unexpectedly contains the Grafana token")
+    path.write_text(text, encoding="utf-8")
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--target-environment",
+        choices=("staging", "production"),
+        default=os.environ.get("OBSERVABILITY_TARGET_ENV", "staging"),
+    )
+    parser.add_argument(
+        "--grafana-url",
+        default=os.environ.get("GRAFANA_PRIVATE_URL", ""),
+    )
+    parser.add_argument(
+        "--public-probe-url",
+        action="append",
+        default=[],
+        help="Public URL that must not expose Grafana/Loki; repeatable.",
+    )
+    parser.add_argument(
+        "--evidence-file",
+        default=os.environ.get(
+            "OBSERVABILITY_EVIDENCE_FILE",
+            "observability-evidence/private-observability.json",
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        grafana_url = _validate_private_grafana_url(args.grafana_url)
+        public_urls = args.public_probe_url or _public_probe_urls(
+            os.environ.get("OBSERVABILITY_PUBLIC_PROBE_URLS")
+        )
+        public_urls = [_validate_public_probe_url(url) for url in public_urls]
+        token = os.environ.get("GRAFANA_HEALTH_TOKEN", "")
+        checks = [
+            *verify_private_grafana(run_command, grafana_url, token),
+            *verify_public_denials(run_command, public_urls),
+        ]
+        _write_evidence(
+            Path(args.evidence_file),
+            target_environment=args.target_environment,
+            grafana_url=grafana_url,
+            checks=checks,
+            token=token,
+        )
+    except VerificationError as exc:
+        for line in str(exc).splitlines():
+            print(f"ERROR: {line}", file=sys.stderr)
+        return 1
+    print(f"Sanitized private observability evidence written to {args.evidence_file}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -3133,6 +3133,7 @@ def test_linux_deployment_artifacts_are_forced_to_lf_and_reject_crlf():
         Path("ops/deploy/verify-certbot-host-state"),
         Path("ops/deploy/verify-staging-edge-boundary"),
         Path("ops/deploy/verify-tailscale-admin-access"),
+        Path("ops/observability/verify-private-observability"),
         Path("ops/tailscale/install-tailscale"),
         Path("ops/tailscale/configure-admin-access"),
         Path("ops/tailscale/verify-admin-access"),
@@ -3161,6 +3162,7 @@ def test_linux_deployment_artifacts_are_forced_to_lf_and_reject_crlf():
     assert "ops/deploy/verify-certbot-host-state text eol=lf" in attributes
     assert "ops/deploy/verify-staging-edge-boundary text eol=lf" in attributes
     assert "ops/deploy/verify-tailscale-admin-access text eol=lf" in attributes
+    assert "ops/observability/* text eol=lf" in attributes
     assert "ops/tailscale/* text eol=lf" in attributes
     assert "ops/backups/* text eol=lf" in attributes
     assert "ops/sudoers/* text eol=lf" in attributes
@@ -3169,6 +3171,120 @@ def test_linux_deployment_artifacts_are_forced_to_lf_and_reject_crlf():
 
     assert "Refusing to install CRLF-formatted Linux file" in bootstrap
     assert "grep -q $'\\r$'" in bootstrap
+
+
+def test_private_observability_workflow_is_manual_protected_and_sanitized():
+    workflow_path = Path(".github/workflows/observability-private-verify.yml")
+    workflow_text = workflow_path.read_text(encoding="utf-8")
+    workflow = yaml.safe_load(workflow_text)
+    triggers = workflow[True]
+    verify = workflow["jobs"]["verify"]
+
+    assert workflow["name"] == "Verify private Grafana Loki observability"
+    assert set(triggers) == {"workflow_dispatch"}
+    assert "pull_request" not in workflow_text
+    assert "pull_request_target" not in workflow_text
+    assert workflow["permissions"] == {}
+    assert workflow["concurrency"] == {
+        "group": "private-observability-verification-${{ inputs.target_environment }}",
+        "cancel-in-progress": False,
+    }
+    assert triggers["workflow_dispatch"]["inputs"]["target_environment"]["options"] == [
+        "staging",
+        "production",
+    ]
+    assert verify["if"] == "github.ref == 'refs/heads/main'"
+    assert verify["runs-on"] == "ubuntu-24.04"
+    assert verify["permissions"] == {"contents": "read"}
+    assert verify["environment"]["name"] == (
+        "observability-${{ inputs.target_environment }}"
+    )
+    assert verify["env"] == {
+        "OBSERVABILITY_TARGET_ENV": "${{ inputs.target_environment }}",
+        "GRAFANA_PRIVATE_URL": "${{ vars.GRAFANA_PRIVATE_URL }}",
+        "OBSERVABILITY_PUBLIC_PROBE_URLS": (
+            "${{ vars.OBSERVABILITY_PUBLIC_PROBE_URLS }}"
+        ),
+        "GRAFANA_HEALTH_TOKEN": "${{ secrets.GRAFANA_HEALTH_TOKEN }}",
+    }
+    assert "GRAFANA_PRIVATE_URL must be a private https Tailscale URL" in workflow_text
+    assert "responded before the protected runner joined the tailnet" in workflow_text
+    assert "tag:github-ci-observability-verify" in workflow_text
+    assert "ops/observability/verify-private-observability" in workflow_text
+    assert "observability-evidence/private-observability.json" in workflow_text
+    assert "operator password" in workflow_text
+    assert "raw log" in workflow_text
+    assert "sudo tailscale logout" in workflow_text
+    assert "set -x" not in workflow_text
+    assert "printenv" not in workflow_text
+    assert "env |" not in workflow_text
+    assert "docker compose" not in workflow_text
+    assert "tailscale funnel" not in workflow_text
+    assert "tailscale serve" not in workflow_text
+
+    uses = _workflow_uses(workflow_text)
+    assert uses == [
+        "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+        "tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8",
+        "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+    ]
+    _assert_pinned_actions(uses, context="Private observability workflow")
+
+    docs = "\n".join(
+        Path(path).read_text(encoding="utf-8")
+        for path in (
+            "docs/GITHUB_ACTIONS.md",
+            "docs/OPERATIONS.md",
+            "docs/runbooks/private-observability-grafana-loki.md",
+            "docs/security/assurance/operational-observability.md",
+        )
+    )
+    for required in (
+        "observability-staging",
+        "observability-production",
+        "GRAFANA_PRIVATE_URL",
+        "GRAFANA_HEALTH_TOKEN",
+        "tag:github-ci-observability-verify",
+        "least-privilege",
+        "anonymous API denial",
+        "public denial probes",
+        "not a pull-request",
+    ):
+        assert required in docs
+    assert "operator passwords" in docs
+    assert "browser sessions" in docs
+    assert "raw logs" in docs
+
+
+def test_private_observability_static_policy_keeps_public_routes_closed():
+    nginx_combined = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in Path("ops/nginx").glob("*.conf")
+    )
+    public_runtime = "\n".join(
+        path.read_text(encoding="utf-8")
+        for root in (Path("app"),)
+        for path in [*root.rglob("*.py"), *root.rglob("*.html"), *root.rglob("*.js")]
+        if path.is_file()
+    )
+    ignored = Path(".gitignore").read_text(encoding="utf-8")
+
+    for forbidden in ("/grafana", "/loki", "/logs", "/metrics"):
+        assert f"location {forbidden}" not in nginx_combined.casefold()
+    assert not re.search(r"proxy_pass\s+http://127\.0\.0\.1:(3000|3100)", nginx_combined)
+    assert not re.search(r"proxy_pass\s+http://(?:grafana|loki)", nginx_combined.casefold())
+    assert "grafana" not in public_runtime.casefold()
+    assert "loki" not in public_runtime.casefold()
+    assert "<iframe" not in public_runtime.casefold()
+    for required in (
+        "observability-evidence/",
+        "private-observability*.json",
+        "grafana-*.json",
+        "loki-*.json",
+        "storage-state*.json",
+        "*.har",
+    ):
+        assert required in ignored
 
 
 def test_certbot_host_state_verifier_enforces_host_managed_tls():

--- a/tests/test_operational_observability_deployment.py
+++ b/tests/test_operational_observability_deployment.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import json
 import re
+import runpy
 from pathlib import Path
 
+import pytest
 import yaml
 
 
 OBS_ROOT = Path("ops/observability")
+VERIFIER_PATH = OBS_ROOT / "verify-private-observability"
 
 
 def _read_observability_files() -> str:
@@ -217,3 +220,125 @@ def test_observability_bootstrap_and_docs_keep_credentials_out_of_repo():
 
     assert "SSH local port forwarding is allowed only for bootstrap" in docs
     assert "No public Nginx production, staging, customer, or admin route" in docs
+
+
+def test_private_observability_verifier_accepts_safe_mocked_live_state(tmp_path):
+    module = runpy.run_path(str(VERIFIER_PATH))
+    token = "fake-grafana-health-token"
+    calls = []
+
+    def fake_runner(arguments):
+        command = tuple(arguments)
+        calls.append(command)
+        url = command[-1]
+        if url.endswith("/api/health"):
+            return module["CommandResult"](0, '{"database":"ok"}')
+        if url.endswith("/api/user") and "Authorization: Bearer " + token in command:
+            return module["CommandResult"](
+                0,
+                json.dumps({"login": "sitbank-verifier", "orgRole": "Viewer"}),
+            )
+        if url.endswith("/api/user"):
+            return module["CommandResult"](
+                0,
+                "HTTP/2 401\r\n\nSITBANK_HTTP_CODE:401\n",
+            )
+        if url.endswith("/api/datasources"):
+            return module["CommandResult"](
+                0,
+                json.dumps([{"uid": "sitbank-loki", "type": "loki"}]),
+            )
+        if url.endswith("/api/datasources/uid/sitbank-loki/health"):
+            return module["CommandResult"](0, '{"status":"OK"}')
+        if "/grafana" in url or "/loki" in url:
+            return module["CommandResult"](
+                0,
+                "HTTP/2 404\r\n\nSITBANK_HTTP_CODE:404\n",
+            )
+        raise AssertionError(command)
+
+    grafana_url = "https://grafana-sitbank.tailca101b.ts.net"
+    checks = [
+        *module["verify_private_grafana"](fake_runner, grafana_url, token),
+        *module["verify_public_denials"](
+            fake_runner,
+            ("https://sitbank.pp.ua/grafana", "https://staging-sitbank.pp.ua/loki"),
+        ),
+    ]
+    evidence = tmp_path / "private-observability.json"
+    module["_write_evidence"](
+        evidence,
+        target_environment="staging",
+        grafana_url=grafana_url,
+        checks=checks,
+        token=token,
+    )
+
+    evidence_text = evidence.read_text(encoding="utf-8")
+    evidence_json = json.loads(evidence_text)
+    assert evidence_json["result"] == "pass"
+    assert evidence_json["workflow_trigger"] == "manual_protected"
+    assert evidence_json["private_grafana_host"] == "grafana-sitbank.tailca101b.ts.net"
+    assert {check["name"] for check in evidence_json["checks"]} >= {
+        "grafana_api_health",
+        "grafana_anonymous_disabled",
+        "grafana_verifier_role_least_privilege",
+        "loki_datasource_health",
+        "public_observability_denial",
+    }
+    assert token not in evidence_text
+    assert "Authorization" not in evidence_text
+    assert "grafana_session" not in evidence_text
+    assert any(
+        "Authorization: Bearer " + token in command
+        for command in calls
+    )
+
+
+def test_private_observability_verifier_fails_closed_on_public_exposure_and_admin_token():
+    module = runpy.run_path(str(VERIFIER_PATH))
+
+    with pytest.raises(module["VerificationError"], match="public SITBank"):
+        module["_validate_private_grafana_url"]("https://sitbank.pp.ua")
+    with pytest.raises(module["VerificationError"], match="Tailscale"):
+        module["_validate_private_grafana_url"]("https://grafana.example.com")
+    with pytest.raises(module["VerificationError"], match="without credentials"):
+        module["_validate_private_grafana_url"](
+            "https://user:pass@grafana-sitbank.tailca101b.ts.net"
+        )
+    with pytest.raises(module["VerificationError"], match="private Tailscale"):
+        module["_validate_public_probe_url"](
+            "https://grafana-sitbank.tailca101b.ts.net/grafana"
+        )
+
+    def admin_runner(arguments):
+        url = tuple(arguments)[-1]
+        if url.endswith("/api/health"):
+            return module["CommandResult"](0, "{}")
+        if url.endswith("/api/user") and "Authorization: Bearer token" in tuple(arguments):
+            return module["CommandResult"](0, json.dumps({"orgRole": "Admin"}))
+        if url.endswith("/api/user"):
+            return module["CommandResult"](
+                0,
+                "HTTP/2 401\r\n\nSITBANK_HTTP_CODE:401\n",
+            )
+        raise AssertionError(arguments)
+
+    with pytest.raises(module["VerificationError"], match="administrative privileges"):
+        module["verify_private_grafana"](
+            admin_runner,
+            "https://grafana-sitbank.tailca101b.ts.net",
+            "token",
+        )
+
+    def public_runner(arguments):
+        return module["CommandResult"](
+            0,
+            "HTTP/2 200\r\nserver: grafana\r\n\nSITBANK_HTTP_CODE:200\n",
+        )
+
+    with pytest.raises(module["VerificationError"], match="public observability"):
+        module["verify_public_denials"](
+            public_runner,
+            ("https://sitbank.pp.ua/grafana",),
+        )

--- a/tests/test_operational_observability_deployment.py
+++ b/tests/test_operational_observability_deployment.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 import re
 import runpy
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -11,6 +13,8 @@ import yaml
 
 OBS_ROOT = Path("ops/observability")
 VERIFIER_PATH = OBS_ROOT / "verify-private-observability"
+PRIVATE_GRAFANA_URL = "https://grafana-sitbank.tailca101b.ts.net"
+FAKE_GRAFANA_TOKEN = "fake-grafana-health-token"
 
 
 def _read_observability_files() -> str:
@@ -27,6 +31,59 @@ def _read_observability_files() -> str:
         for path in paths
         if path.is_file()
     )
+
+
+def _load_verifier_module():
+    return runpy.run_path(str(VERIFIER_PATH))
+
+
+def _status_headers(module, status: str, *headers: str):
+    header_text = "\r\n".join([f"HTTP/2 {status}", *headers])
+    return module["CommandResult"](
+        0,
+        f"{header_text}\r\n\r\nSITBANK_HTTP_CODE:{status}\n",
+    )
+
+
+def _make_grafana_runner(
+    module,
+    *,
+    token: str = FAKE_GRAFANA_TOKEN,
+    anonymous_status: str = "401",
+    user=None,
+    datasources=None,
+    datasource_health_returncode: int = 0,
+):
+    user_payload = (
+        {"login": "sitbank-verifier", "orgRole": "Viewer"}
+        if user is None
+        else user
+    )
+    datasource_payload = (
+        [{"uid": "sitbank-loki", "type": "loki"}]
+        if datasources is None
+        else datasources
+    )
+
+    def fake_runner(arguments):
+        command = tuple(arguments)
+        url = command[-1]
+        if url.endswith("/api/health"):
+            return module["CommandResult"](0, '{"database":"ok"}')
+        if url.endswith("/api/user") and f"Authorization: Bearer {token}" in command:
+            return module["CommandResult"](0, json.dumps(user_payload))
+        if url.endswith("/api/user"):
+            return _status_headers(module, anonymous_status)
+        if url.endswith("/api/datasources"):
+            return module["CommandResult"](0, json.dumps(datasource_payload))
+        if re.search(r"/api/datasources/uid/.+/health$", url):
+            return module["CommandResult"](
+                datasource_health_returncode,
+                '{"status":"OK"}',
+            )
+        raise AssertionError(command)
+
+    return fake_runner
 
 
 def test_private_grafana_loki_alloy_deployment_files_exist_and_are_private():
@@ -342,3 +399,469 @@ def test_private_observability_verifier_fails_closed_on_public_exposure_and_admi
             public_runner,
             ("https://sitbank.pp.ua/grafana",),
         )
+
+
+def test_private_grafana_url_validation_accepts_only_private_tailscale_https():
+    module = _load_verifier_module()
+
+    assert (
+        module["_validate_private_grafana_url"](
+            "https://grafana-sitbank.tailca101b.ts.net/"
+        )
+        == "https://grafana-sitbank.tailca101b.ts.net"
+    )
+
+    invalid_urls = (
+        ("http://grafana-sitbank.tailca101b.ts.net", "https URL"),
+        ("https:///grafana", "https URL"),
+        (
+            "https://user:pass@grafana-sitbank.tailca101b.ts.net",
+            "without credentials",
+        ),
+        ("https://www.sitbank.pp.ua", "public SITBank"),
+        ("https://staging-sitbank.pp.ua", "public SITBank"),
+        ("https://grafana.example.com", "Tailscale"),
+    )
+    for url, message in invalid_urls:
+        with pytest.raises(module["VerificationError"], match=message):
+            module["_validate_private_grafana_url"](url)
+
+
+def test_public_probe_url_validation_allows_only_public_observability_denials():
+    module = _load_verifier_module()
+
+    for path in ("/grafana", "/grafana/login", "/loki", "/logs", "/metrics"):
+        url = f"https://sitbank.pp.ua{path}"
+        assert module["_validate_public_probe_url"](url) == url
+
+    invalid_urls = (
+        ("http://sitbank.pp.ua/grafana", "https URLs"),
+        ("https://user:pass@sitbank.pp.ua/grafana", "without credentials"),
+        (
+            "https://grafana-sitbank.tailca101b.ts.net/grafana",
+            "private Tailscale",
+        ),
+        ("https://sitbank.pp.ua/health/ready", "observability-denial paths"),
+        ("https://sitbank.pp.ua/grafana-public", "observability-denial paths"),
+    )
+    for url, message in invalid_urls:
+        with pytest.raises(module["VerificationError"], match=message):
+            module["_validate_public_probe_url"](url)
+
+
+def test_public_probe_urls_use_defaults_and_validate_custom_input():
+    module = _load_verifier_module()
+
+    assert module["_public_probe_urls"](None) == list(module["DEFAULT_PUBLIC_PROBES"])
+    assert module["_public_probe_urls"]("") == list(module["DEFAULT_PUBLIC_PROBES"])
+    assert module["_public_probe_urls"](
+        "https://sitbank.pp.ua/grafana\n\nhttps://staging-sitbank.pp.ua/loki\n"
+    ) == ["https://sitbank.pp.ua/grafana", "https://staging-sitbank.pp.ua/loki"]
+
+    with pytest.raises(module["VerificationError"], match="At least one"):
+        module["_public_probe_urls"](" \n\t\n")
+    with pytest.raises(module["VerificationError"], match="observability-denial"):
+        module["_public_probe_urls"]("https://sitbank.pp.ua/health/ready")
+
+
+def test_safe_json_load_and_url_label_handle_bad_inputs_safely():
+    module = _load_verifier_module()
+
+    assert module["_safe_json_load"]('{"ok": true}', "Grafana") == {"ok": True}
+    with pytest.raises(module["VerificationError"], match="valid JSON"):
+        module["_safe_json_load"]("{bad json", "Grafana")
+
+    assert (
+        module["_safe_url_label"]("https://sitbank.pp.ua/grafana?token=fake")
+        == "sitbank.pp.ua/grafana"
+    )
+    assert module["_safe_url_label"]("not a url") == "<invalid>not a url"
+    assert module["_safe_url_label"]("https:///grafana") == "<invalid>/grafana"
+
+
+def test_run_command_fails_closed_and_returns_nonzero_results(monkeypatch):
+    module = _load_verifier_module()
+
+    monkeypatch.setattr(module["shutil"], "which", lambda _command: None)
+    with pytest.raises(module["VerificationError"], match="not installed"):
+        module["run_command"](("curl", "--version"))
+
+    monkeypatch.setattr(module["shutil"], "which", lambda _command: "C:/fake/curl.exe")
+
+    def fake_run(arguments, **kwargs):
+        assert arguments == ["C:/fake/curl.exe", "--fail"]
+        assert kwargs["check"] is False
+        assert kwargs["capture_output"] is True
+        assert kwargs["text"] is True
+        assert kwargs["timeout"] == 20
+        return subprocess.CompletedProcess(arguments, 7, "stdout", "stderr")
+
+    monkeypatch.setattr(module["subprocess"], "run", fake_run)
+    result = module["run_command"](("curl", "--fail"))
+    assert result == module["CommandResult"](7, "stdout", "stderr")
+
+    for exception in (
+        OSError("synthetic failure"),
+        subprocess.TimeoutExpired("curl", 20),
+    ):
+
+        def failing_run(_arguments, **_kwargs):
+            raise exception
+
+        monkeypatch.setattr(module["subprocess"], "run", failing_run)
+        with pytest.raises(module["VerificationError"], match="could not run"):
+            module["run_command"](("curl", "--fail"))
+
+
+def test_curl_builds_safe_headers_and_raises_on_request_failure():
+    module = _load_verifier_module()
+    calls = []
+
+    def ok_runner(arguments):
+        calls.append(tuple(arguments))
+        return module["CommandResult"](0, '{"ok":true}')
+
+    assert module["_curl"](ok_runner, f"{PRIVATE_GRAFANA_URL}/api/health") == (
+        0,
+        '{"ok":true}',
+    )
+    assert "Accept: application/json" in calls[-1]
+    assert not any("Authorization:" in argument for argument in calls[-1])
+
+    module["_curl"](
+        ok_runner,
+        f"{PRIVATE_GRAFANA_URL}/api/user",
+        token=FAKE_GRAFANA_TOKEN,
+    )
+    assert "Accept: application/json" in calls[-1]
+    assert f"Authorization: Bearer {FAKE_GRAFANA_TOKEN}" in calls[-1]
+
+    def failing_runner(_arguments):
+        return module["CommandResult"](28, "", "timeout")
+
+    with pytest.raises(module["VerificationError"], match="request failed"):
+        module["_curl"](failing_runner, f"{PRIVATE_GRAFANA_URL}/api/health")
+
+
+def test_curl_status_headers_parses_statuses_and_handles_curl_failures():
+    module = _load_verifier_module()
+
+    for returncode in (0, 22, 47):
+
+        def runner(_arguments, code=returncode):
+            return module["CommandResult"](
+                code,
+                "HTTP/2 403\r\nx-safe: true\r\n\r\nSITBANK_HTTP_CODE:403\n",
+            )
+
+        status, headers = module["_curl_status_headers"](
+            runner,
+            "https://sitbank.pp.ua/grafana",
+        )
+        assert status == "403"
+        assert "x-safe: true" in headers
+
+    def unexpected_failure(_arguments):
+        return module["CommandResult"](
+            6,
+            "HTTP/2 000\r\n\r\nSITBANK_HTTP_CODE:000\n",
+        )
+
+    assert module["_curl_status_headers"](
+        unexpected_failure,
+        "https://sitbank.pp.ua/grafana",
+    ) == ("000", "")
+
+    def redirect_denial(_arguments):
+        return module["CommandResult"](
+            47,
+            (
+                "HTTP/2 302\r\n"
+                "location: https://sitbank.pp.ua/login\r\n\r\n"
+                "SITBANK_HTTP_CODE:302\n"
+            ),
+        )
+
+    status, headers = module["_curl_status_headers"](
+        redirect_denial,
+        "https://sitbank.pp.ua/grafana",
+    )
+    assert status == "302"
+    assert "location: https://sitbank.pp.ua/login" in headers
+
+
+def test_verify_private_grafana_fails_closed_for_unsafe_grafana_states():
+    module = _load_verifier_module()
+
+    with pytest.raises(module["VerificationError"], match="TOKEN is required"):
+        module["verify_private_grafana"](
+            _make_grafana_runner(module),
+            PRIVATE_GRAFANA_URL,
+            "",
+        )
+
+    unsafe_cases = (
+        (
+            _make_grafana_runner(module, anonymous_status="200"),
+            "anonymous API access",
+        ),
+        (
+            _make_grafana_runner(module, user={"isGrafanaAdmin": True}),
+            "administrative privileges",
+        ),
+        (
+            _make_grafana_runner(module, user={"orgRole": "Admin"}),
+            "administrative privileges",
+        ),
+        (
+            _make_grafana_runner(module, datasources={"unexpected": "schema"}),
+            "unexpected schema",
+        ),
+        (
+            _make_grafana_runner(
+                module,
+                datasources=[{"uid": "prometheus", "type": "prometheus"}],
+            ),
+            "no Loki datasource",
+        ),
+        (
+            _make_grafana_runner(
+                module,
+                datasources=[{"uid": "../unsafe", "type": "loki"}],
+            ),
+            "UID is missing or unsafe",
+        ),
+        (
+            _make_grafana_runner(module, datasource_health_returncode=28),
+            "request failed",
+        ),
+    )
+    for runner, message in unsafe_cases:
+        with pytest.raises(module["VerificationError"], match=message):
+            module["verify_private_grafana"](
+                runner,
+                PRIVATE_GRAFANA_URL,
+                FAKE_GRAFANA_TOKEN,
+            )
+
+
+def test_verify_public_denials_accepts_closed_statuses_and_sanitizes_records():
+    module = _load_verifier_module()
+    statuses = {
+        "https://sitbank.pp.ua/grafana": "404",
+        "https://staging-sitbank.pp.ua/loki": "403",
+    }
+
+    def closed_runner(arguments):
+        return _status_headers(module, statuses[tuple(arguments)[-1]])
+
+    checks = module["verify_public_denials"](closed_runner, tuple(statuses))
+    assert checks == [
+        {
+            "name": "public_observability_denial",
+            "result": "pass",
+            "target": "sitbank.pp.ua/grafana",
+            "http_status": "404",
+        },
+        {
+            "name": "public_observability_denial",
+            "result": "pass",
+            "target": "staging-sitbank.pp.ua/loki",
+            "http_status": "403",
+        },
+    ]
+    assert "HTTP/2" not in json.dumps(checks)
+    assert "location:" not in json.dumps(checks).casefold()
+
+
+@pytest.mark.parametrize(
+    ("status", "header", "message"),
+    (
+        ("200", "server: nginx", "public observability"),
+        ("302", "location: https://sitbank.pp.ua/grafana/login", "public observability"),
+        ("302", "location: https://sitbank.pp.ua/loki/", "public observability"),
+        ("404", "authorization: Bearer fake", "sensitive observability headers"),
+        ("404", "cookie: grafana_session=fake", "sensitive observability headers"),
+        ("404", "cf-access-jwt-assertion: fake", "sensitive observability headers"),
+        ("404", "set-cookie: grafana_session=fake", "sensitive observability headers"),
+        ("404", "x-grafana-org-id: 1", "sensitive observability headers"),
+    ),
+)
+def test_verify_public_denials_fails_closed_on_exposure_or_sensitive_headers(
+    status,
+    header,
+    message,
+):
+    module = _load_verifier_module()
+
+    def public_runner(_arguments):
+        return _status_headers(module, status, header)
+
+    with pytest.raises(module["VerificationError"], match=message):
+        module["verify_public_denials"](
+            public_runner,
+            ("https://sitbank.pp.ua/grafana",),
+        )
+
+
+def test_write_evidence_creates_parent_and_retains_only_sanitized_fields(tmp_path):
+    module = _load_verifier_module()
+    evidence_path = tmp_path / "nested" / "private-observability.json"
+    checks = [
+        {
+            "name": "public_observability_denial",
+            "result": "pass",
+            "target": "sitbank.pp.ua/grafana",
+            "http_status": "404",
+        }
+    ]
+
+    module["_write_evidence"](
+        evidence_path,
+        target_environment="production",
+        grafana_url=PRIVATE_GRAFANA_URL,
+        checks=checks,
+        token=FAKE_GRAFANA_TOKEN,
+    )
+
+    evidence_text = evidence_path.read_text(encoding="utf-8")
+    evidence = json.loads(evidence_text)
+    assert evidence["target_environment"] == "production"
+    assert evidence["private_grafana_host"] == "grafana-sitbank.tailca101b.ts.net"
+    assert evidence["checks"] == checks
+    assert evidence["sanitization"] == {
+        "access_assertions_retained": False,
+        "cookies_retained": False,
+        "credentials_retained": False,
+        "raw_http_bodies_retained": False,
+    }
+    for forbidden in (
+        FAKE_GRAFANA_TOKEN,
+        "Authorization: Bearer",
+        "grafana_session=fake",
+        "cf-access-jwt-assertion: fake",
+        "raw response body",
+    ):
+        assert forbidden not in evidence_text
+
+
+def test_write_evidence_refuses_to_write_if_token_would_be_retained(tmp_path):
+    module = _load_verifier_module()
+    evidence_path = tmp_path / "nested" / "private-observability.json"
+
+    with pytest.raises(module["VerificationError"], match="contains the Grafana token"):
+        module["_write_evidence"](
+            evidence_path,
+            target_environment="staging",
+            grafana_url=PRIVATE_GRAFANA_URL,
+            checks=[{"name": "unsafe", "result": FAKE_GRAFANA_TOKEN}],
+            token=FAKE_GRAFANA_TOKEN,
+        )
+
+    assert not evidence_path.exists()
+
+
+def test_parse_args_restricts_target_environment_and_accepts_overrides(tmp_path):
+    module = _load_verifier_module()
+    evidence_path = tmp_path / "private-observability.json"
+
+    args = module["parse_args"](
+        [
+            "--target-environment",
+            "production",
+            "--grafana-url",
+            PRIVATE_GRAFANA_URL,
+            "--public-probe-url",
+            "https://sitbank.pp.ua/grafana",
+            "--evidence-file",
+            str(evidence_path),
+        ]
+    )
+    assert args.target_environment == "production"
+    assert args.grafana_url == PRIVATE_GRAFANA_URL
+    assert args.public_probe_url == ["https://sitbank.pp.ua/grafana"]
+    assert args.evidence_file == str(evidence_path)
+
+    with pytest.raises(SystemExit):
+        module["parse_args"](["--target-environment", "development"])
+
+
+def test_main_success_uses_env_and_writes_evidence_override(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    module = _load_verifier_module()
+    grafana_runner = _make_grafana_runner(module)
+    calls = []
+
+    def fake_run_command(arguments):
+        command = tuple(arguments)
+        calls.append(command)
+        url = command[-1]
+        if url.startswith(PRIVATE_GRAFANA_URL):
+            return grafana_runner(command)
+        return _status_headers(module, "404")
+
+    monkeypatch.setitem(module["main"].__globals__, "run_command", fake_run_command)
+    monkeypatch.setenv("GRAFANA_PRIVATE_URL", f"{PRIVATE_GRAFANA_URL}/")
+    monkeypatch.setenv("GRAFANA_HEALTH_TOKEN", FAKE_GRAFANA_TOKEN)
+    monkeypatch.setenv(
+        "OBSERVABILITY_PUBLIC_PROBE_URLS",
+        "https://sitbank.pp.ua/grafana\nhttps://www.sitbank.pp.ua/loki\n",
+    )
+    evidence_path = tmp_path / "custom" / "private-observability.json"
+
+    assert module["main"](
+        [
+            "--target-environment",
+            "production",
+            "--evidence-file",
+            str(evidence_path),
+        ]
+    ) == 0
+
+    captured = capsys.readouterr()
+    evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+    assert f"written to {evidence_path}" in captured.out
+    assert captured.err == ""
+    assert evidence["target_environment"] == "production"
+    assert evidence["private_grafana_host"] == "grafana-sitbank.tailca101b.ts.net"
+    assert FAKE_GRAFANA_TOKEN not in evidence_path.read_text(encoding="utf-8")
+    assert any(f"Authorization: Bearer {FAKE_GRAFANA_TOKEN}" in call for call in calls)
+
+
+def test_main_failure_returns_one_and_prints_sanitized_error(monkeypatch, capsys):
+    module = _load_verifier_module()
+    monkeypatch.setenv("GRAFANA_HEALTH_TOKEN", FAKE_GRAFANA_TOKEN)
+
+    result = module["main"](
+        [
+            "--grafana-url",
+            "https://sitbank.pp.ua",
+            "--public-probe-url",
+            "https://sitbank.pp.ua/grafana",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "ERROR: GRAFANA_PRIVATE_URL must not be a public SITBank hostname" in captured.err
+    assert FAKE_GRAFANA_TOKEN not in captured.err
+
+
+def test_script_entrypoint_exits_with_sanitized_failure(monkeypatch, capsys):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [str(VERIFIER_PATH), "--grafana-url", "https://sitbank.pp.ua"],
+    )
+    monkeypatch.setenv("GRAFANA_HEALTH_TOKEN", FAKE_GRAFANA_TOKEN)
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(str(VERIFIER_PATH), run_name="__main__")
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 1
+    assert "ERROR: GRAFANA_PRIVATE_URL must not be a public SITBank hostname" in captured.err
+    assert FAKE_GRAFANA_TOKEN not in captured.err


### PR DESCRIPTION
Summary
---
Adds a protected manual live verification workflow for the private Grafana/Loki observability stack.

Why
---
Issue #323 requires live evidence that Grafana remains private, Loki is not exposed publicly, and verification artifacts stay sanitized without adding untrusted PR or public TLS access to observability credentials.

What changed
---
* Added `.github/workflows/observability-private-verify.yml` as a `main`-only, manual, protected-environment workflow for `observability-staging` and `observability-production`.
* Added `ops/observability/verify-private-observability` to check private Grafana health, anonymous API denial, non-admin verifier role, Loki datasource health, public observability route denial, and sanitized evidence output.
* Updated observability, GitHub Actions, operations, and global verification docs, plus ignore/EOL rules for sanitized evidence and the new verifier.
* Added PR-safe tests for workflow trust boundaries, public route closure, sanitizer behavior, mocked verifier responses, and stale documentation coverage.

Security impact
---
AOP, Cloudflare Access, direct-origin 403 behavior, public TLS gates, admin isolation, Tailscale private admin access, and CI security gates were not weakened. Grafana/Loki remain private-only, the new workflow does not run on pull requests or forks, and uploaded evidence excludes operator passwords, browser sessions, cookies, MFA values, raw logs, API response bodies, Access assertions, and Grafana/Loki tokens.

Deployment impact
---
No EC2 bootstrap, staging deployment, production deployment, application deployment, or database migration is required for these repository changes. Secret changes are required before using the live workflow: configure the protected `observability-staging` and/or `observability-production` GitHub Environments with `GRAFANA_PRIVATE_URL`, optional `OBSERVABILITY_PUBLIC_PROBE_URLS`, `GRAFANA_HEALTH_TOKEN`, `TS_OAUTH_CLIENT_ID`, and `TS_OAUTH_SECRET`.

Verification
---
* `git diff --check` - passed
* `.\.venv\Scripts\python.exe -m pytest -q tests/test_zero_trust_access_boundary.py` - 8 passed
* `.\.venv\Scripts\python.exe -m pytest -q tests/test_deployment.py tests/test_admin_isolation.py` - 83 passed, 1 skipped, 6 warnings
* `.\.venv\Scripts\python.exe -m pytest -q tests/test_deployment.py tests/test_admin_route_inventory_security.py tests/test_security_docs_issue_links.py -n auto` - 101 passed, 1 skipped, 6 warnings
* `.\.venv\Scripts\python.exe -m pytest -q tests/test_operational_observability_deployment.py tests/test_github_actions_workflows.py tests/test_workflow_display_names.py -n auto` - 18 passed
* `.\.venv\Scripts\python.exe -m pytest -q -n auto` - 1279 passed, 6 skipped, 6 warnings
* `.\.venv\Scripts\python.exe -m pytest -q -n auto --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term` - 1279 passed, 6 skipped, 6 warnings; coverage.xml written; total coverage 90%

Notes
---
Fixes #323. The live workflow will fail until the protected observability environments and least-privilege Grafana health token are configured.