### PR TITLE
Harden banking controls and browser regressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,14 +71,14 @@ Common local test commands:
 .\.venv\Scripts\python.exe -m pytest -q -m deployment
 .\.venv\Scripts\python.exe -m pytest -q -m "not slow"
 
-# Playwright browser E2E smoke tests
+# Playwright browser E2E regression tests
 $env:PLAYWRIGHT_BROWSERS_PATH = ".playwright-browsers"
 .\.venv\Scripts\python.exe -m playwright install chromium
 $env:SITBANK_RUN_E2E = "1"
 .\.venv\Scripts\python.exe -m pytest -q tests/e2e
 ```
 
-The `not slow` and focused marker commands are for local iteration only. Pull requests and protected CI still run the full pytest suite, including security, deployment, database session integrity, CSRF, MFA, compatibility-route regression checks, route inventory, production guard, dependency lock, and secret-scanning checks. Playwright E2E browser tests run in CI through a dedicated Chromium job; local unscoped pytest runs collect them but skip unless `SITBANK_RUN_E2E=1` is set, and the tests start a loopback Flask server rather than using staging or production hosts.
+The `not slow` and focused marker commands are for local iteration only. Pull requests and protected CI still run the full pytest suite, including security, deployment, database session integrity, CSRF, MFA, compatibility-route regression checks, route inventory, production guard, dependency lock, and secret-scanning checks. Playwright E2E browser tests run in CI through a dedicated Chromium job; local unscoped pytest runs collect them but skip unless `SITBANK_RUN_E2E=1` is set. The browser suite covers authentication, MFA, session, banking, and boundary regressions against a loopback Flask server. These tests do not prove live staging or production provider state and never target staging, production, or the private admin hostname.
 
 On non-Windows shells, use `python -m playwright install chromium` before
 `python -m pytest -q tests/e2e`.

--- a/app/admin/services.py
+++ b/app/admin/services.py
@@ -12,7 +12,7 @@ from typing import Any
 import pyotp
 from flask import current_app, request, session, url_for
 from sqlalchemy import String, cast, func, or_
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
 from app.auth.password_reset import (
     MANUAL_RECOVERY_ACTIVE_STATUSES,
@@ -671,7 +671,6 @@ def _execute_staff_account_lifecycle(
             "revoked_sessions": revoked_sessions,
         },
     )
-    db.session.commit()
     return {"message": "Staff account updated", "account": public_staff_account(target, actor)}
 
 
@@ -1660,11 +1659,23 @@ def approve_admin_action_request_as_root_admin(
         )
         raise AuthError(FRESH_MFA_REQUIRED_ERROR, 403)
 
+    try:
+        result = _execute_admin_action_request(actor, request_record)
+    except (SQLAlchemyError, RuntimeError, TypeError, ValueError) as exc:
+        db.session.rollback()
+        failed_request = _admin_action_request_or_error(request_id)
+        _mark_admin_action_request_execution_failed(
+            actor,
+            failed_request,
+            reason="execution_error",
+            error_type=type(exc).__name__,
+        )
+        raise AuthError("Admin action request execution failed", 409) from exc
+
     request_record.approver_id = actor.id
     request_record.status = "executed"
     request_record.decided_at = _utcnow()
-    result = _execute_admin_action_request(actor, request_record)
-    request_record.executed_at = _utcnow()
+    request_record.executed_at = request_record.decided_at
     audit_event_required(
         "admin_action_request_executed",
         "success",
@@ -1847,26 +1858,12 @@ def _create_admin_action_request(
 
 
 def _execute_admin_action_request(actor: User, request_record: AdminActionRequest) -> dict[str, Any]:
-    try:
-        if request_record.operation_type in STAFF_ACTION_OPERATION_TYPES.values():
-            return _execute_staff_admin_action_request(actor, request_record)
-        if request_record.operation_type in {"manual_recovery_approve", "manual_recovery_deny"}:
-            return _execute_manual_recovery_transition_admin_action_request(actor, request_record)
-        if request_record.operation_type == "manual_recovery_complete":
-            return _execute_manual_recovery_complete_admin_action_request(actor, request_record)
-    except (TypeError, ValueError):
-        _mark_admin_action_request_execution_failed(actor, request_record)
-        raise
-    audit_event(
-        "admin_action_request_execute",
-        "failure",
-        user=actor,
-        metadata={
-            "reason": "unsupported_operation",
-            "request_ref": audit_reference("admin_action_request", request_record.id),
-            "operation_type": request_record.operation_type,
-        },
-    )
+    if request_record.operation_type in STAFF_ACTION_OPERATION_TYPES.values():
+        return _execute_staff_admin_action_request(actor, request_record)
+    if request_record.operation_type in {"manual_recovery_approve", "manual_recovery_deny"}:
+        return _execute_manual_recovery_transition_admin_action_request(actor, request_record)
+    if request_record.operation_type == "manual_recovery_complete":
+        return _execute_manual_recovery_complete_admin_action_request(actor, request_record)
     raise AuthError("Admin action request cannot be executed", 409)
 
 
@@ -1926,14 +1923,23 @@ def _execute_manual_recovery_complete_admin_action_request(
     return {"message": "Manual recovery request completed", "request": result}
 
 
-def _mark_admin_action_request_execution_failed(actor: User, request_record: AdminActionRequest) -> None:
+def _mark_admin_action_request_execution_failed(
+    actor: User,
+    request_record: AdminActionRequest,
+    *,
+    reason: str,
+    error_type: str,
+) -> None:
+    request_record.approver_id = actor.id
     request_record.status = "execution_failed"
     request_record.decided_at = request_record.decided_at or _utcnow()
-    audit_event(
+    audit_event_required(
         "admin_action_request_execute",
         "failure",
         user=actor,
         metadata={
+            "reason": reason,
+            "error_type": str(error_type or "")[:80],
             "request_ref": audit_reference("admin_action_request", request_record.id),
             "operation_type": request_record.operation_type,
         },

--- a/app/auth/services.py
+++ b/app/auth/services.py
@@ -229,7 +229,7 @@ def _registration_duplicate_reason(
 
 def _generate_account_number() -> str:
     for _ in range(10):
-        candidate = "012" + "".join(str(secrets.randbelow(10)) for _ in range(6))
+        candidate = "012" + "".join(str(secrets.randbelow(10)) for _ in range(9))
         if not db.session.execute(db.select(User).where(User.account_number == candidate)).scalar_one_or_none():
             return candidate
     raise AuthError("Could not generate a unique account number", 500)
@@ -638,11 +638,26 @@ def freeze_own_account(user: User, code: str, stepup_token: str | None = None) -
         session_id=session_id,
         metadata={"revoked_other_sessions": revoked},
     )
+    _send_account_freeze_notification(user)
     return {
         "message": "Account frozen. Unfreeze requires manual support review.",
         "session_ref": public_session_reference(session_id),
         "revoked_other_sessions": revoked,
     }
+
+
+def _send_account_freeze_notification(user: User) -> None:
+    body = (
+        "Your SITBank account was frozen from an authenticated session. "
+        "If you did not request this, contact SITBank support through the approved recovery path."
+    )
+    try:
+        send_security_email(user.email, "SITBank account frozen", body)
+    except Exception as exc:
+        current_app.logger.warning("account_freeze_notification_failed error=%s", type(exc).__name__)
+        audit_event("account_freeze_notification", "failure", user=user, metadata={"reason": "email_delivery_failed"})
+        return
+    audit_event("account_freeze_notification", "queued", user=user)
 
 
 def logout_current_session() -> None:

--- a/app/banking/forms.py
+++ b/app/banking/forms.py
@@ -7,7 +7,7 @@ from wtforms.validators import InputRequired, Length, Optional, Regexp
 from app.auth.schemas import PHONE_RE, STEP_UP_TOKEN_RE, TOTP_RE
 
 
-ACCOUNT_NUMBER_RE = r"^[0-9]{9}$"
+ACCOUNT_NUMBER_RE = r"^(?:[0-9]{9}|[0-9]{12})$"
 NICKNAME_RE = r"^[A-Za-z0-9 '\-]{1,64}$"
 AMOUNT_RE = r"^\d+(\.\d{1,2})?$"
 REFERENCE_RE = r"^[A-Za-z0-9 '\-.,/]{0,128}$"
@@ -82,7 +82,7 @@ class AddPayeeForm(FlaskForm):
         "Account number",
         validators=[
             InputRequired(),
-            Regexp(ACCOUNT_NUMBER_RE, message="Account number must be exactly 9 digits"),
+            Regexp(ACCOUNT_NUMBER_RE, message="Account number must be 9 or 12 digits"),
         ],
     )
     totp_code = _totp_code_field()
@@ -97,6 +97,8 @@ class PayupPhoneForm(FlaskForm):
             Regexp(PHONE_RE, message="Enter a valid Singapore phone number (8 digits starting with 8 or 9)"),
         ],
     )
+    totp_code = _totp_code_field()
+    stepup_token = _stepup_token_field()
 
 
 class PayupAmountForm(FlaskForm):

--- a/app/banking/routes.py
+++ b/app/banking/routes.py
@@ -35,13 +35,16 @@ from app.banking.schemas import MAX_TRANSACTION_AMOUNT, MIN_TRANSACTION_AMOUNT
 from app.banking.services import (
     execute_local_transfer,
     execute_payup_transfer,
+    local_transfer_token_verifier,
     payup_amount_used_today,
     payup_requires_step_up,
+    payup_transfer_token_verifier,
     resolve_transfer_limit_choice,
 )
 from app.extensions import db, limiter
 from app.models import Payee, PayupPendingTransfer, PendingTransfer, User
 from app.security.audit import audit_event, audit_reference
+from app.security.rate_limits import DurableRateLimitExceeded, consume_durable_rate_limit
 from app.security.rate_limits import mfa_principal
 from app.web.routes import web_login_required, web_not_frozen_required
 
@@ -50,7 +53,7 @@ banking_bp = Blueprint("banking", __name__, url_prefix="/banking")
 
 _PENDING_PAYEE_TTL = 300  # seconds; user has 5 min to complete MFA after step 1
 _PENDING_TRANSFER_TTL = 300  # seconds; user has 5 min to confirm after MFA step-up
-_ACCOUNT_RE = re.compile(r"^\d{9}$")
+_ACCOUNT_RE = re.compile(r"^(?:\d{9}|\d{12})$")
 _REQUEST_EXPIRED_MESSAGE = "Request expired. Please start again."
 _NO_PENDING_TRANSFER_MESSAGE = "No pending transfer. Please start again."
 _PAYEES_ENDPOINT = "banking.payees"
@@ -187,6 +190,22 @@ def payees_add_submit():
 
     recipient = User.query.filter_by(account_number=account_number).first()
     if not recipient:
+        try:
+            failed_count = consume_durable_rate_limit(
+                "payee_lookup_failure",
+                f"user:{g.current_user.id}",
+                limit=5,
+                window_seconds=60 * 60,
+            )
+        except DurableRateLimitExceeded as exc:
+            audit_event(
+                "payee_lookup",
+                "blocked",
+                user=g.current_user,
+                metadata={"reason": "durable_rate_limit", "retry_after": exc.retry_after},
+            )
+            flash("Could not add that payee. Check the details and try again.", "error")
+            return render_template(_ADD_PAYEE_TEMPLATE, form=form), 429
         audit_event(
             "payee_lookup",
             "failure",
@@ -194,6 +213,7 @@ def payees_add_submit():
             metadata={
                 "reason": "recipient_not_found",
                 "account_ref": audit_reference("payee_account", account_number),
+                "failed_lookup_count": failed_count,
             },
         )
         flash("Could not add that payee. Check the details and try again.", "error")
@@ -427,7 +447,7 @@ def transfer_submit(payee_id: int):
     # client never controls the transfer parameters.
     token = os.urandom(32).hex()
     pending_tfr = PendingTransfer(
-        token=token,
+        token=local_transfer_token_verifier(token),
         user_id=g.current_user.id,
         payee_id=payee_id,
         amount=amount,
@@ -452,7 +472,7 @@ def transfer_confirm(payee_id: int):
         return redirect(url_for(_PAYEES_ENDPOINT))
 
     pending_tfr = PendingTransfer.query.filter_by(
-        token=token,
+        token=local_transfer_token_verifier(token),
         user_id=g.current_user.id,
         payee_id=payee_id,
         consumed_at=None,
@@ -540,6 +560,17 @@ def payup_submit():
     if phone_number == g.current_user.phone_number:
         flash("You cannot PayUp to your own phone number.", "error")
         return render_template(_PAYUP_TEMPLATE, form=form), 400
+
+    try:
+        verify_high_risk_authorization(
+            g.current_user,
+            form.totp_code.data,
+            form.stepup_token.data,
+            "payup_lookup",
+        )
+    except AuthError as exc:
+        flash(exc.message, "error")
+        return render_template(_PAYUP_TEMPLATE, form=form), exc.status_code
 
     recipient = User.query.filter_by(phone_number=phone_number).first()
     if not recipient or recipient.account_status not in ("active", "locked"):
@@ -649,7 +680,7 @@ def payup_amount_submit():
 
     token = os.urandom(32).hex()
     pending_tfr = PayupPendingTransfer(
-        token=token,
+        token=payup_transfer_token_verifier(token),
         user_id=g.current_user.id,
         recipient_user_id=pending["recipient_user_id"],
         amount=amount,
@@ -675,7 +706,7 @@ def payup_confirm():
         return redirect(url_for(_PAYUP_ENDPOINT))
 
     pending_tfr = PayupPendingTransfer.query.filter_by(
-        token=token,
+        token=payup_transfer_token_verifier(token),
         user_id=g.current_user.id,
         consumed_at=None,
     ).first()
@@ -717,7 +748,7 @@ def payup_confirm_submit():
         return redirect(url_for(_PAYUP_ENDPOINT))
 
     pending_tfr = PayupPendingTransfer.query.filter_by(
-        token=token,
+        token=payup_transfer_token_verifier(token),
         user_id=g.current_user.id,
         consumed_at=None,
     ).first()

--- a/app/banking/services.py
+++ b/app/banking/services.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import hmac
 import json
 import uuid
 from collections.abc import Mapping, MutableMapping
@@ -16,7 +17,8 @@ from app.banking.forms import TRANSFER_LIMIT_PRESETS
 from app.extensions import db
 from app.banking.schemas import MAX_TRANSACTION_AMOUNT, MIN_TRANSACTION_AMOUNT, PublicTransactionSchema
 from app.models import Payee, Transaction, User
-from app.security.audit import audit_event, audit_event_required, audit_reference
+from app.security.audit import AuditWriteError, audit_event, audit_event_required, audit_reference
+from app.security.session_hmac import active_hmac_hex
 
 
 PAYUP_STEP_UP_THRESHOLD = Decimal("0.80")
@@ -34,6 +36,39 @@ TRANSFER_RISKS = frozenset(
         TRANSFER_RISK_LARGE_TRANSFER,
     }
 )
+
+
+def local_transfer_token_verifier(token: str) -> str:
+    """Keyed verifier for local-transfer confirmation tokens."""
+    return active_hmac_hex(f"local-transfer-confirmation:{str(token or '')}", length=64)
+
+
+def payup_transfer_token_verifier(token: str) -> str:
+    """Keyed verifier for PayUp confirmation tokens."""
+    return active_hmac_hex(f"payup-transfer-confirmation:{str(token or '')}", length=64)
+
+
+def transaction_hash_matches(transaction: Transaction) -> bool:
+    expected = _transaction_hash(
+        transaction.transaction_ref,
+        int(transaction.sender_id),
+        int(transaction.recipient_id),
+        Decimal(str(transaction.amount)),
+        transaction.reference or "",
+        transaction.created_at,
+    )
+    return hmac.compare_digest(str(transaction.transaction_hash or ""), expected)
+
+
+def _amount_audit_band(amount: Decimal) -> str:
+    normalized = Decimal(str(amount)).copy_abs()
+    if normalized < Decimal("100"):
+        return "under_100"
+    if normalized < Decimal("1000"):
+        return "100_to_999"
+    if normalized < Decimal("10000"):
+        return "1000_to_9999"
+    return "10000_or_more"
 
 
 def ensure_outbound_transfer_allowed(user: User) -> None:
@@ -387,7 +422,7 @@ def execute_local_transfer(
     pending_tfr = db.session.execute(
         db.select(PendingTransfer)
         .where(
-            PendingTransfer.token == confirmation_token,
+            PendingTransfer.token == local_transfer_token_verifier(confirmation_token),
             PendingTransfer.user_id == sender.id,
             PendingTransfer.payee_id == payee.id,
             PendingTransfer.consumed_at.is_(None),
@@ -431,7 +466,7 @@ def execute_local_transfer(
         audit_outbound_transfer(
             sender,
             "failure",
-            metadata={"reason": "invalid_amount_precision", "amount": str(amount)},
+            metadata={"reason": "invalid_amount_precision", "amount_band": _amount_audit_band(amount)},
         )
         db.session.commit()
         raise AuthError("Transfer amount must have at most two decimal places.", 400)
@@ -441,7 +476,7 @@ def execute_local_transfer(
         audit_outbound_transfer(
             sender,
             "failure",
-            metadata={"reason": "amount_out_of_range", "amount": str(amount)},
+            metadata={"reason": "amount_out_of_range", "amount_band": _amount_audit_band(amount)},
         )
         db.session.commit()
         raise AuthError("Transfer amount is out of the allowed range.", 400)
@@ -452,7 +487,7 @@ def execute_local_transfer(
         audit_outbound_transfer(
             sender,
             "failure",
-            metadata={"reason": "insufficient_funds", "amount": str(amount)},
+            metadata={"reason": "insufficient_funds", "amount_band": _amount_audit_band(amount)},
             payee_account=audit_reference("payee_account", payee.account_number),
         )
         db.session.commit()
@@ -480,20 +515,34 @@ def execute_local_transfer(
     )
     pending_tfr.consumed_transaction_ref = txn_ref
 
-    # A09: do not log raw reference — replace with safe metadata that
-    # cannot leak customer free-text into the security audit log.
-    audit_outbound_transfer(
-        sender,
-        "success",
-        metadata={
-            "amount": str(amount),
-            "reference_present": bool(reference),
-            "reference_length": len(reference),
-        },
-        transaction_reference=audit_reference("transaction_reference", txn_ref),
-        payee_account=audit_reference("payee_account", payee.account_number),
-    )
+    _audit_local_transfer_success(sender, payee, amount, reference, txn_ref)
     return txn_ref
+
+
+def _audit_local_transfer_success(
+    sender: User,
+    payee: Payee,
+    amount: Decimal,
+    reference: str,
+    txn_ref: str,
+) -> None:
+    # A09: do not log raw reference; replace it with safe metadata that
+    # cannot leak customer free-text into the security audit log.
+    try:
+        audit_outbound_transfer(
+            sender,
+            "success",
+            metadata={
+                "amount_band": _amount_audit_band(amount),
+                "reference_present": bool(reference),
+                "reference_length": len(reference),
+            },
+            transaction_reference=audit_reference("transaction_reference", txn_ref),
+            payee_account=audit_reference("payee_account", payee.account_number),
+        )
+    except AuditWriteError:
+        db.session.rollback()
+        raise
 
 
 def sgt_day_start_utc(now: datetime | None = None) -> datetime:
@@ -553,7 +602,7 @@ def _load_and_lock_payup_pending_transfer(sender: User, confirmation_token: str)
     pending_tfr = db.session.execute(
         db.select(PayupPendingTransfer)
         .where(
-            PayupPendingTransfer.token == confirmation_token,
+            PayupPendingTransfer.token == payup_transfer_token_verifier(confirmation_token),
             PayupPendingTransfer.user_id == sender.id,
             PayupPendingTransfer.consumed_at.is_(None),
         )
@@ -601,7 +650,7 @@ def _validate_payup_amount(sender: User, pending_tfr) -> Decimal:
             "failure",
             metadata={
                 "reason": "invalid_amount_precision",
-                "amount": str(amount),
+                "amount_band": _amount_audit_band(amount),
                 "transfer_channel": "payup",
             },
         )
@@ -615,7 +664,7 @@ def _validate_payup_amount(sender: User, pending_tfr) -> Decimal:
             "failure",
             metadata={
                 "reason": "amount_out_of_range",
-                "amount": str(amount),
+                "amount_band": _amount_audit_band(amount),
                 "transfer_channel": "payup",
             },
         )
@@ -690,7 +739,7 @@ def execute_payup_transfer(
             "failure",
             metadata={
                 "reason": "payup_daily_limit_exceeded",
-                "amount": str(amount),
+                "amount_band": _amount_audit_band(amount),
                 "transfer_channel": "payup",
             },
         )
@@ -713,7 +762,7 @@ def execute_payup_transfer(
             "failure",
             metadata={
                 "reason": "insufficient_funds",
-                "amount": str(amount),
+                "amount_band": _amount_audit_band(amount),
                 "transfer_channel": "payup",
             },
         )
@@ -743,18 +792,22 @@ def execute_payup_transfer(
     )
     pending_tfr.consumed_transaction_ref = txn_ref
 
-    audit_outbound_transfer(
-        sender,
-        "success",
-        metadata={
-            "amount": str(amount),
-            "reference_present": bool(reference),
-            "reference_length": len(reference),
-            "transfer_channel": "payup",
-            "step_up_used": requires_step_up,
-        },
-        transaction_reference=audit_reference("transaction_reference", txn_ref),
-    )
+    try:
+        audit_outbound_transfer(
+            sender,
+            "success",
+            metadata={
+                "amount_band": _amount_audit_band(amount),
+                "reference_present": bool(reference),
+                "reference_length": len(reference),
+                "transfer_channel": "payup",
+                "step_up_used": requires_step_up,
+            },
+            transaction_reference=audit_reference("transaction_reference", txn_ref),
+        )
+    except AuditWriteError:
+        db.session.rollback()
+        raise
     return txn_ref
 
 
@@ -766,11 +819,11 @@ def _transaction_hash(
     reference: str,
     created_at: datetime,
 ) -> str:
-    """SHA-256 of the canonical transaction fields for tamper-evidence."""
+    """HMAC-SHA256 of canonical transaction fields for keyed tamper evidence."""
     canonical = json.dumps(
         {
             "amount": str(amount),
-            "created_at": created_at.isoformat(),
+            "created_at": _canonical_transaction_timestamp(created_at),
             "recipient_id": recipient_id,
             "reference": reference,
             "sender_id": sender_id,
@@ -779,7 +832,13 @@ def _transaction_hash(
         separators=(",", ":"),
         sort_keys=True,
     )
-    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return active_hmac_hex(f"banking-transaction:{canonical}", length=64)
+
+
+def _canonical_transaction_timestamp(created_at: datetime) -> str:
+    if created_at.tzinfo is not None:
+        created_at = created_at.astimezone(timezone.utc).replace(tzinfo=None)
+    return created_at.isoformat(timespec="microseconds")
 
 
 def _requires_durable_audit(action: str, outcome: str) -> bool:

--- a/app/models.py
+++ b/app/models.py
@@ -23,7 +23,7 @@ class User(db.Model):
     account_status = db.Column(db.String(32), nullable=False, default="active", index=True)
     full_name = db.Column(db.String(128), nullable=False)
     phone_number = db.Column(db.String(8), nullable=True)
-    account_number = db.Column(db.String(9), nullable=True)
+    account_number = db.Column(db.String(12), nullable=True)
     staff_personal_email = db.Column(db.String(255), nullable=True)
     workplace_email_verified_at = db.Column(db.DateTime(timezone=True), nullable=True)
     password_changed_at = db.Column(db.DateTime(timezone=True), nullable=True)
@@ -643,7 +643,7 @@ class Payee(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey(_USER_ID_FOREIGN_KEY), nullable=False, index=True)
     nickname = db.Column(db.String(64), nullable=False)
-    account_number = db.Column(db.String(9), nullable=False)
+    account_number = db.Column(db.String(12), nullable=False)
     recipient_name = db.Column(db.String(128), nullable=False)
     created_at = db.Column(
         db.DateTime(timezone=True),

--- a/app/security/alerts.py
+++ b/app/security/alerts.py
@@ -30,6 +30,7 @@ IMMEDIATE_ALERT_EVENT_TYPES = {
     "password_reset_token_reused": "password_reset_token_reused",
     "password_reset_webauthn_failed": "password_reset_webauthn_failed",
     "manual_recovery_requested": "manual_recovery_requested",
+    "account_freeze": "account_freeze",
 }
 TRANSACTION_EVENT_TYPES = {
     "banking_outbound_transfer",

--- a/app/templates/add_payee.html
+++ b/app/templates/add_payee.html
@@ -8,7 +8,7 @@
     <div class="page-heading">
       <p class="eyebrow">Local Transfer</p>
       <h1>Add a Payee</h1>
-      <p class="muted">Enter the recipient's account number. The name will be looked up from bank records — you cannot change it.</p>
+      <p class="muted">Enter the recipient's account number. The name will be looked up from bank records after authorization - you cannot change it.</p>
     </div>
     <div class="button-row">
       <a class="button secondary" href="{{ url_for('banking.payees') }}">Cancel</a>
@@ -21,7 +21,7 @@
         <p class="eyebrow">How it works</p>
         <h2>Payee lookup</h2>
       </div>
-      <p class="muted">Enter the 9-digit SITBank account number. The bank will fetch the registered name for you to confirm before saving. After adding a payee, a cooldown period applies before transfers are allowed.</p>
+      <p class="muted">Enter the SITBank account number. The bank will fetch the registered name for you to confirm before saving. After adding a payee, a cooldown period applies before transfers are allowed.</p>
     </article>
 
     <article class="profile-panel profile-card">
@@ -39,9 +39,9 @@
         </div>
         <div class="form-group">
           <label for="{{ form.account_number.id }}">Account number</label>
-          {{ form.account_number(autocomplete="off", maxlength="9", placeholder="9-digit account number", inputmode="numeric") }}
+          {{ form.account_number(autocomplete="off", maxlength="12", placeholder="9- or 12-digit account number", inputmode="numeric") }}
           {% for error in form.account_number.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
-          <p class="hint">The 9-digit SITBank account number of the recipient.</p>
+          <p class="hint">The 9- or 12-digit SITBank account number of the recipient.</p>
         </div>
         <div class="form-group">
           <label for="{{ form.totp_code.id }}">Authenticator code</label>

--- a/app/templates/payup.html
+++ b/app/templates/payup.html
@@ -8,7 +8,7 @@
     <div class="page-heading">
       <p class="eyebrow">PayUp</p>
       <h1>Send money by phone number</h1>
-      <p class="muted">Enter the recipient's phone number. We'll look up the registered name for you.</p>
+      <p class="muted">Enter the recipient's phone number and authenticator code before SITBank reveals the registered recipient name.</p>
     </div>
     <div class="button-row">
       <a class="button secondary" href="{{ url_for('web.dashboard') }}">Cancel</a>
@@ -20,7 +20,7 @@
       <div class="profile-panel-title">
         <p class="eyebrow">How it works</p>
       </div>
-      <p class="muted">Enter the recipient's 8-digit Singapore mobile number. If it belongs to a SITBank customer, you'll be taken straight to the amount screen with their name shown for confirmation.</p>
+      <p class="muted">Recipient lookup uses the 8-digit Singapore mobile number. SITBank checks your authenticator code before showing the registered name for confirmation.</p>
     </article>
 
     <article class="profile-panel profile-card">
@@ -34,6 +34,13 @@
           <label for="{{ form.phone_number.id }}">Phone number</label>
           {{ form.phone_number(autocomplete="off", maxlength="8", placeholder="8-digit phone number", inputmode="numeric") }}
           {% for error in form.phone_number.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
+        </div>
+        <div class="form-group">
+          <label for="{{ form.totp_code.id }}">Authenticator code</label>
+          {{ form.totp_code(inputmode="numeric", autocomplete="one-time-code", maxlength="6", placeholder="6-digit code") }}
+          {% for error in form.totp_code.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
+          {{ form.stepup_token() }}
+          <p class="hint">Required before recipient details are looked up.</p>
         </div>
         <button class="button full" type="submit">Continue</button>
       </form>

--- a/config.py
+++ b/config.py
@@ -33,6 +33,22 @@ CONFIG_DOMAIN_RE = re.compile(
     r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])$"
 )
 CONFIG_EMAIL_RE = re.compile(r"^(?=.{1,255}$)(?=.{1,128}@)[^@\x00-\x1f\x7f]+@[^@\x00-\x1f\x7f]+$")
+ROOT_ADMIN_NUMERIC_PLACEHOLDER_RE = re.compile(
+    r"^([a-z][a-z_-]*)(\d+)$"
+)
+ROOT_ADMIN_NUMERIC_PLACEHOLDER_PREFIXES = frozenset(
+    {
+        "admin",
+        "changeme",
+        "demo",
+        "example",
+        "placeholder",
+        "replaceme",
+        "root",
+        "rootadmin",
+        "test",
+    }
+)
 PERSONAL_EMAIL_DOMAINS = frozenset(
     {
         "gmail.com",
@@ -457,6 +473,11 @@ def _root_admin_email_has_placeholder_identity(value: str) -> bool:
         return True
     if local in ROOT_ADMIN_PLACEHOLDER_LOCAL_PARTS:
         return True
+    numeric_placeholder = ROOT_ADMIN_NUMERIC_PLACEHOLDER_RE.fullmatch(local)
+    if numeric_placeholder:
+        normalized_prefix = numeric_placeholder.group(1).replace("-", "").replace("_", "")
+        if normalized_prefix in ROOT_ADMIN_NUMERIC_PLACEHOLDER_PREFIXES:
+            return True
     if any(token in local for token in ("placeholder", "example", "demo", "changeme", "replace")):
         return True
     return domain in {"example.com", "example.test"}
@@ -481,6 +502,7 @@ def root_admin_email_allowlist_failures(
             emails,
             allowed_domains,
             required_count=required_count,
+            allow_builtin_default=not reject_default and frozenset(emails) == DEFAULT_ROOT_ADMIN_EMAILS,
         )
     )
     if reject_default and frozenset(emails) == DEFAULT_ROOT_ADMIN_EMAILS:
@@ -506,6 +528,7 @@ def _root_admin_email_shape_failures(
     allowed_domains: object,
     *,
     required_count: int,
+    allow_builtin_default: bool = False,
 ) -> list[str]:
     failures: list[str] = []
     if any(not item for item in emails):
@@ -521,7 +544,7 @@ def _root_admin_email_shape_failures(
     email_set = frozenset(emails)
     if any(not _valid_config_email(item) for item in emails) or not _all_email_domains_allowed(email_set, allowed):
         failures.append("ROOT_ADMIN_EMAILS must use approved admin workplace domains")
-    if any(_root_admin_email_has_placeholder_identity(item) for item in emails):
+    if not allow_builtin_default and any(_root_admin_email_has_placeholder_identity(item) for item in emails):
         failures.append("ROOT_ADMIN_EMAILS must not contain placeholder, demo, or example identities")
     return failures
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -136,6 +136,18 @@ choosing an account. Run this migration in staging first and resolve any
 reported alias collision through a reviewed account-recovery process before
 production rollout.
 
+Migration `20260703_0022` adds PayUp support with `users.payup_daily_limit`,
+the `transactions.transaction_type` constraint, and the
+`payup_pending_transfers` table. After upgrade, verify PayUp lookup, amount,
+confirmation, daily-limit, and transfer-limit settings through staging before
+production rollout.
+
+Migration `20260703_0024` widens `users.account_number` and
+`payees.account_number` from 9 to 12 characters. New registrations receive
+12-digit account numbers while legacy 9-digit rows remain valid. The downgrade
+refuses to narrow the columns when any 12-digit account number exists, which
+prevents truncating customer or payee identifiers.
+
 ## Deployment Prerequisites
 
 Install `/etc/sitbank/secrets/security_alert_webhook_url` or

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -67,7 +67,10 @@ the hashed development dependencies, installs Chromium with `python -m
 playwright install --with-deps chromium`, and runs `python -m pytest -q
 tests/e2e` with `SITBANK_RUN_E2E=1` and `PLAYWRIGHT_BROWSERS_PATH` set to
 `.playwright-browsers`. The tests use a loopback Flask server from the pytest
-app fixture and do not target staging, production, or private-admin hosts.
+app fixture for authentication, MFA, session, banking, and boundary
+regressions. They do not prove live staging or production provider state and do
+not target staging, production, or private-admin hosts. Browser cache, reports,
+traces, screenshots, and videos are ignored and are not uploaded by the job.
 
 Changing a job display name can change its required status-check context even
 when the internal ID is unchanged. Repository files do not update GitHub

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -684,19 +684,43 @@ investigate row tampering, chain rewind, anchor corruption, or tail deletion
 before resuming routine deployments.
 
 The current banking implementation audits public transaction validation,
-TOTP-backed transaction authorization checks, and local transfer execution.
+TOTP-backed transaction authorization checks, Local Transfer execution, and
+PayUp execution. New customer account numbers are 12 digits; legacy 9-digit
+account numbers remain accepted for existing rows and payee lookup while the
+schema is widened.
+
 Local transfer performs final ledger movement: the sender balance is debited,
 the recipient balance is credited, and a `Transaction` record is created in a
 single atomic commit. The two-step transfer flow requires MFA step-up before a
-DB-backed `PendingTransfer` record is created; the single-use confirmation token
-is consumed atomically with `SELECT FOR UPDATE` to prevent concurrent
-double-submit replay. Row locks are acquired in ascending `id` order to prevent
-deadlocks. Payee ownership and cooldown are enforced at the service layer
-independently of the route layer. Transfer amounts are validated to at most two
-decimal places. Recipient account state is checked before funds move.
-Blocked authorization failures, including payee ownership mismatches, are
-audited safely using opaque references so raw account numbers, payee details,
-and pending transfer tokens do not appear in the audit log.
+DB-backed `PendingTransfer` record is created. The browser session keeps only
+the raw single-use confirmation token; the database stores a keyed verifier.
+Confirmation consumes the record atomically with `SELECT FOR UPDATE` to prevent
+concurrent double-submit replay. Row locks are acquired in ascending `id` order
+to prevent deadlocks. Payee ownership and cooldown are enforced at the service
+layer independently of the route layer. Transfer amounts are validated to at
+most two decimal places. Recipient account state is checked before funds move.
+The Local Transfer daily limit remains a documented placeholder until a limit is
+implemented for that channel.
+
+PayUp lookup requires an authenticator code before SITBank reveals the
+recipient name for a phone number. Unknown, unavailable, and revoked recipients
+return the same generic `Invalid phone number` response and the audit metadata
+uses opaque references instead of raw phone numbers. PayUp has a per-customer
+daily limit stored on `users.payup_daily_limit` and reset at midnight Singapore
+time. The default limit is SGD 500; customers can choose a preset or custom
+value from transfer settings with TOTP step-up. Confirmation recomputes whether
+the transfer brings today's cumulative PayUp spend to at least 80% of the limit
+under the current database state. If so, a fresh authenticator code is required
+before funds move.
+
+Completed Local Transfer and PayUp rows store an HMAC-SHA256 transaction hash
+over canonical transaction fields. Required audit writes are part of the same
+business transaction boundary; if a required success audit fails, ledger
+mutation rolls back. Customer-initiated account freezes send a security email
+and produce an immediate `account_freeze` alert. Blocked authorization
+failures, including payee ownership mismatches, are audited safely using opaque
+references so raw account numbers, phone numbers, payee details, exact transfer
+amounts, and pending transfer tokens do not appear in the audit log.
 
 The admin boundary audits root-admin-controlled staff invite onboarding,
 admin login success/failure, TOTP verification, admin step-up, admin data

--- a/docs/runbooks/global-verification.md
+++ b/docs/runbooks/global-verification.md
@@ -54,8 +54,10 @@ $env:SITBANK_RUN_E2E = "1"
 .\.venv\Scripts\python.exe -m pytest -q tests/e2e
 ```
 
-The browser tests start a loopback Flask server. They do not target staging,
-production, or the private admin hostname.
+The browser tests cover authentication, MFA, session, banking, and boundary
+regressions against a loopback Flask server. They do not prove live staging or
+production provider state and do not target staging, production, or the private
+admin hostname.
 
 ### Normal CI-Equivalent Checks
 

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -16,6 +16,7 @@ evidence, and governance records remain easy to navigate.
 ## Assurance
 
 - [Audit and alerting](assurance/audit-and-alerting.md)
+- [Feature security checklist](assurance/feature-security-checklist.md)
 - [Operational observability with Grafana and Loki](assurance/operational-observability.md)
 - [Repository secret scanning](assurance/secret-scanning.md)
 - [Secure coding](assurance/secure-coding.md)

--- a/docs/security/architecture/access-control.md
+++ b/docs/security/architecture/access-control.md
@@ -98,6 +98,19 @@ configuration fails closed unless the cooldown is at least 12 hours.
 | Add payee confirmation | Pending payee state exists only after `payee_add` TOTP authorization, is consumed before insert, recipient is reloaded from the database, and duplicate checks are repeated | `app/banking/routes.py::payees_confirm_submit()` |
 | Remove payee | Payee is loaded with `id` and current `user_id`; TOTP step-up is required | `app/banking/routes.py::payees_remove_submit()` |
 
+Local Transfer and PayUp share the banking service boundary for final ledger
+movement. Pending confirmation tokens are kept raw only in the browser session;
+the database stores keyed verifiers. Service execution reloads pending transfer
+records, validates ownership, account state, amount, replay state, and lock
+order, then writes balances and a transaction row in one required-audit-backed
+commit.
+
+| Action | Authorization control | Evidence |
+| --- | --- | --- |
+| Local Transfer confirmation | Payee must belong to the sender, be outside cooldown, and pass final recipient-account checks before ledger movement | `app/banking/services.py::execute_local_transfer()`, `tests/test_local_transfer_security.py` |
+| PayUp phone lookup | `payup_lookup` TOTP step-up runs before recipient name disclosure; unknown and unavailable recipients return the same generic response | `app/banking/routes.py::payup_submit()`, `tests/test_payup.py::test_payup_phone_lookup_requires_totp_before_name_disclosure` |
+| PayUp amount and confirmation | Daily PayUp limit resets at midnight Singapore time; confirmation recomputes the 80% step-up requirement under current usage before executing | `app/banking/services.py::payup_requires_step_up()`, `tests/test_payup.py::test_payup_confirm_rechecks_stepup_when_usage_changes_after_amount_entry` |
+
 Transfer payload validation and future transaction-risk primitives are in
 `app/banking/services.py` and `app/banking/schemas.py`, covered by
 `tests/test_banking_transaction_security.py`.
@@ -162,6 +175,16 @@ changes.
 | Staff/customer self-action guard | `app/admin/separation.py::assert_not_self_customer_action()` | `tests/test_admin_staff_invites.py::test_separation_guard_blocks_linked_staff_acting_on_own_customer`, `tests/test_admin_manual_recovery.py::test_root_admin_cannot_transition_own_customer_manual_recovery` |
 | Admin session context drift | Any detected coarse-network, browser-family, or detailed User-Agent drift revokes the admin session and requires full login | `app/security/sessions.py`, `tests/test_session_risk_binding.py::test_admin_context_change_revokes_session_under_stricter_policy` |
 
+Root-admin allowlist validation rejects placeholder/demo/default identities
+including numeric shapes such as `root8`, `root-admin8`, `admin1`, and `demo1`
+even when the count and workplace domain checks pass.
+
+Root-admin maker-checker approval executes the requested operation before
+marking the request `executed`. Staff lifecycle operations use the caller's
+transaction boundary for the target mutation, request state, and required audit
+write, so an execution error rolls back the staff-account change and records
+`execution_failed` instead of leaving a partially executed approval.
+
 Production Nginx does not publish the admin app. The admin application access
 path is the Tailscale Serve URL `https://admin-sitbank.tailca101b.ts.net/`;
 operators open `/login`, complete the normal Flask admin password and TOTP
@@ -220,6 +243,8 @@ High-risk customer actions use `verify_high_risk_authorization()` in
 | Terminate one session | Authenticated user, current-user ownership, public reference | `app/auth/services.py::terminate_session_for_user()`, `tests/test_pentest_auth_bypass.py::test_cannot_terminate_other_users_session` |
 | Payee add confirmation | Authenticated user, pending payee state, recipient revalidation, TOTP step-up | `app/banking/routes.py::payees_confirm_submit()` |
 | Payee removal | Authenticated user, payee ownership check, TOTP step-up | `app/banking/routes.py::payees_remove_submit()` |
+| PayUp phone lookup | Authenticated MFA-ready customer, CSRF, rate limit, and TOTP step-up before recipient name disclosure | `app/banking/routes.py::payup_submit()`, `tests/test_payup.py` |
+| PayUp confirmation near limit | Authenticated customer, pending PayUp verifier, daily-limit recomputation, and TOTP step-up when the transfer reaches at least 80% of the daily PayUp limit | `app/banking/routes.py::payup_confirm_submit()`, `tests/test_payup.py` |
 | Staff invite create/revoke | Root admin session and TOTP code | `app/admin/services.py::create_staff_invite()`, `app/admin/services.py::revoke_staff_invite()` |
 | Staff/admin account lifecycle | Requesting root admin session, CSRF, rate limit, TOTP step-up, no self-management, durable maker-checker request, different active root-admin approver with fresh TOTP, HMAC integrity, expiry, and safe audit metadata | `app/admin/services.py::transition_staff_account_as_root_admin()`, `app/admin/services.py::approve_admin_action_request_as_root_admin()`, `tests/test_admin_maker_checker.py` |
 | Manual recovery public request | No step-up because the caller is unauthenticated; it creates only a pending request and does not unlock or mutate the account | `app/auth/password_reset.py::request_manual_recovery()`, `tests/test_password_reset.py::test_manual_recovery_request_does_not_freeze_or_unlock_account` |

--- a/docs/security/assurance/feature-security-checklist.md
+++ b/docs/security/assurance/feature-security-checklist.md
@@ -1,0 +1,43 @@
+# Feature Security Checklist
+
+This checklist is the current repository-level index for feature security
+status. It is not a substitute for the focused architecture, governance,
+deployment, and runbook documents linked from `docs/security/README.md`.
+
+Category: [Security assurance](../README.md#assurance).
+
+## Current Feature Status
+
+| Feature or boundary | Current security status | Evidence |
+| --- | --- | --- |
+| Customer registration | Email OTP is required before account creation; client-supplied account numbers and admin-domain customer emails are rejected; new account numbers are 12-digit server-generated identifiers | `app/auth/registration_otp.py`, `app/auth/services.py`, `tests/test_auth_registration_login.py` |
+| Customer login and MFA | Password login uses generic errors, PBKDF2 password hashing, failed-attempt controls, encrypted TOTP seeds, recovery-code fallback, and TOTP replay prevention | `app/auth/services.py`, `app/security/passwords.py`, `tests/test_auth_registration_login.py`, `tests/test_mfa_lifecycle.py` |
+| Customer sessions | Server-side sessions use opaque cookie identifiers, HMAC-signed payloads, absolute lifetime enforcement, risk drift handling, and scoped session termination | `app/security/sessions.py`, `tests/test_session_management.py`, `tests/test_session_absolute_lifetime.py`, `tests/test_session_risk_binding.py` |
+| CSRF | Global Flask-WTF CSRF is expected on unsafe browser routes and is tracked by route inventories plus targeted runtime tests | `app/extensions.py`, `tests/test_route_inventory_security.py`, `tests/test_payup.py` |
+| Password reset and manual recovery | Token and recovery-code verifiers are HMAC-backed; manual recovery is request-only until root-admin review and maker-checker approval | `app/auth/password_reset.py`, `tests/test_password_reset.py`, `tests/test_admin_manual_recovery.py`, `tests/test_admin_maker_checker.py` |
+| Account freeze | Customer-initiated freeze requires TOTP, revokes other sessions, blocks sensitive actions, sends a security email, and produces an immediate alert | `app/auth/services.py`, `app/security/alerts.py`, `tests/test_account_security_actions.py`, `tests/test_audit_alerting.py` |
+| Payee management | Payee lookup requires TOTP before recipient identity disclosure; self, duplicate, missing, expired, and cross-user paths fail closed | `app/banking/routes.py`, `tests/test_payee_management_security.py`, `tests/test_payee_idor.py` |
+| Local Transfer | Final execution reloads the payee and pending record, validates owner/account/amount state, consumes a keyed pending-token verifier, locks rows in deterministic order, and commits ledger movement with required audit | `app/banking/services.py`, `tests/test_local_transfer.py`, `tests/test_local_transfer_security.py` |
+| PayUp | Phone lookup requires TOTP before recipient name disclosure; unknown and unavailable recipients are generic; daily limits reset at midnight Singapore time; the 80% confirmation step-up is recomputed at send time; pending tokens are keyed verifiers | `app/banking/routes.py`, `app/banking/services.py`, `tests/test_payup.py` |
+| Transfer limits | PayUp limit changes require TOTP and CSRF; custom limits are server-side validated | `app/banking/routes.py`, `tests/test_transfer_limits.py`, `tests/test_payup.py` |
+| Staff/admin login | Admin runtime is isolated from the customer app and accepts only active staff roles with approved workplace email, verified workplace email, password, and TOTP | `app/__init__.py`, `app/admin/services.py`, `tests/test_admin_isolation.py`, `tests/test_admin_dashboard_operations.py` |
+| Root-admin bootstrap and allowlist | Production root-admin allowlists require exact environment-specific counts, approved domains, no duplicates, no defaults, and no placeholder or numeric placeholder identities | `config.py`, `app/admin/bootstrap.py`, `tests/test_config.py`, `tests/test_production_guard.py` |
+| Staff/admin maker-checker | Highest-risk staff lifecycle and manual recovery changes require a requester and different active root-admin approver; target state and request state are updated atomically for staff lifecycle execution | `app/admin/services.py`, `tests/test_admin_maker_checker.py` |
+| Audit and alerts | Audit metadata redacts sensitive values, audit chains are HMAC-linked, selected critical events are immediate alerts, and webhook delivery sanitizes payloads | `app/security/audit.py`, `app/security/alerts.py`, `tests/test_audit_alerting.py`, `tests/test_audit_metadata_sanitization.py` |
+| Deployment and runtime boundaries | Customer/admin runtimes, database roles, Docker secrets, Tailscale private admin access, Cloudflare staging controls, Nginx TLS, and readiness gates are documented and tested from repo-controlled artifacts | `docs/DEPLOYMENT.md`, `tests/test_deployment.py`, `tests/test_zero_trust_access_boundary.py`, `tests/test_tailscale_admin_access.py` |
+| Browser E2E | Local-only Playwright tests exercise browser-rendered authentication, MFA, session, banking, and boundary regressions against a loopback Flask server; they do not prove live staging or production provider state | `tests/e2e/`, `tests/test_playwright_e2e_config.py` |
+
+## Maintenance Rules
+
+- When a feature changes authentication, authorization, CSRF, rate limiting,
+  session state, audit metadata, alerting, banking ledger behavior, migration
+  shape, deployment gates, or operator action, update this checklist or a more
+  specific linked security document in the same change.
+- Add or update a stale-documentation test when the documented security status
+  could otherwise drift silently.
+- Do not describe live provider state, branch protection, SonarQube results, or
+  production deployment outcomes as current unless the change also includes the
+  verification artifact or points to the external evidence owner.
+- Use fake values in examples and tests. Never add production secrets, real
+  customer data, raw session ids, CSRF tokens, TOTP seeds, recovery codes, JWTs,
+  private keys, provider exports, or real infrastructure credentials.

--- a/docs/security/assurance/secure-coding.md
+++ b/docs/security/assurance/secure-coding.md
@@ -30,6 +30,7 @@ Examples of server-side validation:
 | Control | Evidence |
 | --- | --- |
 | Client-supplied account numbers are rejected during registration | `tests/test_auth_registration_login.py::test_api_registration_rejects_client_supplied_account_number` |
+| New customer account numbers are server-generated as 12 digits while legacy 9-digit identifiers remain accepted for preserved rows | `app/auth/services.py::_generate_account_number()`, `tests/test_auth_registration_login.py::test_registration_hashes_password_with_pbkdf2`, `tests/test_payee_management_security.py::test_payee_lookup_accepts_new_twelve_digit_account_numbers` |
 | Staff invite acceptance rejects privileged forged fields such as `role`, `workplace_email`, `email`, `account_type`, `customer_user_id`, and `is_admin` | `app/admin/services.py::_reject_forged_invite_fields()` |
 | Transaction payloads reject server-controlled fields and unsafe business values | `tests/test_banking_transaction_security.py::test_future_transaction_payload_guardrails_reject_server_controlled_fields`, `tests/test_banking_transaction_security.py::test_public_transaction_payload_business_rules_reject_unsafe_values` |
 | Route inventory records method-level auth, CSRF, rate-limit, and step-up decisions | `tests/test_route_inventory_security.py` |
@@ -84,7 +85,7 @@ tests.
 | Secure, HttpOnly, SameSite Strict cookies | `config.py`, `tests/test_session_management.py::test_login_sets_secure_session_cookie_and_hides_raw_session_id` |
 | Absolute authenticated session lifetime | `app/security/sessions.py`, `config.py`, `tests/test_session_absolute_lifetime.py` |
 | CSRF on unsafe customer routes | `app/extensions.py`, `app/__init__.py`, `tests/test_route_inventory_security.py::test_route_inventory_has_complete_security_decisions` |
-| Explicit CSRF regression tests | `tests/test_account_security_actions.py`, `tests/test_admin_manual_recovery.py`, `tests/test_route_inventory_security.py` |
+| Explicit CSRF regression tests | `tests/test_account_security_actions.py`, `tests/test_admin_manual_recovery.py`, `tests/test_payup.py::test_payup_and_transfer_limit_posts_require_csrf_when_enabled`, `tests/test_route_inventory_security.py` |
 
 Fully authenticated customer sessions default to a 12-hour absolute lifetime,
 and admin sessions default to a 4-hour absolute lifetime. The `auth_created_at`
@@ -104,6 +105,7 @@ customer route inventory prevents silent addition of unclassified routes.
 | Admin routes use a generated route inventory | `tests/test_admin_route_inventory_security.py` |
 | High-risk customer actions use TOTP step-up | `app/auth/services.py::verify_high_risk_authorization()` |
 | Payee routes filter by current user id | `app/banking/routes.py` |
+| PayUp recipient lookup uses TOTP before name disclosure and confirmation recomputes conditional step-up at the current daily-limit state | `app/banking/routes.py`, `app/banking/services.py`, `tests/test_payup.py` |
 | Session management uses public references, ownership checks, and absolute lifetime enforcement | `app/auth/services.py::terminate_session_for_user()`, `app/security/sessions.py` |
 
 Customer and admin route-inventory matrices are intentionally separate so each
@@ -142,6 +144,7 @@ Audit integrity uses an HMAC-SHA256 hash chain.
 | Audit metadata redaction | `app/security/audit.py`, `tests/test_audit_metadata_sanitization.py` |
 | Structured logs are sanitized | `tests/test_audit_alerting.py::test_structured_audit_log_output_is_sanitized` |
 | Required audit writes can fail closed for critical actions | `app/security/audit.py::audit_event_required()`, `tests/test_audit_alerting.py` |
+| Banking pending-token database rows store keyed verifiers, and transaction rows store HMAC-SHA256 integrity hashes over canonical fields | `app/banking/services.py`, `tests/test_local_transfer_security.py`, `tests/test_payup.py` |
 | Audit chain records, verifies, and exports anchors | `tests/test_audit_alerting.py::test_audit_hash_chain_records_verifies_and_exports_anchor` |
 | Runtime database privilege verifier checks append-only audit behavior | `app/ops/db_privileges.py`, `tests/test_deployment.py::test_audit_operations_runbook_and_append_only_privileges_are_present` |
 | 500 handler logs sanitized context | `tests/test_audit_alerting.py::test_500_handler_logs_sanitized_context` |

--- a/docs/security/assurance/test-automation-and-dependencies.md
+++ b/docs/security/assurance/test-automation-and-dependencies.md
@@ -49,7 +49,7 @@ applicable unless a frontend package manager is added.
 | Trivy image scans | `.github/workflows/ci-deploy.yml` | Uses pinned Trivy `v0.71.2` for built-image and repository filesystem scans; `.trivyignore` exceptions are tested |
 | CodeQL | `.github/workflows/codeql.yml` | Runs Python security-extended static analysis when the repository is public |
 | SonarQube Cloud | `.github/workflows/ci-deploy.yml`, `.github/workflows/sonarqube.yml`, `sonar-project.properties` | Reuses the CI test job's `coverage.xml` artifact to report private-repository code quality, duplication, maintainability, and security findings without rerunning pytest; initial quality gate is non-blocking |
-| Playwright E2E | `.github/workflows/ci-deploy.yml`, `tests/e2e/` | Installs Chromium in a dedicated CI job and exercises browser-rendered customer login, protected redirects, security headers, and MFA-onboarding navigation against a loopback Flask server |
+| Playwright E2E | `.github/workflows/ci-deploy.yml`, `tests/e2e/` | Installs Chromium in a dedicated CI job and exercises browser-rendered authentication, MFA, session, banking, and boundary regressions against a loopback Flask server |
 | Bandit | `scripts/ci-local`, `.github/workflows/ci-deploy.yml` | Runs a high-confidence Python security scan |
 | Custom repository secret scanner | `ops/security/scan_repository_secrets.py` | Scans tracked files and, in CI/local CI, git history for private keys and common token formats |
 | Gitleaks | `.github/workflows/gitleaks.yml`, `.gitleaks.toml` | Independently scans all refs with the built-in Gitleaks rules, redacted output, no production secrets, and no SARIF or raw report upload |
@@ -107,7 +107,7 @@ deployment.
 | Audit, alerts, and redaction | `tests/test_audit_alerting.py`, `tests/test_audit_metadata_sanitization.py` |
 | Deployment, Nginx, Docker, workflows, and runtime contracts | `tests/test_deployment.py` |
 | UI security regressions | `tests/test_authenticated_portal_ui.py`, `tests/test_dashboard.py` |
-| Browser E2E smoke paths | `tests/e2e/test_customer_auth_browser.py` |
+| Browser E2E regressions | `tests/e2e/test_customer_auth_browser.py`, `tests/e2e/test_customer_security_browser.py` |
 
 Payee ownership, direct banking MFA gating, pre-TOTP lookup blocking,
 duplicate/self-payee protections, expiry behavior, and removal IDOR are covered
@@ -118,8 +118,10 @@ Admin route authorization has a separate generated route-inventory matrix in
 tests for staff invites, manual recovery, maker-checker approval, and the
 manual-only root-admin bootstrap boundary.
 
-Playwright E2E browser tests are opt-in for local unscoped pytest because they
-require browser binaries. To run them locally:
+Playwright E2E browser tests cover authentication, MFA, session, banking, and
+boundary regressions against a loopback Flask server. They are opt-in for local
+unscoped pytest because they require browser binaries, and they do not prove
+live staging or production provider state. To run them locally:
 
 ```powershell
 $env:PLAYWRIGHT_BROWSERS_PATH = ".playwright-browsers"

--- a/migrations/versions/20260703_0024_harden_banking_identifiers.py
+++ b/migrations/versions/20260703_0024_harden_banking_identifiers.py
@@ -1,0 +1,82 @@
+"""Harden banking account identifier length.
+
+Revision ID: 20260703_0024
+Revises: 20260703_0023
+Create Date: 2026-07-03 18:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260703_0024"
+down_revision = "20260703_0023"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    if op.get_context().as_sql:
+        op.execute("ALTER TABLE users ALTER COLUMN account_number TYPE VARCHAR(12)")
+        op.execute("ALTER TABLE payees ALTER COLUMN account_number TYPE VARCHAR(12)")
+        return
+
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.alter_column(
+            "account_number",
+            existing_type=sa.String(length=9),
+            type_=sa.String(length=12),
+            existing_nullable=True,
+        )
+    with op.batch_alter_table("payees") as batch_op:
+        batch_op.alter_column(
+            "account_number",
+            existing_type=sa.String(length=9),
+            type_=sa.String(length=12),
+            existing_nullable=False,
+        )
+
+
+def downgrade() -> None:
+    if op.get_context().as_sql:
+        op.execute(
+            sa.text(
+                "-- Downgrade requires no users/payees with 12-digit account numbers; "
+                "otherwise it must be handled manually to avoid identifier corruption."
+            )
+        )
+        op.execute("ALTER TABLE payees ALTER COLUMN account_number TYPE VARCHAR(9)")
+        op.execute("ALTER TABLE users ALTER COLUMN account_number TYPE VARCHAR(9)")
+        return
+    else:
+        connection = op.get_bind()
+        users = sa.table("users", sa.column("account_number", sa.String()))
+        payees = sa.table("payees", sa.column("account_number", sa.String()))
+        user_count = connection.execute(
+            sa.select(sa.func.count()).select_from(users).where(
+                sa.func.length(users.c.account_number) > 9
+            )
+        ).scalar_one()
+        payee_count = connection.execute(
+            sa.select(sa.func.count()).select_from(payees).where(
+                sa.func.length(payees.c.account_number) > 9
+            )
+        ).scalar_one()
+        if int(user_count or 0) or int(payee_count or 0):
+            raise RuntimeError(
+                "Cannot safely downgrade account_number length while 12-digit account numbers exist"
+            )
+    with op.batch_alter_table("payees") as batch_op:
+        batch_op.alter_column(
+            "account_number",
+            existing_type=sa.String(length=12),
+            type_=sa.String(length=9),
+            existing_nullable=False,
+        )
+    with op.batch_alter_table("users") as batch_op:
+        batch_op.alter_column(
+            "account_number",
+            existing_type=sa.String(length=12),
+            type_=sa.String(length=9),
+            existing_nullable=True,
+        )

--- a/tests/e2e/support.py
+++ b/tests/e2e/support.py
@@ -2,10 +2,17 @@ from __future__ import annotations
 
 import os
 import threading
+from decimal import Decimal
 from urllib.parse import urlparse
 
+import pyotp
 import pytest
 from werkzeug.serving import make_server
+
+from app.extensions import db
+from app.models import User
+from app.security.crypto import encrypt_mfa_secret
+from app.security.passwords import hash_password
 
 
 RUN_E2E_ENV = "SITBANK_RUN_E2E"
@@ -56,6 +63,73 @@ def browser_page():
         finally:
             context.close()
             browser.close()
+
+
+def create_e2e_customer(
+    app,
+    *,
+    username: str,
+    password: str,
+    email: str,
+    phone_number: str,
+    account_number: str,
+    full_name: str,
+    balance: Decimal = Decimal("5000.00"),
+    mfa_enabled: bool = False,
+) -> dict[str, str]:
+    with app.app_context():
+        user = User(
+            username=username,
+            email=email,
+            password_hash=hash_password(password),
+            full_name=full_name,
+            phone_number=phone_number,
+            account_number=account_number,
+            account_type="customer",
+            account_status="active",
+            balance=balance,
+        )
+        db.session.add(user)
+        db.session.flush()
+        secret = ""
+        if mfa_enabled:
+            secret = pyotp.random_base32(length=32)
+            user.mfa_secret_nonce, user.mfa_secret_ciphertext = encrypt_mfa_secret(secret, user.id)
+            user.mfa_enabled = True
+        db.session.commit()
+    return {
+        "username": username,
+        "password": password,
+        "secret": secret,
+        "phone_number": phone_number,
+        "full_name": full_name,
+    }
+
+
+def login_customer_with_mfa(page, base_url: str, customer: dict[str, str]) -> None:
+    page.goto(f"{base_url}/login", wait_until="load")
+    page.locator("input[name='identifier']").fill(customer["username"])
+    page.locator("input[name='password']").fill(customer["password"])
+    page.locator("button[type='submit']").click()
+    page.wait_for_url("**/mfa/verify", wait_until="load")
+    page.locator("input[name='totp_code']").fill(current_totp(customer["secret"]))
+    page.get_by_role("button", name="Verify code").click()
+    page.wait_for_url("**/dashboard", wait_until="load")
+
+
+def current_totp(secret: str) -> str:
+    return pyotp.TOTP(secret, digits=6, interval=30).now()
+
+
+def record_console_errors(page) -> list[str]:
+    errors: list[str] = []
+
+    def collect_error(message):
+        if message.type == "error":
+            errors.append(message.text)
+
+    page.on("console", collect_error)
+    return errors
 
 
 def _assert_local_base_url(base_url: str) -> None:

--- a/tests/e2e/test_customer_auth_browser.py
+++ b/tests/e2e/test_customer_auth_browser.py
@@ -7,7 +7,7 @@ import pytest
 from app.extensions import db
 from app.models import User
 from app.security.passwords import hash_password
-from tests.e2e.support import RUN_E2E_ENV, browser_page, live_server
+from tests.e2e.support import RUN_E2E_ENV, browser_page, live_server, record_console_errors
 
 
 pytestmark = [pytest.mark.e2e]
@@ -41,7 +41,7 @@ def test_login_page_renders_with_security_headers_and_no_console_errors(
     live_server,
     browser_page,
 ):
-    console_errors = _record_console_errors(browser_page)
+    console_errors = record_console_errors(browser_page)
 
     response = browser_page.goto(f"{live_server}/login", wait_until="load")
 
@@ -57,7 +57,7 @@ def test_unauthenticated_dashboard_redirects_to_customer_login(
     live_server,
     browser_page,
 ):
-    console_errors = _record_console_errors(browser_page)
+    console_errors = record_console_errors(browser_page)
 
     browser_page.goto(f"{live_server}/dashboard", wait_until="load")
 
@@ -71,7 +71,7 @@ def test_password_login_reaches_mfa_setup_without_external_services(
     browser_page,
     e2e_customer,
 ):
-    console_errors = _record_console_errors(browser_page)
+    console_errors = record_console_errors(browser_page)
 
     browser_page.goto(f"{live_server}/login", wait_until="load")
     browser_page.locator("input[name='identifier']").fill(e2e_customer["username"])
@@ -81,14 +81,3 @@ def test_password_login_reaches_mfa_setup_without_external_services(
     browser_page.wait_for_url("**/mfa/setup", wait_until="load")
     browser_page.get_by_role("heading", name="MFA setup").wait_for()
     assert console_errors == []
-
-
-def _record_console_errors(page):
-    errors: list[str] = []
-
-    def collect_error(message):
-        if message.type == "error":
-            errors.append(message.text)
-
-    page.on("console", collect_error)
-    return errors

--- a/tests/e2e/test_customer_security_browser.py
+++ b/tests/e2e/test_customer_security_browser.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import os
+from decimal import Decimal
+
+import pytest
+
+from tests.e2e.support import (
+    RUN_E2E_ENV,
+    browser_page,
+    create_e2e_customer,
+    current_totp,
+    live_server,
+    login_customer_with_mfa,
+    record_console_errors,
+)
+
+
+pytestmark = [pytest.mark.e2e]
+if os.environ.get(RUN_E2E_ENV) != "1":
+    pytestmark.append(
+        pytest.mark.skip(reason=f"set {RUN_E2E_ENV}=1 to run Playwright E2E browser tests")
+    )
+
+_PASSWORD = "Correct Horse Battery Staple 2026!"
+
+
+@pytest.fixture()
+def e2e_mfa_customer(app):
+    return create_e2e_customer(
+        app,
+        username="e2e_mfa_customer",
+        password=_PASSWORD,
+        email="e2e.mfa@example.test",
+        phone_number="91234567",
+        account_number="012345678901",
+        full_name="E2E MFA Customer",
+        mfa_enabled=True,
+    )
+
+
+@pytest.fixture()
+def e2e_payup_pair(app, e2e_mfa_customer):
+    recipient = create_e2e_customer(
+        app,
+        username="e2e_payup_recipient",
+        password=_PASSWORD,
+        email="e2e.payup.recipient@example.test",
+        phone_number="81234567",
+        account_number="012555999123",
+        full_name="E2E PayUp Recipient",
+        balance=Decimal("1000.00"),
+        mfa_enabled=False,
+    )
+    return {"sender": e2e_mfa_customer, "recipient": recipient}
+
+
+def test_mfa_login_logout_then_protected_banking_redirects_to_login(
+    live_server,
+    browser_page,
+    e2e_mfa_customer,
+):
+    console_errors = record_console_errors(browser_page)
+
+    login_customer_with_mfa(browser_page, live_server, e2e_mfa_customer)
+    browser_page.get_by_role("heading", name="E2E MFA Customer").wait_for()
+    browser_page.locator("#account-menu-button").click()
+    browser_page.get_by_role("menuitem", name="Log Out").click()
+    browser_page.wait_for_url("**/login", wait_until="load")
+    browser_page.goto(f"{live_server}/banking/payees", wait_until="load")
+
+    assert browser_page.url.endswith("/login")
+    browser_page.get_by_role("heading", name="Welcome back").wait_for()
+    assert console_errors == []
+
+
+def test_payup_lookup_browser_flow_requires_totp_before_recipient_name(
+    live_server,
+    browser_page,
+    e2e_payup_pair,
+):
+    sender = e2e_payup_pair["sender"]
+    recipient = e2e_payup_pair["recipient"]
+    console_errors = record_console_errors(browser_page)
+
+    login_customer_with_mfa(browser_page, live_server, sender)
+    browser_page.goto(f"{live_server}/banking/payup", wait_until="load")
+    browser_page.locator("input[name='phone_number']").fill(recipient["phone_number"])
+    browser_page.locator("input[name='totp_code']").fill(current_totp(sender["secret"]))
+    browser_page.get_by_role("button", name="Continue").click()
+    browser_page.wait_for_url("**/banking/payup/amount", wait_until="load")
+
+    browser_page.get_by_role("heading", name=f"Pay to {recipient['full_name']}").wait_for()
+    assert console_errors == []
+
+
+def test_customer_app_does_not_register_admin_browser_surface(
+    live_server,
+    browser_page,
+    e2e_mfa_customer,
+):
+    login_customer_with_mfa(browser_page, live_server, e2e_mfa_customer)
+    response = browser_page.goto(f"{live_server}/admin", wait_until="load")
+
+    assert response is not None
+    assert response.status == 404
+    assert "Admin Dashboard" not in browser_page.content()

--- a/tests/test_account_security_actions.py
+++ b/tests/test_account_security_actions.py
@@ -7,6 +7,7 @@ def test_account_freeze_is_durable_and_blocks_group_a_sensitive_actions(client):
     from app.auth.services import FrozenAccountError
     from app.banking.services import ensure_outbound_transfer_allowed
     from app.security.crypto import encrypt_mfa_secret
+    from app.security.email import password_reset_outbox
 
     register(client)
     login(client)
@@ -27,6 +28,8 @@ def test_account_freeze_is_durable_and_blocks_group_a_sensitive_actions(client):
 
     assert response.status_code == 302
     assert user.is_frozen is True
+    assert password_reset_outbox()[-1]["to"] == "alice@example.com"
+    assert password_reset_outbox()[-1]["subject"] == "SITBank account frozen"
     with current_app.test_request_context("/banking/outbound-transfer", method="POST"):
         with pytest.raises(FrozenAccountError):
             ensure_outbound_transfer_allowed(user)
@@ -38,6 +41,11 @@ def test_account_freeze_is_durable_and_blocks_group_a_sensitive_actions(client):
     )
     assert event.user_id == user.id
     assert event.event_metadata["reason"] == "account_frozen"
+    assert db.session.query(SecurityAuditEvent).filter_by(
+        event_type="account_freeze_notification",
+        outcome="queued",
+        user_id=user.id,
+    ).count() == 1
 
 def test_frozen_account_cannot_create_new_login_session(client):
     register(client)

--- a/tests/test_admin_maker_checker.py
+++ b/tests/test_admin_maker_checker.py
@@ -9,6 +9,7 @@ import pytest
 
 from app.extensions import db
 from app.models import AdminActionRequest, ManualRecoveryRequest, SecurityAuditEvent, User
+from app.security.audit import AuditWriteError
 from app.security.crypto import encrypt_mfa_secret
 from app.security.email import password_reset_outbox
 from app.security.passwords import hash_password
@@ -210,6 +211,79 @@ def test_staff_lifecycle_requires_maker_checker_before_execution(admin_client):
         event_type="staff_account_deactivated",
         outcome="success",
     ).count() == 1
+
+
+def test_staff_lifecycle_audit_failure_rolls_back_target_and_marks_request_failed(
+    admin_client,
+    monkeypatch,
+):
+    from app.admin import services as admin_services
+
+    _root1, root1_secret = _create_staff_identity(
+        username="root-one",
+        email=ROOT1_EMAIL,
+        account_type="root_admin",
+        phone_number="91234567",
+    )
+    root2, root2_secret = _create_staff_identity(
+        username="root-two",
+        email=ROOT2_EMAIL,
+        account_type="root_admin",
+        phone_number="91234568",
+    )
+    target, _target_secret = _create_staff_identity(
+        username="target-admin",
+        email="target.admin@sit.singaporetech.edu.sg",
+        account_type="admin",
+        phone_number="91234569",
+    )
+    _login_admin(admin_client, root1_secret, ROOT1_EMAIL)
+    approver_client = admin_client.application.test_client()
+    _login_admin(approver_client, root2_secret, ROOT2_EMAIL)
+
+    requested = admin_client.post(
+        f"/staff/{target.id}/deactivate",
+        json={"totp_code": _totp(root1_secret)},
+    )
+    request_id = requested.get_json()["request"]["id"]
+    original_required_audit = admin_services.audit_event_required
+
+    def fail_staff_lifecycle_audit(event_type, outcome, **kwargs):
+        if event_type == "staff_account_deactivated":
+            raise AuditWriteError("required audit failed")
+        return original_required_audit(event_type, outcome, **kwargs)
+
+    monkeypatch.setattr(
+        admin_services,
+        "audit_event_required",
+        fail_staff_lifecycle_audit,
+    )
+
+    failed = approver_client.post(
+        f"/admin-action-requests/{request_id}/approve",
+        json={"totp_code": _totp(root2_secret)},
+    )
+
+    db.session.expire_all()
+    persisted_target = db.session.get(User, target.id)
+    action_request = db.session.get(AdminActionRequest, request_id)
+
+    assert failed.status_code == 409
+    assert failed.get_json()["error"] == "Admin action request execution failed"
+    assert persisted_target.account_status == "active"
+    assert action_request.status == "execution_failed"
+    assert action_request.approver_id == root2.id
+    assert action_request.executed_at is None
+    failure_event = db.session.query(SecurityAuditEvent).filter_by(
+        event_type="admin_action_request_execute",
+        outcome="failure",
+    ).one()
+    assert failure_event.event_metadata["reason"] == "execution_error"
+    assert failure_event.event_metadata["error_type"] == "AuditWriteError"
+    assert db.session.query(SecurityAuditEvent).filter_by(
+        event_type="staff_account_deactivated",
+        outcome="success",
+    ).count() == 0
 
 
 def test_manual_recovery_approval_and_completion_use_different_approver(admin_client):

--- a/tests/test_audit_alerting.py
+++ b/tests/test_audit_alerting.py
@@ -569,6 +569,7 @@ def test_security_alert_evaluator_cli_and_output_are_sanitized(app):
             audit_event("rate_limit", "blocked", metadata={"authorization": raw_token})
         audit_event("security_audit_write_failed", "failure", metadata={"token": raw_token})
         audit_event("account_lock", "locked", metadata={"reason": "mfa_failed"})
+        audit_event("account_freeze", "success", metadata={"reason": "customer_requested"})
         audit_event("webauthn_clone_detected", "locked", metadata={"credential_id": "credential-ref"})
         audit_event("session_integrity", "failure", metadata={"reason": "invalid_signature"})
 
@@ -599,6 +600,7 @@ def test_security_alert_evaluator_cli_and_output_are_sanitized(app):
     for expected in (
         "security_audit_write_failed",
         "account_lock",
+        "account_freeze",
         "webauthn_clone_detected",
         "session_integrity_failure",
         "login_failure_burst",

--- a/tests/test_auth_registration_login.py
+++ b/tests/test_auth_registration_login.py
@@ -327,6 +327,10 @@ def test_registration_hashes_password_with_pbkdf2(client):
 
     assert response.status_code == 302
     user = db.session.execute(db.select(User).where(User.username == "alice01")).scalar_one()
+    assert user.account_number is not None
+    assert len(user.account_number) == 12
+    assert user.account_number.startswith("012")
+    assert user.account_number.isdigit()
     assert not user.password_hash.endswith("correct horse battery staple")
     assert user.password_hash.startswith(f"{PBKDF2_PREFIX}$v1$i=600000$")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -198,6 +198,39 @@ def test_root_admin_allowlist_rejects_malformed_collection_and_placeholder_shape
     )
 
 
+@pytest.mark.parametrize(
+    "placeholder_email",
+    [
+        "root8@sit.singaporetech.edu.sg",
+        "root-admin8@sit.singaporetech.edu.sg",
+        "root_admin8@sit.singaporetech.edu.sg",
+        "admin1@sit.singaporetech.edu.sg",
+        "demo1@sit.singaporetech.edu.sg",
+        "test1@sit.singaporetech.edu.sg",
+        "example1@sit.singaporetech.edu.sg",
+        "placeholder1@sit.singaporetech.edu.sg",
+        "changeme1@sit.singaporetech.edu.sg",
+        "replace1@sit.singaporetech.edu.sg",
+    ],
+)
+def test_root_admin_allowlist_rejects_numeric_placeholder_identities(placeholder_email):
+    emails = [
+        *(f"chief{index}@sit.singaporetech.edu.sg" for index in range(1, 7)),
+        placeholder_email,
+    ]
+
+    failures = root_admin_email_allowlist_failures(
+        emails,
+        allowed_domains=frozenset({"sit.singaporetech.edu.sg"}),
+        reject_default=True,
+        required_count=7,
+    )
+
+    assert "ROOT_ADMIN_EMAILS must not contain placeholder, demo, or example identities" in failures
+    assert "ROOT_ADMIN_EMAILS must configure exactly" not in " ".join(failures)
+    assert "ROOT_ADMIN_EMAILS must use approved admin workplace domains" not in failures
+
+
 def test_root_admin_allowlist_accepts_explicit_non_placeholder_workplace_set():
     emails = frozenset(
         f"chief{index}@sit.singaporetech.edu.sg"

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -628,10 +628,27 @@ def test_staff_invite_personal_email_migration_allows_workplace_only_invites():
     assert "nullable=False" not in migration
 
 
+def test_account_identifier_length_migration_preserves_legacy_rows_and_blocks_unsafe_downgrade():
+    migration = Path(
+        "migrations/versions/20260703_0024_harden_banking_identifiers.py"
+    ).read_text(encoding="utf-8")
+    deployment_docs = Path("docs/DEPLOYMENT.md").read_text(encoding="utf-8")
+
+    assert 'revision = "20260703_0024"' in migration
+    assert 'down_revision = "20260703_0023"' in migration
+    assert '"account_number"' in migration
+    assert "String(length=12)" in migration
+    assert "String(length=9)" in migration
+    assert "Cannot safely downgrade account_number length" in migration
+    assert "Migration `20260703_0024`" in deployment_docs
+    assert "12-digit account numbers" in deployment_docs
+
+
 def test_migration_baseline_drift_metadata_matches_reviewed_migrations():
     from app.models import (
         ManualRecoveryRequest,
         PendingTransfer,
+        Payee,
         RecoveryCode,
         StaffInvite,
         Transaction,
@@ -648,6 +665,8 @@ def test_migration_baseline_drift_metadata_matches_reviewed_migrations():
 
     assert User.__table__.c.phone_number.unique is None
     assert User.__table__.c.account_number.unique is None
+    assert User.__table__.c.account_number.type.length == 12
+    assert Payee.__table__.c.account_number.type.length == 12
     assert any(index.name == "ix_users_phone_number" and index.unique for index in user_indexes)
     assert any(index.name == "ix_users_account_number" and index.unique for index in user_indexes)
     assert any(index.name == "ix_recovery_codes_code_hmac" and index.unique for index in recovery_indexes)

--- a/tests/test_documentation_consistency.py
+++ b/tests/test_documentation_consistency.py
@@ -71,3 +71,66 @@ def test_private_admin_docs_reject_wildcard_public_https():
     assert "`PUBLIC_BIND_ADDRESS`" in deployment
     assert "without wildcard public listeners" in deployment
     assert "reject wildcard\nport `443`" in architecture
+
+
+def test_payup_security_docs_match_current_banking_contract():
+    docs = "\n".join(
+        Path(path).read_text(encoding="utf-8")
+        for path in (
+            "docs/OPERATIONS.md",
+            "docs/DEPLOYMENT.md",
+            "docs/security/architecture/access-control.md",
+            "docs/security/assurance/secure-coding.md",
+            "docs/security/assurance/feature-security-checklist.md",
+        )
+    )
+
+    for required in (
+        "PayUp lookup requires an authenticator code",
+        "Invalid phone number",
+        "daily limit stored on `users.payup_daily_limit`",
+        "midnight Singapore time",
+        "at least 80% of the limit",
+        "The Local Transfer daily limit remains a documented placeholder",
+        "keyed verifier",
+        "HMAC-SHA256 transaction hash",
+        "Migration `20260703_0022` adds PayUp support",
+        "`payup_pending_transfers`",
+        "`transactions.transaction_type`",
+        "Migration `20260703_0024` widens `users.account_number`",
+        "12-digit account numbers",
+    ):
+        assert required in docs
+
+    stale_phrases = (
+        "PayUp lookup reveals recipient name before MFA",
+        "PayUp lookup does not require MFA",
+        "Local Transfer daily limit is enforced",
+    )
+    for stale in stale_phrases:
+        assert stale not in docs
+
+
+def test_feature_security_checklist_is_indexed_and_avoids_external_overclaims():
+    index = Path("docs/security/README.md").read_text(encoding="utf-8")
+    checklist = Path("docs/security/assurance/feature-security-checklist.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "Feature security checklist" in index
+    for required in (
+        "Current Feature Status",
+        "PayUp",
+        "Root-admin bootstrap and allowlist",
+        "Staff/admin maker-checker",
+        "Browser E2E",
+        "do not prove live staging or production provider state",
+        "stale-documentation test",
+    ):
+        assert required in checklist
+    for forbidden in (
+        "live provider state is verified",
+        "branch protection is enforced",
+        "SonarQube gate is passing",
+    ):
+        assert forbidden not in checklist

--- a/tests/test_local_transfer.py
+++ b/tests/test_local_transfer.py
@@ -11,7 +11,7 @@ import pyotp
 
 from _auth_flow_helpers import enable_mfa_for_user, login, mark_recent_mfa, register
 from app.auth.services import AuthError
-from app.banking.services import execute_local_transfer
+from app.banking.services import execute_local_transfer, local_transfer_token_verifier
 from app.extensions import db
 from app.models import Payee, PendingTransfer, SecurityAuditEvent, Transaction, User
 from app.security.passwords import hash_password
@@ -27,7 +27,7 @@ def _make_pending_transfer(
 ) -> str:
     token = os.urandom(32).hex()
     pending = PendingTransfer(
-        token=token,
+        token=local_transfer_token_verifier(token),
         user_id=user.id,
         payee_id=payee.id,
         amount=amount,

--- a/tests/test_local_transfer_security.py
+++ b/tests/test_local_transfer_security.py
@@ -14,9 +14,15 @@ from pathlib import Path
 import pytest
 
 from app.auth.services import AuthError
-from app.banking.services import execute_local_transfer
+from app.banking.services import (
+    _amount_audit_band,
+    execute_local_transfer,
+    local_transfer_token_verifier,
+    transaction_hash_matches,
+)
 from app.extensions import db
 from app.models import Payee, PendingTransfer, SecurityAuditEvent, Transaction, User
+from app.security.audit import AuditWriteError
 from app.security.passwords import hash_password
 
 
@@ -72,7 +78,7 @@ def _make_pending_transfer(
 ) -> str:
     token = os.urandom(32).hex()
     pending = PendingTransfer(
-        token=token,
+        token=local_transfer_token_verifier(token),
         user_id=user.id,
         payee_id=payee.id,
         amount=amount,
@@ -371,6 +377,8 @@ def test_replay_attack_second_consume_fails(app, sec_ctx):
 
     assert exc_info.value.status_code == 409
     assert Transaction.query.count() == 1
+    pending = PendingTransfer.query.filter_by(token=local_transfer_token_verifier(token)).one()
+    assert pending.token != token
 
 
 def test_sequential_double_submit_results_in_one_transaction(app, sec_ctx):
@@ -534,8 +542,17 @@ def test_success_audit_metadata_contains_safe_reference_fields(app, sec_ctx):
     meta = event.event_metadata
     assert "reference_present" in meta
     assert "reference_length" in meta
+    assert "amount" not in meta
+    assert meta["amount_band"] == "under_100"
     assert meta["reference_present"] is True
     assert meta["reference_length"] == len("Rent")
+
+
+def test_amount_audit_band_uses_coarse_ranges():
+    assert _amount_audit_band(Decimal("-50.00")) == "under_100"
+    assert _amount_audit_band(Decimal("100.00")) == "100_to_999"
+    assert _amount_audit_band(Decimal("1000.00")) == "1000_to_9999"
+    assert _amount_audit_band(Decimal("10000.00")) == "10000_or_more"
 
 
 def test_empty_reference_reflected_in_audit_metadata(app, sec_ctx):
@@ -613,6 +630,29 @@ def test_failed_transfer_leaves_balances_unchanged(app, sec_ctx):
     assert Transaction.query.count() == 0
 
 
+def test_required_audit_failure_rolls_back_ledger_mutation(app, sec_ctx, monkeypatch):
+    alice = sec_ctx["alice"]
+    bob = sec_ctx["bob"]
+    payee = sec_ctx["payee"]
+    token = _make_pending_transfer(alice, payee, Decimal("10.00"))
+    alice_before = Decimal(str(alice.balance))
+    bob_before = Decimal(str(bob.balance))
+
+    def fail_required_audit(*_args, **_kwargs):
+        raise AuditWriteError("audit unavailable")
+
+    monkeypatch.setattr("app.banking.services.audit_event_required", fail_required_audit)
+
+    with app.test_request_context("/banking/transfer/confirm", method="POST"):
+        with pytest.raises(AuditWriteError):
+            execute_local_transfer(sender=alice, payee=payee, confirmation_token=token)
+
+    db.session.expire_all()
+    assert Decimal(str(db.session.get(User, alice.id).balance)) == alice_before
+    assert Decimal(str(db.session.get(User, bob.id).balance)) == bob_before
+    assert Transaction.query.count() == 0
+
+
 # ── Transaction content hash (tamper-evidence) ────────────────────────────────
 
 def test_transaction_hash_is_stored_on_success(app, sec_ctx):
@@ -625,7 +665,8 @@ def test_transaction_hash_is_stored_on_success(app, sec_ctx):
 
     txn = Transaction.query.filter_by(transaction_ref=txn_ref).one()
     assert txn.transaction_hash, "transaction_hash must be set"
-    assert len(txn.transaction_hash) == 64, "SHA-256 hex digest is 64 characters"
+    assert len(txn.transaction_hash) == 64, "HMAC-SHA256 hex digest is 64 characters"
+    assert transaction_hash_matches(txn)
 
 
 def test_transaction_hash_changes_when_amount_changes(app, sec_ctx):
@@ -658,6 +699,21 @@ def test_transaction_hash_changes_when_amount_changes(app, sec_ctx):
 
 # ── Consumed token stores transaction reference ────────────────────────────────
 
+def test_transaction_hash_verification_detects_amount_tampering(app, sec_ctx):
+    alice = sec_ctx["alice"]
+    payee = sec_ctx["payee"]
+    token = _make_pending_transfer(alice, payee, Decimal("10.00"))
+
+    with app.test_request_context("/banking/transfer/confirm", method="POST"):
+        txn_ref = execute_local_transfer(sender=alice, payee=payee, confirmation_token=token)
+
+    txn = Transaction.query.filter_by(transaction_ref=txn_ref).one()
+    assert transaction_hash_matches(txn)
+
+    txn.amount = Decimal("10.01")
+    assert not transaction_hash_matches(txn)
+
+
 def test_consumed_token_stores_transaction_ref(app, sec_ctx):
     alice = sec_ctx["alice"]
     payee = sec_ctx["payee"]
@@ -667,6 +723,6 @@ def test_consumed_token_stores_transaction_ref(app, sec_ctx):
         txn_ref = execute_local_transfer(sender=alice, payee=payee, confirmation_token=token)
 
     db.session.expire_all()
-    pending = PendingTransfer.query.filter_by(token=token).one()
+    pending = PendingTransfer.query.filter_by(token=local_transfer_token_verifier(token)).one()
     assert pending.consumed_at is not None
     assert pending.consumed_transaction_ref == txn_ref

--- a/tests/test_payee_management_security.py
+++ b/tests/test_payee_management_security.py
@@ -165,6 +165,40 @@ def test_payee_lookup_requires_totp_before_confirmation(app, client, monkeypatch
     assert payee.recipient_name == bob.full_name
 
 
+def test_payee_lookup_accepts_new_twelve_digit_account_numbers(app, client, monkeypatch):
+    bob_client = app.test_client()
+    _register_customer(
+        client,
+        username="alice01",
+        email="alice@example.com",
+        phone="91234567",
+        account="012345678901",
+    )
+    bob = _register_customer(
+        bob_client,
+        username="bob02",
+        email="bob@example.com",
+        phone="81234567",
+        account="012555999123",
+    )
+    _alice, secret = _login_mfa_customer(client)
+    totp_time = _freeze_totp_verifier(monkeypatch)
+
+    lookup = client.post(
+        "/banking/payees/add",
+        data={
+            "nickname": "Bob",
+            "account_number": bob.account_number,
+            "totp_code": _current_totp(secret, totp_time),
+        },
+    )
+    save = client.post("/banking/payees/confirm")
+
+    assert lookup.status_code == 302
+    assert save.status_code == 302
+    assert db.session.query(Payee).filter_by(account_number="012555999123").count() == 1
+
+
 def test_payee_add_rejects_passkey_stepup_token(app, client):
     bob_client = app.test_client()
     _register_customer(
@@ -224,6 +258,41 @@ def test_invalid_payee_lookup_is_generic_and_audited(client, monkeypatch):
     assert b"Could not add that payee" in response.data
     assert "account_ref" in event.event_metadata
     assert "012000999" not in str(event.event_metadata)
+
+
+def test_invalid_payee_lookup_blocks_after_durable_rate_limit(client, monkeypatch):
+    _register_customer(
+        client,
+        username="alice01",
+        email="alice@example.com",
+        phone="91234567",
+        account="012345678",
+    )
+    _alice, secret = _login_mfa_customer(client)
+    base_time = int(time.time())
+
+    response = None
+    for attempt in range(6):
+        timestamp = base_time + (attempt * 31)
+        monkeypatch.setattr("app.auth.services.time.time", lambda timestamp=timestamp: timestamp)
+        response = client.post(
+            "/banking/payees/add",
+            data={
+                "nickname": "Missing",
+                "account_number": "012000999",
+                "totp_code": _current_totp(secret, timestamp),
+            },
+        )
+
+    assert response is not None
+    assert response.status_code == 429
+    assert b"Could not add that payee" in response.data
+    blocked_event = db.session.query(SecurityAuditEvent).filter_by(
+        event_type="payee_lookup",
+        outcome="blocked",
+    ).one()
+    assert blocked_event.event_metadata["reason"] == "durable_rate_limit"
+    assert "012000999" not in str(blocked_event.event_metadata)
 
 
 def test_payee_add_and_remove_audit_metadata_uses_safe_references(app, client, monkeypatch):

--- a/tests/test_payup.py
+++ b/tests/test_payup.py
@@ -16,10 +16,11 @@ from app.banking.services import (
     execute_payup_transfer,
     payup_amount_used_today,
     payup_requires_step_up,
+    payup_transfer_token_verifier,
     sgt_day_start_utc,
 )
 from app.extensions import db
-from app.models import PayupPendingTransfer, Transaction, User
+from app.models import PayupPendingTransfer, SecurityAuditEvent, Transaction, User
 
 
 def _make_payup_pending(
@@ -32,7 +33,7 @@ def _make_payup_pending(
 ) -> str:
     token = os.urandom(32).hex()
     pending = PayupPendingTransfer(
-        token=token,
+        token=payup_transfer_token_verifier(token),
         user_id=user.id,
         recipient_user_id=recipient.id,
         amount=amount,
@@ -44,12 +45,29 @@ def _make_payup_pending(
     return token
 
 
+def _totp_code(secret: str, timestamp: int | None = None) -> str:
+    return pyotp.TOTP(secret, digits=6, interval=30).at(timestamp or int(time.time()))
+
+
+def _payup_lookup_data(
+    payup_context: dict,
+    phone_number: str = "81234567",
+    timestamp: int | None = None,
+    totp_code: str | None = None,
+) -> dict[str, str]:
+    return {
+        "phone_number": phone_number,
+        "totp_code": totp_code or _totp_code(payup_context["alice_secret"], timestamp),
+    }
+
+
 def _make_payup_transaction(
     sender: User,
     recipient: User,
     amount: Decimal,
     *,
     created_at: datetime | None = None,
+    reference: str = "",
     status: str = "completed",
 ) -> Transaction:
     txn = Transaction(
@@ -59,7 +77,7 @@ def _make_payup_transaction(
         recipient_id=recipient.id,
         payee_id=None,
         amount=amount,
-        reference="",
+        reference=reference,
         status=status,
         transaction_type="payup",
         created_at=created_at or datetime.now(timezone.utc),
@@ -161,6 +179,8 @@ def test_execute_payup_transfer_debits_sender_and_credits_recipient(app, payup_c
     bob_before = Decimal(str(bob.balance))
     amount = Decimal("100.00")
     token = _make_payup_pending(alice, bob, amount, reference="Lunch")
+    pending = PayupPendingTransfer.query.filter_by(token=payup_transfer_token_verifier(token)).one()
+    assert pending.token != token
 
     with app.test_request_context("/banking/payup/confirm", method="POST"):
         txn_ref = execute_payup_transfer(sender=alice, confirmation_token=token, authorized=False)
@@ -285,7 +305,7 @@ def test_execute_payup_transfer_expired_token_blocked(app, payup_context):
 # ── Phone lookup route ───────────────────────────────────────────────────────────
 
 def test_payup_phone_lookup_success_redirects_to_amount(client, payup_context):
-    response = client.post("/banking/payup", data={"phone_number": "81234567"})
+    response = client.post("/banking/payup", data=_payup_lookup_data(payup_context))
 
     assert response.status_code == 302
     assert "payup/amount" in response.headers["Location"]
@@ -297,14 +317,76 @@ def test_payup_phone_lookup_success_redirects_to_amount(client, payup_context):
 
 
 def test_payup_phone_lookup_unknown_number_shows_error(client, payup_context):
-    response = client.post("/banking/payup", data={"phone_number": "89999999"})
+    response = client.post(
+        "/banking/payup",
+        data=_payup_lookup_data(payup_context, phone_number="89999999"),
+    )
+    event = db.session.query(SecurityAuditEvent).filter_by(
+        event_type="payup_lookup",
+        outcome="failure",
+    ).one()
 
     assert response.status_code == 400
     assert b"Invalid phone number" in response.data
+    assert response.data.count(b"Bob Recipient") == 0
+    assert "89999999" not in str(event.event_metadata)
+
+
+def test_payup_phone_lookup_requires_totp_before_name_disclosure(client, payup_context):
+    response = client.post("/banking/payup", data={"phone_number": "81234567"})
+
+    assert response.status_code == 400
+    assert b"Bob Recipient" not in response.data
+    with client.session_transaction() as sess:
+        assert "pending_payup_recipient" not in sess
+
+
+def test_payup_phone_lookup_invalid_totp_does_not_disclose_recipient(client, payup_context):
+    response = client.post(
+        "/banking/payup",
+        data=_payup_lookup_data(payup_context, totp_code="000000"),
+    )
+
+    assert response.status_code == 401
+    assert b"Bob Recipient" not in response.data
+    with client.session_transaction() as sess:
+        assert "pending_payup_recipient" not in sess
+
+
+def test_payup_unavailable_recipient_matches_unknown_number_response(client, payup_context, monkeypatch):
+    bob = payup_context["bob"]
+    bob.account_status = "revoked"
+    db.session.commit()
+    first_step = int(time.time())
+    second_step = first_step + 31
+
+    monkeypatch.setattr("app.auth.services.time.time", lambda: first_step)
+    unavailable = client.post(
+        "/banking/payup",
+        data=_payup_lookup_data(payup_context, timestamp=first_step),
+    )
+    monkeypatch.setattr("app.auth.services.time.time", lambda: second_step)
+    unknown = client.post(
+        "/banking/payup",
+        data=_payup_lookup_data(
+            payup_context,
+            phone_number="89999999",
+            timestamp=second_step,
+        ),
+    )
+
+    assert unavailable.status_code == 400
+    assert unknown.status_code == 400
+    assert b"Invalid phone number" in unavailable.data
+    assert b"Invalid phone number" in unknown.data
+    assert b"Bob Recipient" not in unavailable.data
 
 
 def test_payup_phone_lookup_self_number_blocked(client, payup_context):
-    response = client.post("/banking/payup", data={"phone_number": "91234567"})
+    response = client.post(
+        "/banking/payup",
+        data=_payup_lookup_data(payup_context, phone_number="91234567"),
+    )
 
     assert response.status_code == 400
     assert b"own phone number" in response.data
@@ -313,7 +395,7 @@ def test_payup_phone_lookup_self_number_blocked(client, payup_context):
 # ── Amount step: daily limit enforcement ─────────────────────────────────────────
 
 def test_payup_amount_rejects_amount_exceeding_daily_limit(client, payup_context):
-    client.post("/banking/payup", data={"phone_number": "81234567"})
+    client.post("/banking/payup", data=_payup_lookup_data(payup_context))
 
     response = client.post("/banking/payup/amount", data={"amount": "600.00"})
 
@@ -327,7 +409,7 @@ def test_payup_amount_rejects_amount_exceeding_available_balance(client, payup_c
     alice.balance = Decimal("50.00")
     db.session.commit()
 
-    client.post("/banking/payup", data={"phone_number": "81234567"})
+    client.post("/banking/payup", data=_payup_lookup_data(payup_context))
 
     # Under the 500 SGD daily limit, but over the 50.00 available balance.
     response = client.post("/banking/payup/amount", data={"amount": "100.00"})
@@ -338,19 +420,24 @@ def test_payup_amount_rejects_amount_exceeding_available_balance(client, payup_c
 
 
 def test_payup_amount_accepts_amount_under_limit(client, payup_context):
-    client.post("/banking/payup", data={"phone_number": "81234567"})
+    client.post("/banking/payup", data=_payup_lookup_data(payup_context))
 
     response = client.post("/banking/payup/amount", data={"amount": "100.00"})
 
     assert response.status_code == 302
     assert "payup/confirm" in response.headers["Location"]
     assert PayupPendingTransfer.query.count() == 1
+    pending = PayupPendingTransfer.query.one()
+    with client.session_transaction() as sess:
+        raw_token = sess["pending_payup_token"]
+    assert pending.token == payup_transfer_token_verifier(raw_token)
+    assert pending.token != raw_token
 
 
 # ── Full route flow: conditional MFA step-up ─────────────────────────────────────
 
 def test_complete_payup_route_flow_below_threshold_no_mfa(client, payup_context):
-    client.post("/banking/payup", data={"phone_number": "81234567"})
+    client.post("/banking/payup", data=_payup_lookup_data(payup_context))
     client.post("/banking/payup/amount", data={"amount": "100.00", "reference": "Lunch"})
 
     confirm_page = client.get("/banking/payup/confirm")
@@ -365,7 +452,7 @@ def test_complete_payup_route_flow_below_threshold_no_mfa(client, payup_context)
 def test_complete_payup_route_flow_crossing_threshold_requires_mfa(client, payup_context, monkeypatch):
     alice_secret = payup_context["alice_secret"]
 
-    client.post("/banking/payup", data={"phone_number": "81234567"})
+    client.post("/banking/payup", data=_payup_lookup_data(payup_context))
     client.post("/banking/payup/amount", data={"amount": "450.00"})
 
     confirm_page = client.get("/banking/payup/confirm")
@@ -378,7 +465,7 @@ def test_complete_payup_route_flow_crossing_threshold_requires_mfa(client, payup
     assert Transaction.query.count() == 0
 
     stepup_time = int(time.time())
-    totp_code = pyotp.TOTP(alice_secret, digits=6, interval=30).at(stepup_time)
+    totp_code = _totp_code(alice_secret, stepup_time)
     monkeypatch.setattr("app.auth.services.time.time", lambda: stepup_time)
 
     confirm_submit = client.post("/banking/payup/confirm", data={"totp_code": totp_code})
@@ -386,11 +473,63 @@ def test_complete_payup_route_flow_crossing_threshold_requires_mfa(client, payup
     assert Transaction.query.filter_by(transaction_type="payup").count() == 1
 
 
+def test_payup_confirm_rechecks_stepup_when_usage_changes_after_amount_entry(client, payup_context):
+    alice = payup_context["alice"]
+    bob = payup_context["bob"]
+
+    client.post("/banking/payup", data=_payup_lookup_data(payup_context))
+    client.post("/banking/payup/amount", data={"amount": "100.00", "reference": "Late stepup"})
+    _make_payup_transaction(alice, bob, Decimal("300.00"), reference="Earlier PayUp")
+
+    response = client.post("/banking/payup/confirm", data={})
+
+    assert response.status_code == 403
+    assert b"Authenticator code" in response.data
+    assert Transaction.query.filter_by(reference="Late stepup", transaction_type="payup").count() == 0
+    with client.session_transaction() as sess:
+        assert sess.get("pending_payup_token")
+
+
 def test_payup_confirm_rejects_wrong_totp_code(client, payup_context):
-    client.post("/banking/payup", data={"phone_number": "81234567"})
+    client.post("/banking/payup", data=_payup_lookup_data(payup_context))
     client.post("/banking/payup/amount", data={"amount": "450.00"})
 
     response = client.post("/banking/payup/confirm", data={"totp_code": "000000"})
 
     assert response.status_code == 401
     assert Transaction.query.count() == 0
+
+
+def test_payup_and_transfer_limit_posts_require_csrf_when_enabled(app, client, payup_context):
+    alice = payup_context["alice"]
+    bob = payup_context["bob"]
+    token = _make_payup_pending(alice, bob, Decimal("10.00"))
+    original = app.config["WTF_CSRF_ENABLED"]
+    app.config["WTF_CSRF_ENABLED"] = True
+    try:
+        with client.session_transaction() as sess:
+            sess["pending_payup_recipient"] = {
+                "recipient_user_id": bob.id,
+                "recipient_name": bob.full_name,
+                "recipient_phone": bob.phone_number,
+                "expires_at": (datetime.now(timezone.utc) + timedelta(minutes=5)).isoformat(),
+            }
+        lookup = client.post("/banking/payup", data=_payup_lookup_data(payup_context))
+        amount = client.post("/banking/payup/amount", data={"amount": "10.00"})
+        with client.session_transaction() as sess:
+            sess["pending_payup_token"] = token
+        confirm = client.post("/banking/payup/confirm", data={})
+        limit_update = client.post(
+            "/banking/settings/transfer-limits",
+            data={
+                "payup_limit": "1000",
+                "totp_code": _totp_code(payup_context["alice_secret"]),
+            },
+        )
+    finally:
+        app.config["WTF_CSRF_ENABLED"] = original
+
+    assert lookup.status_code == 400
+    assert amount.status_code == 400
+    assert confirm.status_code == 400
+    assert limit_update.status_code == 400

--- a/tests/test_playwright_e2e_config.py
+++ b/tests/test_playwright_e2e_config.py
@@ -2,12 +2,19 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 import yaml
+
+from tests.e2e.support import _assert_local_base_url
 
 
 CI_WORKFLOW_PATH = Path(".github/workflows/ci-deploy.yml")
 E2E_SUPPORT_PATH = Path("tests/e2e/support.py")
-E2E_TEST_PATH = Path("tests/e2e/test_customer_auth_browser.py")
+E2E_TEST_PATHS = tuple(sorted(Path("tests/e2e").glob("test_*.py")))
+
+
+def _combined_e2e_tests() -> str:
+    return "\n".join(path.read_text(encoding="utf-8") for path in E2E_TEST_PATHS)
 
 
 def test_playwright_dependency_is_locked_for_browser_e2e():
@@ -21,12 +28,14 @@ def test_playwright_dependency_is_locked_for_browser_e2e():
 
 def test_playwright_e2e_defaults_to_opt_in_local_loopback():
     support = E2E_SUPPORT_PATH.read_text(encoding="utf-8")
-    tests = E2E_TEST_PATH.read_text(encoding="utf-8")
+    tests = _combined_e2e_tests()
     combined = f"{support}\n{tests}"
 
     assert not Path("tests/e2e/conftest.py").exists()
     assert "SITBANK_RUN_E2E" in combined
-    assert "from tests.e2e.support import RUN_E2E_ENV, browser_page, live_server" in tests
+    assert "from tests.e2e.support import" in tests
+    assert "record_console_errors" in tests
+    assert "login_customer_with_mfa" in tests
     assert "from support import" not in tests
     assert "pytest.mark.skip" in tests
     assert 'make_server("127.0.0.1", 0, app, threaded=False)' in support
@@ -34,6 +43,20 @@ def test_playwright_e2e_defaults_to_opt_in_local_loopback():
     assert "pytest.mark.e2e" in tests
     assert "https://sitbank.pp.ua" not in combined
     assert "https://staging-sitbank.pp.ua" not in combined
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://sitbank.pp.ua",
+        "https://staging-sitbank.pp.ua",
+        "https://admin-sitbank.tailca101b.ts.net",
+        "http://203.0.113.10:5000",
+    ],
+)
+def test_playwright_e2e_rejects_non_loopback_targets(base_url):
+    with pytest.raises(RuntimeError, match="loopback live server"):
+        _assert_local_base_url(base_url)
 
 
 def test_ci_has_dedicated_playwright_browser_e2e_job():
@@ -67,6 +90,22 @@ def test_ci_has_dedicated_playwright_browser_e2e_job():
     assert steps["Run Playwright E2E tests"]["run"] == (
         "python -m pytest -q tests/e2e"
     )
+    assert not any("upload-artifact" in str(step) for step in job["steps"])
+
+
+def test_playwright_browser_artifacts_are_ignored_and_not_committed():
+    gitignore = Path(".gitignore").read_text(encoding="utf-8")
+
+    for required in (
+        ".playwright-browsers/",
+        "playwright-report/",
+        "test-results/",
+        "tests/e2e/artifacts/",
+    ):
+        assert required in gitignore
+    assert not any(Path("tests/e2e").glob("**/*.webm"))
+    assert not any(Path("tests/e2e").glob("**/*.zip"))
+    assert not any(Path("tests/e2e").glob("**/trace*"))
 
 
 def test_playwright_e2e_docs_are_current():
@@ -87,5 +126,7 @@ def test_playwright_e2e_docs_are_current():
         "python -m playwright install chromium",
         "python -m pytest -q tests/e2e",
         "loopback Flask server",
+        "authentication, MFA, session, banking, and boundary regressions",
+        "do not prove live staging or production provider state",
     ):
         assert required in docs

--- a/tests/test_route_inventory_security.py
+++ b/tests/test_route_inventory_security.py
@@ -955,7 +955,7 @@ ROUTE_SECURITY_INVENTORY = {
         "classification": "payup_transfer",
         "csrf": "required",
         "rate_limit": "per_route",
-        "step_up": "not_required",
+        "step_up": "required",
         "public_justification": "",
     },
     "banking.payup_amount": {

--- a/tests/test_security_docs_issue_links.py
+++ b/tests/test_security_docs_issue_links.py
@@ -519,6 +519,7 @@ def test_security_docs_are_grouped_and_indexed_by_purpose():
         },
         "assurance": {
             "audit-and-alerting.md",
+            "feature-security-checklist.md",
             "operational-observability.md",
             "secret-scanning.md",
             "secure-coding.md",


### PR DESCRIPTION
Summary
---
Hardened the verified banking, PayUp, root-admin, documentation, and browser E2E gaps for issues #369, #366, #362, #361, #359, and #351.

Why
---
The reviewed issues were accurate: raw pending-transfer tokens, PayUp lookup disclosure before fresh MFA, exact amount audit metadata, non-atomic maker-checker execution, placeholder root-admin identities, 9-digit-only account identifiers, stale docs/checks, and limited browser E2E coverage left security behavior easier to drift or misuse.

What changed
---
- Store keyed verifiers for local-transfer and PayUp confirmation tokens, HMAC transaction tamper evidence, redacted amount bands, and audit-failure rollback for ledger writes.
- Require TOTP step-up before PayUp recipient lookup, rate-limit missing payee lookups durably, support 12-digit generated account identifiers with a guarded migration, and send freeze notification alerts.
- Make root-admin allowlist validation reject numeric placeholders and keep maker-checker lifecycle execution atomic with failed-execution audit status.
- Add the feature security checklist, stale-doc checks, route inventory updates, deployment docs, and loopback Playwright browser coverage.

Security impact
---
Strengthens banking token secrecy, recipient identity disclosure, auditability, account identifier entropy, root-admin identity hygiene, and maker-checker atomicity. No secrets, provider exports, or real customer data are included.

Deployment impact
---
Database migration `20260703_0024` widens `users.account_number` and `payees.account_number` to 12 characters and blocks unsafe online downgrade when 12-digit rows exist. Requires staging deployment before production deployment; no EC2 bootstrap or secret changes.

Verification
---
- `git diff --check`
- `.\.venv\Scripts\python.exe -m pytest -q -n 4`
- `.\.venv\Scripts\python.exe -m pytest -q -n 4 --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term` (coverage 90%, `coverage.xml` generated)
- `$env:PLAYWRIGHT_BROWSERS_PATH='.playwright-browsers'; $env:SITBANK_RUN_E2E='1'; $env:SITBANK_E2E_HEADLESS='1'; .\.venv\Scripts\python.exe -m pytest -q tests\e2e`
- Local SonarQube-for-IDE analysis was attempted but the tool returned `Failed to request analysis of the list of files`; PR-level Sonar should run after GitHub analysis is available.

Notes
---
Closes #369.
Closes #366.
Closes #362.
Closes #361.
Closes #359.
Closes #351.