### PR TITLE
Accept staging origin connection rejection

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -925,8 +925,9 @@ testssl.sh --warnings batch --color 0 https://staging-sitbank.pp.ua
 Expected: unauthenticated browser traffic receives the Cloudflare Access
 challenge at `staging-sitbank.pp.ua` before reaching staging, approved operators can pass Cloudflare
 Access and then reach the normal staging controls, direct EC2-origin access to
-`/` is rejected during TLS client-certificate verification or returns the
-approved Nginx `400`/`403` denial without Cloudflare's origin-pull certificate,
+`/` is rejected during TLS client-certificate verification, rejected at the
+connection layer, or returns the approved Nginx `400`/`403` denial without
+Cloudflare's origin-pull certificate,
 direct loopback Flask access to `/` returns `403` without an Access assertion,
 external `/health/ready` is unavailable, local app and Nginx readiness
 succeed, and the

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -179,9 +179,9 @@ entry before deployment.
 
 Expected: the loopback Flask root returns `403` without an Access assertion,
 local Flask and Nginx staging readiness return exact non-redirect `200`
-responses, direct Nginx origin access fails TLS client-certificate verification
-or returns the approved Nginx `400`/`403` denial without Cloudflare's
-origin-pull client certificate, and the
+responses, direct Nginx origin access fails TLS client-certificate verification,
+rejects the connection, or returns the approved Nginx `400`/`403` denial
+without Cloudflare's origin-pull client certificate, and the
 private admin URL is reachable only from an approved tailnet path. Tailscale
 Funnel must stay disabled for SITBank admin.
 Tailscale is the private network/device boundary for admin access; it does not

--- a/docs/security/architecture/admin-and-staging-zero-trust-access.md
+++ b/docs/security/architecture/admin-and-staging-zero-trust-access.md
@@ -315,7 +315,8 @@ ssl_verify_client on;
 This server-level gate covers every public TLS location, including
 `/health/live`, and prevents a future location from omitting a copied check.
 Direct-origin connections without Cloudflare's client certificate fail the
-TLS client-certificate exchange. Nginx readiness is isolated on
+TLS client-certificate exchange or are rejected at the connection layer.
+Nginx readiness is isolated on
 `127.0.0.1:8081` and `[::1]:8081`; the public TLS `/health/ready` location
 does not proxy to Flask. The local readiness location sets the forwarded scheme
 to `https` explicitly, and the deployment wrapper requires an exact `200` plus
@@ -468,8 +469,8 @@ curl --fail http://127.0.0.1:5001/health/ready
 Expected: local readiness succeeds through loopback, a direct request to the
 Flask staging root returns `403` without an Access assertion, and direct Nginx
 origin access to `/` fails the TLS client-certificate exchange without
-Cloudflare's authenticated origin-pull client certificate or returns an
-approved Nginx `400`/`403` fail-closed denial.
+Cloudflare's authenticated origin-pull client certificate, is rejected at the
+connection layer, or returns an approved Nginx `400`/`403` fail-closed denial.
 
 The automated verification proves that the Access application and narrow
 policy match, DNS is proxied, the audience exists, unauthenticated edge traffic

--- a/docs/security/architecture/cloudflare-staging-access.md
+++ b/docs/security/architecture/cloudflare-staging-access.md
@@ -20,7 +20,8 @@ does not require or read the API token. `--apply` reconciles the Access
 application, approved-operator policy, and proxied DNS record only after the
 exact confirmation phrase. `--verify` makes read-only API calls, checks that an
 unauthenticated edge request receives the Access challenge, and proves that a
-direct request to the EC2 origin is blocked by Nginx or the network.
+direct request to the EC2 origin is blocked by Nginx, TLS client-certificate
+verification, or the network.
 
 Category: [Security architecture](../README.md#architecture).
 

--- a/ops/deploy/verify-staging-edge-boundary
+++ b/ops/deploy/verify-staging-edge-boundary
@@ -66,6 +66,10 @@ if [[ "${direct_exit}" -eq 0 && "${direct_status}" =~ ^(400|403)$ ]]; then
     echo "Staging direct origin failed closed with HTTP ${direct_status}"
     exit 0
 fi
+if [[ "${direct_exit}" -eq 7 ]]; then
+    echo "Staging direct origin failed closed by rejecting the connection"
+    exit 0
+fi
 if [[ "${direct_exit}" =~ ^(35|52|56)$ ]]; then
     echo "Staging direct origin failed closed during TLS client-certificate verification"
     exit 0

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -3219,10 +3219,12 @@ done
 if [[ "${direct}" -eq 1 ]]; then
     exit 7
 fi
-printf 'HTTP/2 302\\r\\n'
-printf 'location: https://small-boat-a77f.cloudflareaccess.com/cdn-cgi/access/login\\r\\n'
-printf 'server: cloudflare\\r\\n'
-printf 'cf-ray: fake-ray\\r\\n\\r\\n'
+printf '%s\n' \
+    'HTTP/2 302' \
+    'location: https://small-boat-a77f.cloudflareaccess.com/cdn-cgi/access/login' \
+    'server: cloudflare' \
+    'cf-ray: fake-ray' \
+    ''
 """,
         encoding="utf-8",
         newline="\n",

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import os
 import re
+import shutil
 import subprocess
 import sys
 import importlib.util
@@ -3188,6 +3189,60 @@ def test_linux_deployment_artifacts_are_forced_to_lf_and_reject_crlf():
 
     assert "Refusing to install CRLF-formatted Linux file" in bootstrap
     assert "grep -q $'\\r$'" in bootstrap
+
+
+def test_staging_edge_verifier_accepts_connection_rejection_as_fail_closed(
+    tmp_path,
+    monkeypatch,
+):
+    if shutil.which("bash") is None:
+        pytest.skip("bash is not installed")
+    bash_probe = subprocess.run(
+        ["bash", "-lc", "printf ok"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if bash_probe.returncode != 0 or bash_probe.stdout != "ok":
+        pytest.skip("bash is not usable")
+
+    fake_curl = tmp_path / "curl"
+    fake_curl.write_text(
+        """#!/usr/bin/env bash
+set -Eeuo pipefail
+direct=0
+for arg in "$@"; do
+    if [[ "${arg}" == "--resolve" ]]; then
+        direct=1
+    fi
+done
+if [[ "${direct}" -eq 1 ]]; then
+    exit 7
+fi
+printf 'HTTP/2 302\\r\\n'
+printf 'location: https://small-boat-a77f.cloudflareaccess.com/cdn-cgi/access/login\\r\\n'
+printf 'server: cloudflare\\r\\n'
+printf 'cf-ray: fake-ray\\r\\n\\r\\n'
+""",
+        encoding="utf-8",
+        newline="\n",
+    )
+    fake_curl.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{tmp_path}{os.pathsep}{os.environ['PATH']}")
+
+    result = subprocess.run(
+        [
+            "bash",
+            "ops/deploy/verify-staging-edge-boundary",
+            "staging-sitbank.pp.ua",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "failed closed by rejecting the connection" in result.stdout
 
 
 def test_certbot_host_state_verifier_enforces_host_managed_tls():


### PR DESCRIPTION
Summary
---
Fixes the post-merge staging deployment failure where the direct-origin boundary verifier rejected curl exit 7 even though connection rejection is an approved fail-closed outcome.

Why
---
The main run `28659614415` failed in `Deploy staging` after the verifier saw `curl: (7) Failed to connect to staging-sitbank.pp.ua port 443` and then reported `Staging direct origin did not fail closed`. Repo policy allows direct-origin connection rejection, TLS client-certificate failure, or HTTP 400/403 as fail-closed behavior.

What changed
---
- Accept curl exit 7 in `ops/deploy/verify-staging-edge-boundary` as direct-origin connection rejection.
- Add a fake-curl regression that reproduces the main staging failure path on Linux CI.
- Update staging deployment and access docs to list connection rejection alongside TLS and HTTP-denial outcomes.

Security impact
---
Preserves the Cloudflare Access and Authenticated Origin Pull boundary. This does not expose staging; it recognizes a stricter fail-closed network outcome as safe.

Deployment impact
---
Staging deployment fix only. No secret changes, EC2 bootstrap change, production deployment change, or database migration. The updated deployment wrapper must be installed by the normal trusted bootstrap/deploy path before the failing staging run is retried.

Verification
---
- `git diff --check`
- `.\.venv\Scripts\python.exe -m pytest -q tests\test_deployment.py::test_staging_edge_verifier_accepts_connection_rejection_as_fail_closed tests\test_deployment.py::test_linux_deployment_artifacts_are_forced_to_lf_and_reject_crlf tests\test_deployment.py::test_staging_edge_runbook_documents_operator_verification_steps tests\test_zero_trust_access_boundary.py::test_staging_nginx_blocks_direct_origin_bypass_but_keeps_local_health`
- `.\.venv\Scripts\python.exe -m pytest -q tests\test_security_docs_issue_links.py tests\test_documentation_consistency.py`
- `.\.venv\Scripts\python.exe -m pytest -q -n 4`
- `.\.venv\Scripts\python.exe -m pytest -q -n 4 --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term` (coverage 90%, `coverage.xml` generated)

Notes
---
The new bash regression skips on this Windows host because its `bash` command is a non-usable WSL shim, but it runs on Linux CI.