### PR TITLE
Fix Alloy storage for private observability

### DIFF
--- a/docs/runbooks/private-observability-grafana-loki.md
+++ b/docs/runbooks/private-observability-grafana-loki.md
@@ -41,6 +41,12 @@ Do not put passwords, tokens, API keys, webhook URLs, cookies, database URLs, or
 SMTP credentials in `observability.env`. Secret files must be `root:root` mode
 `0600`.
 
+Bootstrap also creates root-owned runtime state directories under
+`/var/lib/sitbank-observability`. Alloy keeps only its runtime state under
+`/var/lib/alloy`, backed by
+`/var/lib/sitbank-observability/alloy`, so the container can remain
+`read_only: true` while its remoting/config services have writable storage.
+
 ## Bootstrap
 
 From a reviewed checkout on EC2:
@@ -164,3 +170,8 @@ sudo ss -ltnp | grep -E ':(3000|3100)([[:space:]]|$)' && exit 1 || true
 Disabling observability must not change SITBank customer, staging, or admin app
 routing. The admin audit viewer remains backed by `SecurityAuditEvent`, not
 Loki.
+
+Rollback stops the containers but intentionally leaves
+`/var/lib/sitbank-observability/alloy` and the Grafana/Loki state directories
+in place for review or a later restart. Remove state only through a separate
+approved retention decision.

--- a/ops/deploy/bootstrap-observability-ec2
+++ b/ops/deploy/bootstrap-observability-ec2
@@ -47,8 +47,10 @@ install -d -o root -g root -m 0755 "${OBS_ROOT}/grafana/dashboards"
 install -d -o root -g root -m 0755 "${OBS_ROOT}/loki"
 install -d -o root -g root -m 0755 "${OBS_ROOT}/alloy"
 install -d -o root -g root -m 0700 "${OBS_ROOT}/secrets"
+install -d -o root -g root -m 0755 "${OBS_DATA_ROOT}"
 install -d -o 472 -g 472 -m 0750 "${OBS_DATA_ROOT}/grafana"
 install -d -o 10001 -g 10001 -m 0750 "${OBS_DATA_ROOT}/loki"
+install -d -o root -g root -m 0750 "${OBS_DATA_ROOT}/alloy"
 
 install -o root -g root -m 0644 \
     "${repo_root}/ops/observability/compose.observability.yml" \

--- a/ops/observability/compose.observability.yml
+++ b/ops/observability/compose.observability.yml
@@ -101,6 +101,7 @@ services:
     command:
       - run
       - --server.http.listen-addr=127.0.0.1:12345
+      - --storage.path=/var/lib/alloy
       - /etc/alloy/config.alloy
     volumes:
       - type: bind
@@ -125,6 +126,12 @@ services:
         source: /var/run/docker.sock
         target: /var/run/docker.sock
         read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: /var/lib/sitbank-observability/alloy
+        target: /var/lib/alloy
+        read_only: false
         bind:
           create_host_path: false
     tmpfs:

--- a/tests/test_operational_observability_deployment.py
+++ b/tests/test_operational_observability_deployment.py
@@ -98,6 +98,7 @@ def test_private_grafana_loki_alloy_deployment_files_exist_and_are_private():
     assert services["alloy"]["command"] == [
         "run",
         "--server.http.listen-addr=127.0.0.1:12345",
+        "--storage.path=/var/lib/alloy",
         "/etc/alloy/config.alloy",
     ]
     assert compose["networks"]["observability"]["internal"] is True
@@ -126,6 +127,19 @@ def test_private_grafana_loki_alloy_deployment_files_exist_and_are_private():
     assert compose["secrets"]["grafana_admin_password"]["file"] == (
         "/etc/sitbank-observability/secrets/grafana_admin_password"
     )
+
+    alloy_storage_mount = next(
+        volume
+        for volume in services["alloy"]["volumes"]
+        if volume["target"] == "/var/lib/alloy"
+    )
+    assert alloy_storage_mount == {
+        "type": "bind",
+        "source": "/var/lib/sitbank-observability/alloy",
+        "target": "/var/lib/alloy",
+        "read_only": False,
+        "bind": {"create_host_path": False},
+    }
 
 
 def test_loki_retention_and_grafana_datasource_are_configured_without_credentials():
@@ -259,10 +273,12 @@ def test_observability_bootstrap_and_docs_keep_credentials_out_of_repo():
         "/etc/sitbank-observability/observability.env",
         "/etc/sitbank-observability/secrets/grafana_admin_user",
         "/etc/sitbank-observability/secrets/grafana_admin_password",
+        "/var/lib/sitbank-observability/alloy",
         "root:root mode 0600",
         "docker compose --env-file",
         "Grafana listens only on `127.0.0.1:3000`",
         "Loki listens only on `127.0.0.1:3100`",
+        "Alloy keeps only its runtime state under `/var/lib/alloy`",
         "The admin audit viewer remains backed by `SecurityAuditEvent`, not Loki",
     ):
         assert required in normalized_combined


### PR DESCRIPTION
Summary
---
Fixes the production observability bootstrap failure where Alloy v1.17 could not create its runtime storage on a read-only container filesystem.

Why
---
The private observability compose model correctly keeps Alloy `read_only: true`, but it did not provide Alloy a writable storage path. Alloy then failed closed on EC2 with `mkdir data-alloy: read-only file system`, leaving the Grafana/Loki/Alloy stack unhealthy.

What changed
---
- Add `--storage.path=/var/lib/alloy` to the Alloy command.
- Bind `/var/lib/sitbank-observability/alloy` to `/var/lib/alloy` as Alloy's only writable state mount.
- Create the Alloy state directory during EC2 observability bootstrap with root ownership and restrictive permissions.
- Extend static deployment tests and the private observability runbook for the writable state path and rollback behavior.

Security impact
---
The private-only model is preserved. Alloy remains `read_only: true`, keeps `cap_drop: ALL` and `no-new-privileges`, publishes no host port, uses only the existing read-only Docker socket bind, and stays on the internal observability network. Grafana remains bound to `127.0.0.1:3000`, Loki remains bound to `127.0.0.1:3100`, and no public Nginx, Tailscale Serve, Funnel, secret, token, or logging exposure is added.

Deployment impact
---
EC2 observability bootstrap must be rerun from the reviewed main checkout after merge so `/etc/sitbank-observability/compose.yml` and `/var/lib/sitbank-observability/alloy` are refreshed. No database migration, application deployment, secret change, Cloudflare change, Nginx route, Tailscale Serve/Funnel change, UFW change, AWS security-group change, or public SSH change is required.

Verification
---
- `git diff --check` passed.
- `.\.venv\Scripts\python.exe -m pytest -q tests/test_operational_observability_deployment.py` -> 30 passed.
- `.\.venv\Scripts\python.exe -m pytest -q -n auto` -> 1338 passed, 15 skipped.
- `.\.venv\Scripts\python.exe -m pytest -q -n auto --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term` -> 1338 passed, 15 skipped; total coverage 90%; `ops\observability\verify-private-observability` 100%.

Notes
---
Do not merge until the maintainer approves. After merge, rerun the trusted observability bootstrap and the EC2-local checks before continuing private Grafana access setup.