### PR TITLE
Fix observability loopback network

### DIFF
--- a/docs/runbooks/private-observability-grafana-loki.md
+++ b/docs/runbooks/private-observability-grafana-loki.md
@@ -8,12 +8,20 @@ Grafana Alloy stack from `ops/observability/`.
 - Grafana binds to `127.0.0.1:3000` on the EC2 host.
 - Loki binds to `127.0.0.1:3100` on the EC2 host.
 - Alloy does not publish a host port.
+- Grafana and Loki also join `sitbank-observability-loopback`.
+  `sitbank-observability-loopback` is a bridge network used only for Docker's
+  host-loopback port publishing. The private boundary is the explicit
+  `127.0.0.1` host binding plus no public Nginx/Tailscale Funnel route.
+- `sitbank-observability` remains an internal service network for
+  container-to-container traffic.
 - Normal operator access uses a private Tailscale path such as
   `https://grafana-sitbank.tailca101b.ts.net/` mapped to local Grafana.
 - SSH local port forwarding is allowed only for bootstrap or break-glass
   troubleshooting.
 - No public Nginx production, staging, customer, or admin route proxies Grafana,
   Loki, or Alloy.
+- Private browser access must use SSH local forwarding or a reviewed private
+  Tailscale access design, not public Nginx.
 - The SITBank Flask and admin runtimes do not receive Grafana credentials, Loki
   credentials, datasource credentials, or broad log-reader credentials.
 
@@ -101,18 +109,32 @@ The protected workflow is live network-path evidence. It is not a pull-request
 check and must never run on forks, untrusted branches, or public GitHub-hosted
 TLS jobs.
 
+When running the verifier directly on EC2, pass `--verify-host-loopback` to
+include the local Grafana and Loki readiness checks in the sanitized evidence.
+Do not use that flag from a GitHub-hosted runner because `127.0.0.1` would be
+the runner, not the EC2 host.
+
 ### Host Checks
 
 ```bash
 sudo docker compose --env-file /etc/sitbank-observability/observability.env -f /etc/sitbank-observability/compose.yml ps
-sudo ss -ltnp | grep -E ':(3000|3100)([[:space:]]|$)'
-curl -fsS http://127.0.0.1:3100/ready
+sudo docker network inspect sitbank-observability --format '{{.Internal}}'
+sudo docker network inspect sitbank-observability-loopback --format '{{.Internal}}'
+sudo docker port sitbank-grafana 3000/tcp
+sudo docker port sitbank-loki 3100/tcp
+test -z "$(sudo docker port sitbank-alloy)"
+sudo ss -ltnp | grep -E '127\.0\.0\.1:(3000|3100)([[:space:]]|$)'
+sudo ss -ltnp | grep -E '0\.0\.0\.0:(3000|3100)|\[::\]:(3000|3100)|\*:(3000|3100)' && exit 1 || true
 curl -fsSI http://127.0.0.1:3000/login
+curl -fsS http://127.0.0.1:3100/ready
 sudo nginx -T | grep -iE 'grafana|loki' && exit 1 || true
 ```
 
 Expected:
 
+- `sitbank-observability` reports `true` for `Internal`.
+- `sitbank-observability-loopback` reports `false` for `Internal` so Docker's
+  host-loopback port publishing works on EC2.
 - Grafana listens only on `127.0.0.1:3000`.
 - Loki listens only on `127.0.0.1:3100`.
 - Alloy publishes no host listener.

--- a/ops/observability/compose.observability.yml
+++ b/ops/observability/compose.observability.yml
@@ -52,6 +52,7 @@ services:
     pids_limit: 256
     mem_limit: 512m
     networks:
+      - host-loopback
       - observability
     depends_on:
       - loki
@@ -89,6 +90,7 @@ services:
     pids_limit: 256
     mem_limit: 768m
     networks:
+      - host-loopback
       - observability
 
   alloy:
@@ -154,6 +156,11 @@ secrets:
     file: /etc/sitbank-observability/secrets/grafana_admin_password
 
 networks:
+  host-loopback:
+    name: sitbank-observability-loopback
+    driver: bridge
+    internal: false
   observability:
     name: sitbank-observability
+    driver: bridge
     internal: true

--- a/ops/observability/verify-private-observability
+++ b/ops/observability/verify-private-observability
@@ -37,6 +37,10 @@ SECRET_MARKERS = (
     "x-grafana-org-id",
 )
 PUBLIC_EXPOSURE_PATHS = ("/grafana", "/loki", "/logs", "/metrics")
+HOST_LOOPBACK_READINESS_TARGETS = (
+    ("grafana_host_loopback_login", "http://127.0.0.1:3000/login"),
+    ("loki_host_loopback_ready", "http://127.0.0.1:3100/ready"),
+)
 
 
 class VerificationError(RuntimeError):
@@ -230,6 +234,26 @@ def verify_private_grafana(
     return checks
 
 
+def verify_host_loopback_readiness(runner: Runner) -> list[dict[str, str]]:
+    checks: list[dict[str, str]] = []
+    failures: list[str] = []
+    for name, url in HOST_LOOPBACK_READINESS_TARGETS:
+        status, _headers = _curl_status_headers(runner, url)
+        checks.append(
+            {
+                "name": name,
+                "result": "pass" if status == "200" else "fail",
+                "target": _safe_url_label(url),
+                "http_status": status,
+            }
+        )
+        if status != "200":
+            failures.append(f"{_safe_url_label(url)} did not return HTTP 200")
+    if failures:
+        raise VerificationError("\n".join(failures))
+    return checks
+
+
 def verify_public_denials(
     runner: Runner,
     public_urls: Sequence[str],
@@ -312,6 +336,11 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
             "observability-evidence/private-observability.json",
         ),
     )
+    parser.add_argument(
+        "--verify-host-loopback",
+        action="store_true",
+        help="Also verify EC2-local Grafana and Loki loopback readiness.",
+    )
     return parser.parse_args(argv)
 
 
@@ -325,6 +354,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         public_urls = [_validate_public_probe_url(url) for url in public_urls]
         token = os.environ.get("GRAFANA_HEALTH_TOKEN", "")
         checks = [
+            *(
+                verify_host_loopback_readiness(run_command)
+                if args.verify_host_loopback
+                else []
+            ),
             *verify_private_grafana(run_command, grafana_url, token),
             *verify_public_denials(run_command, public_urls),
         ]

--- a/tests/test_operational_observability_deployment.py
+++ b/tests/test_operational_observability_deployment.py
@@ -101,10 +101,24 @@ def test_private_grafana_loki_alloy_deployment_files_exist_and_are_private():
         "--storage.path=/var/lib/alloy",
         "/etc/alloy/config.alloy",
     ]
-    assert compose["networks"]["observability"]["internal"] is True
+    assert services["grafana"]["networks"] == ["host-loopback", "observability"]
+    assert services["loki"]["networks"] == ["host-loopback", "observability"]
+    assert services["alloy"]["networks"] == ["observability"]
+    assert compose["networks"]["host-loopback"] == {
+        "name": "sitbank-observability-loopback",
+        "driver": "bridge",
+        "internal": False,
+    }
+    assert compose["networks"]["observability"] == {
+        "name": "sitbank-observability",
+        "driver": "bridge",
+        "internal": True,
+    }
 
     for service_name, service in services.items():
         assert "0.0.0.0:" not in str(service.get("ports", []))
+        assert "[::]:" not in str(service.get("ports", []))
+        assert "*:" not in str(service.get("ports", []))
         assert service["restart"] == "unless-stopped"
         assert service["security_opt"] == ["no-new-privileges:true"]
         assert service["cap_drop"] == ["ALL"]
@@ -278,6 +292,8 @@ def test_observability_bootstrap_and_docs_keep_credentials_out_of_repo():
         "docker compose --env-file",
         "Grafana listens only on `127.0.0.1:3000`",
         "Loki listens only on `127.0.0.1:3100`",
+        "`sitbank-observability-loopback` is a bridge network used only for "
+        "Docker's host-loopback port publishing",
         "Alloy keeps only its runtime state under `/var/lib/alloy`",
         "The admin audit viewer remains backed by `SecurityAuditEvent`, not Loki",
     ):
@@ -669,6 +685,44 @@ def test_verify_private_grafana_fails_closed_for_unsafe_grafana_states():
             )
 
 
+def test_verify_host_loopback_readiness_requires_local_grafana_and_loki():
+    module = _load_verifier_module()
+
+    def ready_runner(arguments):
+        url = tuple(arguments)[-1]
+        if url == "http://127.0.0.1:3000/login":
+            return _status_headers(module, "200")
+        if url == "http://127.0.0.1:3100/ready":
+            return _status_headers(module, "200")
+        raise AssertionError(arguments)
+
+    assert module["verify_host_loopback_readiness"](ready_runner) == [
+        {
+            "name": "grafana_host_loopback_login",
+            "result": "pass",
+            "target": "127.0.0.1/login",
+            "http_status": "200",
+        },
+        {
+            "name": "loki_host_loopback_ready",
+            "result": "pass",
+            "target": "127.0.0.1/ready",
+            "http_status": "200",
+        },
+    ]
+
+    def failing_runner(arguments):
+        url = tuple(arguments)[-1]
+        if url == "http://127.0.0.1:3000/login":
+            return _status_headers(module, "200")
+        if url == "http://127.0.0.1:3100/ready":
+            return module["CommandResult"](7, "", "connection refused")
+        raise AssertionError(arguments)
+
+    with pytest.raises(module["VerificationError"], match="127.0.0.1/ready"):
+        module["verify_host_loopback_readiness"](failing_runner)
+
+
 def test_verify_public_denials_accepts_closed_statuses_and_sanitizes_records():
     module = _load_verifier_module()
     statuses = {
@@ -799,12 +853,14 @@ def test_parse_args_restricts_target_environment_and_accepts_overrides(tmp_path)
             "https://sitbank.pp.ua/grafana",
             "--evidence-file",
             str(evidence_path),
+            "--verify-host-loopback",
         ]
     )
     assert args.target_environment == "production"
     assert args.grafana_url == PRIVATE_GRAFANA_URL
     assert args.public_probe_url == ["https://sitbank.pp.ua/grafana"]
     assert args.evidence_file == str(evidence_path)
+    assert args.verify_host_loopback is True
 
     with pytest.raises(SystemExit):
         module["parse_args"](["--target-environment", "development"])
@@ -823,6 +879,11 @@ def test_main_success_uses_env_and_writes_evidence_override(
         command = tuple(arguments)
         calls.append(command)
         url = command[-1]
+        if url in {
+            "http://127.0.0.1:3000/login",
+            "http://127.0.0.1:3100/ready",
+        }:
+            return _status_headers(module, "200")
         if url.startswith(PRIVATE_GRAFANA_URL):
             return grafana_runner(command)
         return _status_headers(module, "404")
@@ -840,6 +901,7 @@ def test_main_success_uses_env_and_writes_evidence_override(
         [
             "--target-environment",
             "production",
+            "--verify-host-loopback",
             "--evidence-file",
             str(evidence_path),
         ]
@@ -851,6 +913,10 @@ def test_main_success_uses_env_and_writes_evidence_override(
     assert captured.err == ""
     assert evidence["target_environment"] == "production"
     assert evidence["private_grafana_host"] == "grafana-sitbank.tailca101b.ts.net"
+    assert {
+        "grafana_host_loopback_login",
+        "loki_host_loopback_ready",
+    } <= {check["name"] for check in evidence["checks"]}
     assert FAKE_GRAFANA_TOKEN not in evidence_path.read_text(encoding="utf-8")
     assert any(f"Authorization: Bearer {FAKE_GRAFANA_TOKEN}" in call for call in calls)
 


### PR DESCRIPTION
Summary
---
Fixes the private observability network model so Grafana and Loki can be reached from the EC2 host loopback while remaining unavailable on public interfaces.

Why
---
After the Alloy storage fix, the observability containers stayed running but host-local readiness still failed for `http://127.0.0.1:3000/login` and `http://127.0.0.1:3100/ready`. The EC2 evidence showed loopback port publication was not usable while Grafana and Loki were attached only to an `internal: true` Docker network.

What changed
---
- Add a separate `sitbank-observability-loopback` bridge network for Grafana and Loki host-loopback port publishing.
- Keep `sitbank-observability` as an internal service network, with Alloy attached only to that internal network.
- Keep Grafana bound only to `127.0.0.1:3000`, Loki bound only to `127.0.0.1:3100`, and Alloy with no published host port.
- Add optional `--verify-host-loopback` checks to the private observability verifier for EC2-local Grafana/Loki readiness evidence.
- Update static tests and the runbook for the split-network model and EC2 verification commands.

Security impact
---
The private-only model is preserved. This PR does not add public Nginx routes, Tailscale Serve, Tailscale Funnel, public SSH, Cloudflare changes, firewall changes, secrets, or token handling changes. Grafana and Loki remain host-loopback only, Alloy still publishes no host port, the Docker socket bind remains the existing reviewed read-only bind, and container hardening remains `read_only`, `cap_drop: ALL`, and `no-new-privileges`.

Deployment impact
---
Production observability bootstrap must be rerun from merged `main` so `/etc/sitbank-observability/compose.yml` receives the split-network model. No database migration, app runtime deployment, secret change, Cloudflare change, Nginx route, Tailscale Serve/Funnel change, UFW change, AWS security-group change, or public SSH change is required.

Verification
---
- `docker compose -f ops\observability\compose.observability.yml config --format json` rendered Grafana and Loki with `host_ip: 127.0.0.1` published ports, Alloy with no ports, `sitbank-observability` internal, and `sitbank-observability-loopback` as the non-internal bridge for loopback publishing.
- `git diff --check` passed.
- `.\.venv\Scripts\python.exe -m pytest -q tests/test_operational_observability_deployment.py` -> 31 passed.
- `.\.venv\Scripts\python.exe -m pytest -q -n auto` -> 1339 passed, 15 skipped.
- `.\.venv\Scripts\python.exe -m pytest -q -n auto --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term` -> 1339 passed, 15 skipped; total coverage 90%; `ops\observability\verify-private-observability` 100%.

Notes
---
The Nginx log permission and Alloy journal parser warnings are not changed here because they are separate from host-loopback reachability. Track them as a follow-up unless they still block readiness after this network fix is deployed.