### PR TITLE
Fix Alloy host log access

### DIFF
--- a/docs/runbooks/private-observability-grafana-loki.md
+++ b/docs/runbooks/private-observability-grafana-loki.md
@@ -55,6 +55,19 @@ Bootstrap also creates root-owned runtime state directories under
 `/var/lib/sitbank-observability/alloy`, so the container can remain
 `read_only: true` while its remoting/config services have writable storage.
 
+Bootstrap resolves the host `adm` and `systemd-journal` numeric GIDs with
+`getent` and writes only these non-secret values to `observability.env`:
+
+```text
+ALLOY_NGINX_LOG_GROUP_ID=<host-adm-gid>
+ALLOY_JOURNAL_GROUP_ID=<host-systemd-journal-gid>
+```
+
+Compose passes those values to Alloy through `group_add`. Nginx log files
+remain `0640` and group-readable by `adm`; Journal files remain group-readable
+by `systemd-journal`. Do not chmod host logs to `0644`, make logs
+world-readable, or add broad host users/groups to work around collector access.
+
 ## Bootstrap
 
 From a reviewed checkout on EC2:
@@ -153,6 +166,12 @@ Alloy collects only:
 The collector labels are coarse and non-secret: `service`, `environment`,
 `host_role`, and `source`.
 
+Alloy reads each allowlisted systemd unit through its own
+`loki.source.journal` block with a single exact `_SYSTEMD_UNIT=<unit>` match.
+The journal sources read the mounted `/var/log/journal` path. Do not use `OR`
+or `+` expressions in journal `matches`; Alloy supports exact field matches
+and combines multiple matches as logical AND.
+
 Alloy redacts recognized authorization, cookie, CSRF, session, password,
 token, secret, TOTP, recovery-code, database URL, SMTP credential, API key,
 webhook URL, Cloudflare token, Tailscale key, and SSH key fields before writing
@@ -165,6 +184,25 @@ transcripts, secret files, request bodies, authorization headers, cookies, CSRF
 tokens, session IDs, reset links, TOTP values, recovery codes, database URLs,
 SMTP credentials, Cloudflare tokens, Tailscale keys, SSH keys, or raw provider
 exports to collector paths.
+
+Verify only labels and sanitized samples when checking Loki. Do not paste raw
+log bodies into issues or chat:
+
+```bash
+curl -fsS http://127.0.0.1:3100/loki/api/v1/label/source/values
+curl -fsS http://127.0.0.1:3100/loki/api/v1/label/service/values
+curl -fsG http://127.0.0.1:3100/loki/api/v1/query_range \
+  --data-urlencode 'query={source="nginx_access"}' \
+  --data-urlencode 'limit=5'
+curl -fsG http://127.0.0.1:3100/loki/api/v1/query_range \
+  --data-urlencode 'query={source="systemd"}' \
+  --data-urlencode 'limit=5'
+```
+
+Expected stream labels include `source="nginx_access"`,
+`source="nginx_error"`, `source="container"`, and `source="systemd"` after
+matching activity occurs. Systemd streams are limited to
+`sitbank-security-alerts`, `certbot`, and `docker`.
 
 ## Retention
 
@@ -197,3 +235,9 @@ Rollback stops the containers but intentionally leaves
 `/var/lib/sitbank-observability/alloy` and the Grafana/Loki state directories
 in place for review or a later restart. Remove state only through a separate
 approved retention decision.
+
+The generated `ALLOY_NGINX_LOG_GROUP_ID` and `ALLOY_JOURNAL_GROUP_ID` entries
+are non-secret and inert after the containers stop. If observability is
+permanently disabled, remove those two lines with `sudoedit` only after the
+stack is down; do not alter `/var/log/nginx` or journal file modes as part of
+rollback.

--- a/ops/deploy/bootstrap-observability-ec2
+++ b/ops/deploy/bootstrap-observability-ec2
@@ -13,6 +13,59 @@ usage() {
     echo "Usage: bootstrap-observability-ec2 [repo-root]" >&2
 }
 
+host_group_gid() {
+    local group_name="$1"
+    local purpose="$2"
+    local group_entry gid
+
+    if ! group_entry="$(getent group "${group_name}")"; then
+        echo "Missing required host group for ${purpose}: ${group_name}" >&2
+        exit 1
+    fi
+
+    gid="${group_entry#*:}"
+    gid="${gid#*:}"
+    gid="${gid%%:*}"
+    if [[ ! "${gid}" =~ ^[0-9]+$ ]]; then
+        echo "Could not resolve a numeric GID for host group: ${group_name}" >&2
+        exit 1
+    fi
+    printf '%s' "${gid}"
+}
+
+set_observability_env_value() {
+    local key="$1"
+    local value="$2"
+    local tmp mode owner group
+
+    if [[ ! "${key}" =~ ^[A-Z0-9_]+$ || ! "${value}" =~ ^[0-9]+$ ]]; then
+        echo "Invalid generated observability environment value for ${key}" >&2
+        exit 1
+    fi
+
+    mode="$(stat -c '%a' -- "${OBS_ENV_FILE}")"
+    owner="$(stat -c '%U' -- "${OBS_ENV_FILE}")"
+    group="$(stat -c '%G' -- "${OBS_ENV_FILE}")"
+    tmp="$(mktemp "${OBS_ENV_FILE}.XXXXXX")"
+    awk -v key="${key}" -v value="${value}" '
+        BEGIN { found = 0 }
+        $0 ~ "^" key "=" {
+            print key "=" value
+            found = 1
+            next
+        }
+        { print }
+        END {
+            if (found == 0) {
+                print key "=" value
+            }
+        }
+    ' "${OBS_ENV_FILE}" >"${tmp}"
+    chown "${owner}:${group}" "${tmp}"
+    chmod "${mode}" "${tmp}"
+    mv -f "${tmp}" "${OBS_ENV_FILE}"
+}
+
 if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
     usage
     exit 0
@@ -94,6 +147,11 @@ if grep -Eiq '(password|token|secret|key)[[:space:]]*=' "${OBS_ENV_FILE}"; then
     echo "${OBS_ENV_FILE} must contain non-secret image references and private URL settings only." >&2
     exit 1
 fi
+
+alloy_nginx_log_gid="$(host_group_gid adm "Nginx log files")"
+alloy_journal_gid="$(host_group_gid systemd-journal "systemd journal files")"
+set_observability_env_value ALLOY_NGINX_LOG_GROUP_ID "${alloy_nginx_log_gid}"
+set_observability_env_value ALLOY_JOURNAL_GROUP_ID "${alloy_journal_gid}"
 
 docker compose --env-file "${OBS_ENV_FILE}" -f "${OBS_COMPOSE_FILE}" config >/dev/null
 docker compose --env-file "${OBS_ENV_FILE}" -f "${OBS_COMPOSE_FILE}" up -d

--- a/ops/observability/alloy/config.alloy
+++ b/ops/observability/alloy/config.alloy
@@ -76,11 +76,38 @@ loki.source.docker "sitbank_containers" {
   forward_to = [loki.process.redact_sensitive.receiver]
 }
 
-loki.source.journal "sitbank_systemd" {
+loki.source.journal "sitbank_security_alerts" {
+  path = "/var/log/journal"
   max_age = "12h"
-  matches = "_SYSTEMD_UNIT=sitbank-security-alerts.service OR _SYSTEMD_UNIT=certbot.service OR _SYSTEMD_UNIT=docker.service"
+  matches = "_SYSTEMD_UNIT=sitbank-security-alerts.service"
   labels = {
-    service = "sitbank-systemd",
+    service = "sitbank-security-alerts",
+    environment = "production",
+    host_role = "edge",
+    source = "systemd",
+  }
+  forward_to = [loki.process.redact_sensitive.receiver]
+}
+
+loki.source.journal "certbot" {
+  path = "/var/log/journal"
+  max_age = "12h"
+  matches = "_SYSTEMD_UNIT=certbot.service"
+  labels = {
+    service = "certbot",
+    environment = "production",
+    host_role = "edge",
+    source = "systemd",
+  }
+  forward_to = [loki.process.redact_sensitive.receiver]
+}
+
+loki.source.journal "docker" {
+  path = "/var/log/journal"
+  max_age = "12h"
+  matches = "_SYSTEMD_UNIT=docker.service"
+  labels = {
+    service = "docker",
     environment = "production",
     host_role = "edge",
     source = "systemd",

--- a/ops/observability/compose.observability.yml
+++ b/ops/observability/compose.observability.yml
@@ -97,6 +97,9 @@ services:
     image: ${ALLOY_IMAGE:?ALLOY_IMAGE must be an immutable digest reference}
     container_name: sitbank-alloy
     user: "0:0"
+    group_add:
+      - "${ALLOY_NGINX_LOG_GROUP_ID:?ALLOY_NGINX_LOG_GROUP_ID must be rendered by bootstrap from the host adm group}"
+      - "${ALLOY_JOURNAL_GROUP_ID:?ALLOY_JOURNAL_GROUP_ID must be rendered by bootstrap from the host systemd-journal group}"
     read_only: true
     init: true
     restart: unless-stopped

--- a/tests/test_operational_observability_deployment.py
+++ b/tests/test_operational_observability_deployment.py
@@ -92,18 +92,23 @@ def test_private_grafana_loki_alloy_deployment_files_exist_and_are_private():
     services = compose["services"]
 
     assert set(services) == {"grafana", "loki", "alloy"}
+    alloy = services["alloy"]
     assert services["grafana"]["ports"] == ["127.0.0.1:3000:3000"]
     assert services["loki"]["ports"] == ["127.0.0.1:3100:3100"]
-    assert "ports" not in services["alloy"]
-    assert services["alloy"]["command"] == [
+    assert "ports" not in alloy
+    assert alloy["command"] == [
         "run",
         "--server.http.listen-addr=127.0.0.1:12345",
         "--storage.path=/var/lib/alloy",
         "/etc/alloy/config.alloy",
     ]
+    assert alloy["group_add"] == [
+        "${ALLOY_NGINX_LOG_GROUP_ID:?ALLOY_NGINX_LOG_GROUP_ID must be rendered by bootstrap from the host adm group}",
+        "${ALLOY_JOURNAL_GROUP_ID:?ALLOY_JOURNAL_GROUP_ID must be rendered by bootstrap from the host systemd-journal group}",
+    ]
     assert services["grafana"]["networks"] == ["host-loopback", "observability"]
     assert services["loki"]["networks"] == ["host-loopback", "observability"]
-    assert services["alloy"]["networks"] == ["observability"]
+    assert alloy["networks"] == ["observability"]
     assert compose["networks"]["host-loopback"] == {
         "name": "sitbank-observability-loopback",
         "driver": "bridge",
@@ -144,7 +149,7 @@ def test_private_grafana_loki_alloy_deployment_files_exist_and_are_private():
 
     alloy_storage_mount = next(
         volume
-        for volume in services["alloy"]["volumes"]
+        for volume in alloy["volumes"]
         if volume["target"] == "/var/lib/alloy"
     )
     assert alloy_storage_mount == {
@@ -193,6 +198,17 @@ def test_loki_retention_and_grafana_datasource_are_configured_without_credential
 
 def test_alloy_collects_only_approved_sources_and_redacts_sensitive_patterns():
     alloy = (OBS_ROOT / "alloy" / "config.alloy").read_text(encoding="utf-8")
+    journal_matches = re.findall(r'matches = "([^"]+)"', alloy)
+
+    assert set(journal_matches) == {
+        "_SYSTEMD_UNIT=sitbank-security-alerts.service",
+        "_SYSTEMD_UNIT=certbot.service",
+        "_SYSTEMD_UNIT=docker.service",
+    }
+    for journal_match in journal_matches:
+        assert " OR " not in journal_match
+        assert "+" not in journal_match
+        assert re.fullmatch(r"_SYSTEMD_UNIT=[A-Za-z0-9_.@-]+", journal_match)
 
     for required in (
         '/var/log/nginx/sitbank.access.log',
@@ -206,6 +222,10 @@ def test_alloy_collects_only_approved_sources_and_redacts_sensitive_patterns():
         'target_label = "environment"',
         'target_label = "host_role"',
         'replacement = "container"',
+        'loki.source.journal "sitbank_security_alerts"',
+        'loki.source.journal "certbot"',
+        'loki.source.journal "docker"',
+        'path = "/var/log/journal"',
         "_SYSTEMD_UNIT=sitbank-security-alerts.service",
         "_SYSTEMD_UNIT=certbot.service",
         "_SYSTEMD_UNIT=docker.service",
@@ -288,10 +308,17 @@ def test_observability_bootstrap_and_docs_keep_credentials_out_of_repo():
         "/etc/sitbank-observability/secrets/grafana_admin_user",
         "/etc/sitbank-observability/secrets/grafana_admin_password",
         "/var/lib/sitbank-observability/alloy",
+        "ALLOY_NGINX_LOG_GROUP_ID",
+        "ALLOY_JOURNAL_GROUP_ID",
+        "getent group",
+        "host_group_gid adm \"Nginx log files\"",
+        "host_group_gid systemd-journal \"systemd journal files\"",
         "root:root mode 0600",
         "docker compose --env-file",
         "Grafana listens only on `127.0.0.1:3000`",
         "Loki listens only on `127.0.0.1:3100`",
+        "Nginx log files remain `0640` and group-readable by `adm`",
+        "Journal files remain group-readable by `systemd-journal`",
         "`sitbank-observability-loopback` is a bridge network used only for "
         "Docker's host-loopback port publishing",
         "Alloy keeps only its runtime state under `/var/lib/alloy`",
@@ -302,6 +329,11 @@ def test_observability_bootstrap_and_docs_keep_credentials_out_of_repo():
     assert "cat \"${secret_file}\"" not in bootstrap
     assert "printenv" not in bootstrap
     assert "env |" not in bootstrap
+    assert "chmod 644" not in bootstrap
+    assert "chmod 0644 /var/log" not in bootstrap
+    assert "chmod -R" not in bootstrap
+    assert "chown -R" not in bootstrap
+    assert "usermod" not in bootstrap
     assert "GF_SECURITY_ADMIN_PASSWORD=" not in combined
     assert "loki_" + "token=" not in combined.casefold()
     assert "datasource_" + "password=" not in combined.casefold()


### PR DESCRIPTION
Summary
---
Fixes private observability host log collection so Alloy can read approved Nginx and systemd journal sources without making host logs world-readable.

Why
---
Production Alloy was running and container log collection worked, but Nginx file tailers failed with permission denied and the journal source failed because its `matches` value used an unsupported OR expression. The host logs are intentionally group-readable only, so Alloy needs least-privilege group access rather than broader file modes.

What changed
---
- Add Alloy `group_add` entries driven by non-secret `ALLOY_NGINX_LOG_GROUP_ID` and `ALLOY_JOURNAL_GROUP_ID` values.
- Update observability bootstrap to resolve host `adm` and `systemd-journal` GIDs with `getent` and idempotently write those numeric values to `observability.env`.
- Split Alloy journal collection into one exact `_SYSTEMD_UNIT=<unit>` source per approved unit and set the mounted `/var/log/journal` path explicitly.
- Update static tests for host log access, unsupported journal OR syntax, unchanged private port bindings, and no public Nginx observability routes.
- Update the private observability runbook with permission handling, Loki label checks, and rollback notes.

Security impact
---
This keeps Nginx and journal files non-world-readable and does not chmod logs to `0644`. Grafana remains bound only to `127.0.0.1:3000`, Loki remains bound only to `127.0.0.1:3100`, Alloy still publishes no host port, and no public Nginx route, Tailscale Serve, Funnel, secret, token, or Docker socket broadening is added. Alloy keeps `read_only: true`, `cap_drop: ALL`, and `no-new-privileges`.

Deployment impact
---
Production observability bootstrap must be rerun from merged `main` so `/etc/sitbank-observability/compose.yml`, `/etc/sitbank-observability/alloy/config.alloy`, and the non-secret `ALLOY_*_GROUP_ID` env entries are refreshed. No database migration, app runtime deployment, secret change, Cloudflare change, Nginx route, Tailscale Serve/Funnel change, UFW change, AWS security-group change, or public SSH change is required.

Verification
---
- Official Grafana Alloy journal docs checked for `matches` syntax and journal group access guidance: https://grafana.com/docs/alloy/latest/reference/components/loki/loki.source.journal/
- `docker compose -f ops\observability\compose.observability.yml config --format json` rendered Alloy with numeric `group_add` values, no Alloy host ports, Grafana/Loki loopback ports unchanged, and the internal observability network unchanged.
- `git diff --check` passed.
- `.\.venv\Scripts\python.exe -m pytest -q tests/test_operational_observability_deployment.py` -> 31 passed.
- `.\.venv\Scripts\python.exe -m pytest -q -n auto` -> 1339 passed, 15 skipped.
- `.\.venv\Scripts\python.exe -m pytest -q -n auto --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term` -> 1339 passed, 15 skipped; total coverage 90%; `ops\observability\verify-private-observability` 100%.
- Git Bash `bash -n ops/deploy/bootstrap-observability-ec2` passed. `shellcheck` was not installed locally.

Notes
---
Do not merge until approved. After merge and bootstrap, verify Loki labels for `source=nginx_access`, `source=nginx_error`, `source=container`, and `source=systemd` without pasting raw log bodies into issues or chat.