### PR TITLE
Document private Grafana Serve access

### DIFF
--- a/docs/runbooks/private-observability-grafana-loki.md
+++ b/docs/runbooks/private-observability-grafana-loki.md
@@ -43,11 +43,23 @@ GRAFANA_IMAGE=example.invalid/grafana@sha256:<reviewed-digest>
 LOKI_IMAGE=example.invalid/loki@sha256:<reviewed-digest>
 ALLOY_IMAGE=example.invalid/alloy@sha256:<reviewed-digest>
 GRAFANA_PRIVATE_ROOT_URL=https://grafana-sitbank.tailca101b.ts.net/
+GRAFANA_SERVE_FROM_SUB_PATH=false
 ```
 
 Do not put passwords, tokens, API keys, webhook URLs, cookies, database URLs, or
 SMTP credentials in `observability.env`. Secret files must be `root:root` mode
 `0600`.
+
+For the reviewed Tailscale Serve path model, change only the non-secret
+Grafana URL settings before rerunning observability bootstrap:
+
+```text
+GRAFANA_PRIVATE_ROOT_URL=https://admin-sitbank.tailca101b.ts.net/grafana/
+GRAFANA_SERVE_FROM_SUB_PATH=true
+```
+
+Keep `GRAFANA_SERVE_FROM_SUB_PATH=false` when Grafana is served at a private
+hostname root such as `https://grafana-sitbank.tailca101b.ts.net/`.
 
 Bootstrap also creates root-owned runtime state directories under
 `/var/lib/sitbank-observability`. Alloy keeps only its runtime state under
@@ -153,6 +165,100 @@ Expected:
 - Alloy publishes no host listener.
 - Public SITBank Nginx configs contain no Grafana or Loki route.
 - The private Tailscale URL reaches Grafana only for approved operators.
+
+### Private Tailscale Serve Browser Access Plan
+
+The preferred convenient browser path is
+`https://admin-sitbank.tailca101b.ts.net/grafana/`, served by Tailscale Serve
+from the existing private admin tailnet hostname to Grafana's loopback
+listener at `http://127.0.0.1:3000`. This keeps Grafana behind the same private
+tailnet access boundary as the admin app and avoids a public DNS hostname.
+
+Do not run these commands until an approved operator has confirmed the live
+Serve configuration. Tailscale Serve supports path mounts with `--set-path` and
+local reverse-proxy targets, while Tailscale Funnel is the public sharing mode;
+Funnel must remain disabled. The backend target must stay on localhost.
+
+Preflight on EC2:
+
+```bash
+sudo tailscale status --json | jq -r '.BackendState'
+sudo tailscale serve status
+sudo tailscale serve status --json | jq .
+sudo tailscale funnel status --json | jq .
+sudo /usr/local/sbin/verify-tailscale-admin-access --mode serve
+curl -fsSI http://127.0.0.1:3000/login
+curl -fsS http://127.0.0.1:3100/ready
+sudo nginx -T | grep -iE 'grafana|loki' && exit 1 || true
+```
+
+Expected before change:
+
+- Tailscale backend is `Running`.
+- Funnel status proves Funnel is disabled.
+- Existing Serve config contains the approved admin root mapping to
+  `http://127.0.0.1:5002` and no unexpected public or stale handlers.
+- Grafana and Loki are healthy on host loopback.
+- Public Nginx still has no Grafana or Loki route.
+
+If the current Serve status is missing the admin root mapping, contains
+unexpected handlers, or does not prove Funnel is disabled, stop and repair the
+admin Tailscale configuration first. Do not reset the entire Serve
+configuration as a shortcut because that can remove the admin root mapping.
+
+After updating `observability.env` to the `/grafana/` root URL and
+`GRAFANA_SERVE_FROM_SUB_PATH=true`, rerun
+`sudo ops/deploy/bootstrap-observability-ec2 "$(pwd)"`, then add the path
+mapping:
+
+```bash
+sudo tailscale serve --bg --https=443 --set-path=/grafana http://127.0.0.1:3000
+```
+
+Verification:
+
+```bash
+sudo tailscale serve status
+sudo tailscale serve status --json | jq .
+sudo tailscale funnel status --json | jq .
+curl -fsSI http://127.0.0.1:3000/login
+curl -fsS http://127.0.0.1:3100/ready
+curl -fsSI https://admin-sitbank.tailca101b.ts.net/grafana/login
+curl -fsSI https://sitbank.pp.ua/grafana
+curl -fsSI https://sitbank.pp.ua/loki
+curl -fsSI https://staging-sitbank.pp.ua/grafana
+sudo ss -ltnp | grep -E '0\.0\.0\.0:(3000|3100)|\[::\]:(3000|3100)|\*:(3000|3100)' && exit 1 || true
+sudo nginx -T | grep -iE 'grafana|loki' && exit 1 || true
+```
+
+Expected after change:
+
+- `https://admin-sitbank.tailca101b.ts.net/grafana/` reaches Grafana only from
+  approved tailnet clients.
+- `https://admin-sitbank.tailca101b.ts.net/` still reaches the admin app.
+- Funnel remains disabled.
+- Loki is not served directly.
+- Public SITBank hostnames do not expose Grafana or Loki.
+- No `0.0.0.0`, public IPv4, or public IPv6 listener exists for ports `3000`
+  or `3100`.
+
+Rollback the Grafana path only:
+
+```bash
+sudo tailscale serve --https=443 --set-path=/grafana off
+sudo tailscale serve status
+sudo /usr/local/sbin/verify-tailscale-admin-access --mode serve
+```
+
+Then set `GRAFANA_PRIVATE_ROOT_URL` back to the reviewed private hostname root
+or temporary SSH-forwarding URL model, set `GRAFANA_SERVE_FROM_SUB_PATH=false`,
+and rerun observability bootstrap. Rollback must preserve the admin root Serve
+mapping, leave Funnel disabled, and avoid any public Nginx or firewall change.
+
+Alternative design: a separate private `grafana-sitbank.tailca101b.ts.net`
+Serve hostname avoids path-prefix behavior but requires separate hostname/tag
+and ACL review. Do not implement that alternative without a separate reviewed
+automation change.
 
 ## Approved Log Sources
 

--- a/ops/observability/compose.observability.yml
+++ b/ops/observability/compose.observability.yml
@@ -14,6 +14,7 @@ services:
       GF_PATHS_PROVISIONING: /etc/grafana/provisioning
       GF_PATHS_DATA: /var/lib/grafana
       GF_SERVER_ROOT_URL: ${GRAFANA_PRIVATE_ROOT_URL:?GRAFANA_PRIVATE_ROOT_URL must be the private Tailscale URL}
+      GF_SERVER_SERVE_FROM_SUB_PATH: ${GRAFANA_SERVE_FROM_SUB_PATH:-false}
       GF_SECURITY_ADMIN_USER__FILE: /run/secrets/grafana_admin_user
       GF_SECURITY_ADMIN_PASSWORD__FILE: /run/secrets/grafana_admin_password
       GF_AUTH_ANONYMOUS_ENABLED: "false"

--- a/tests/test_operational_observability_deployment.py
+++ b/tests/test_operational_observability_deployment.py
@@ -134,6 +134,9 @@ def test_private_grafana_loki_alloy_deployment_files_exist_and_are_private():
     grafana = services["grafana"]
     assert grafana["environment"]["GF_AUTH_ANONYMOUS_ENABLED"] == "false"
     assert grafana["environment"]["GF_USERS_ALLOW_SIGN_UP"] == "false"
+    assert grafana["environment"]["GF_SERVER_SERVE_FROM_SUB_PATH"] == (
+        "${GRAFANA_SERVE_FROM_SUB_PATH:-false}"
+    )
     assert grafana["environment"]["GF_SECURITY_ADMIN_USER__FILE"] == (
         "/run/secrets/grafana_admin_user"
     )
@@ -317,6 +320,14 @@ def test_observability_bootstrap_and_docs_keep_credentials_out_of_repo():
         "docker compose --env-file",
         "Grafana listens only on `127.0.0.1:3000`",
         "Loki listens only on `127.0.0.1:3100`",
+        "GRAFANA_PRIVATE_ROOT_URL=https://admin-sitbank.tailca101b.ts.net/grafana/",
+        "GRAFANA_SERVE_FROM_SUB_PATH=true",
+        "Private Tailscale Serve Browser Access Plan",
+        "sudo tailscale serve --bg --https=443 --set-path=/grafana http://127.0.0.1:3000",
+        "sudo tailscale serve --https=443 --set-path=/grafana off",
+        "verify-tailscale-admin-access --mode serve",
+        "https://admin-sitbank.tailca101b.ts.net/grafana/",
+        "https://sitbank.pp.ua/grafana",
         "Nginx log files remain `0640` and group-readable by `adm`",
         "Journal files remain group-readable by `systemd-journal`",
         "`sitbank-observability-loopback` is a bridge network used only for "
@@ -334,6 +345,13 @@ def test_observability_bootstrap_and_docs_keep_credentials_out_of_repo():
     assert "chmod -R" not in bootstrap
     assert "chown -R" not in bootstrap
     assert "usermod" not in bootstrap
+    assert "tailscale serve reset" not in docs
+    assert "grafana.sitbank.pp.ua" not in docs
+    assert "grafana-staging.pp.ua" not in docs
+    assert "0.0.0.0:3000" not in docs
+    assert "0.0.0.0:3100" not in docs
+    assert "ufw allow 3000" not in docs.casefold()
+    assert "ufw allow 3100" not in docs.casefold()
     assert "GF_SECURITY_ADMIN_PASSWORD=" not in combined
     assert "loki_" + "token=" not in combined.casefold()
     assert "datasource_" + "password=" not in combined.casefold()


### PR DESCRIPTION
Summary
---
Documents the reviewed private Tailscale Serve plan for convenient Grafana browser access under the existing private admin tailnet hostname, and adds dormant Compose support for Grafana subpath serving.

Why
---
Production observability is healthy on EC2 loopback, but operator browser access still needs a reviewed private-only path. The plan keeps Grafana behind Tailscale, keeps Loki unserved directly, and avoids public DNS, public Nginx routes, firewall changes, Funnel, or ACL weakening.

What changed
---
- Added `GF_SERVER_SERVE_FROM_SUB_PATH` to the observability Compose file, defaulting to `false` so the current loopback/private-hostname model remains unchanged.
- Updated the private observability runbook with the `/grafana/` Tailscale Serve access plan, preflight checks, verification commands, rollback, and the separate-hostname alternative.
- Extended observability deployment tests to assert the subpath setting is explicit and that the runbook does not introduce public Grafana/Loki exposure, destructive Serve reset guidance, or firewall-open commands.

Security impact
---
This preserves the private-only model: Grafana remains bound to `127.0.0.1:3000`, Loki remains bound to `127.0.0.1:3100`, Alloy publishes no host port, no public Nginx route is added, Funnel remains forbidden, and no credentials or tokens are introduced. The runbook requires checking current Tailscale Serve status before any operator change and uses a path-specific rollback.

Deployment impact
---
No deployment action required by this PR alone. A future approved operator step may update non-secret `observability.env` values and add a path-specific Tailscale Serve mapping after confirming the existing admin Serve mapping and Funnel-disabled state. No database migration, secret change, public DNS change, AWS security-group change, UFW change, or Nginx change is included.

Verification
---
- `git diff --check`
- `.\.venv\Scripts\python.exe -m pytest -q tests/test_operational_observability_deployment.py` -> `31 passed`
- `.\.venv\Scripts\python.exe -m pytest -q -n auto` -> `1339 passed, 15 skipped`
- `.\.venv\Scripts\python.exe -m pytest -q -n auto --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term` -> `1339 passed, 15 skipped`, total coverage `90%`, `ops\observability\verify-private-observability` remains `100%`
- `docker compose -f ops\observability\compose.observability.yml config --format json` with fake non-secret image/env values

Notes
---
Official Tailscale Serve documentation used for the operator plan: https://tailscale.com/docs/reference/tailscale-cli/serve and https://tailscale.com/docs/features/tailscale-serve. No GitHub issue was opened; this PR carries the focused implementation plan for review.