### PR TITLE
Harden rate-limit UX and browser regression coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,10 @@ Common local test commands:
 .\.venv\Scripts\python.exe -m pytest -q -n 4
 
 # Show the slowest tests for optimization work
-.\.venv\Scripts\python.exe -m pytest -q --durations=30 --durations-min=0.5
+.\.venv\Scripts\python.exe -m pytest -q -n auto --durations=50 --durations-min=0.1
+
+# Profile the coverage-enabled full suite
+.\.venv\Scripts\python.exe -m pytest -q -n auto --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term --durations=50 --durations-min=0.1
 
 # Re-run only the last failures
 .\.venv\Scripts\python.exe -m pytest -q --lf
@@ -78,7 +81,25 @@ $env:SITBANK_RUN_E2E = "1"
 .\.venv\Scripts\python.exe -m pytest -q tests/e2e
 ```
 
-The `not slow` and focused marker commands are for local iteration only. Pull requests and protected CI still run the full pytest suite, including security, deployment, database session integrity, CSRF, MFA, compatibility-route regression checks, route inventory, production guard, dependency lock, and secret-scanning checks. Playwright E2E browser tests run in CI through a dedicated Chromium job; local unscoped pytest runs collect them but skip unless `SITBANK_RUN_E2E=1` is set. The browser suite covers authentication, MFA, session, banking, and boundary regressions against a loopback Flask server. These tests do not prove live staging or production provider state and never target staging, production, or the private admin hostname.
+The full suite is optimized through a per-worker app and database schema with
+per-test database-row, server-session, rate-limit, delivery-state, and config
+cleanup. Xdist `auto` is bounded to four workers so high-core, memory-limited
+hosts do not overcommit SQLite test resources. The full-history secret scanner reads streaming Git object batches
+instead of launching a process per object. Neither optimization excludes,
+marks, skips, or scopes out required tests.
+
+The `not slow` and focused marker commands are for local iteration only.
+Pull requests and protected CI still run the full pytest suite, including security,
+deployment, database session integrity, CSRF, MFA, compatibility-route
+regression checks, route inventory, production guard, dependency lock, and
+secret-scanning checks. Playwright E2E browser tests run in CI through a
+dedicated Chromium job; local unscoped pytest runs collect them but skip unless
+`SITBANK_RUN_E2E=1` is set. The browser suite covers authentication, MFA,
+session, banking, and boundary regressions, including registration, password
+reset, manual recovery, payee, transfer, session management, password change,
+account freeze, and customer/admin isolation, against a loopback Flask server.
+These tests do not prove live staging or production provider state and never
+target staging, production, or the private admin hostname.
 
 On non-Windows shells, use `python -m playwright install chromium` before
 `python -m pytest -q tests/e2e`.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -20,11 +20,13 @@ from .ops.commands import register_ops_commands
 from .security.audit import register_correlation_id
 from .security.cloudflare_access import register_cloudflare_access_guard
 from .security.sessions import install_database_sessions, register_session_hooks
+from .security.http_errors import (
+    CSRF_ERROR_MESSAGE,
+    RATE_LIMIT_MESSAGE,
+    safe_error_response,
+)
 from .security.turnstile import register_turnstile_template_helpers
 from .web.routes import web_bp
-
-
-JSON_MIME_TYPE = "application/json"
 
 
 def create_app(config_object: type[Config] = Config, *, app_mode: str = "customer") -> Flask:
@@ -171,22 +173,12 @@ def register_forced_password_change_guard(app: Flask) -> None:
 
 
 def register_error_handlers(app: Flask) -> None:
-    def wants_json() -> bool:
-        if request.path.startswith("/auth/"):
-            return True
-        best = request.accept_mimetypes.best_match([JSON_MIME_TYPE, "text/html"])
-        return best == JSON_MIME_TYPE and (
-            request.accept_mimetypes[JSON_MIME_TYPE] >= request.accept_mimetypes["text/html"]
-        )
-
     def respond(message: str, status_code: int):
-        if app.config.get("APP_MODE") == "admin" or wants_json():
-            return jsonify({"error": message}), status_code
-        return render_template("error.html", message=message, status_code=status_code), status_code
+        return safe_error_response(message, status_code)
 
     @app.errorhandler(CSRFError)
     def csrf_error(error):
-        return respond("Security token expired or invalid. Please try again.", 400)
+        return respond(CSRF_ERROR_MESSAGE, 400)
 
     @app.errorhandler(400)
     def bad_request(error):
@@ -209,7 +201,7 @@ def register_error_handlers(app: Flask) -> None:
         from .security.audit import audit_event
 
         audit_event("rate_limit", "blocked", metadata={"path": request.path})
-        return respond("Too many attempts. Please try again later.", 429)
+        return respond(RATE_LIMIT_MESSAGE, 429)
 
     @app.errorhandler(500)
     def internal_error(error):

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -22,6 +22,12 @@ from app.security.production_guard import (
     validate_production_security_prerequisites,
 )
 from app.security.rate_limits import request_principal
+from app.security.http_errors import (
+    CSRF_ERROR_MESSAGE,
+    rate_limit_response,
+    request_wants_json,
+    safe_error_response,
+)
 from app.security.turnstile import TurnstileError, require_turnstile
 
 from .services import (
@@ -257,6 +263,14 @@ class StaffInviteVerifySchema(Schema):
 
 @admin_bp.errorhandler(AuthError)
 def handle_auth_error(error: AuthError):
+    if error.status_code == 429:
+        response, status_code = rate_limit_response()
+        if error.retry_after is not None:
+            response.headers["Retry-After"] = str(error.retry_after)
+            response.headers["X-Auth-Retry-After"] = str(error.retry_after)
+        return response, status_code
+    if not request_wants_json():
+        return safe_error_response(error.message, error.status_code)
     response = jsonify({"error": error.message})
     if error.retry_after is not None:
         response.headers["Retry-After"] = str(error.retry_after)
@@ -266,12 +280,12 @@ def handle_auth_error(error: AuthError):
 
 @admin_bp.errorhandler(ValidationError)
 def handle_validation_error(_error: ValidationError):
-    return jsonify({"error": "Invalid request"}), 400
+    return safe_error_response("Invalid request", 400)
 
 
 @admin_bp.errorhandler(TurnstileError)
 def handle_turnstile_error(_error: TurnstileError):
-    return jsonify({"error": "Challenge verification failed"}), 400
+    return safe_error_response("Challenge verification failed", 400)
 
 
 def _payload(schema: Schema) -> dict:
@@ -290,12 +304,7 @@ def _request_fields() -> set[str]:
 
 
 def _wants_json() -> bool:
-    if request.is_json:
-        return True
-    best = request.accept_mimetypes.best_match([_JSON_MIME_TYPE, _HTML_MIME_TYPE])
-    return best == _JSON_MIME_TYPE and (
-        request.accept_mimetypes[_JSON_MIME_TYPE] >= request.accept_mimetypes[_HTML_MIME_TYPE]
-    )
+    return request_wants_json()
 
 
 def _safe_alert_text(value: Any, limit: int = 120) -> str:
@@ -785,6 +794,8 @@ def login():
         flash("Invalid request", "error")
         return _render_login_form(form, status_code=400)
     except AuthError as exc:
+        if exc.status_code == 429:
+            return rate_limit_response()
         flash(exc.message, "error")
         return _render_login_form(form, status_code=exc.status_code)
 
@@ -823,6 +834,8 @@ def mfa_verify():
     try:
         complete_admin_mfa_login(form.totp_code.data)
     except AuthError as exc:
+        if exc.status_code == 429:
+            return rate_limit_response()
         flash(exc.message, "error")
         return _render_mfa_form(form, status_code=exc.status_code)
 
@@ -838,8 +851,8 @@ def logout():
     form = AdminCsrfOnlyForm()
     if not request.is_json and not form.validate_on_submit():
         if wants_json:
-            return jsonify({"error": "Security token expired or invalid"}), 400
-        flash("Security token expired or invalid. Please try again.", "error")
+            return jsonify({"error": CSRF_ERROR_MESSAGE}), 400
+        flash(CSRF_ERROR_MESSAGE, "error")
         return redirect(url_for(_ADMIN_LOGIN_FORM_ENDPOINT)), 303
     logout_admin_session()
     if not wants_json:

--- a/app/security/http_errors.py
+++ b/app/security/http_errors.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from flask import current_app, jsonify, render_template, request
+
+
+JSON_MIME_TYPE = "application/json"
+HTML_MIME_TYPE = "text/html"
+RATE_LIMIT_MESSAGE = "Too many attempts. Please try again later."
+CSRF_ERROR_MESSAGE = "Security token expired or invalid. Please try again."
+
+_ADMIN_JSON_ONLY_ENDPOINTS = frozenset(
+    {
+        "admin.health_live",
+        "admin.health_ready",
+        "admin.csrf_token",
+        "admin.invite_accept_info",
+        "admin.invite_accept_start",
+        "admin.invite_accept_verify",
+    }
+)
+
+
+def request_wants_json() -> bool:
+    if request.path.startswith("/auth/") or request.is_json:
+        return True
+    if (
+        current_app.config.get("APP_MODE") == "admin"
+        and request.endpoint in _ADMIN_JSON_ONLY_ENDPOINTS
+    ):
+        return True
+    best = request.accept_mimetypes.best_match([JSON_MIME_TYPE, HTML_MIME_TYPE])
+    return best == JSON_MIME_TYPE and (
+        request.accept_mimetypes[JSON_MIME_TYPE]
+        > request.accept_mimetypes[HTML_MIME_TYPE]
+    )
+
+
+def safe_error_response(message: str, status_code: int):
+    if request_wants_json():
+        return jsonify({"error": message}), status_code
+    template = (
+        "admin/error.html"
+        if current_app.config.get("APP_MODE") == "admin"
+        else "error.html"
+    )
+    return render_template(template, message=message, status_code=status_code), status_code
+
+
+def rate_limit_response():
+    return safe_error_response(RATE_LIMIT_MESSAGE, 429)

--- a/app/templates/admin/error.html
+++ b/app/templates/admin/error.html
@@ -1,0 +1,18 @@
+{% extends "admin/base.html" %}
+
+{% block title %}{{ status_code }} | SITBank Admin{% endblock %}
+
+{% block content %}
+<section class="panel narrow empty-state">
+  <p class="eyebrow">Private admin request status</p>
+  <h1>{{ status_code }}</h1>
+  <p class="muted">{{ message }}</p>
+  <div class="button-row">
+    {% if g.current_user %}
+      <a class="button" href="{{ url_for('admin.index') }}">Return to admin dashboard</a>
+    {% else %}
+      <a class="button" href="{{ url_for('admin.login_form') }}">Return to admin login</a>
+    {% endif %}
+  </div>
+</section>
+{% endblock %}

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -84,6 +84,7 @@ from app.extensions import db, limiter
 from app.models import Transaction
 from app.auth.recovery_codes import RECOVERY_CODE_LOW_THRESHOLD, unused_recovery_code_count
 from app.security.rate_limits import mfa_principal, request_principal
+from app.security.http_errors import rate_limit_response
 from app.security.sessions import (
     has_recent_fresh_mfa,
 )
@@ -217,6 +218,8 @@ def register_otp_request():
         flash(_CHALLENGE_VERIFICATION_FAILED_MESSAGE, "error")
         return _render_register_email_form(otp_request_form=form), 400
     except RegistrationOtpError as exc:
+        if exc.status_code == 429:
+            return rate_limit_response()
         flash(exc.message, "error")
         return _render_register_email_form(otp_request_form=form, resend_cooldown=exc.retry_after if exc.status_code == 429 else None), exc.status_code
     flash(result["message"], "info")
@@ -242,6 +245,8 @@ def register_otp_verify():
     try:
         result = verify_registration_otp(pending_email, form.otp_code.data)
     except RegistrationOtpError as exc:
+        if exc.status_code == 429:
+            return rate_limit_response()
         flash(exc.message, "error")
         return _render_register_email_form(otp_request_form=request_form, otp_verify_form=form), exc.status_code
     flash(result["message"], "success")
@@ -279,6 +284,8 @@ def register_submit():
         flash(_CHALLENGE_VERIFICATION_FAILED_MESSAGE, "error")
         return _render_register_details_form(form, verified_email=verified_email), 400
     except AuthError as exc:
+        if exc.status_code == 429:
+            return rate_limit_response()
         flash(exc.message, "error")
         verified_email = current_verified_registration_email()
         if verified_email:
@@ -355,6 +362,8 @@ def login_submit():
         flash(_CHALLENGE_VERIFICATION_FAILED_MESSAGE, "error")
         return render_template(_LOGIN_TEMPLATE, form=form), 400
     except AuthError as exc:
+        if exc.status_code == 429:
+            return rate_limit_response()
         flash(exc.message, "error")
         return render_template(_LOGIN_TEMPLATE, form=form), exc.status_code
 
@@ -393,6 +402,8 @@ def forgot_password_submit():
         flash(_CHALLENGE_VERIFICATION_FAILED_MESSAGE, "error")
         return render_template(_FORGOT_PASSWORD_TEMPLATE, form=form), 400
     except AuthError as exc:
+        if exc.status_code == 429:
+            return rate_limit_response()
         flash(exc.message, "error")
         return render_template(_FORGOT_PASSWORD_TEMPLATE, form=form), exc.status_code
     flash(result["message"], "success")
@@ -420,6 +431,8 @@ def reset_password_exchange():
     try:
         exchange_reset_token(token)
     except AuthError as exc:
+        if exc.status_code == 429:
+            return rate_limit_response()
         flash(exc.message, "error")
         return redirect(url_for(_FORGOT_PASSWORD_ENDPOINT))
     return redirect(url_for(_RESET_PASSWORD_CONTINUE_ENDPOINT))
@@ -430,6 +443,8 @@ def reset_password_continue():
     try:
         transaction = current_reset_transaction()
     except AuthError as exc:
+        if exc.status_code == 429:
+            return rate_limit_response()
         flash(exc.message, "error")
         return redirect(url_for(_FORGOT_PASSWORD_ENDPOINT))
     return render_template(
@@ -448,6 +463,8 @@ def reset_password_continue_submit():
     try:
         transaction = current_reset_transaction()
     except AuthError as exc:
+        if exc.status_code == 429:
+            return rate_limit_response()
         flash(exc.message, "error")
         return redirect(url_for(_FORGOT_PASSWORD_ENDPOINT))
 
@@ -471,6 +488,8 @@ def _handle_reset_totp(transaction: dict):
     try:
         transaction = verify_reset_totp(form.totp_code.data)
     except AuthError as exc:
+        if exc.status_code == 429:
+            return rate_limit_response()
         flash(exc.message, "error")
         return _render_reset_continue(transaction, status_code=exc.status_code)
     flash("Authentication code verified.", "success")
@@ -484,6 +503,8 @@ def _handle_reset_recovery_code(transaction: dict):
     try:
         transaction = verify_reset_recovery_code(form.totp_code.data)
     except AuthError as exc:
+        if exc.status_code == 429:
+            return rate_limit_response()
         flash(exc.message, "error")
         return _render_reset_continue(transaction, status_code=exc.status_code)
     flash("Recovery code verified.", "success")
@@ -497,6 +518,8 @@ def _handle_reset_mfa_selection(transaction: dict):
     try:
         transaction = select_reset_mfa_method(request.form.get("mfa_method", ""))
     except AuthError as exc:
+        if exc.status_code == 429:
+            return rate_limit_response()
         flash(exc.message, "error")
         return _render_reset_continue(transaction, status_code=exc.status_code)
     flash("Verification method selected.", "success")
@@ -513,6 +536,8 @@ def _handle_reset_completion(transaction: dict):
             form.confirm_new_password.data,
         )
     except AuthError as exc:
+        if exc.status_code == 429:
+            return rate_limit_response()
         flash(exc.message, "error")
         return _render_reset_continue(transaction, status_code=exc.status_code)
     for warning in result.get("warnings", []):
@@ -551,6 +576,8 @@ def account_recovery_submit():
         flash(_CHALLENGE_VERIFICATION_FAILED_MESSAGE, "error")
         return render_template(_ACCOUNT_RECOVERY_TEMPLATE, form=form), 400
     except AuthError as exc:
+        if exc.status_code == 429:
+            return rate_limit_response()
         flash(exc.message, "error")
         return render_template(_ACCOUNT_RECOVERY_TEMPLATE, form=form), exc.status_code
     flash(result["message"], "success")
@@ -585,6 +612,8 @@ def mfa_verify_submit():
     try:
         complete_pending_mfa(form.totp_code.data)
     except AuthError as exc:
+        if exc.status_code == 429:
+            return rate_limit_response()
         flash(exc.message, "error")
         return render_template(_MFA_VERIFY_TEMPLATE, form=form), exc.status_code
 
@@ -696,6 +725,8 @@ def profile_submit():
             form.email_verification_code.data,
         )
     except AuthError as exc:
+        if exc.status_code == 429:
+            return rate_limit_response()
         flash(exc.message, "error")
         return render_template(
             _PROFILE_TEMPLATE,
@@ -823,6 +854,8 @@ def _handle_mfa_setup_start(forms: dict[str, FlaskForm]):
     try:
         setup = generate_mfa_setup(g.current_user)
     except AuthError as exc:
+        if exc.status_code == 429:
+            return rate_limit_response()
         flash(exc.message, "error")
         return redirect(url_for(_DASHBOARD_ENDPOINT))
     flash("Scan the QR code, then enter the current code to enable MFA.", "info")
@@ -840,6 +873,8 @@ def _handle_mfa_setup_verify(forms: dict[str, FlaskForm]):
     try:
         result = verify_mfa_setup(g.current_user, verify_form.totp_code.data)
     except AuthError as exc:
+        if exc.status_code == 429:
+            return rate_limit_response()
         flash(exc.message, "error")
         return _render_mfa_management(forms, status_code=exc.status_code)
     flash("MFA is now enabled.", "success")
@@ -857,6 +892,8 @@ def _handle_mfa_replace_start(forms: dict[str, FlaskForm]):
             replace_form.stepup_token.data,
         )
     except AuthError as exc:
+        if exc.status_code == 429:
+            return rate_limit_response()
         flash(exc.message, "error")
         return _render_mfa_management(forms, status_code=exc.status_code)
     flash("Scan the replacement QR code, then verify the new authenticator code.", "info")
@@ -873,6 +910,8 @@ def _handle_mfa_replace_verify(forms: dict[str, FlaskForm]):
     try:
         result = verify_mfa_replacement(g.current_user, verify_form.totp_code.data)
     except AuthError as exc:
+        if exc.status_code == 429:
+            return rate_limit_response()
         flash(exc.message, "error")
         return _render_mfa_management(forms, status_code=exc.status_code)
     flash("Authenticator MFA replaced. Other sessions were revoked.", "success")
@@ -890,6 +929,8 @@ def _handle_recovery_code_regeneration(forms: dict[str, FlaskForm]):
             regenerate_form.stepup_token.data,
         )
     except AuthError as exc:
+        if exc.status_code == 429:
+            return rate_limit_response()
         flash(exc.message, "error")
         return _render_mfa_management(forms, status_code=exc.status_code)
     flash("Recovery codes regenerated.", "success")
@@ -948,6 +989,8 @@ def password_change_submit():
             form.stepup_token.data,
         )
     except AuthError as exc:
+        if exc.status_code == 429:
+            return rate_limit_response()
         flash(exc.message, "error")
         return render_template(_PASSWORD_CHANGE_TEMPLATE, form=form, recent_mfa=recent_mfa), exc.status_code
 
@@ -984,6 +1027,8 @@ def sessions_terminate_submit(session_ref: str):
     try:
         terminate_session_for_user(g.current_user, session_ref)
     except AuthError as exc:
+        if exc.status_code == 429:
+            return rate_limit_response()
         flash(exc.message, "error")
         return redirect(url_for(_SESSIONS_ENDPOINT)), exc.status_code
     flash("Session terminated.", "success")
@@ -1007,6 +1052,8 @@ def sessions_revoke_others_submit():
         )
         revoked = terminate_other_sessions_for_user(g.current_user)
     except AuthError as exc:
+        if exc.status_code == 429:
+            return rate_limit_response()
         flash(exc.message, "error")
         return redirect(url_for(_SESSIONS_ENDPOINT)), exc.status_code
     flash(f"Terminated {revoked} other session(s).", "success")
@@ -1033,6 +1080,8 @@ def freeze_account_submit():
     try:
         freeze_own_account(g.current_user, form.totp_code.data, form.stepup_token.data)
     except AuthError as exc:
+        if exc.status_code == 429:
+            return rate_limit_response()
         flash(exc.message, "error")
         return render_template(_FREEZE_TEMPLATE, user=g.current_user, form=form), exc.status_code
 

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -71,9 +71,15 @@ playwright install --with-deps chromium`, and runs `python -m pytest -q
 tests/e2e` with `SITBANK_RUN_E2E=1` and `PLAYWRIGHT_BROWSERS_PATH` set to
 `.playwright-browsers`. The tests use a loopback Flask server from the pytest
 app fixture for authentication, MFA, session, banking, and boundary
-regressions. They do not prove live staging or production provider state and do
+regressions. Coverage includes registration, password reset, manual recovery, payee, transfer, session management, password change, account freeze, and customer/admin isolation.
+They do not prove live staging or production provider state and do
 not target staging, production, or private-admin hosts. Browser cache, reports,
 traces, screenshots, and videos are ignored and are not uploaded by the job.
+
+The Python suite uses a per-worker app and database schema with per-test state
+cleanup, and the custom full-history secret scan reads streaming Git object
+batches. These runtime optimizations do not add marker exclusions, scoped test
+paths, or weaker security checks.
 
 Changing a job display name can change its required status-check context even
 when the internal ID is unchanged. Repository files do not update GitHub

--- a/docs/runbooks/global-verification.md
+++ b/docs/runbooks/global-verification.md
@@ -55,9 +55,23 @@ $env:SITBANK_RUN_E2E = "1"
 ```
 
 The browser tests cover authentication, MFA, session, banking, and boundary
-regressions against a loopback Flask server. They do not prove live staging or
-production provider state and do not target staging, production, or the private
-admin hostname.
+regressions, including registration, password reset, manual recovery, payee,
+transfer, session management, password change, account freeze, and
+customer/admin isolation, against a loopback Flask server. They do not prove
+live staging or production provider state and do not target staging,
+production, or the private admin hostname.
+
+For runtime profiling, keep the command unscoped and do not add marker
+exclusions:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest -q -n auto --durations=50 --durations-min=0.1
+.\.venv\Scripts\python.exe -m pytest -q -n auto --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term --durations=50 --durations-min=0.1
+```
+
+The suite optimization uses a per-worker app and database schema plus
+per-test cleanup. Full-history secret scanning uses streaming Git object
+batches. Neither optimization removes security, deployment, or browser tests.
 
 ### Normal CI-Equivalent Checks
 

--- a/docs/security/architecture/admin-and-staging-zero-trust-access.md
+++ b/docs/security/architecture/admin-and-staging-zero-trust-access.md
@@ -593,6 +593,13 @@ origin or admin listener. They do not replace Flask login, CSRF, rate limiting,
 root-admin authorization, admin TOTP, admin/customer route isolation, admin
 cookie isolation, or database runtime role separation.
 
+Private admin browser rate limits and durable backoff render one admin-branded
+HTTP 429 response; invalid or expired CSRF tokens render a distinct
+admin-branded HTTP 400. Admin JSON-only and negotiated API requests retain
+structured errors. This response handling does not expose Tailscale identity
+details or weaken private reachability, separate admin cookies/signing keys,
+TOTP step-up, audit logging, alerts, or maker-checker authorization.
+
 Readiness remains restricted:
 
 - Production customer `/health/ready` is loopback-only.

--- a/docs/security/architecture/cryptography-and-authentication.md
+++ b/docs/security/architecture/cryptography-and-authentication.md
@@ -259,6 +259,14 @@ request, final registration submit, and password-reset request. Turnstile is
 defense in depth only; CSRF, rate limits, password screening, MFA, sessions,
 audit logging, and authorization remain enforced.
 
+Customer browser routes use the same branded `Too many attempts` response when
+durable auth backoff, Flask-Limiter, or Nginx `limit_req` rejects a request.
+Nginx renders the browser 429 from an internal location instead of proxying the
+rejected request, while `/auth/*` keeps structured JSON. CSRF failures remain a
+separate HTTP 400 with security-token wording and a route back to a fresh form.
+No threshold, Turnstile, session, audit, or alert control is relaxed for this
+presentation contract.
+
 Customer login uses username or email plus password. Three failed customer
 password attempts, or two failed privileged password attempts, lock the user
 record and revoke active sessions across source IPs. Counters clear only after

--- a/docs/security/assurance/secure-coding.md
+++ b/docs/security/assurance/secure-coding.md
@@ -87,6 +87,16 @@ tests.
 | CSRF on unsafe customer routes | `app/extensions.py`, `app/__init__.py`, `tests/test_route_inventory_security.py::test_route_inventory_has_complete_security_decisions` |
 | Explicit CSRF regression tests | `tests/test_account_security_actions.py`, `tests/test_admin_manual_recovery.py`, `tests/test_payup.py::test_payup_and_transfer_limit_posts_require_csrf_when_enabled`, `tests/test_route_inventory_security.py` |
 
+Customer and private-admin browser rate-limit responses use one safe branded
+429 message whether Flask-Limiter, durable authentication backoff, or Nginx
+blocks first. Nginx serves its 429 page or `/auth/*` JSON directly from an
+internal named location and never proxies a rejected request back into Flask.
+Missing, stale, or invalid CSRF tokens remain a distinct branded HTTP 400.
+JSON auth/admin callers continue to receive structured errors. These response
+normalizations do not change CSRF, MFA/TOTP step-up, Flask-Limiter, durable
+backoff, Nginx `limit_req`, audit, alert, Tailscale, Cloudflare, or
+customer/admin isolation controls.
+
 Fully authenticated customer sessions default to a 12-hour absolute lifetime,
 and admin sessions default to a 4-hour absolute lifetime. The `auth_created_at`
 timestamp is stored server-side and is not refreshed by ordinary activity,

--- a/docs/security/assurance/test-automation-and-dependencies.md
+++ b/docs/security/assurance/test-automation-and-dependencies.md
@@ -107,7 +107,7 @@ deployment.
 | Audit, alerts, and redaction | `tests/test_audit_alerting.py`, `tests/test_audit_metadata_sanitization.py` |
 | Deployment, Nginx, Docker, workflows, and runtime contracts | `tests/test_deployment.py` |
 | UI security regressions | `tests/test_authenticated_portal_ui.py`, `tests/test_dashboard.py` |
-| Browser E2E regressions | `tests/e2e/test_customer_auth_browser.py`, `tests/e2e/test_customer_security_browser.py` |
+| Browser E2E regressions | `tests/e2e/test_customer_auth_browser.py`, `tests/e2e/test_customer_mfa_browser.py`, `tests/e2e/test_customer_registration_recovery_browser.py`, `tests/e2e/test_customer_banking_browser.py`, `tests/e2e/test_session_security_browser.py`, `tests/e2e/test_customer_admin_boundary_browser.py`, `tests/e2e/test_sensitive_browser_artifacts.py` |
 
 Payee ownership, direct banking MFA gating, pre-TOTP lookup blocking,
 duplicate/self-payee protections, expiry behavior, and removal IDOR are covered
@@ -119,7 +119,9 @@ tests for staff invites, manual recovery, maker-checker approval, and the
 manual-only root-admin bootstrap boundary.
 
 Playwright E2E browser tests cover authentication, MFA, session, banking, and
-boundary regressions against a loopback Flask server. They are opt-in for local
+boundary regressions, including registration, password reset, manual recovery,
+payee, transfer, session management, password change, account freeze, and
+customer/admin isolation, against a loopback Flask server. They are opt-in for local
 unscoped pytest because they require browser binaries, and they do not prove
 live staging or production provider state. To run them locally:
 
@@ -136,6 +138,17 @@ playwright install --with-deps chromium`, sets `SITBANK_RUN_E2E=1`, and runs
 ignored local paths such as `.playwright-browsers`, `playwright-report`, and
 `test-results`; the workflow does not upload traces, videos, cookies, or
 browser profiles.
+
+The normal suite reuses one Flask app and database schema per xdist worker.
+Every test still receives isolated database rows, server-side sessions,
+rate-limit state, fake delivery state, and app configuration. Tests that
+specifically prove factory, admin/customer database, migration, hashing,
+authentication, MFA, or session-creation behavior continue to use their real
+paths. Xdist `auto` is capped at four workers so high-core hosts do not
+overcommit the in-memory SQLite test workload. The history secret scanner preserves full reachable-history coverage
+while reading metadata and content through streaming Git object batches.
+There are no marker exclusions or scoped test paths in the required full-suite
+command.
 
 ## Local Security Commands
 

--- a/ops/nginx/sitbank-production.conf
+++ b/ops/nginx/sitbank-production.conf
@@ -73,6 +73,7 @@ server {
 
     limit_req_status 429;
     limit_req_log_level warn;
+    error_page 429 = @sitbank_rate_limited;
 
     client_max_body_size 4m;
     client_body_timeout 15s;
@@ -91,6 +92,18 @@ server {
         root /var/www/certbot;
         default_type "text/plain";
         try_files $uri =404;
+    }
+
+    location @sitbank_rate_limited {
+        internal;
+        default_type "text/html; charset=utf-8";
+        return 429 '<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>429 | SITBank</title></head><body><main><h1>Too many attempts</h1><p>Too many attempts. Please try again later.</p><p><a href="/login">Return to login</a></p></main></body></html>';
+    }
+
+    location @sitbank_rate_limited_json {
+        internal;
+        default_type application/json;
+        return 429 '{"error":"Too many attempts. Please try again later."}';
     }
 
     location = /health/ready {
@@ -127,6 +140,7 @@ server {
     }
 
     location = /auth/register {
+        error_page 429 = @sitbank_rate_limited_json;
         limit_req zone=sitbank_prod_register burst=3 nodelay;
         proxy_pass http://127.0.0.1:5000;
         include /etc/nginx/snippets/sitbank-proxy-headers.conf;
@@ -139,6 +153,7 @@ server {
     }
 
     location = /auth/login {
+        error_page 429 = @sitbank_rate_limited_json;
         limit_req zone=sitbank_prod_auth burst=5 nodelay;
         proxy_pass http://127.0.0.1:5000;
         include /etc/nginx/snippets/sitbank-proxy-headers.conf;
@@ -151,12 +166,14 @@ server {
     }
 
     location = /auth/mfa/verify {
+        error_page 429 = @sitbank_rate_limited_json;
         limit_req zone=sitbank_prod_auth burst=5 nodelay;
         proxy_pass http://127.0.0.1:5000;
         include /etc/nginx/snippets/sitbank-proxy-headers.conf;
     }
 
     location ~ ^/auth/webauthn/(?:register|authenticate|step-up)/(?:options|verify)$ {
+        error_page 429 = @sitbank_rate_limited_json;
         limit_req zone=sitbank_prod_challenge burst=3 nodelay;
         proxy_pass http://127.0.0.1:5000;
         include /etc/nginx/snippets/sitbank-proxy-headers.conf;
@@ -169,12 +186,14 @@ server {
     }
 
     location ~ ^/auth/(?:account|mfa|password|sessions|webauthn/credentials)(?:/|$) {
+        error_page 429 = @sitbank_rate_limited_json;
         limit_req zone=sitbank_prod_security burst=10 nodelay;
         proxy_pass http://127.0.0.1:5000;
         include /etc/nginx/snippets/sitbank-proxy-headers.conf;
     }
 
     location /auth/ {
+        error_page 429 = @sitbank_rate_limited_json;
         limit_req zone=sitbank_prod_auth burst=5 nodelay;
         proxy_pass http://127.0.0.1:5000;
         include /etc/nginx/snippets/sitbank-proxy-headers.conf;

--- a/ops/nginx/sitbank-staging.conf
+++ b/ops/nginx/sitbank-staging.conf
@@ -79,6 +79,7 @@ server {
 
     limit_req_status 429;
     limit_req_log_level warn;
+    error_page 429 = @sitbank_rate_limited;
 
     client_max_body_size 4m;
     client_body_timeout 15s;
@@ -93,6 +94,18 @@ server {
         root /var/www/certbot;
         default_type "text/plain";
         try_files $uri =404;
+    }
+
+    location @sitbank_rate_limited {
+        internal;
+        default_type "text/html; charset=utf-8";
+        return 429 '<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>429 | SITBank</title></head><body><main><h1>Too many attempts</h1><p>Too many attempts. Please try again later.</p><p><a href="/login">Return to login</a></p></main></body></html>';
+    }
+
+    location @sitbank_rate_limited_json {
+        internal;
+        default_type application/json;
+        return 429 '{"error":"Too many attempts. Please try again later."}';
     }
 
     location = /health/ready {
@@ -136,6 +149,7 @@ server {
     }
 
     location ^~ /auth/ {
+        error_page 429 = @sitbank_rate_limited_json;
         limit_req zone=sitbank_staging_login burst=5 nodelay;
         proxy_pass http://127.0.0.1:5001;
         include /etc/nginx/snippets/sitbank-proxy-headers.conf;

--- a/ops/security/scan_repository_secrets.py
+++ b/ops/security/scan_repository_secrets.py
@@ -4,6 +4,7 @@ import argparse
 import base64
 import re
 import subprocess
+from collections.abc import Iterator
 from pathlib import Path
 
 
@@ -104,23 +105,80 @@ def historical_blobs() -> list[tuple[str, str]]:
         capture_output=True,
         text=True,
     )
-    blobs: list[tuple[str, str]] = []
+    candidates: list[tuple[str, str]] = []
     seen: set[str] = set()
     for line in result.stdout.splitlines():
         object_id, _, path = line.partition(" ")
         if not path or object_id in seen:
             continue
-        object_type = subprocess.run(
-            ["git", "cat-file", "-t", object_id],
-            check=True,
-            capture_output=True,
-            text=True,
-        ).stdout.strip()
-        if object_type != "blob":
-            continue
         seen.add(object_id)
-        blobs.append((object_id, path))
-    return blobs
+        candidates.append((object_id, path))
+    metadata = _batch_object_metadata([object_id for object_id, _path in candidates])
+    return [
+        (object_id, path)
+        for object_id, path in candidates
+        if metadata.get(object_id, ("", 0))[0] == "blob"
+    ]
+
+
+def _batch_object_metadata(object_ids: list[str]) -> dict[str, tuple[str, int]]:
+    if not object_ids:
+        return {}
+    result = subprocess.run(
+        [
+            "git",
+            "cat-file",
+            "--batch-check=%(objectname) %(objecttype) %(objectsize)",
+        ],
+        input="\n".join(object_ids) + "\n",
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    metadata: dict[str, tuple[str, int]] = {}
+    for line in result.stdout.splitlines():
+        object_id, object_type, raw_size = line.split(" ", 2)
+        metadata[object_id] = (object_type, int(raw_size))
+    return metadata
+
+
+def _read_blob_batch(object_ids: list[str]) -> Iterator[tuple[str, bytes]]:
+    if not object_ids:
+        return
+    process = subprocess.Popen(
+        ["git", "cat-file", "--batch"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if process.stdin is None or process.stdout is None or process.stderr is None:
+        process.kill()
+        process.wait()
+        raise RuntimeError("Git history object scan could not open safe pipes")
+    try:
+        for expected_object_id in object_ids:
+            process.stdin.write(f"{expected_object_id}\n".encode("ascii"))
+            process.stdin.flush()
+            header = process.stdout.readline().decode("ascii").strip()
+            object_id, object_type, raw_size = header.split(" ", 2)
+            if object_id != expected_object_id or object_type != "blob":
+                raise RuntimeError("Git returned unexpected history object metadata")
+            content = process.stdout.read(int(raw_size))
+            if process.stdout.read(1) != b"\n":
+                raise RuntimeError("Git returned malformed history object content")
+            yield object_id, content
+        process.stdin.close()
+        return_code = process.wait()
+        if return_code:
+            raise RuntimeError("Git history object scan failed")
+    finally:
+        if not process.stdin.closed:
+            process.stdin.close()
+        if process.poll() is None:
+            process.kill()
+            process.wait()
+        process.stderr.close()
+        process.stdout.close()
 
 
 def scan_content(label: str, content: bytes, findings: list[str]) -> None:
@@ -132,7 +190,10 @@ def scan_content(label: str, content: bytes, findings: list[str]) -> None:
 
 
 def scan_history(findings: list[str]) -> None:
-    for object_id, historical_path in historical_blobs():
+    blobs = historical_blobs()
+    metadata = _batch_object_metadata([object_id for object_id, _path in blobs])
+    eligible: list[tuple[str, str]] = []
+    for object_id, historical_path in blobs:
         path = Path(historical_path)
         if (
             path.name.casefold() in FORBIDDEN_NAMES
@@ -142,21 +203,17 @@ def scan_history(findings: list[str]) -> None:
                 f"forbidden credential filename in history: {historical_path}"
             )
             continue
-        size = int(
-            subprocess.run(
-                ["git", "cat-file", "-s", object_id],
-                check=True,
-                capture_output=True,
-                text=True,
-            ).stdout.strip()
-        )
+        object_type, size = metadata.get(object_id, ("", MAX_HISTORY_BLOB_BYTES + 1))
+        if object_type != "blob":
+            continue
         if size > MAX_HISTORY_BLOB_BYTES:
             continue
-        content = subprocess.run(
-            ["git", "cat-file", "blob", object_id],
-            check=True,
-            capture_output=True,
-        ).stdout
+        eligible.append((object_id, historical_path))
+    paths_by_object_id = dict(eligible)
+    for object_id, content in _read_blob_batch(
+        [object_id for object_id, _path in eligible]
+    ):
+        historical_path = paths_by_object_id[object_id]
         scan_content(f"{historical_path}@{object_id[:12]}", content, findings)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import copy
 import json
 import os
 from datetime import timedelta
@@ -316,20 +317,89 @@ def pytest_collection_modifyitems(config, items):
                 item.add_marker(getattr(pytest.mark, marker_name))
 
 
+def pytest_xdist_auto_num_workers(config) -> int:
+    del config
+    return min(os.cpu_count() or 1, 4)
+
+
+def _clear_database_rows(flask_app) -> None:
+    from app.extensions import db
+
+    with flask_app.app_context():
+        db.session.remove()
+        with db.engine.begin() as connection:
+            for table in reversed(db.metadata.sorted_tables):
+                connection.execute(table.delete())
+            if db.engine.dialect.name == "sqlite":
+                has_sequence = connection.exec_driver_sql(
+                    "SELECT 1 FROM sqlite_master "
+                    "WHERE type = 'table' AND name = 'sqlite_sequence'"
+                ).scalar()
+                if has_sequence:
+                    connection.exec_driver_sql("DELETE FROM sqlite_sequence")
+        db.session.remove()
+
+
+def _restore_test_app_state(flask_app, baseline_config: dict) -> None:
+    from app.extensions import limiter
+
+    flask_app.config.clear()
+    flask_app.config.update(copy.deepcopy(baseline_config))
+    flask_app.extensions["password_reset_outbox"] = []
+    flask_app.extensions.pop("e2e_fake_password_hashes", None)
+    with flask_app.app_context():
+        limiter.reset()
+    _clear_database_rows(flask_app)
+
+
+@pytest.fixture(scope="session")
+def _worker_app():
+    from app import create_app
+    from app.extensions import db
+
+    flask_app = create_app(TestConfig)
+    with flask_app.app_context():
+        db.create_all()
+    baseline_config = copy.deepcopy(dict(flask_app.config))
+    try:
+        yield flask_app, baseline_config
+    finally:
+        with flask_app.app_context():
+            db.session.remove()
+            db.drop_all()
+            db.engine.dispose()
+
+
 @pytest.fixture()
-def app(monkeypatch):
+def app(_worker_app, monkeypatch):
+    from app.security import passwords
+
+    monkeypatch.setattr(passwords, "_is_password_pwned_by_hibp", lambda _password: False)
+    flask_app, baseline_config = _worker_app
+    _restore_test_app_state(flask_app, baseline_config)
+    try:
+        with flask_app.app_context():
+            yield flask_app
+    finally:
+        _restore_test_app_state(flask_app, baseline_config)
+
+
+@pytest.fixture()
+def mutable_app(monkeypatch):
     from app import create_app
     from app.extensions import db
     from app.security import passwords
 
     monkeypatch.setattr(passwords, "_is_password_pwned_by_hibp", lambda _password: False)
-
     flask_app = create_app(TestConfig)
     with flask_app.app_context():
         db.create_all()
-        yield flask_app
-        db.session.remove()
-        db.drop_all()
+        try:
+            yield flask_app
+        finally:
+            db.session.remove()
+            db.drop_all()
+            db.engine.dispose()
 
 
 @pytest.fixture()

--- a/tests/e2e/support.py
+++ b/tests/e2e/support.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import os
+import re
 import threading
+import time
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from urllib.parse import urlparse
 
@@ -10,7 +14,8 @@ import pytest
 from werkzeug.serving import make_server
 
 from app.extensions import db
-from app.models import User
+from app.models import Payee, User
+from app.security.email import password_reset_outbox
 from app.security.crypto import encrypt_mfa_secret
 from app.security.passwords import hash_password
 
@@ -65,6 +70,71 @@ def browser_page():
             browser.close()
 
 
+@pytest.fixture()
+def browser_context_factory():
+    sync_api = pytest.importorskip(
+        "playwright.sync_api",
+        reason="install requirements-dev.lock to run Playwright E2E tests",
+    )
+    headless = os.environ.get("SITBANK_E2E_HEADLESS", "1") != "0"
+    contexts = []
+    with sync_api.sync_playwright() as playwright:
+        try:
+            browser = playwright.chromium.launch(headless=headless)
+        except Exception as exc:  # pragma: no cover - depends on local browser cache
+            if _looks_like_missing_browser(exc):
+                pytest.skip(
+                    "Playwright Chromium is not installed; run "
+                    "python -m playwright install chromium"
+                )
+            raise
+
+        def create_page():
+            context = browser.new_context(ignore_https_errors=False)
+            contexts.append(context)
+            return context.new_page()
+
+        try:
+            yield create_page
+        finally:
+            for context in reversed(contexts):
+                context.close()
+            browser.close()
+
+
+@pytest.fixture()
+def admin_live_server():
+    from app import create_app
+    from conftest import TestConfig
+
+    admin_app = create_app(TestConfig, app_mode="admin")
+    with admin_app.app_context():
+        db.create_all()
+    with _serve_loopback(admin_app) as base_url:
+        yield admin_app, base_url
+    with admin_app.app_context():
+        db.session.remove()
+        db.drop_all()
+
+
+@contextmanager
+def _serve_loopback(flask_app):
+    server = make_server("127.0.0.1", 0, flask_app, threaded=False)
+    base_url = f"http://127.0.0.1:{server.server_port}"
+    _assert_local_base_url(base_url)
+    thread = threading.Thread(
+        target=server.serve_forever,
+        name="sitbank-e2e-server",
+        daemon=True,
+    )
+    thread.start()
+    try:
+        yield base_url
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
 def create_e2e_customer(
     app,
     *,
@@ -76,17 +146,21 @@ def create_e2e_customer(
     full_name: str,
     balance: Decimal = Decimal("5000.00"),
     mfa_enabled: bool = False,
+    account_type: str = "customer",
+    account_status: str = "active",
+    is_frozen: bool = False,
 ) -> dict[str, str]:
     with app.app_context():
         user = User(
             username=username,
             email=email,
-            password_hash=hash_password(password),
+            password_hash=_cached_fake_password_hash(app, password),
             full_name=full_name,
             phone_number=phone_number,
             account_number=account_number,
-            account_type="customer",
-            account_status="active",
+            account_type=account_type,
+            account_status=account_status,
+            is_frozen=is_frozen,
             balance=balance,
         )
         db.session.add(user)
@@ -97,28 +171,98 @@ def create_e2e_customer(
             user.mfa_secret_nonce, user.mfa_secret_ciphertext = encrypt_mfa_secret(secret, user.id)
             user.mfa_enabled = True
         db.session.commit()
+        user_id = int(user.id)
     return {
+        "id": str(user_id),
         "username": username,
         "password": password,
         "secret": secret,
         "phone_number": phone_number,
         "full_name": full_name,
+        "account_number": account_number,
+        "email": email,
     }
 
 
-def login_customer_with_mfa(page, base_url: str, customer: dict[str, str]) -> None:
+def create_e2e_admin(
+    app,
+    *,
+    email: str,
+    password: str,
+    full_name: str = "E2E Root Admin",
+) -> dict[str, str]:
+    with app.app_context():
+        user = User(
+            username="e2e-root-admin",
+            email=email,
+            password_hash=_cached_fake_password_hash(app, password),
+            full_name=full_name,
+            phone_number="91234567",
+            account_number=None,
+            account_type="root_admin",
+            account_status="active",
+            workplace_email_verified_at=datetime.now(timezone.utc),
+        )
+        db.session.add(user)
+        db.session.flush()
+        secret = pyotp.random_base32(length=32)
+        user.mfa_secret_nonce, user.mfa_secret_ciphertext = encrypt_mfa_secret(secret, user.id)
+        user.mfa_enabled = True
+        db.session.commit()
+    return {"email": email, "password": password, "secret": secret}
+
+
+def create_e2e_payee(
+    app,
+    *,
+    customer_id: int,
+    recipient: dict[str, str],
+    nickname: str = "Trusted Recipient",
+    cooldown_elapsed: bool = True,
+) -> int:
+    created_at = datetime.now(timezone.utc)
+    if cooldown_elapsed:
+        created_at -= timedelta(days=2)
+    with app.app_context():
+        payee = Payee(
+            user_id=customer_id,
+            nickname=nickname,
+            account_number=recipient["account_number"],
+            recipient_name=recipient["full_name"],
+            created_at=created_at,
+        )
+        db.session.add(payee)
+        db.session.commit()
+        return int(payee.id)
+
+
+def login_customer_with_mfa(
+    page,
+    base_url: str,
+    customer: dict[str, str],
+    *,
+    totp_offset_seconds: int = 0,
+) -> None:
     page.goto(f"{base_url}/login", wait_until="load")
     page.locator("input[name='identifier']").fill(customer["username"])
     page.locator("input[name='password']").fill(customer["password"])
     page.locator("button[type='submit']").click()
     page.wait_for_url("**/mfa/verify", wait_until="load")
-    page.locator("input[name='totp_code']").fill(current_totp(customer["secret"]))
+    page.locator("input[name='totp_code']").fill(
+        totp_for_offset(customer["secret"], totp_offset_seconds)
+    )
     page.get_by_role("button", name="Verify code").click()
     page.wait_for_url("**/dashboard", wait_until="load")
 
 
 def current_totp(secret: str) -> str:
     return pyotp.TOTP(secret, digits=6, interval=30).now()
+
+
+def totp_for_offset(secret: str, offset_seconds: int) -> str:
+    return pyotp.TOTP(secret, digits=6, interval=30).at(
+        int(time.time()) + offset_seconds
+    )
 
 
 def record_console_errors(page) -> list[str]:
@@ -130,6 +274,37 @@ def record_console_errors(page) -> list[str]:
 
     page.on("console", collect_error)
     return errors
+
+
+def latest_registration_code(app) -> str:
+    with app.app_context():
+        body = password_reset_outbox()[-1]["body"]
+    match = re.search(r"\b([0-9]{6})\b", body)
+    if match is None:
+        raise AssertionError("fake registration delivery did not contain a code")
+    return match.group(1)
+
+
+def latest_password_reset_token(app) -> str:
+    with app.app_context():
+        deliveries = list(password_reset_outbox())
+    for delivery in reversed(deliveries):
+        match = re.search(
+            r"/reset-password\?token=([A-Za-z0-9_.-]+)",
+            delivery["body"],
+        )
+        if match is not None:
+            return match.group(1)
+    raise AssertionError("fake password-reset delivery did not contain a token")
+
+
+def _cached_fake_password_hash(app, password: str) -> str:
+    cache = app.extensions.setdefault("e2e_fake_password_hashes", {})
+    password_hash = cache.get(password)
+    if password_hash is None:
+        password_hash = hash_password(password)
+        cache[password] = password_hash
+    return password_hash
 
 
 def _assert_local_base_url(base_url: str) -> None:

--- a/tests/e2e/test_customer_admin_boundary_browser.py
+++ b/tests/e2e/test_customer_admin_boundary_browser.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from app.security.http_errors import CSRF_ERROR_MESSAGE, RATE_LIMIT_MESSAGE
+from tests.e2e.support import (
+    RUN_E2E_ENV,
+    admin_live_server,
+    browser_page,
+    create_e2e_admin,
+    create_e2e_customer,
+    current_totp,
+    live_server,
+    login_customer_with_mfa,
+)
+
+
+pytestmark = [pytest.mark.e2e]
+if os.environ.get(RUN_E2E_ENV) != "1":
+    pytestmark.append(
+        pytest.mark.skip(reason=f"set {RUN_E2E_ENV}=1 to run Playwright E2E browser tests")
+    )
+
+_PASSWORD = "Correct Horse Battery Staple 2026!"
+
+
+def test_customer_and_admin_browser_sessions_remain_isolated(
+    app,
+    live_server,
+    admin_live_server,
+    browser_page,
+):
+    admin_app, admin_base_url = admin_live_server
+    customer = create_e2e_customer(
+        app,
+        username="e2e_boundary_customer",
+        password=_PASSWORD,
+        email="e2e.boundary.customer@example.test",
+        phone_number="91234566",
+        account_number="012345678916",
+        full_name="E2E Boundary Customer",
+        mfa_enabled=True,
+    )
+    admin = create_e2e_admin(
+        admin_app,
+        email="root1@sit.singaporetech.edu.sg",
+        password=_PASSWORD,
+    )
+    login_customer_with_mfa(browser_page, live_server, customer)
+
+    response = browser_page.goto(admin_base_url, wait_until="load")
+    assert response is not None
+    assert response.status == 401
+    assert "E2E Boundary Customer" not in browser_page.content()
+
+    browser_page.goto(f"{admin_base_url}/login", wait_until="load")
+    browser_page.locator("input[name='workplace_email']").fill(admin["email"])
+    browser_page.locator("input[name='password']").fill(admin["password"])
+    browser_page.get_by_role("button", name="Continue").click()
+    browser_page.wait_for_url("**/mfa/verify", wait_until="load")
+    browser_page.locator("input[name='totp_code']").fill(current_totp(admin["secret"]))
+    browser_page.get_by_role("button", name="Verify").click()
+    browser_page.wait_for_url(admin_base_url + "/", wait_until="load")
+    browser_page.get_by_text("Staff and admin operations", exact=True).wait_for()
+
+    browser_page.goto(f"{live_server}/dashboard", wait_until="load")
+    browser_page.get_by_role("heading", name="E2E Boundary Customer").wait_for()
+    cookie_names = {cookie["name"] for cookie in browser_page.context.cookies()}
+    assert "__Host-sitbank_session" in cookie_names
+    assert "__Host-sitbank_admin_session" in cookie_names
+
+
+def test_admin_browser_csrf_and_backoff_are_distinct_private_pages(
+    admin_live_server,
+    browser_page,
+):
+    admin_app, admin_base_url = admin_live_server
+    admin_app.config["WTF_CSRF_ENABLED"] = True
+    browser_page.goto(f"{admin_base_url}/login", wait_until="load")
+    browser_page.locator("input[name='workplace_email']").fill(
+        "fake.admin@sit.singaporetech.edu.sg"
+    )
+    browser_page.locator("input[name='password']").fill("clearly-fake-password")
+    browser_page.locator("input[name='csrf_token']").evaluate(
+        "(element) => { element.value = 'invalid-test-token'; }"
+    )
+    browser_page.get_by_role("button", name="Continue").click()
+    browser_page.get_by_text(CSRF_ERROR_MESSAGE, exact=True).wait_for()
+    assert browser_page.get_by_role("heading", name="400").count() == 1
+    assert RATE_LIMIT_MESSAGE not in browser_page.content()
+
+    admin_app.config["WTF_CSRF_ENABLED"] = False
+    for _attempt in range(4):
+        browser_page.goto(f"{admin_base_url}/login", wait_until="load")
+        browser_page.locator("input[name='workplace_email']").fill(
+            "unknown.admin@sit.singaporetech.edu.sg"
+        )
+        browser_page.locator("input[name='password']").fill("clearly-fake-password")
+        browser_page.get_by_role("button", name="Continue").click()
+        browser_page.wait_for_load_state("load")
+        if browser_page.get_by_role("heading", name="429").count():
+            break
+
+    browser_page.get_by_role("heading", name="429").wait_for()
+    browser_page.get_by_text(RATE_LIMIT_MESSAGE, exact=True).wait_for()
+    assert "Authentication backoff" not in browser_page.content()

--- a/tests/e2e/test_customer_auth_browser.py
+++ b/tests/e2e/test_customer_auth_browser.py
@@ -4,6 +4,7 @@ import os
 
 import pytest
 
+from app.security.http_errors import CSRF_ERROR_MESSAGE, RATE_LIMIT_MESSAGE
 from app.extensions import db
 from app.models import User
 from app.security.passwords import hash_password
@@ -44,6 +45,9 @@ def test_login_page_renders_with_security_headers_and_no_console_errors(
     console_errors = record_console_errors(browser_page)
 
     response = browser_page.goto(f"{live_server}/login", wait_until="load")
+    if console_errors == ["Failed to load resource: net::ERR_NO_BUFFER_SPACE"]:
+        console_errors.clear()
+        response = browser_page.reload(wait_until="load")
 
     assert response is not None
     assert response.status == 200
@@ -81,3 +85,40 @@ def test_password_login_reaches_mfa_setup_without_external_services(
     browser_page.wait_for_url("**/mfa/setup", wait_until="load")
     browser_page.get_by_role("heading", name="MFA setup").wait_for()
     assert console_errors == []
+
+
+def test_login_csrf_failure_stays_a_branded_security_token_400(
+    app,
+    live_server,
+    browser_page,
+):
+    app.config["WTF_CSRF_ENABLED"] = True
+    browser_page.goto(f"{live_server}/login", wait_until="load")
+    browser_page.locator("input[name='identifier']").fill("fake-customer")
+    browser_page.locator("input[name='password']").fill("clearly-fake-password")
+    browser_page.locator("input[name='csrf_token']").evaluate(
+        "(element) => { element.value = 'invalid-test-token'; }"
+    )
+    browser_page.locator("button[type='submit']").click()
+
+    browser_page.get_by_role("heading", name="400").wait_for()
+    browser_page.get_by_text(CSRF_ERROR_MESSAGE, exact=True).wait_for()
+    assert RATE_LIMIT_MESSAGE not in browser_page.content()
+
+
+def test_repeated_login_failures_use_the_standard_branded_429(
+    live_server,
+    browser_page,
+):
+    for _attempt in range(4):
+        browser_page.goto(f"{live_server}/login", wait_until="load")
+        browser_page.locator("input[name='identifier']").fill("unknown-e2e-customer")
+        browser_page.locator("input[name='password']").fill("clearly-fake-password")
+        browser_page.locator("button[type='submit']").click()
+        browser_page.wait_for_load_state("load")
+        if browser_page.get_by_role("heading", name="429").count():
+            break
+
+    browser_page.get_by_role("heading", name="429").wait_for()
+    browser_page.get_by_text(RATE_LIMIT_MESSAGE, exact=True).wait_for()
+    assert "Authentication backoff" not in browser_page.content()

--- a/tests/e2e/test_customer_banking_browser.py
+++ b/tests/e2e/test_customer_banking_browser.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import os
+from decimal import Decimal
+
+import pytest
+
+from tests.e2e.support import (
+    RUN_E2E_ENV,
+    browser_page,
+    create_e2e_customer,
+    create_e2e_payee,
+    current_totp,
+    live_server,
+    login_customer_with_mfa,
+)
+
+
+pytestmark = [pytest.mark.e2e]
+if os.environ.get(RUN_E2E_ENV) != "1":
+    pytestmark.append(
+        pytest.mark.skip(reason=f"set {RUN_E2E_ENV}=1 to run Playwright E2E browser tests")
+    )
+
+_PASSWORD = "Correct Horse Battery Staple 2026!"
+
+
+@pytest.fixture()
+def e2e_banking_pair(app):
+    sender = create_e2e_customer(
+        app,
+        username="e2e_banking_sender",
+        password=_PASSWORD,
+        email="e2e.banking.sender@example.test",
+        phone_number="91234564",
+        account_number="012345678914",
+        full_name="E2E Banking Sender",
+        balance=Decimal("5000.00"),
+        mfa_enabled=True,
+    )
+    recipient = create_e2e_customer(
+        app,
+        username="e2e_banking_recipient",
+        password=_PASSWORD,
+        email="e2e.banking.recipient@example.test",
+        phone_number="81234564",
+        account_number="012345678924",
+        full_name="E2E Banking Recipient",
+        balance=Decimal("1000.00"),
+    )
+    return {"sender": sender, "recipient": recipient}
+
+
+def test_add_payee_requires_totp_and_displays_only_masked_account(
+    live_server,
+    browser_page,
+    e2e_banking_pair,
+):
+    sender = e2e_banking_pair["sender"]
+    recipient = e2e_banking_pair["recipient"]
+    login_customer_with_mfa(browser_page, live_server, sender)
+    browser_page.goto(f"{live_server}/banking/payees/add", wait_until="load")
+    browser_page.locator("input[name='nickname']").fill("Browser Recipient")
+    browser_page.locator("input[name='account_number']").fill(
+        recipient["account_number"]
+    )
+    browser_page.locator("input[name='totp_code']").fill(current_totp(sender["secret"]))
+    browser_page.get_by_role("button", name="Look Up Recipient").click()
+
+    browser_page.wait_for_url("**/banking/payees/confirm", wait_until="load")
+    content = browser_page.content()
+    assert recipient["full_name"] in content
+    assert recipient["account_number"] not in content
+    assert recipient["account_number"][-3:] in content
+    browser_page.get_by_role("button", name="Confirm and Add Payee").click()
+    browser_page.wait_for_url("**/banking/payees", wait_until="load")
+    browser_page.get_by_text("Browser Recipient", exact=True).wait_for()
+
+
+def test_self_payee_and_invalid_account_fail_without_recipient_disclosure(
+    live_server,
+    browser_page,
+    e2e_banking_pair,
+):
+    sender = e2e_banking_pair["sender"]
+    recipient = e2e_banking_pair["recipient"]
+    login_customer_with_mfa(browser_page, live_server, sender)
+    browser_page.goto(f"{live_server}/banking/payees/add", wait_until="load")
+    browser_page.locator("input[name='nickname']").fill("Self")
+    browser_page.locator("input[name='account_number']").fill(sender["account_number"])
+    browser_page.locator("input[name='totp_code']").fill(current_totp(sender["secret"]))
+    browser_page.get_by_role("button", name="Look Up Recipient").click()
+
+    browser_page.get_by_text(
+        "You cannot add your own account as a payee.",
+        exact=True,
+    ).wait_for()
+    assert recipient["full_name"] not in browser_page.content()
+
+
+@pytest.mark.parametrize(
+    ("amount", "expected_text"),
+    [
+        ("125.50", "Transfer of SGD 125.50000"),
+        ("9000.00", "Insufficient funds."),
+    ],
+)
+def test_transfer_review_and_completion_paths_are_server_bound(
+    app,
+    live_server,
+    browser_page,
+    e2e_banking_pair,
+    amount,
+    expected_text,
+):
+    sender = e2e_banking_pair["sender"]
+    recipient = e2e_banking_pair["recipient"]
+    payee_id = create_e2e_payee(
+        app,
+        customer_id=int(sender["id"]),
+        recipient=recipient,
+    )
+    login_customer_with_mfa(browser_page, live_server, sender)
+    browser_page.goto(
+        f"{live_server}/banking/transfer/{payee_id}",
+        wait_until="load",
+    )
+    browser_page.locator("input[name='amount']").fill(amount)
+    browser_page.locator("input[name='reference']").fill("Browser transfer")
+    browser_page.locator("input[name='totp_code']").fill(current_totp(sender["secret"]))
+    browser_page.get_by_role("button", name="Review Transfer").click()
+
+    browser_page.wait_for_url(
+        f"**/banking/transfer/{payee_id}/confirm",
+        wait_until="load",
+    )
+    browser_page.get_by_role("heading", name="Confirm Transfer").wait_for()
+    assert recipient["account_number"] not in browser_page.content()
+    browser_page.get_by_role("button", name="Confirm Transfer").click()
+    browser_page.wait_for_url("**/banking/payees", wait_until="load")
+    browser_page.get_by_text(expected_text, exact=False).wait_for()

--- a/tests/e2e/test_customer_mfa_browser.py
+++ b/tests/e2e/test_customer_mfa_browser.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tests.e2e.support import (
+    RUN_E2E_ENV,
+    browser_page,
+    create_e2e_customer,
+    current_totp,
+    live_server,
+    record_console_errors,
+)
+
+
+pytestmark = [pytest.mark.e2e]
+if os.environ.get(RUN_E2E_ENV) != "1":
+    pytestmark.append(
+        pytest.mark.skip(reason=f"set {RUN_E2E_ENV}=1 to run Playwright E2E browser tests")
+    )
+
+_PASSWORD = "Correct Horse Battery Staple 2026!"
+
+
+@pytest.fixture()
+def e2e_mfa_setup_customer(app):
+    return create_e2e_customer(
+        app,
+        username="e2e_mfa_setup_customer",
+        password=_PASSWORD,
+        email="e2e.mfa.setup@example.test",
+        phone_number="91234561",
+        account_number="012345678911",
+        full_name="E2E MFA Setup Customer",
+    )
+
+
+@pytest.fixture()
+def e2e_mfa_login_customer(app):
+    return create_e2e_customer(
+        app,
+        username="e2e_mfa_login_customer",
+        password=_PASSWORD,
+        email="e2e.mfa.login@example.test",
+        phone_number="91234562",
+        account_number="012345678912",
+        full_name="E2E MFA Login Customer",
+        mfa_enabled=True,
+    )
+
+
+def test_mfa_setup_completes_and_recovery_codes_are_one_time(
+    live_server,
+    browser_page,
+    e2e_mfa_setup_customer,
+):
+    console_errors = record_console_errors(browser_page)
+    browser_page.goto(f"{live_server}/login", wait_until="load")
+    browser_page.locator("input[name='identifier']").fill(
+        e2e_mfa_setup_customer["username"]
+    )
+    browser_page.locator("input[name='password']").fill(
+        e2e_mfa_setup_customer["password"]
+    )
+    browser_page.locator("button[type='submit']").click()
+    browser_page.wait_for_url("**/mfa/setup", wait_until="load")
+
+    browser_page.get_by_role(
+        "button",
+        name="Generate authenticator setup",
+    ).first.click()
+    manual_secret = browser_page.locator("#manual-entry-secret").input_value()
+    browser_page.locator("input[name='totp_code']").fill(current_totp(manual_secret))
+    browser_page.get_by_role("button", name="Enable MFA").click()
+
+    browser_page.get_by_text("MFA is now enabled.", exact=True).wait_for()
+    recovery_codes = browser_page.locator("[data-recovery-code]")
+    assert recovery_codes.count() >= 8
+    assert browser_page.locator("#manual-entry-secret").count() == 0
+    browser_page.goto(f"{live_server}/dashboard", wait_until="load")
+    followup = browser_page.goto(f"{live_server}/mfa/setup", wait_until="load")
+    assert browser_page.locator("[data-recovery-code]").count() == 0
+    assert followup is not None
+    assert "no-store" in followup.headers["cache-control"]
+    assert console_errors == []
+
+
+def test_mfa_failure_is_generic_and_repeated_attempts_use_branded_429(
+    live_server,
+    browser_page,
+    e2e_mfa_login_customer,
+):
+    browser_page.goto(f"{live_server}/login", wait_until="load")
+    browser_page.locator("input[name='identifier']").fill(
+        e2e_mfa_login_customer["username"]
+    )
+    browser_page.locator("input[name='password']").fill(
+        e2e_mfa_login_customer["password"]
+    )
+    browser_page.locator("button[type='submit']").click()
+    browser_page.wait_for_url("**/mfa/verify", wait_until="load")
+
+    browser_page.locator("input[name='totp_code']").fill("000000")
+    browser_page.get_by_role("button", name="Verify code").click()
+    browser_page.get_by_text(
+        "Incorrect code. Check your authenticator and try again.",
+        exact=True,
+    ).wait_for()
+
+    for _attempt in range(3):
+        browser_page.locator("input[name='totp_code']").fill("000000")
+        browser_page.get_by_role("button", name="Verify code").click()
+        browser_page.wait_for_load_state("load")
+        if browser_page.get_by_role("heading", name="429").count():
+            break
+
+    browser_page.get_by_role("heading", name="429").wait_for()
+    browser_page.get_by_text(
+        "Too many attempts. Please try again later.",
+        exact=True,
+    ).wait_for()
+    assert e2e_mfa_login_customer["secret"] not in browser_page.content()

--- a/tests/e2e/test_customer_registration_recovery_browser.py
+++ b/tests/e2e/test_customer_registration_recovery_browser.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from app.auth.password_reset import (
+    GENERIC_FORGOT_PASSWORD_MESSAGE,
+    GENERIC_MANUAL_RECOVERY_MESSAGE,
+)
+from tests.e2e.support import (
+    RUN_E2E_ENV,
+    browser_page,
+    create_e2e_customer,
+    current_totp,
+    latest_password_reset_token,
+    latest_registration_code,
+    live_server,
+)
+
+
+pytestmark = [pytest.mark.e2e]
+if os.environ.get(RUN_E2E_ENV) != "1":
+    pytestmark.append(
+        pytest.mark.skip(reason=f"set {RUN_E2E_ENV}=1 to run Playwright E2E browser tests")
+    )
+
+_PASSWORD = "Correct Horse Battery Staple 2026!"
+
+
+@pytest.fixture()
+def e2e_recovery_customer(app):
+    return create_e2e_customer(
+        app,
+        username="e2e_recovery_customer",
+        password=_PASSWORD,
+        email="e2e.recovery@example.com",
+        phone_number="91234563",
+        account_number="012345678913",
+        full_name="E2E Recovery Customer",
+        mfa_enabled=True,
+    )
+
+
+def test_registration_email_otp_and_required_fields_complete_in_browser(
+    app,
+    live_server,
+    browser_page,
+):
+    browser_page.goto(f"{live_server}/register", wait_until="load")
+    browser_page.get_by_role("button", name="Send verification code").click()
+    browser_page.get_by_text("This field is required.", exact=True).wait_for()
+
+    browser_page.locator("#otp_request_email").fill("new.e2e.customer@example.com")
+    browser_page.get_by_role("button", name="Send verification code").click()
+    browser_page.locator("input[name='otp_code']").fill(
+        latest_registration_code(app)
+    )
+    browser_page.get_by_role("button", name="Verify email").click()
+    browser_page.get_by_role("heading", name="Complete your account").wait_for()
+
+    browser_page.locator("input[name='username']").fill("new_e2e_customer")
+    browser_page.locator("input[name='full_name']").fill("New Browser Customer")
+    browser_page.locator("input[name='phone_number']").fill("81234563")
+    browser_page.locator("input[name='password']").fill(_PASSWORD)
+    browser_page.locator("input[name='confirm_password']").fill(_PASSWORD)
+    browser_page.get_by_role("button", name="Create account").click()
+
+    browser_page.wait_for_url("**/login", wait_until="load")
+    browser_page.get_by_text(
+        "Registration successful. Please log in.",
+        exact=True,
+    ).wait_for()
+    assert "new.e2e.customer@example.com" not in browser_page.url
+
+
+def test_forgot_password_is_generic_and_reset_token_leaves_the_url(
+    app,
+    live_server,
+    browser_page,
+    e2e_recovery_customer,
+):
+    browser_page.goto(f"{live_server}/forgot-password", wait_until="load")
+    browser_page.locator("input[name='email']").fill(e2e_recovery_customer["email"])
+    browser_page.get_by_role("button", name="Send reset link").click()
+    browser_page.get_by_text(GENERIC_FORGOT_PASSWORD_MESSAGE, exact=True).wait_for()
+    token = latest_password_reset_token(app)
+
+    browser_page.goto(
+        f"{live_server}/reset-password?token={token}",
+        wait_until="load",
+    )
+    browser_page.get_by_role("button", name="Continue password reset").click()
+    browser_page.wait_for_url("**/reset-password/continue", wait_until="load")
+    assert token not in browser_page.url
+    browser_page.locator("input[name='totp_code']").fill(
+        current_totp(e2e_recovery_customer["secret"])
+    )
+    browser_page.get_by_role("button", name="Verify code").click()
+
+    new_password = "New Correct Horse Battery Staple 2026!"
+    browser_page.locator("input[name='new_password']").fill(new_password)
+    browser_page.locator("input[name='confirm_new_password']").fill(new_password)
+    browser_page.get_by_role("button", name="Reset Password").click()
+    browser_page.wait_for_url("**/login", wait_until="load")
+    browser_page.get_by_text(
+        "Your password has been reset. You can now log in.",
+        exact=True,
+    ).wait_for()
+
+    browser_page.goto(f"{live_server}/forgot-password", wait_until="load")
+    browser_page.locator("input[name='email']").fill("unknown@example.com")
+    browser_page.get_by_role("button", name="Send reset link").click()
+    browser_page.get_by_text(GENERIC_FORGOT_PASSWORD_MESSAGE, exact=True).wait_for()
+
+
+def test_manual_recovery_known_and_unknown_identifiers_share_generic_message(
+    live_server,
+    browser_page,
+    e2e_recovery_customer,
+):
+    for identifier in (
+        e2e_recovery_customer["username"],
+        "unknown-e2e-recovery-user",
+    ):
+        browser_page.goto(f"{live_server}/account-recovery", wait_until="load")
+        browser_page.locator("input[name='identifier']").fill(identifier)
+        browser_page.get_by_role("button", name="Request recovery review").click()
+        browser_page.get_by_text(
+            GENERIC_MANUAL_RECOVERY_MESSAGE,
+            exact=True,
+        ).wait_for()
+        assert identifier not in browser_page.url

--- a/tests/e2e/test_sensitive_browser_artifacts.py
+++ b/tests/e2e/test_sensitive_browser_artifacts.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tests.e2e.support import (
+    RUN_E2E_ENV,
+    browser_page,
+    create_e2e_customer,
+    live_server,
+    login_customer_with_mfa,
+)
+
+
+pytestmark = [pytest.mark.e2e]
+if os.environ.get(RUN_E2E_ENV) != "1":
+    pytestmark.append(
+        pytest.mark.skip(reason=f"set {RUN_E2E_ENV}=1 to run Playwright E2E browser tests")
+    )
+
+
+def test_sensitive_values_do_not_appear_in_dom_url_or_console(
+    app,
+    live_server,
+    browser_page,
+):
+    password = "Correct Horse Battery Staple 2026!"
+    customer = create_e2e_customer(
+        app,
+        username="e2e_sensitive_customer",
+        password=password,
+        email="e2e.sensitive@example.test",
+        phone_number="91234567",
+        account_number="012345678917",
+        full_name="E2E Sensitive Customer",
+        mfa_enabled=True,
+    )
+    console_messages: list[str] = []
+    browser_page.on("console", lambda message: console_messages.append(message.text))
+    login_customer_with_mfa(browser_page, live_server, customer)
+    browser_page.goto(f"{live_server}/sessions", wait_until="load")
+
+    content = browser_page.content()
+    assert password not in content
+    assert customer["secret"] not in content
+    assert customer["account_number"] not in content
+    assert password not in browser_page.url
+    assert customer["secret"] not in browser_page.url
+    assert customer["account_number"] not in browser_page.url
+    assert not any(password in message for message in console_messages)
+    assert not any(customer["secret"] in message for message in console_messages)

--- a/tests/e2e/test_session_security_browser.py
+++ b/tests/e2e/test_session_security_browser.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tests.e2e.support import (
+    RUN_E2E_ENV,
+    browser_context_factory,
+    browser_page,
+    create_e2e_customer,
+    current_totp,
+    live_server,
+    login_customer_with_mfa,
+)
+
+
+pytestmark = [pytest.mark.e2e]
+if os.environ.get(RUN_E2E_ENV) != "1":
+    pytestmark.append(
+        pytest.mark.skip(reason=f"set {RUN_E2E_ENV}=1 to run Playwright E2E browser tests")
+    )
+
+_PASSWORD = "Correct Horse Battery Staple 2026!"
+
+
+@pytest.fixture()
+def e2e_session_customer(app):
+    return create_e2e_customer(
+        app,
+        username="e2e_session_customer",
+        password=_PASSWORD,
+        email="e2e.session@example.test",
+        phone_number="91234565",
+        account_number="012345678915",
+        full_name="E2E Session Customer",
+        mfa_enabled=True,
+    )
+
+
+def test_session_page_enforces_single_session_cap_and_public_refs(
+    live_server,
+    browser_context_factory,
+    e2e_session_customer,
+):
+    first_page = browser_context_factory()
+    second_page = browser_context_factory()
+    login_customer_with_mfa(first_page, live_server, e2e_session_customer)
+    login_customer_with_mfa(
+        second_page,
+        live_server,
+        e2e_session_customer,
+        totp_offset_seconds=30,
+    )
+
+    second_page.goto(f"{live_server}/sessions", wait_until="load")
+    second_page.get_by_text("Current session", exact=True).wait_for()
+    session_refs = second_page.locator("table[aria-label='Active sessions'] code")
+    past_refs = second_page.locator("table[aria-label='Past sessions'] code")
+    assert session_refs.count() == 1
+    assert past_refs.count() >= 1
+    assert len(session_refs.first.inner_text()) == 32
+    assert all(
+        len(past_refs.nth(index).inner_text()) == 32
+        for index in range(past_refs.count())
+    )
+    assert second_page.get_by_role("button", name="Terminate").count() == 0
+    assert "revoke-others" not in second_page.content()
+
+    first_page.goto(f"{live_server}/dashboard", wait_until="load")
+    first_page.wait_for_url("**/login", wait_until="load")
+    first_page.get_by_role("heading", name="Welcome back").wait_for()
+
+
+def test_password_change_requires_totp_and_invalidates_the_browser_session(
+    live_server,
+    browser_page,
+    e2e_session_customer,
+):
+    login_customer_with_mfa(browser_page, live_server, e2e_session_customer)
+    browser_page.goto(f"{live_server}/password/change", wait_until="load")
+    browser_page.locator("input[name='current_password']").fill(_PASSWORD)
+    new_password = "New Correct Horse Battery Staple 2026!"
+    browser_page.locator("input[name='new_password']").fill(new_password)
+    browser_page.locator("input[name='confirm_new_password']").fill(new_password)
+    browser_page.locator("input[name='totp_code']").fill(
+        current_totp(e2e_session_customer["secret"])
+    )
+    browser_page.get_by_role("button", name="Verify and change password").click()
+
+    browser_page.wait_for_url("**/login", wait_until="load")
+    browser_page.get_by_text(
+        "Password changed. Please log in again.",
+        exact=True,
+    ).wait_for()
+    browser_page.goto(f"{live_server}/dashboard", wait_until="load")
+    browser_page.wait_for_url("**/login", wait_until="load")
+
+
+def test_account_freeze_blocks_follow_on_high_risk_banking(
+    live_server,
+    browser_page,
+    e2e_session_customer,
+):
+    login_customer_with_mfa(browser_page, live_server, e2e_session_customer)
+    browser_page.goto(f"{live_server}/account/freeze", wait_until="load")
+    browser_page.locator("input[name='totp_code']").fill(
+        current_totp(e2e_session_customer["secret"])
+    )
+    browser_page.get_by_role("button", name="Verify and freeze account").click()
+    browser_page.get_by_text(
+        "Account frozen. Unfreeze requires manual support review.",
+        exact=True,
+    ).wait_for()
+
+    browser_page.goto(f"{live_server}/banking/payees/add", wait_until="load")
+    browser_page.wait_for_url("**/dashboard", wait_until="load")
+    browser_page.get_by_text(
+        "Account is frozen. This action is blocked pending review.",
+        exact=True,
+    ).wait_for()

--- a/tests/test_audit_alerting.py
+++ b/tests/test_audit_alerting.py
@@ -988,15 +988,15 @@ def test_security_alert_config_validation_and_db_dedupe(app, monkeypatch):
     with pytest.raises(AlertConfigurationError, match="DEDUPE"):
         validate_security_alert_config(environ={"SECURITY_ALERT_DEDUPE_TTL_SECONDS": "1"})
 
-def test_500_handler_logs_sanitized_context(app, client, caplog):
-    app.config["PROPAGATE_EXCEPTIONS"] = False
+def test_500_handler_logs_sanitized_context(mutable_app, caplog):
+    mutable_app.config["PROPAGATE_EXCEPTIONS"] = False
 
-    @app.post("/explode")
+    @mutable_app.post("/explode")
     def explode():
         raise RuntimeError("boom")
 
-    caplog.set_level("ERROR", logger=app.logger.name)
-    response = client.post(
+    caplog.set_level("ERROR", logger=mutable_app.logger.name)
+    response = mutable_app.test_client().post(
         "/explode?password=query-secret",
         data={"password": "form-secret"},
         headers={

--- a/tests/test_ci_local.py
+++ b/tests/test_ci_local.py
@@ -45,6 +45,24 @@ def test_default_mode_reports_docker_checks_skipped_when_docker_is_unavailable(
     assert "OVERALL: PASS (PARTIAL" in output
 
 
+def test_full_suite_command_remains_unscoped_and_has_no_marker_exclusions(
+    ci_local_module,
+):
+    command = dict(ci_local_module.PYTHON_CHECKS)["Full parallel test suite"]
+
+    assert command[:6] == (
+        sys.executable,
+        "-m",
+        "pytest",
+        "-q",
+        "-n",
+        "auto",
+    )
+    assert "-m" not in command[3:]
+    assert "tests" not in command
+    assert not any(str(argument).startswith("tests/") for argument in command)
+
+
 def test_strict_mode_fails_when_docker_is_unavailable(
     ci_local_module, monkeypatch, capsys
 ):

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -3751,6 +3751,17 @@ def test_staging_nginx_enforces_https_auth_health_and_rate_limits():
     assert "limit_req_zone $binary_remote_addr zone=sitbank_staging_app:10m rate=10r/s;" in rate_limits
     assert "limit_req_status 429;" in nginx
     assert "limit_req_log_level warn;" in nginx
+    assert "error_page 429 = @sitbank_rate_limited;" in nginx
+    assert "location @sitbank_rate_limited {" in nginx
+    assert "Too many attempts. Please try again later." in nginx
+    assert "proxy_pass" not in _nginx_location_bodies(
+        nginx,
+        "@sitbank_rate_limited",
+    )[0]
+    auth_error_bodies = _nginx_location_bodies(nginx, "@sitbank_rate_limited_json")
+    assert len(auth_error_bodies) == 1
+    assert "default_type application/json;" in auth_error_bodies[0]
+    assert "proxy_pass" not in auth_error_bodies[0]
     assert "limit_req_status" not in rate_limits
     assert "limit_req_log_level" not in rate_limits
     for selector in ("= /login", "= /register", "= /mfa/verify", "^~ /auth/"):
@@ -3940,6 +3951,21 @@ def test_production_nginx_edge_config_enforces_network_boundary_and_limits():
         assert zone in rate_limits
     assert "limit_req_status 429;" in nginx
     assert "limit_req_log_level warn;" in nginx
+    assert "error_page 429 = @sitbank_rate_limited;" in nginx
+    browser_error_bodies = _nginx_location_bodies(
+        customer_nginx,
+        "@sitbank_rate_limited",
+    )
+    assert len(browser_error_bodies) == 1
+    assert "Too many attempts. Please try again later." in browser_error_bodies[0]
+    assert "proxy_pass" not in browser_error_bodies[0]
+    api_error_bodies = _nginx_location_bodies(
+        customer_nginx,
+        "@sitbank_rate_limited_json",
+    )
+    assert len(api_error_bodies) == 1
+    assert "default_type application/json;" in api_error_bodies[0]
+    assert "proxy_pass" not in api_error_bodies[0]
     assert "limit_req_status" not in rate_limits
     assert "limit_req_log_level" not in rate_limits
 

--- a/tests/test_owasp_regressions.py
+++ b/tests/test_owasp_regressions.py
@@ -75,21 +75,21 @@ def test_url_like_mass_assignment_field_is_rejected(client):
     assert response.get_json() == {"error": "Invalid request"}
 
 
-def test_server_errors_do_not_disclose_tracebacks(app):
-    original = app.config.get("PROPAGATE_EXCEPTIONS")
-    app.config["PROPAGATE_EXCEPTIONS"] = False
+def test_server_errors_do_not_disclose_tracebacks(mutable_app):
+    original = mutable_app.config.get("PROPAGATE_EXCEPTIONS")
+    mutable_app.config["PROPAGATE_EXCEPTIONS"] = False
 
-    @app.get("/_owasp-error-disclosure-test")
+    @mutable_app.get("/_owasp-error-disclosure-test")
     def raise_for_error_disclosure_test():
         raise RuntimeError("sensitive-internal-marker")
 
     try:
-        response = app.test_client().get(
+        response = mutable_app.test_client().get(
             "/_owasp-error-disclosure-test",
             headers={"Accept": "application/json"},
         )
     finally:
-        app.config["PROPAGATE_EXCEPTIONS"] = original
+        mutable_app.config["PROPAGATE_EXCEPTIONS"] = original
 
     assert response.status_code == 500
     assert response.get_json() == {

--- a/tests/test_playwright_e2e_config.py
+++ b/tests/test_playwright_e2e_config.py
@@ -11,6 +11,16 @@ from tests.e2e.support import _assert_local_base_url
 CI_WORKFLOW_PATH = Path(".github/workflows/ci-deploy.yml")
 E2E_SUPPORT_PATH = Path("tests/e2e/support.py")
 E2E_TEST_PATHS = tuple(sorted(Path("tests/e2e").glob("test_*.py")))
+EXPECTED_E2E_FILES = {
+    "test_customer_admin_boundary_browser.py",
+    "test_customer_auth_browser.py",
+    "test_customer_banking_browser.py",
+    "test_customer_mfa_browser.py",
+    "test_customer_registration_recovery_browser.py",
+    "test_customer_security_browser.py",
+    "test_sensitive_browser_artifacts.py",
+    "test_session_security_browser.py",
+}
 
 
 def _combined_e2e_tests() -> str:
@@ -43,6 +53,21 @@ def test_playwright_e2e_defaults_to_opt_in_local_loopback():
     assert "pytest.mark.e2e" in tests
     assert "https://sitbank.pp.ua" not in combined
     assert "https://staging-sitbank.pp.ua" not in combined
+    assert {path.name for path in E2E_TEST_PATHS} == EXPECTED_E2E_FILES
+    for required_flow in (
+        "test_mfa_setup_completes",
+        "test_registration_email_otp",
+        "test_forgot_password",
+        "test_manual_recovery",
+        "test_add_payee",
+        "test_transfer_review",
+        "test_session_page",
+        "test_password_change",
+        "test_account_freeze",
+        "test_customer_and_admin_browser_sessions_remain_isolated",
+        "test_sensitive_values_do_not_appear",
+    ):
+        assert required_flow in tests
 
 
 @pytest.mark.parametrize(
@@ -106,6 +131,10 @@ def test_playwright_browser_artifacts_are_ignored_and_not_committed():
     assert not any(Path("tests/e2e").glob("**/*.webm"))
     assert not any(Path("tests/e2e").glob("**/*.zip"))
     assert not any(Path("tests/e2e").glob("**/trace*"))
+    support = E2E_SUPPORT_PATH.read_text(encoding="utf-8")
+    assert "record_video_dir" not in support
+    assert "tracing.start" not in support
+    assert "page.screenshot" not in support
 
 
 def test_playwright_e2e_docs_are_current():
@@ -127,6 +156,9 @@ def test_playwright_e2e_docs_are_current():
         "python -m pytest -q tests/e2e",
         "loopback Flask server",
         "authentication, MFA, session, banking, and boundary regressions",
+        "registration, password reset, manual recovery, payee, transfer, session management, password change, account freeze, and customer/admin isolation",
+        "per-worker app and database schema",
+        "streaming Git object batches",
         "do not prove live staging or production provider state",
     ):
         assert required in docs

--- a/tests/test_rate_limit_error_ux.py
+++ b/tests/test_rate_limit_error_ux.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import pytest
+
+from app.auth.services import AuthError
+from app.extensions import db, limiter
+from app.security.http_errors import CSRF_ERROR_MESSAGE, RATE_LIMIT_MESSAGE
+from conftest import TestConfig
+
+
+@contextmanager
+def _admin_test_app():
+    from app import create_app
+
+    admin_app = create_app(TestConfig, app_mode="admin")
+    with admin_app.app_context():
+        db.create_all()
+        limiter.reset()
+        try:
+            yield admin_app
+        finally:
+            limiter.reset()
+            db.session.remove()
+            db.drop_all()
+
+
+def _raise_auth_error(message: str, status_code: int, *, retry_after: int | None = None):
+    def raise_error(*_args, **_kwargs):
+        raise AuthError(message, status_code, retry_after=retry_after)
+
+    return raise_error
+
+
+def test_customer_browser_auth_backoff_uses_standard_branded_response(app, monkeypatch):
+    monkeypatch.setattr(
+        "app.web.routes.authenticate_primary",
+        _raise_auth_error("backend-specific throttling detail", 429, retry_after=17),
+    )
+
+    response = app.test_client().post(
+        "/login",
+        data={"identifier": "fake-customer", "password": "clearly-fake-password"},
+    )
+
+    assert response.status_code == 429
+    assert response.content_type.startswith("text/html")
+    assert RATE_LIMIT_MESSAGE.encode() in response.data
+    assert b"SITBank" in response.data
+    assert b"backend-specific throttling detail" not in response.data
+
+
+def test_customer_limiter_and_auth_api_keep_safe_channel_specific_responses(app, monkeypatch):
+    monkeypatch.setattr(
+        "app.web.routes.authenticate_primary",
+        _raise_auth_error("Invalid username or password", 401),
+    )
+    browser_client = app.test_client()
+    for _attempt in range(5):
+        response = browser_client.post(
+            "/login",
+            data={"identifier": "fake-customer", "password": "clearly-fake-password"},
+        )
+        assert response.status_code == 401
+
+    browser_limited = browser_client.post(
+        "/login",
+        data={"identifier": "fake-customer", "password": "clearly-fake-password"},
+    )
+
+    limiter.reset()
+    monkeypatch.setattr(
+        "app.auth.routes.authenticate_primary",
+        _raise_auth_error("API throttling detail", 429, retry_after=11),
+    )
+    api_limited = app.test_client().post(
+        "/auth/login",
+        json={"identifier": "fake-customer", "password": "clearly-fake-password"},
+    )
+
+    assert browser_limited.status_code == 429
+    assert browser_limited.content_type.startswith("text/html")
+    assert RATE_LIMIT_MESSAGE.encode() in browser_limited.data
+    assert api_limited.status_code == 429
+    assert api_limited.is_json
+    assert api_limited.get_json() == {"error": "API throttling detail"}
+    assert api_limited.headers["X-Auth-Retry-After"] == "11"
+    assert int(api_limited.headers["Retry-After"]) > 0
+
+
+def test_customer_csrf_failure_stays_distinct_from_rate_limiting(app):
+    original = app.config["WTF_CSRF_ENABLED"]
+    app.config["WTF_CSRF_ENABLED"] = True
+    try:
+        response = app.test_client().post(
+            "/login",
+            data={"identifier": "fake-customer", "password": "clearly-fake-password"},
+        )
+    finally:
+        app.config["WTF_CSRF_ENABLED"] = original
+
+    assert response.status_code == 400
+    assert response.content_type.startswith("text/html")
+    assert CSRF_ERROR_MESSAGE.encode() in response.data
+    assert RATE_LIMIT_MESSAGE.encode() not in response.data
+    assert b'href="/login"' in response.data
+
+
+def test_admin_browser_backoff_and_csrf_use_private_admin_pages(monkeypatch):
+    with _admin_test_app() as admin_app:
+        monkeypatch.setattr(
+            "app.admin.routes.authenticate_admin_primary",
+            _raise_auth_error("private authentication detail", 429, retry_after=13),
+        )
+        browser_client = admin_app.test_client()
+        backoff = browser_client.post(
+            "/login",
+            data={
+                "workplace_email": "fake.admin@sit.singaporetech.edu.sg",
+                "password": "clearly-fake-password",
+            },
+        )
+
+        admin_app.config["WTF_CSRF_ENABLED"] = True
+        csrf_failure = admin_app.test_client().post(
+            "/login",
+            data={
+                "workplace_email": "fake.admin@sit.singaporetech.edu.sg",
+                "password": "clearly-fake-password",
+            },
+        )
+
+    assert backoff.status_code == 429
+    assert backoff.content_type.startswith("text/html")
+    assert b"Private admin request status" in backoff.data
+    assert RATE_LIMIT_MESSAGE.encode() in backoff.data
+    assert b"private authentication detail" not in backoff.data
+    assert csrf_failure.status_code == 400
+    assert csrf_failure.content_type.startswith("text/html")
+    assert CSRF_ERROR_MESSAGE.encode() in csrf_failure.data
+    assert RATE_LIMIT_MESSAGE.encode() not in csrf_failure.data
+    assert b"Return to admin login" in csrf_failure.data
+
+
+def test_admin_json_limiter_response_remains_structured(monkeypatch):
+    with _admin_test_app() as admin_app:
+        monkeypatch.setattr(
+            "app.admin.routes.authenticate_admin_primary",
+            _raise_auth_error("Invalid workplace email, password, or authentication code", 401),
+        )
+        client = admin_app.test_client()
+        for _attempt in range(5):
+            response = client.post(
+                "/login",
+                json={
+                    "workplace_email": "fake.admin@sit.singaporetech.edu.sg",
+                    "password": "clearly-fake-password",
+                },
+            )
+            assert response.status_code == 401
+
+        limited = client.post(
+            "/login",
+            json={
+                "workplace_email": "fake.admin@sit.singaporetech.edu.sg",
+                "password": "clearly-fake-password",
+            },
+        )
+
+    assert limited.status_code == 429
+    assert limited.is_json
+    assert limited.get_json() == {"error": RATE_LIMIT_MESSAGE}
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/invites",
+        "/invites/1/revoke",
+        "/staff/1/deactivate",
+        "/manual-recovery/requests/1/transition",
+        "/manual-recovery/requests/1/complete",
+        "/admin-action-requests/1/approve",
+        "/alerts/deliver",
+    ],
+)
+def test_admin_high_risk_browser_routes_share_rate_limit_page(path):
+    with _admin_test_app() as admin_app:
+        client = admin_app.test_client()
+        responses = [
+            client.post(
+                path,
+                data={"totp_code": "000000", "reason": "fake test reason", "status": "denied"},
+                environ_overrides={"REMOTE_ADDR": "198.51.100.200"},
+            )
+            for _index in range(11)
+        ]
+
+    limited = next((response for response in responses if response.status_code == 429), None)
+    assert limited is not None
+    assert limited.content_type.startswith("text/html")
+    assert b"Private admin request status" in limited.data
+    assert RATE_LIMIT_MESSAGE.encode() in limited.data

--- a/tests/test_rate_limit_error_ux.py
+++ b/tests/test_rate_limit_error_ux.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+from types import SimpleNamespace
 
 import pytest
 
@@ -171,6 +172,176 @@ def test_admin_json_limiter_response_remains_structured(monkeypatch):
     assert limited.status_code == 429
     assert limited.is_json
     assert limited.get_json() == {"error": RATE_LIMIT_MESSAGE}
+
+
+def test_admin_blueprint_auth_handler_preserves_retry_headers_for_json():
+    from app.admin.routes import handle_auth_error
+
+    with _admin_test_app() as admin_app:
+        with admin_app.test_request_context(
+            "/staff/invites/accept/start",
+            method="POST",
+            json={"invite_token": "clearly-fake-token"},
+        ):
+            response, status_code = handle_auth_error(
+                AuthError("safe API throttling detail", 429, retry_after=7)
+            )
+
+    assert status_code == 429
+    assert response.get_json() == {"error": RATE_LIMIT_MESSAGE}
+    assert response.headers["Retry-After"] == "7"
+    assert response.headers["X-Auth-Retry-After"] == "7"
+
+
+@pytest.mark.parametrize(
+    ("handler_name", "service_name", "form_key"),
+    [
+        ("_handle_mfa_setup_start", "generate_mfa_setup", "start"),
+        ("_handle_mfa_setup_verify", "verify_mfa_setup", "verify"),
+        ("_handle_mfa_replace_start", "generate_mfa_replacement", "replace_start"),
+        ("_handle_mfa_replace_verify", "verify_mfa_replacement", "replace_verify"),
+    ],
+)
+def test_customer_mfa_handlers_use_standard_429(
+    app,
+    monkeypatch,
+    handler_name,
+    service_name,
+    form_key,
+):
+    from flask import g
+    from app.web import routes
+
+    form = SimpleNamespace(
+        validate_on_submit=lambda: True,
+        totp_code=SimpleNamespace(data="000000"),
+        stepup_token=SimpleNamespace(data="clearly-fake-step-up-token"),
+    )
+    monkeypatch.setattr(
+        routes,
+        service_name,
+        _raise_auth_error("internal throttling detail", 429),
+    )
+
+    with app.test_request_context("/mfa/setup", method="POST"):
+        g.current_user = SimpleNamespace(id=123)
+        response, status_code = getattr(routes, handler_name)({form_key: form})
+
+    assert status_code == 429
+    assert RATE_LIMIT_MESSAGE in response
+    assert "internal throttling detail" not in response
+
+
+@pytest.mark.parametrize(
+    ("path", "data", "service_name", "requires_turnstile"),
+    [
+        (
+            "/forgot-password",
+            {"email": "fake.customer@example.com"},
+            "request_password_reset",
+            True,
+        ),
+        (
+            "/reset-password",
+            {"token": "clearly-fake-reset-token"},
+            "exchange_reset_token",
+            False,
+        ),
+        (
+            "/reset-password/continue",
+            None,
+            "current_reset_transaction",
+            False,
+        ),
+        (
+            "/reset-password/continue",
+            {"action": "complete"},
+            "current_reset_transaction",
+            False,
+        ),
+        (
+            "/account-recovery",
+            {"identifier": "fake-customer"},
+            "request_manual_recovery",
+            True,
+        ),
+    ],
+)
+def test_customer_public_security_routes_use_standard_429(
+    app,
+    monkeypatch,
+    path,
+    data,
+    service_name,
+    requires_turnstile,
+):
+    monkeypatch.setattr(
+        f"app.web.routes.{service_name}",
+        _raise_auth_error("internal throttling detail", 429),
+    )
+    if requires_turnstile:
+        monkeypatch.setattr(
+            "app.web.routes.require_turnstile",
+            lambda _action: None,
+        )
+
+    client = app.test_client()
+    response = client.get(path) if data is None else client.post(path, data=data)
+
+    assert response.status_code == 429
+    assert RATE_LIMIT_MESSAGE.encode() in response.data
+    assert b"internal throttling detail" not in response.data
+
+
+@pytest.mark.parametrize(
+    ("handler_name", "service_name", "data"),
+    [
+        ("_handle_reset_totp", "verify_reset_totp", {"totp_code": "000000"}),
+        (
+            "_handle_reset_recovery_code",
+            "verify_reset_recovery_code",
+            {"totp_code": "clearly-fake-recovery-code"},
+        ),
+        (
+            "_handle_reset_mfa_selection",
+            "select_reset_mfa_method",
+            {"mfa_method": "totp"},
+        ),
+        (
+            "_handle_reset_completion",
+            "complete_password_reset",
+            {
+                "new_password": "Clearly-Fake-Password-2026!",
+                "confirm_new_password": "Clearly-Fake-Password-2026!",
+            },
+        ),
+    ],
+)
+def test_customer_reset_handlers_use_standard_429(
+    app,
+    monkeypatch,
+    handler_name,
+    service_name,
+    data,
+):
+    from app.web import routes
+
+    monkeypatch.setattr(
+        routes,
+        service_name,
+        _raise_auth_error("internal throttling detail", 429),
+    )
+
+    with app.test_request_context(
+        "/reset-password/continue",
+        method="POST",
+        data=data,
+    ):
+        response, status_code = getattr(routes, handler_name)({"state": "fake"})
+
+    assert status_code == 429
+    assert RATE_LIMIT_MESSAGE in response
+    assert "internal throttling detail" not in response
 
 
 @pytest.mark.parametrize(

--- a/tests/test_secret_scanner.py
+++ b/tests/test_secret_scanner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import io
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -109,6 +110,76 @@ def test_tracked_files_and_historical_blobs_parse_git_output(monkeypatch):
     assert any("--batch-check=" in command[-1] for command in calls)
 
 
+class _FakeBatchProcess:
+    def __init__(self, output: bytes, *, return_code: int = 0, missing_pipe=False):
+        self.stdin = None if missing_pipe else io.BytesIO()
+        self.stdout = io.BytesIO(output)
+        self.stderr = io.BytesIO()
+        self.return_code = return_code
+        self.finished = False
+        self.killed = False
+
+    def wait(self):
+        self.finished = True
+        return self.return_code
+
+    def poll(self):
+        return self.return_code if self.finished else None
+
+    def kill(self):
+        self.killed = True
+        self.finished = True
+
+
+def test_batch_helpers_handle_empty_input_and_missing_pipes(monkeypatch):
+    assert scanner._batch_object_metadata([]) == {}
+    assert list(scanner._read_blob_batch([])) == []
+
+    process = _FakeBatchProcess(b"", missing_pipe=True)
+    monkeypatch.setattr(scanner.subprocess, "Popen", lambda *_args, **_kwargs: process)
+
+    with pytest.raises(RuntimeError, match="could not open safe pipes"):
+        list(scanner._read_blob_batch(["a" * 40]))
+    assert process.killed is True
+
+
+@pytest.mark.parametrize(
+    ("output", "return_code", "message"),
+    [
+        (
+            (("b" * 40) + " blob 4\nsafe\n").encode(),
+            0,
+            "unexpected history object metadata",
+        ),
+        (
+            (("a" * 40) + " blob 4\nsafex").encode(),
+            0,
+            "malformed history object content",
+        ),
+        (
+            (("a" * 40) + " blob 4\nsafe\n").encode(),
+            1,
+            "history object scan failed",
+        ),
+    ],
+)
+def test_blob_batch_fails_closed_for_invalid_git_output(
+    monkeypatch,
+    output,
+    return_code,
+    message,
+):
+    process = _FakeBatchProcess(output, return_code=return_code)
+    monkeypatch.setattr(scanner.subprocess, "Popen", lambda *_args, **_kwargs: process)
+
+    with pytest.raises(RuntimeError, match=message):
+        list(scanner._read_blob_batch(["a" * 40]))
+
+    assert process.stdin.closed is True
+    assert process.stdout.closed is True
+    assert process.stderr.closed is True
+
+
 def test_scan_history_skips_forbidden_and_large_blobs_and_scans_small_content(monkeypatch):
     monkeypatch.setattr(
         scanner,
@@ -117,6 +188,7 @@ def test_scan_history_skips_forbidden_and_large_blobs_and_scans_small_content(mo
             ("a" * 40, ".env"),
             ("b" * 40, "large.py"),
             ("c" * 40, "small.py"),
+            ("d" * 40, "tree-entry"),
         ],
     )
     scanned = []
@@ -128,6 +200,7 @@ def test_scan_history_skips_forbidden_and_large_blobs_and_scans_small_content(mo
             "a" * 40: ("blob", 10),
             "b" * 40: ("blob", scanner.MAX_HISTORY_BLOB_BYTES + 1),
             "c" * 40: ("blob", 10),
+            "d" * 40: ("tree", 10),
         },
     )
     monkeypatch.setattr(

--- a/tests/test_secret_scanner.py
+++ b/tests/test_secret_scanner.py
@@ -93,14 +93,20 @@ def test_tracked_files_and_historical_blobs_parse_git_output(monkeypatch):
             return SimpleNamespace(
                 stdout="a" * 40 + " app.py\n" + "b" * 40 + " tree\n" + "a" * 40 + " duplicate.py\n"
             )
-        object_id = command[-1]
-        return SimpleNamespace(stdout="blob\n" if object_id == "a" * 40 else "tree\n")
+        if command[:2] == ["git", "cat-file"]:
+            return SimpleNamespace(
+                stdout=(
+                    ("a" * 40) + " blob 10\n"
+                    + ("b" * 40) + " tree 0\n"
+                )
+            )
+        raise AssertionError(f"unexpected command: {command}")
 
     monkeypatch.setattr(scanner.subprocess, "run", fake_run)
 
     assert scanner.tracked_files() == [Path("app.py"), Path("docs/README.md")]
     assert scanner.historical_blobs() == [("a" * 40, "app.py")]
-    assert any(command[:2] == ["git", "cat-file"] for command in calls)
+    assert any("--batch-check=" in command[-1] for command in calls)
 
 
 def test_scan_history_skips_forbidden_and_large_blobs_and_scans_small_content(monkeypatch):
@@ -115,14 +121,20 @@ def test_scan_history_skips_forbidden_and_large_blobs_and_scans_small_content(mo
     )
     scanned = []
 
-    def fake_run(command, **kwargs):
-        object_id = command[-1]
-        if command[2] == "-s":
-            size = scanner.MAX_HISTORY_BLOB_BYTES + 1 if object_id == "b" * 40 else 10
-            return SimpleNamespace(stdout=f"{size}\n")
-        return SimpleNamespace(stdout=b"safe")
-
-    monkeypatch.setattr(scanner.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        scanner,
+        "_batch_object_metadata",
+        lambda _object_ids: {
+            "a" * 40: ("blob", 10),
+            "b" * 40: ("blob", scanner.MAX_HISTORY_BLOB_BYTES + 1),
+            "c" * 40: ("blob", 10),
+        },
+    )
+    monkeypatch.setattr(
+        scanner,
+        "_read_blob_batch",
+        lambda object_ids: iter((object_id, b"safe") for object_id in object_ids),
+    )
     monkeypatch.setattr(
         scanner,
         "scan_content",

--- a/tests/test_shared_fixture_isolation.py
+++ b/tests/test_shared_fixture_isolation.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from app.extensions import db, limiter
+from app.models import User
+from conftest import _restore_test_app_state
+from conftest import pytest_xdist_auto_num_workers
+
+
+def test_shared_worker_app_reset_clears_rows_limiter_and_config(app):
+    baseline_config = dict(app.config)
+    original_cookie_name = app.config["SESSION_COOKIE_NAME"]
+    with app.app_context():
+        db.session.add(
+            User(
+                username="fixture-reset-customer",
+                email="fixture.reset@example.test",
+                password_hash="clearly-fake-not-a-real-password-hash",
+                full_name="Fixture Reset Customer",
+                phone_number="81234567",
+                account_number="012345678901",
+            )
+        )
+        db.session.commit()
+
+    client = app.test_client()
+    for _attempt in range(5):
+        client.post(
+            "/auth/login",
+            json={"identifier": "unknown-before-reset", "password": "clearly-fake-password"},
+        )
+    app.config["SESSION_COOKIE_NAME"] = "__Host-mutated-test-cookie"
+    app.extensions["password_reset_outbox"] = [{"body": "fake delivery"}]
+
+    _restore_test_app_state(app, baseline_config)
+
+    with app.app_context():
+        assert db.session.query(User).count() == 0
+    assert app.config["SESSION_COOKIE_NAME"] == original_cookie_name
+    assert app.extensions["password_reset_outbox"] == []
+    limiter.reset()
+    response = app.test_client().post(
+        "/auth/login",
+        json={"identifier": "unknown-after-reset", "password": "clearly-fake-password"},
+    )
+    assert response.status_code == 401
+
+
+def test_shared_worker_app_uses_per_process_memory_database(app):
+    assert app.config["SQLALCHEMY_DATABASE_URI"] == "sqlite:///:memory:"
+    assert app.config["TESTING"] is True
+
+
+def test_xdist_auto_worker_count_is_bounded_for_sqlite_isolation(monkeypatch):
+    monkeypatch.setattr("conftest.os.cpu_count", lambda: 32)
+    assert pytest_xdist_auto_num_workers(None) == 4
+    monkeypatch.setattr("conftest.os.cpu_count", lambda: 1)
+    assert pytest_xdist_auto_num_workers(None) == 1


### PR DESCRIPTION
Summary
---
Standardizes customer and private-admin HTTP 429 presentation across Flask and Nginx, expands loopback-only browser regression coverage, and reduces the full pytest runtime without removing security gates or test scope.

Closes #382
Closes #381
Closes #365
Closes #362

Why
---
Rate-limit and CSRF failures had inconsistent browser/API presentation, the Playwright suite did not cover several critical account journeys, and repeated application setup plus per-object Git subprocesses made the full suite unnecessarily slow.

What changed
---
- Added centralized content-negotiated Flask error responses, branded customer/admin 429 pages, distinct CSRF 400 handling, and internal Nginx HTML/JSON 429 locations that do not proxy rejected requests.
- Expanded local-only Playwright coverage for registration, password recovery, MFA, payees, transfers, session invalidation, password change, account freeze, sensitive browser artifacts, and customer/admin isolation.
- Reused an isolated app/schema per xdist worker, capped `-n auto` at four workers, and streamed Git history through batched `cat-file` operations. The full suite still runs unscoped.
- Updated security, deployment, CI, and verification documentation plus regression tests.

Security impact
---
Existing Flask-Limiter and Nginx thresholds, durable authentication backoff, CSRF, MFA/TOTP step-up, audit/alert behavior, customer/admin cookies and signing keys, Cloudflare, Tailscale, and maker-checker boundaries remain enforced. API endpoints retain structured JSON; browser responses disclose no security internals. Browser tests use clearly fake data against loopback servers only and do not persist traces, videos, screenshots, cookies, or profiles.

Deployment impact
---
Requires staging deployment and production deployment of the updated Nginx configuration with the existing validation and staging-first gates. No EC2 bootstrap, database migration, secret change, provider configuration change, or permission expansion is required.

Verification
---
- `.\.venv\Scripts\python.exe -m pytest -q -n 4` - 1,373 passed, 32 skipped in 47.47s.
- `.\.venv\Scripts\python.exe -m pytest -q -n auto --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term` - 1,373 passed, 32 skipped; total coverage 90% and local new-code line coverage 89.9%.
- `$env:SITBANK_RUN_E2E = 1; .\.venv\Scripts\python.exe -m pytest -q tests/e2e` - 23 passed.
- Bandit, both hashed dependency audits, dependency-lock validation, package consistency, staged full-history secret scan, Python compilation, whitespace checks, and all 17 shell syntax checks passed.

Notes
---
The local CI wrapper selected the Windows WSL launcher despite no installed WSL distribution, so its shell phase exited before analysis. Running the same discovered 17 shell targets with Git Bash directly passed. ShellCheck, Hadolint, Semgrep, Docker/Compose, Nginx runtime validation, and Sonar remain authoritative CI gates.

