### PR TITLE
Refine private observability denial probes

### DIFF
--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -359,9 +359,12 @@ status, verifies anonymous API denial, verifies the non-admin verifier role,
 checks Loki datasource health through Grafana with explicit HTTP `200` status
 and schema validation, verifies direct private `/loki` and `/metrics` denial
 on the Tailscale host, and runs public denial probes for `/grafana`, `/loki`,
-`/logs`, and `/metrics`. It fails closed when private or public responses
-include Grafana/Loki-identifying headers or cookies, uploads only sanitized
-JSON evidence for 30 days, and logs out of Tailscale at completion.
+`/logs`, and `/metrics`. Cloudflare Access challenges, generic Cloudflare
+headers, and app/Nginx `401`, `403`, or `404` responses count as public-denial
+evidence. The verifier fails closed when private or public responses include
+Grafana/Loki-identifying headers, `grafana_session` cookies, or redirects to
+Grafana/Loki login paths, uploads only sanitized JSON evidence for 30 days,
+and logs out of Tailscale at completion.
 
 ## Gitleaks
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -363,11 +363,14 @@ Tailscale with `tag:github-ci-observability-verify`, verifies private Grafana
 health with explicit HTTP `200` status, anonymous denial, non-admin verifier
 role, Loki datasource health with explicit HTTP `200` status and schema
 validation, direct private `/loki` and `/metrics` denial, and public denial
-probes, then uploads only sanitized evidence. The private Grafana URL must be
-the approved `https://admin-sitbank.tailca101b.ts.net/grafana/` Tailscale
-subpath. It must not run on pull requests or public TLS jobs and must not
-receive operator passwords, browser sessions, cookies, MFA values, raw logs,
-datasource credentials, or Grafana admin credentials.
+probes, then uploads only sanitized evidence. Cloudflare Access challenges,
+generic Cloudflare headers, and app/Nginx `401`, `403`, or `404` responses are
+valid public-denial evidence; Grafana/Loki headers, `grafana_session` cookies,
+or redirects to Grafana/Loki login paths fail closed. The private Grafana URL
+must be the approved `https://admin-sitbank.tailca101b.ts.net/grafana/`
+Tailscale subpath. It must not run on pull requests or public TLS jobs and
+must not receive operator passwords, browser sessions, cookies, MFA values, raw
+logs, datasource credentials, or Grafana admin credentials.
 
 ## Production Cloudflare Origin Operations
 

--- a/docs/runbooks/private-observability-grafana-loki.md
+++ b/docs/runbooks/private-observability-grafana-loki.md
@@ -119,10 +119,14 @@ reachable from the public runner, then joins Tailscale, verifies Grafana API
 health with explicit HTTP `200` status validation, verifies anonymous API
 denial, checks the verifier role is not admin, checks Loki datasource health
 through Grafana with explicit HTTP `200` status and response-schema
-validation, and verifies public SITBank paths do not expose Grafana or Loki. It
-uploads only
+validation, and verifies public SITBank paths do not expose Grafana or Loki.
+Cloudflare Access challenges, generic Cloudflare edge headers, and app/Nginx
+`401`, `403`, and `404` denials are valid public-denial evidence; Grafana/Loki
+server headers, `x-grafana-*` or `x-loki-*` headers, `grafana_session` cookies,
+and public redirects to Grafana/Loki login paths fail closed. It uploads only
 `observability-evidence/private-observability.json`, a sanitized summary with
-HTTP status codes and check names, not raw API responses.
+target labels, HTTP status codes, denial categories, and check names, not raw
+headers, cookies, redirect URLs, or API responses.
 
 The protected workflow is live network-path evidence. It is not a pull-request
 check and must never run on forks, untrusted branches, or public GitHub-hosted

--- a/ops/observability/verify-private-observability
+++ b/ops/observability/verify-private-observability
@@ -32,18 +32,25 @@ DEFAULT_PUBLIC_PROBES = (
 SECRET_MARKERS = (
     "authorization:",
     "cookie:",
+    "set-cookie:",
     "cf-access-jwt-assertion",
     "grafana_session",
     "x-grafana-org-id",
 )
-OBSERVABILITY_HEADER_MARKERS = (
-    "server: grafana",
+EVIDENCE_FORBIDDEN_MARKERS = (
+    *SECRET_MARKERS,
+    "location:",
+    "/cdn-cgi/access",
+    "cloudflareaccess.",
+    "redirect_url=",
+    "raw response",
+)
+OBSERVABILITY_HEADER_PREFIXES = (
     "x-grafana-",
-    "grafana_session",
-    "server: loki",
     "x-loki-",
 )
 PUBLIC_EXPOSURE_PATHS = ("/grafana", "/loki", "/logs", "/metrics")
+REDIRECT_STATUSES = {"301", "302", "303", "307", "308"}
 APPROVED_GRAFANA_HOST = "admin-sitbank.tailca101b.ts.net"
 APPROVED_GRAFANA_PATH = "/grafana"
 PRIVATE_DIRECT_EXPOSURE_PATHS = ("/loki", "/metrics")
@@ -256,6 +263,76 @@ def _curl_status_headers(runner: Runner, url: str) -> tuple[str, str]:
     return status, result.stdout
 
 
+def _header_entries(headers: str) -> list[tuple[str, str]]:
+    entries: list[tuple[str, str]] = []
+    for raw_line in headers.splitlines():
+        line = raw_line.strip()
+        if not line or ":" not in line or line.startswith(HTTP_STATUS_MARKER):
+            continue
+        name, value = line.split(":", 1)
+        entries.append((name.strip().casefold(), value.strip().casefold()))
+    return entries
+
+
+def _header_values(headers: str, name: str) -> list[str]:
+    lookup = name.casefold()
+    return [value for header_name, value in _header_entries(headers) if header_name == lookup]
+
+
+def _location_path(value: str) -> str:
+    parsed = urlparse(value.strip())
+    if parsed.scheme or parsed.netloc:
+        return parsed.path or "/"
+    if value.startswith("/"):
+        return value.split("?", 1)[0].split("#", 1)[0] or "/"
+    return ""
+
+
+def _redirects_to_observability(headers: str) -> bool:
+    for value in _header_values(headers, "location"):
+        path = _location_path(value).casefold()
+        if path in {"/grafana/login", "/loki"} or path.startswith(("/grafana/login/", "/loki/")):
+            return True
+    return False
+
+
+def _observability_exposure_reasons(headers: str) -> list[str]:
+    reasons: list[str] = []
+    entries = _header_entries(headers)
+    if any(name == "server" and value.startswith(("grafana", "loki")) for name, value in entries):
+        reasons.append("observability server header")
+    if any(name.startswith(OBSERVABILITY_HEADER_PREFIXES) for name, _value in entries):
+        reasons.append("observability response header")
+    if "grafana_session" in headers.casefold():
+        reasons.append("grafana session cookie")
+    if _redirects_to_observability(headers):
+        reasons.append("observability login redirect")
+    return reasons
+
+
+def _denial_category(status: str, headers: str) -> str:
+    header_text = headers.casefold()
+    location_paths = [_location_path(value).casefold() for value in _header_values(headers, "location")]
+    if (
+        "cf-access" in header_text
+        or "cf-ray:" in header_text
+        or "server: cloudflare" in header_text
+        or any(path.startswith("/cdn-cgi/access/") for path in location_paths)
+    ):
+        return "cloudflare_access_denial"
+    if status == "000":
+        return "network_denial"
+    if status == "404":
+        return "not_found_denial"
+    if status in {"401", "403"}:
+        return "http_auth_denial"
+    if status in REDIRECT_STATUSES:
+        return "redirect_denial"
+    if status == "200":
+        return "unexpected_success"
+    return "non_success_denial"
+
+
 def verify_private_grafana(
     runner: Runner,
     grafana_url: str,
@@ -367,25 +444,18 @@ def verify_public_denials(
     failures: list[str] = []
     for url in public_urls:
         status, headers = _curl_status_headers(runner, url)
-        header_text = headers.casefold()
         url_failures: list[str] = []
-        if (
-            status == "200"
-            or "location:" in header_text
-            and re.search(r"/(?:grafana|loki)(?:/|$)", header_text)
-            or any(marker in header_text for marker in OBSERVABILITY_HEADER_MARKERS)
-        ):
+        exposure_reasons = _observability_exposure_reasons(headers)
+        if status == "200" or exposure_reasons:
             url_failures.append("public observability access evidence")
             failures.append(f"{_safe_url_label(url)} returned public observability access evidence")
-        if any(marker in header_text for marker in SECRET_MARKERS):
-            url_failures.append("sensitive observability headers")
-            failures.append(f"{_safe_url_label(url)} returned sensitive observability headers")
         checks.append(
             {
                 "name": "public_observability_denial",
                 "result": "pass" if not url_failures else "fail",
                 "target": _safe_url_label(url),
                 "http_status": status,
+                "denial_category": _denial_category(status, headers),
             }
         )
     if failures:
@@ -404,27 +474,20 @@ def verify_private_direct_denials(
     for path in PRIVATE_DIRECT_EXPOSURE_PATHS:
         url = f"https://{hostname}{path}"
         status, headers = _curl_status_headers(runner, url)
-        header_text = headers.casefold()
         url_failures: list[str] = []
-        if (
-            status == "200"
-            or "location:" in header_text
-            and re.search(r"/(?:grafana|loki)(?:/|$)", header_text)
-            or any(marker in header_text for marker in OBSERVABILITY_HEADER_MARKERS)
-        ):
+        exposure_reasons = _observability_exposure_reasons(headers)
+        if status == "200" or exposure_reasons:
             url_failures.append("private direct observability access evidence")
             failures.append(
                 f"{_safe_url_label(url)} returned private direct observability access evidence"
             )
-        if any(marker in header_text for marker in SECRET_MARKERS):
-            url_failures.append("sensitive observability headers")
-            failures.append(f"{_safe_url_label(url)} returned sensitive observability headers")
         checks.append(
             {
                 "name": "private_direct_observability_denial",
                 "result": "pass" if not url_failures else "fail",
                 "target": _safe_url_label(url),
                 "http_status": status,
+                "denial_category": _denial_category(status, headers),
             }
         )
     if failures:
@@ -461,6 +524,9 @@ def _write_evidence(
     text = json.dumps(evidence, indent=2, sort_keys=True) + "\n"
     if token and token in text:
         raise VerificationError("sanitized evidence unexpectedly contains the Grafana token")
+    evidence_text = text.casefold()
+    if any(marker in evidence_text for marker in EVIDENCE_FORBIDDEN_MARKERS):
+        raise VerificationError("sanitized evidence unexpectedly contains raw observability metadata")
     path.write_text(text, encoding="utf-8")
 
 

--- a/tests/test_operational_observability_deployment.py
+++ b/tests/test_operational_observability_deployment.py
@@ -1024,16 +1024,86 @@ def test_verify_public_denials_accepts_closed_statuses_and_sanitizes_records():
             "result": "pass",
             "target": "sitbank.pp.ua/grafana",
             "http_status": "404",
+            "denial_category": "not_found_denial",
         },
         {
             "name": "public_observability_denial",
             "result": "pass",
             "target": "staging-sitbank.pp.ua/loki",
             "http_status": "403",
+            "denial_category": "http_auth_denial",
         },
     ]
     assert "HTTP/2" not in json.dumps(checks)
     assert "location:" not in json.dumps(checks).casefold()
+
+
+def test_verify_public_denials_accepts_cloudflare_access_denials_without_raw_metadata():
+    module = _load_verifier_module()
+    urls = (
+        "https://staging-sitbank.pp.ua/grafana",
+        "https://staging-sitbank.pp.ua/loki",
+        "https://staging-sitbank.pp.ua/logs",
+        "https://staging-sitbank.pp.ua/metrics",
+    )
+
+    def cloudflare_access_runner(arguments):
+        url = tuple(arguments)[-1]
+        status = "302" if url.endswith("/grafana") else "403"
+        return _status_headers(
+            module,
+            status,
+            "server: cloudflare",
+            "cf-ray: fake-ray-id",
+            "cf-access-jwt-assertion: fake-access-assertion",
+            "set-cookie: CF_Authorization=fake-access-cookie; HttpOnly; Secure",
+            "location: /cdn-cgi/access/login",
+            "x-frame-options: DENY",
+        )
+
+    checks = module["verify_public_denials"](cloudflare_access_runner, urls)
+
+    assert {check["target"] for check in checks} == {
+        "staging-sitbank.pp.ua/grafana",
+        "staging-sitbank.pp.ua/loki",
+        "staging-sitbank.pp.ua/logs",
+        "staging-sitbank.pp.ua/metrics",
+    }
+    assert all(check["result"] == "pass" for check in checks)
+    assert all(check["denial_category"] == "cloudflare_access_denial" for check in checks)
+    serialized = json.dumps(checks)
+    assert "cf-access-jwt-assertion" not in serialized
+    assert "CF_Authorization" not in serialized
+    assert "/cdn-cgi/access/login" not in serialized
+
+
+def test_verify_public_denials_accepts_app_and_nginx_denials():
+    module = _load_verifier_module()
+    statuses = {
+        "https://sitbank.pp.ua/grafana": "404",
+        "https://sitbank.pp.ua/loki": "401",
+        "https://sitbank.pp.ua/logs": "403",
+        "https://sitbank.pp.ua/metrics": "404",
+    }
+
+    def denial_runner(arguments):
+        return _status_headers(
+            module,
+            statuses[tuple(arguments)[-1]],
+            "server: nginx",
+            "x-content-type-options: nosniff",
+            "content-security-policy: default-src 'self'",
+        )
+
+    checks = module["verify_public_denials"](denial_runner, tuple(statuses))
+
+    assert [check["result"] for check in checks] == ["pass", "pass", "pass", "pass"]
+    assert [check["denial_category"] for check in checks] == [
+        "not_found_denial",
+        "http_auth_denial",
+        "http_auth_denial",
+        "not_found_denial",
+    ]
 
 
 def test_verify_private_direct_denials_keep_loki_and_metrics_unserved():
@@ -1054,12 +1124,14 @@ def test_verify_private_direct_denials_keep_loki_and_metrics_unserved():
             "result": "pass",
             "target": "admin-sitbank.tailca101b.ts.net/loki",
             "http_status": "404",
+            "denial_category": "not_found_denial",
         },
         {
             "name": "private_direct_observability_denial",
             "result": "pass",
             "target": "admin-sitbank.tailca101b.ts.net/metrics",
             "http_status": "403",
+            "denial_category": "http_auth_denial",
         },
     ]
 
@@ -1083,14 +1155,12 @@ def test_verify_private_direct_denials_keep_loki_and_metrics_unserved():
         ("404", "x-loki-warning: fake", "public observability"),
         ("302", "location: https://sitbank.pp.ua/grafana/login", "public observability"),
         ("302", "location: https://sitbank.pp.ua/loki/", "public observability"),
-        ("404", "authorization: Bearer fake", "sensitive observability headers"),
-        ("404", "cookie: grafana_session=fake", "sensitive observability headers"),
-        ("404", "cf-access-jwt-assertion: fake", "sensitive observability headers"),
-        ("404", "set-cookie: grafana_session=fake", "sensitive observability headers"),
-        ("404", "x-grafana-org-id: 1", "sensitive observability headers"),
+        ("404", "cookie: grafana_session=fake", "public observability"),
+        ("404", "set-cookie: grafana_session=fake", "public observability"),
+        ("404", "x-grafana-org-id: 1", "public observability"),
     ),
 )
-def test_verify_public_denials_fails_closed_on_exposure_or_sensitive_headers(
+def test_verify_public_denials_fails_closed_on_observability_exposure(
     status,
     header,
     message,
@@ -1116,6 +1186,7 @@ def test_write_evidence_creates_parent_and_retains_only_sanitized_fields(tmp_pat
             "result": "pass",
             "target": "sitbank.pp.ua/grafana",
             "http_status": "404",
+            "denial_category": "not_found_denial",
         }
     ]
 
@@ -1143,6 +1214,9 @@ def test_write_evidence_creates_parent_and_retains_only_sanitized_fields(tmp_pat
         "Authorization: Bearer",
         "grafana_session=fake",
         "cf-access-jwt-assertion: fake",
+        "location:",
+        "cloudflareaccess.",
+        "redirect_url=",
         "raw response body",
     ):
         assert forbidden not in evidence_text
@@ -1162,6 +1236,31 @@ def test_write_evidence_refuses_to_write_if_token_would_be_retained(tmp_path):
         )
 
     assert not evidence_path.exists()
+
+
+def test_write_evidence_refuses_raw_headers_cookies_and_redirects(tmp_path):
+    module = _load_verifier_module()
+    evidence_path = tmp_path / "private-observability.json"
+
+    unsafe_checks = [
+        {"name": "unsafe", "result": "pass", "raw_header": "authorization: Bearer fake"},
+        {"name": "unsafe", "result": "pass", "raw_header": "set-cookie: grafana_session=fake"},
+        {
+            "name": "unsafe",
+            "result": "pass",
+            "raw_location": "https://example.cloudflareaccess.test/cdn-cgi/access/login?redirect_url=fake",
+        },
+    ]
+    for check in unsafe_checks:
+        with pytest.raises(module["VerificationError"], match="raw observability metadata"):
+            module["_write_evidence"](
+                evidence_path,
+                target_environment="staging",
+                grafana_url=PRIVATE_GRAFANA_URL,
+                checks=[check],
+                token=FAKE_GRAFANA_TOKEN,
+            )
+        assert not evidence_path.exists()
 
 
 def test_parse_args_restricts_target_environment_and_accepts_overrides(tmp_path):


### PR DESCRIPTION
Summary
---
Refines the private Grafana/Loki observability verifier so public denial probes accept expected Cloudflare Access and app/Nginx denial responses without treating sanitized denial evidence as an observability exposure.

Why
---
The protected verification workflow failed when public SITBank paths returned Cloudflare Access denial metadata. Those responses prove the public paths are denied, but the verifier treated generic Access/security headers as sensitive observability headers.

What changed
---
* Restricts public and private direct exposure failures to Grafana/Loki-specific evidence: successful access, Grafana/Loki server headers, `x-grafana-*` or `x-loki-*` headers, `grafana_session` cookies, and direct redirects to Grafana/Loki login paths.
* Adds sanitized denial categories for Cloudflare Access, app/Nginx authorization denial, not found denial, redirect denial, network denial, and unexpected success.
* Hardens evidence writing so raw headers, cookies, redirect URLs, tokens, and raw response content are rejected before artifact creation.
* Updates observability workflow tests and operational documentation for the accepted denial evidence and fail-closed exposure cases.

Security impact
---
Preserves private-only Grafana/Loki observability. Public probes remain mandatory and still fail closed on real Grafana/Loki exposure, credential-bearing evidence in artifacts, non-HTTPS or unexpected private Grafana URLs, public SITBank Grafana URLs, and direct Loki/metrics exposure. The workflow trigger, main-only guard, protected environment, Tailscale use, and sanitized evidence model are unchanged.

Deployment impact
---
No EC2 bootstrap, staging deployment, production deployment, database migration, secret change, Cloudflare provider change, Tailscale provider change, or Nginx change required. After merge, rerun the protected `Verify private Grafana Loki observability` workflow from main for live path evidence.

Verification
---
* `git diff --check`
* `.\.venv\Scripts\python.exe -m pytest -q tests/test_operational_observability_deployment.py`
* `.\.venv\Scripts\python.exe -m pytest -q -n auto`
* `.\.venv\Scripts\python.exe -m pytest -q -n auto --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term`

Notes
---
No follow-up required beyond the protected post-merge workflow rerun.