### PR TITLE
Align DAST smoke session risk context

### DIFF
--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -449,11 +449,14 @@ Synthetic DAST users remain the only authenticated scan identities. The smoke
 helper writes the authenticated session cookie and ZAP replacer configuration to
 temporary `0600` files created under `umask 077`; the DAST cookie is not passed
 as a raw process argument. ZAP loads the authenticated-cookie replacer from a
-restricted `-configfile` path, and the cookie/config directory is removed by the
-smoke-test cleanup trap on success or failure. Do not upload `auth-cookie` or
-`zap-replacer.properties`, do not print environment dumps or shell-expanded
-secret values, and investigate immediately if either file or a session value
-appears in logs, summaries, or artifacts.
+restricted `-configfile` path. That same restricted config pins the smoke
+request identity headers (`User-Agent`, `X-Forwarded-For`, and
+`X-Forwarded-Proto`) so the authenticated crawl matches the server-side session
+risk context without weakening reauthentication checks. The cookie/config
+directory is removed by the smoke-test cleanup trap on success or failure. Do
+not upload `auth-cookie` or `zap-replacer.properties`, do not print environment
+dumps or shell-expanded secret values, and investigate immediately if either
+file or a session value appears in logs, summaries, or artifacts.
 
 ## SonarQube Cloud
 

--- a/docs/security/assurance/test-automation-and-dependencies.md
+++ b/docs/security/assurance/test-automation-and-dependencies.md
@@ -301,12 +301,14 @@ sets `umask 077`, writes each secret file as `0600`, validates the cookie shape
 inside the container, mounts the DAST directory read-only into ZAP, and passes
 the non-secret scanner home option `-dir /zap/wrk/.ZAP` plus
 `-configfile /run/dast/zap-replacer.properties` on the host-visible ZAP command
-line. ZAP loads the authenticated-cookie replacer from a restricted file, so the
-DAST cookie is not passed as a raw process argument. The temporary directory is
-removed by the smoke-test cleanup trap on success and failure. ZAP's own cache,
-browser profile, and report workspace run on container tmpfs so scanner-owned
-files are discarded with the container instead of becoming host cleanup
-artifacts.
+line. ZAP loads the authenticated-cookie replacer plus the non-secret
+`User-Agent`, `X-Forwarded-For`, and `X-Forwarded-Proto` smoke identity headers
+from a restricted file, so the DAST cookie is not passed as a raw process
+argument and the crawl matches the server-side session risk context. The
+temporary directory is removed by the smoke-test cleanup trap on success and
+failure. ZAP's own cache, browser profile, and report workspace run on container
+tmpfs so scanner-owned files are discarded with the container instead of
+becoming host cleanup artifacts.
 
 The DAST bind-mount directory is relaxed for container UID compatibility, but
 the secret files inside remain owner-only and are not uploaded as GitHub

--- a/ops/container/create_dast_session.py
+++ b/ops/container/create_dast_session.py
@@ -15,6 +15,9 @@ from sqlalchemy.exc import IntegrityError
 
 
 DAST_COOKIE_RE = re.compile(r"^__Host-sitbank_session=[A-Za-z0-9._~-]+$")
+DAST_FORWARDED_FOR = "127.0.0.1"
+DAST_FORWARDED_PROTO = "https"
+DAST_USER_AGENT = "sitbank-dast-session"
 
 
 class DastClient:
@@ -35,7 +38,7 @@ class DastClient:
             # The smoke test connects over HTTP but sets X-Forwarded-Proto=https to
             # exercise production proxy behavior. Flask-WTF SSL-strict CSRF checks
             # therefore require a same-origin HTTPS Referer.
-            ("https", parsed.netloc, "/", "", "")
+            (DAST_FORWARDED_PROTO, parsed.netloc, "/", "", "")
         )
         self.cookies: dict[str, str] = {}
 
@@ -51,7 +54,9 @@ class DastClient:
         body = None
         headers = {
             "Accept": "application/json",
-            "X-Forwarded-Proto": "https",
+            "User-Agent": DAST_USER_AGENT,
+            "X-Forwarded-For": DAST_FORWARDED_FOR,
+            "X-Forwarded-Proto": DAST_FORWARDED_PROTO,
         }
         if payload is not None:
             body = json.dumps(payload).encode("utf-8")
@@ -144,8 +149,8 @@ def issue_dast_session_cookie(*, user_id: int, session_base_url: str) -> str:
         with app.test_request_context(
             "/",
             base_url=session_base_url,
-            environ_base={"REMOTE_ADDR": "127.0.0.1"},
-            headers={"User-Agent": "sitbank-dast-session"},
+            environ_base={"REMOTE_ADDR": DAST_FORWARDED_FOR},
+            headers={"User-Agent": DAST_USER_AGENT},
         ):
             establish_authenticated_session(
                 user_id=user.id,
@@ -246,7 +251,17 @@ def write_zap_replacer_config(path: Path, cookie: str, *, allowed_root: Path) ->
             "replacer.full_list(1).enabled=true",
             "replacer.full_list(1).matchtype=REQ_HEADER",
             "replacer.full_list(1).matchstr=X-Forwarded-Proto",
-            "replacer.full_list(1).replacement=https",
+            f"replacer.full_list(1).replacement={DAST_FORWARDED_PROTO}",
+            "replacer.full_list(2).description=trusted-forwarded-for",
+            "replacer.full_list(2).enabled=true",
+            "replacer.full_list(2).matchtype=REQ_HEADER",
+            "replacer.full_list(2).matchstr=X-Forwarded-For",
+            f"replacer.full_list(2).replacement={DAST_FORWARDED_FOR}",
+            "replacer.full_list(3).description=dast-session-user-agent",
+            "replacer.full_list(3).enabled=true",
+            "replacer.full_list(3).matchtype=REQ_HEADER",
+            "replacer.full_list(3).matchstr=User-Agent",
+            f"replacer.full_list(3).replacement={DAST_USER_AGENT}",
         )
     )
     _write_secret_file(path, f"{config}\n", allowed_root=allowed_root)

--- a/tests/test_dast_helper_security.py
+++ b/tests/test_dast_helper_security.py
@@ -118,6 +118,10 @@ def test_dast_session_helper_writes_restricted_cookie_and_zap_config(tmp_path):
     zap_config = config_path.read_text(encoding="utf-8")
     assert f"replacer.full_list(0).replacement={cookie}" in zap_config
     assert "replacer.full_list(1).replacement=https" in zap_config
+    assert "replacer.full_list(2).matchstr=X-Forwarded-For" in zap_config
+    assert "replacer.full_list(2).replacement=127.0.0.1" in zap_config
+    assert "replacer.full_list(3).matchstr=User-Agent" in zap_config
+    assert "replacer.full_list(3).replacement=sitbank-dast-session" in zap_config
     if os.name != "nt":
         assert stat.S_IMODE(cookie_path.stat().st_mode) == 0o600
         assert stat.S_IMODE(config_path.stat().st_mode) == 0o600
@@ -195,6 +199,8 @@ def test_dast_docs_describe_secret_file_cookie_model():
         "DAST cookie is not passed as a raw process argument",
         "ZAP loads the authenticated-cookie replacer from a restricted",
         "Synthetic DAST users remain the only authenticated scan identities",
+        "server-side session risk context",
+        "`User-Agent`, `X-Forwarded-For`, and",
         "auth-cookie` or `zap-replacer.properties",
         "tests/test_dast_helper_security.py",
     ):
@@ -248,6 +254,9 @@ def test_dast_client_request_builds_safe_json_request_and_captures_cookies(monke
     assert timeout == 15
     assert request.full_url == "http://127.0.0.1:5000/auth/example"
     assert json.loads(request.data) == {"value": "fake"}
+    assert request.headers["User-agent"] == module.DAST_USER_AGENT
+    assert request.headers["X-forwarded-for"] == module.DAST_FORWARDED_FOR
+    assert request.headers["X-forwarded-proto"] == module.DAST_FORWARDED_PROTO
     assert request.headers["X-csrftoken"] == "fake-csrf"
     assert request.headers["Referer"] == "https://127.0.0.1:5000/"
     assert client.cookies == {"__Host-sitbank_session": "fake-session"}
@@ -482,6 +491,30 @@ def test_issue_dast_session_cookie_persists_mfa_session(app, monkeypatch):
     assert loaded_session["auth_context"] == "dast_smoke"
     assert loaded_session["mfa_verified_at"]
     assert loaded_session["fresh_mfa_verified_at"]
+
+    headers = {
+        "Cookie": f"{app.config['SESSION_COOKIE_NAME']}={cookie_value}",
+        "User-Agent": module.DAST_USER_AGENT,
+        "X-Forwarded-For": module.DAST_FORWARDED_FOR,
+        "X-Forwarded-Proto": module.DAST_FORWARDED_PROTO,
+    }
+    sessions_response = app.test_client(use_cookies=False).get(
+        "/auth/sessions",
+        base_url="https://smoke:5000/",
+        headers=headers,
+        environ_overrides={"REMOTE_ADDR": module.DAST_FORWARDED_FOR},
+    )
+    assert sessions_response.status_code == 200, sessions_response.get_data(as_text=True)
+    assert sessions_response.get_json()["sessions"][0]["current"] is True
+
+    mismatched_response = app.test_client(use_cookies=False).get(
+        "/auth/sessions",
+        base_url="https://smoke:5000/",
+        headers={**headers, "User-Agent": "Mozilla/5.0 Firefox/122.0"},
+        environ_overrides={"REMOTE_ADDR": "203.0.113.20"},
+    )
+    assert mismatched_response.status_code == 401
+    assert mismatched_response.get_json()["error"] == "Session verification required"
 
 
 def test_issue_dast_session_cookie_rejects_missing_synthetic_user(app, monkeypatch):

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -580,6 +580,9 @@ def test_dast_session_creator_matches_registration_contract():
     assert "issue_dast_session_cookie(" in source
     assert "establish_authenticated_session(" in source
     assert 'client.request("GET", "/auth/sessions", expected_status=200)' in source
+    assert '"User-Agent": DAST_USER_AGENT' in source
+    assert '"X-Forwarded-For": DAST_FORWARDED_FOR' in source
+    assert "replacer.full_list(3).matchstr=User-Agent" in source
     assert '"/auth/login"' not in source
     assert '"cf-turnstile-response"' not in source
     assert "hash_password(password)" in source


### PR DESCRIPTION
Summary
---
Aligns the authenticated release DAST smoke helper with the session risk context it mints, so the main release-verification smoke scan can validate the synthetic server-side session without using public login or weakening Turnstile/session controls.

Why
---
The automatic main workflow for merge commit `2ed29b82ba9557a3308692f8df936eee6badf02f` still failed in `Release verification` because the helper minted the synthetic cookie under one request identity and then validated `/auth/sessions` from a different Docker source/user-agent context. The application correctly treated that as a high-risk session change and returned `Session verification required`.

What changed
---
* Centralized the isolated DAST smoke request identity in `ops/container/create_dast_session.py`.
* Sent the same `User-Agent`, `X-Forwarded-For`, and `X-Forwarded-Proto` headers during helper validation and through the restricted ZAP replacer config.
* Added regression coverage proving the cookie reaches `/auth/sessions` under the matching smoke identity and is rejected for a high-risk identity mismatch.
* Updated DAST workflow documentation for the smoke identity headers and restricted config model.

Security impact
---
Public login, Turnstile exact-action validation, session risk binding, MFA, CSRF, and reauthentication controls remain enabled. The change is limited to isolated smoke/DAST automation, uses only non-secret identity headers in the restricted ZAP config, keeps the synthetic session cookie in `0600` files, and does not expose or log the cookie value.

Deployment impact
---
No EC2 bootstrap, staging deployment, production deployment, database migration, secret change, Cloudflare change, Tailscale change, Nginx change, AWS security group change, or operator action required. This only repairs the trusted main release-verification path before deployment jobs proceed.

Verification
---
* `git diff --check`
* `.\.venv\Scripts\python.exe -m pytest -q tests/test_dast_helper_security.py tests/test_deployment.py -n auto`
* `.\.venv\Scripts\python.exe -m pytest -q tests/test_session_risk_binding.py -n auto`
* `.\.venv\Scripts\python.exe -m pytest -q -n auto`
* `.\.venv\Scripts\python.exe -m pytest -q -n auto --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term` — 91% total coverage

Notes
---
Follow-up to the failed main workflow after PR #431. Docker-backed release verification remains authoritative in GitHub Actions because Docker Desktop is unavailable in this workstation session.