### PR TITLE
Align DAST session binding with smoke scan context

### DIFF
--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -448,12 +448,14 @@ recorded in `docs/security/governance/github-branch-protection-evidence.md`.
 Synthetic DAST users remain the only authenticated scan identities. The smoke
 helper writes the authenticated session cookie and ZAP replacer configuration to
 temporary `0600` files created under `umask 077`; the DAST cookie is not passed
-as a raw process argument. ZAP loads the authenticated-cookie replacer from a
-restricted `-configfile` path, and the cookie/config directory is removed by the
-smoke-test cleanup trap on success or failure. Do not upload `auth-cookie` or
-`zap-replacer.properties`, do not print environment dumps or shell-expanded
-secret values, and investigate immediately if either file or a session value
-appears in logs, summaries, or artifacts.
+as a raw process argument. ZAP loads the authenticated-cookie replacer, the
+synthetic `X-Forwarded-For: 127.0.0.1` header, and the
+`User-Agent: sitbank-dast-session` header from a restricted `-configfile` path
+so the session-risk binding used to mint the cookie matches the smoke scan. The
+cookie/config directory is removed by the smoke-test cleanup trap on success or
+failure. Do not upload `auth-cookie` or `zap-replacer.properties`, do not print
+environment dumps or shell-expanded secret values, and investigate immediately
+if either file or a session value appears in logs, summaries, or artifacts.
 
 ## SonarQube Cloud
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1099,14 +1099,18 @@ and `zap-replacer.properties` as temporary `0600` files under `umask 077`, and
 passes only non-secret startup options plus
 `-configfile /run/dast/zap-replacer.properties` to ZAP. The non-secret
 `-dir /zap/wrk/.ZAP` option gives the scanner UID a writable ZAP home without
-relaxing cookie-file permissions. ZAP's cache, browser profile, and report
-workspace run on container tmpfs and are discarded with the scanner container, so
-host cleanup does not depend on deleting scanner-owned cache files. The cookie is
-not passed as a raw process argument, and neither file belongs in GitHub
-artifacts, job summaries, chat, screenshots, or issue comments. If a DAST cookie
-or full replacer config is exposed, cancel the run, remove the artifact, treat
-the synthetic session as compromised until the run cleanup completes, and review
-the workflow/script change before retrying.
+relaxing cookie-file permissions. The restricted replacer file also fixes the
+synthetic `X-Forwarded-For: 127.0.0.1` header and
+`User-Agent: sitbank-dast-session` header used to mint the session cookie, so
+normal session-risk checks stay enabled during the smoke scan. ZAP's cache,
+browser profile, and report workspace run on container tmpfs and are discarded
+with the scanner container, so host cleanup does not depend on deleting
+scanner-owned cache files. The cookie is not passed as a raw process argument,
+and neither file belongs in GitHub artifacts, job summaries, chat, screenshots,
+or issue comments. If a DAST cookie or full replacer config is exposed, cancel
+the run, remove the artifact, treat the synthetic session as compromised until
+the run cleanup completes, and review the workflow/script change before
+retrying.
 
 Pull requests additionally run a 12-minute local-only DAST smoke against an
 ephemeral image and database. Its two-minute unauthenticated ZAP baseline

--- a/docs/security/assurance/test-automation-and-dependencies.md
+++ b/docs/security/assurance/test-automation-and-dependencies.md
@@ -302,11 +302,14 @@ inside the container, mounts the DAST directory read-only into ZAP, and passes
 the non-secret scanner home option `-dir /zap/wrk/.ZAP` plus
 `-configfile /run/dast/zap-replacer.properties` on the host-visible ZAP command
 line. ZAP loads the authenticated-cookie replacer from a restricted file, so the
-DAST cookie is not passed as a raw process argument. The temporary directory is
-removed by the smoke-test cleanup trap on success and failure. ZAP's own cache,
-browser profile, and report workspace run on container tmpfs so scanner-owned
-files are discarded with the container instead of becoming host cleanup
-artifacts.
+DAST cookie is not passed as a raw process argument. The same restricted config
+also pins the synthetic `X-Forwarded-For: 127.0.0.1` header and
+`User-Agent: sitbank-dast-session` header used when minting the cookie, keeping
+session-risk binding active without depending on transient Docker container IPs
+or scanner defaults. The temporary directory is removed by the smoke-test
+cleanup trap on success and failure. ZAP's own cache, browser profile, and
+report workspace run on container tmpfs so scanner-owned files are discarded
+with the container instead of becoming host cleanup artifacts.
 
 The DAST bind-mount directory is relaxed for container UID compatibility, but
 the secret files inside remain owner-only and are not uploaded as GitHub

--- a/ops/container/create_dast_session.py
+++ b/ops/container/create_dast_session.py
@@ -15,6 +15,8 @@ from sqlalchemy.exc import IntegrityError
 
 
 DAST_COOKIE_RE = re.compile(r"^__Host-sitbank_session=[A-Za-z0-9._~-]+$")
+DAST_FORWARDED_FOR = "127.0.0.1"
+DAST_USER_AGENT = "sitbank-dast-session"
 
 
 class DastClient:
@@ -51,6 +53,8 @@ class DastClient:
         body = None
         headers = {
             "Accept": "application/json",
+            "User-Agent": DAST_USER_AGENT,
+            "X-Forwarded-For": DAST_FORWARDED_FOR,
             "X-Forwarded-Proto": "https",
         }
         if payload is not None:
@@ -145,7 +149,7 @@ def issue_dast_session_cookie(*, user_id: int, session_base_url: str) -> str:
             "/",
             base_url=session_base_url,
             environ_base={"REMOTE_ADDR": "127.0.0.1"},
-            headers={"User-Agent": "sitbank-dast-session"},
+            headers={"User-Agent": DAST_USER_AGENT},
         ):
             establish_authenticated_session(
                 user_id=user.id,
@@ -247,6 +251,16 @@ def write_zap_replacer_config(path: Path, cookie: str, *, allowed_root: Path) ->
             "replacer.full_list(1).matchtype=REQ_HEADER",
             "replacer.full_list(1).matchstr=X-Forwarded-Proto",
             "replacer.full_list(1).replacement=https",
+            "replacer.full_list(2).description=trusted-forwarded-for",
+            "replacer.full_list(2).enabled=true",
+            "replacer.full_list(2).matchtype=REQ_HEADER",
+            "replacer.full_list(2).matchstr=X-Forwarded-For",
+            f"replacer.full_list(2).replacement={DAST_FORWARDED_FOR}",
+            "replacer.full_list(3).description=synthetic-dast-user-agent",
+            "replacer.full_list(3).enabled=true",
+            "replacer.full_list(3).matchtype=REQ_HEADER",
+            "replacer.full_list(3).matchstr=User-Agent",
+            f"replacer.full_list(3).replacement={DAST_USER_AGENT}",
         )
     )
     _write_secret_file(path, f"{config}\n", allowed_root=allowed_root)

--- a/tests/test_dast_helper_security.py
+++ b/tests/test_dast_helper_security.py
@@ -118,6 +118,14 @@ def test_dast_session_helper_writes_restricted_cookie_and_zap_config(tmp_path):
     zap_config = config_path.read_text(encoding="utf-8")
     assert f"replacer.full_list(0).replacement={cookie}" in zap_config
     assert "replacer.full_list(1).replacement=https" in zap_config
+    assert (
+        f"replacer.full_list(2).replacement={create_dast_session.DAST_FORWARDED_FOR}"
+        in zap_config
+    )
+    assert (
+        f"replacer.full_list(3).replacement={create_dast_session.DAST_USER_AGENT}"
+        in zap_config
+    )
     if os.name != "nt":
         assert stat.S_IMODE(cookie_path.stat().st_mode) == 0o600
         assert stat.S_IMODE(config_path.stat().st_mode) == 0o600
@@ -196,6 +204,8 @@ def test_dast_docs_describe_secret_file_cookie_model():
         "ZAP loads the authenticated-cookie replacer from a restricted",
         "Synthetic DAST users remain the only authenticated scan identities",
         "auth-cookie` or `zap-replacer.properties",
+        "X-Forwarded-For: 127.0.0.1",
+        "sitbank-dast-session",
         "tests/test_dast_helper_security.py",
     ):
         assert required in docs
@@ -249,6 +259,9 @@ def test_dast_client_request_builds_safe_json_request_and_captures_cookies(monke
     assert request.full_url == "http://127.0.0.1:5000/auth/example"
     assert json.loads(request.data) == {"value": "fake"}
     assert request.headers["X-csrftoken"] == "fake-csrf"
+    assert request.headers["User-agent"] == module.DAST_USER_AGENT
+    assert request.headers["X-forwarded-for"] == module.DAST_FORWARDED_FOR
+    assert request.headers["X-forwarded-proto"] == "https"
     assert request.headers["Referer"] == "https://127.0.0.1:5000/"
     assert client.cookies == {"__Host-sitbank_session": "fake-session"}
 


### PR DESCRIPTION
Summary
---
Aligns the authenticated DAST smoke helper, its validation request, and the ZAP scan with the same synthetic proxy client context used when minting the temporary DAST session cookie.

Why
---
Main release verification failed because the helper minted a server-side session with one risk context but validated it through the live smoke app with a different Docker-network source and default scanner user agent. That caused /auth/sessions to reject the synthetic DAST cookie with 401 while normal session-risk controls were still active.

What changed
---
* Added fixed synthetic X-Forwarded-For and User-Agent values to the DAST helper validation requests.
* Wrote the same forwarded-for and user-agent headers into the restricted ZAP replacer config alongside the authenticated cookie and forwarded-proto header.
* Updated DAST helper tests and runbook documentation so the header binding remains part of the DAST cookie contract.

Security impact
---
Normal authentication, Turnstile action checks, and session-risk enforcement remain enabled. The change is limited to the synthetic DAST smoke identity and keeps the cookie in the existing restricted temporary files instead of process arguments, logs, artifacts, or GitHub secrets.

Deployment impact
---
No EC2 bootstrap, database migration, or secret changes are required. The change affects release verification and scheduled authenticated DAST behavior after staging deployment or production deployment workflows build the updated container image.

Verification
---
* git diff --check
* .\.venv\Scripts\python.exe -m pytest -q tests/test_dast_helper_security.py tests/test_deployment.py tests/test_turnstile_public_auth.py
* .\.venv\Scripts\python.exe -m pytest -q -n auto
* .\.venv\Scripts\python.exe -m pytest -q -n auto --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term

Notes
---
This follows up the main-branch release verification failure in run 28703207563; the final proof is the next main release-verification run after merge.