### PR TITLE
Resolve main Sonar findings

### DIFF
--- a/app/banking/services.py
+++ b/app/banking/services.py
@@ -695,24 +695,29 @@ def resolve_transfer_limit_choice(choice: str, custom_value: str | None) -> Deci
     if choice_text in PAYUP_DAILY_LIMIT_PRESETS:
         return Decimal(choice_text).quantize(PAYUP_DAILY_LIMIT_PRECISION)
     if choice_text == "custom":
-        custom_text = str(custom_value or "").strip()
-        if not custom_text:
-            raise AuthError("Enter a custom amount.", 400)
-        if "." in custom_text and len(custom_text.rsplit(".", 1)[1]) > 2:
-            raise AuthError("Custom amount must use cents precision.", 400)
-        try:
-            amount = Decimal(custom_text)
-        except InvalidOperation as exc:
-            raise AuthError("Enter a valid custom amount.", 400) from exc
-        if not amount.is_finite():
-            raise AuthError("Enter a valid custom amount.", 400)
-        amount = amount.quantize(PAYUP_DAILY_LIMIT_PRECISION)
-        if amount < PAYUP_DAILY_LIMIT_MIN:
-            raise AuthError("Custom amount must be at least SGD 100.00.", 400)
-        if amount > PAYUP_DAILY_LIMIT_MAX:
-            raise AuthError("Custom amount must not exceed SGD 10000.00.", 400)
-        return amount
+        return _resolve_custom_transfer_limit(custom_value)
     raise AuthError("Invalid limit selection.", 400)
+
+
+def _resolve_custom_transfer_limit(custom_value: str | None) -> Decimal:
+    custom_text = str(custom_value or "").strip()
+    if not custom_text:
+        raise AuthError("Enter a custom amount.", 400)
+    if "." in custom_text and len(custom_text.rsplit(".", 1)[1]) > 2:
+        raise AuthError("Custom amount must use cents precision.", 400)
+    try:
+        amount = Decimal(custom_text)
+    except InvalidOperation as exc:
+        raise AuthError("Enter a valid custom amount.", 400) from exc
+    if not amount.is_finite():
+        raise AuthError("Enter a valid custom amount.", 400)
+
+    amount = amount.quantize(PAYUP_DAILY_LIMIT_PRECISION)
+    if amount < PAYUP_DAILY_LIMIT_MIN:
+        raise AuthError("Custom amount must be at least SGD 100.00.", 400)
+    if amount > PAYUP_DAILY_LIMIT_MAX:
+        raise AuthError("Custom amount must not exceed SGD 10000.00.", 400)
+    return amount
 
 
 def _load_and_lock_payup_pending_transfer(sender: User, confirmation_token: str):

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -485,8 +485,8 @@ img {
 }
 
 .auth-intro .notice-icon {
-  background: rgba(255, 255, 255, 0.14);
-  color: #ffffff;
+  background: #ffffff;
+  color: var(--primary);
   box-shadow: none;
 }
 

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -731,6 +731,7 @@ def transaction_detail(transaction_id: int):
 
 _DISPUTE_ALREADY_OPEN_MESSAGE = "An open issue report already exists for this transaction."
 _DISPUTE_FORM_TEMPLATE = "transaction_dispute_form.html"
+_TRANSACTION_DETAIL_ENDPOINT = "web.transaction_detail"
 
 
 def _owned_transaction_or_404(transaction_id: int) -> Transaction:
@@ -760,7 +761,7 @@ def transaction_dispute_new(transaction_id: int):
     txn = _owned_transaction_or_404(transaction_id)
     if _open_dispute_for_transaction(txn.id) is not None:
         flash(_DISPUTE_ALREADY_OPEN_MESSAGE, "warning")
-        return redirect(url_for("web.transaction_detail", transaction_id=txn.id))
+        return redirect(url_for(_TRANSACTION_DETAIL_ENDPOINT, transaction_id=txn.id))
     form = TransactionDisputeForm()
     return render_template(_DISPUTE_FORM_TEMPLATE, form=form, transaction=txn)
 
@@ -778,7 +779,7 @@ def transaction_dispute_create(transaction_id: int):
 
     if _open_dispute_for_transaction(txn.id) is not None:
         flash(_DISPUTE_ALREADY_OPEN_MESSAGE, "warning")
-        return redirect(url_for("web.transaction_detail", transaction_id=txn.id))
+        return redirect(url_for(_TRANSACTION_DETAIL_ENDPOINT, transaction_id=txn.id))
 
     try:
         consume_durable_rate_limit(
@@ -795,7 +796,7 @@ def transaction_dispute_create(transaction_id: int):
             metadata={"reason": "durable_rate_limit", "retry_after": exc.retry_after},
         )
         flash("Too many issue reports submitted today. Please try again tomorrow.", "error")
-        return redirect(url_for("web.transaction_detail", transaction_id=txn.id))
+        return redirect(url_for(_TRANSACTION_DETAIL_ENDPOINT, transaction_id=txn.id))
 
     dispute = TransactionDispute(
         transaction_id=txn.id,
@@ -821,13 +822,13 @@ def transaction_dispute_create(transaction_id: int):
     except IntegrityError:
         db.session.rollback()
         flash(_DISPUTE_ALREADY_OPEN_MESSAGE, "warning")
-        return redirect(url_for("web.transaction_detail", transaction_id=txn.id))
+        return redirect(url_for(_TRANSACTION_DETAIL_ENDPOINT, transaction_id=txn.id))
     except AuditWriteError:
         db.session.rollback()
         raise
 
     flash("Issue reported. Our staff will review it shortly.", "success")
-    return redirect(url_for("web.transaction_detail", transaction_id=txn.id))
+    return redirect(url_for(_TRANSACTION_DETAIL_ENDPOINT, transaction_id=txn.id))
 
 
 @web_bp.get("/disputes")

--- a/tests/e2e/support.py
+++ b/tests/e2e/support.py
@@ -22,6 +22,8 @@ from app.security.passwords import hash_password
 
 RUN_E2E_ENV = "SITBANK_RUN_E2E"
 LOCAL_HOSTS = {"127.0.0.1", "localhost", "::1"}
+_TOTP_INTERVAL_SECONDS = 30
+_MIN_TOTP_SECONDS_REMAINING = 10
 
 
 @pytest.fixture()
@@ -256,6 +258,7 @@ def login_customer_with_mfa(
 
 
 def current_totp(secret: str) -> str:
+    _wait_for_stable_totp_window()
     return pyotp.TOTP(secret, digits=6, interval=30).now()
 
 
@@ -263,6 +266,12 @@ def totp_for_offset(secret: str, offset_seconds: int) -> str:
     return pyotp.TOTP(secret, digits=6, interval=30).at(
         int(time.time()) + offset_seconds
     )
+
+
+def _wait_for_stable_totp_window() -> None:
+    remaining = _TOTP_INTERVAL_SECONDS - (time.time() % _TOTP_INTERVAL_SECONDS)
+    if remaining < _MIN_TOTP_SECONDS_REMAINING:
+        time.sleep(remaining + 0.2)
 
 
 def record_console_errors(page) -> list[str]:

--- a/tests/test_authenticated_portal_ui.py
+++ b/tests/test_authenticated_portal_ui.py
@@ -66,6 +66,16 @@ def test_theme_assets_are_csp_compatible_and_store_only_theme_preference(client)
     assert 'fill="#c8102e"' in logo
     assert 'fill="#ffffff"' in logo
 
+
+def test_auth_intro_notice_icon_uses_contrasting_solid_surface():
+    stylesheet = Path("app/static/css/app.css").read_text(encoding="utf-8")
+    notice_icon_rule = stylesheet.split(".auth-intro .notice-icon {", 1)[1].split("}", 1)[0]
+
+    assert "background: #ffffff;" in notice_icon_rule
+    assert "color: var(--primary);" in notice_icon_rule
+    assert "rgba(255, 255, 255, 0.14)" not in notice_icon_rule
+
+
 def test_authenticated_layout_contains_working_profile_menu_destinations(client):
     register(client)
     login(client)

--- a/tests/test_transaction_dispute_flow.py
+++ b/tests/test_transaction_dispute_flow.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from app.extensions import db
 from app.models import SecurityAuditEvent, TransactionDispute
+from app.security.rate_limits import DurableRateLimitExceeded
+from sqlalchemy.exc import IntegrityError
 from test_dashboard import login_with_mfa
 from test_transaction_history_idor import _create_transaction, _second_customer
 
@@ -57,6 +59,13 @@ def test_second_open_dispute_on_same_transaction_is_blocked(client):
     )
     assert first.status_code == 302
 
+    duplicate_get = client.get(
+        f"/transactions/{txn.id}/dispute",
+        follow_redirects=True,
+    )
+    assert duplicate_get.status_code == 200
+    assert b"already exists" in duplicate_get.data
+
     second = client.post(
         f"/transactions/{txn.id}/dispute",
         data={"issue_type": "other", "reason": "Second report on the same transaction"},
@@ -73,6 +82,81 @@ def test_second_open_dispute_on_same_transaction_is_blocked(client):
     )
     assert len(disputes) == 1
     assert disputes[0].reason == "First report"
+
+
+def test_dispute_create_durable_rate_limit_blocks_without_persisting(client, monkeypatch):
+    alice = login_with_mfa(client)
+    client.post("/logout")
+    bob, bob_secret = _second_customer(client)
+    txn = _create_transaction(alice, bob)
+
+    from test_transaction_history_idor import _login_customer
+
+    _login_customer(client, "bob02", bob_secret)
+
+    def block_dispute_submission(*_args, **_kwargs):
+        raise DurableRateLimitExceeded(3600)
+
+    monkeypatch.setattr("app.web.routes.consume_durable_rate_limit", block_dispute_submission)
+
+    response = client.post(
+        f"/transactions/{txn.id}/dispute",
+        data={"issue_type": "other", "reason": "Daily dispute limit should block this."},
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert b"Too many issue reports submitted today" in response.data
+
+    disputes = (
+        db.session.execute(
+            db.select(TransactionDispute).where(TransactionDispute.transaction_id == txn.id)
+        )
+        .scalars()
+        .all()
+    )
+    assert disputes == []
+
+    blocked_event = db.session.execute(
+        db.select(SecurityAuditEvent).where(
+            SecurityAuditEvent.event_type == "transaction_dispute_create",
+            SecurityAuditEvent.outcome == "blocked",
+        )
+    ).scalar_one()
+    assert blocked_event.event_metadata["reason"] == "durable_rate_limit"
+    assert blocked_event.event_metadata["retry_after"] == 3600
+
+
+def test_dispute_create_handles_concurrent_open_dispute_race(client, monkeypatch):
+    alice = login_with_mfa(client)
+    client.post("/logout")
+    bob, bob_secret = _second_customer(client)
+    txn = _create_transaction(alice, bob)
+
+    from test_transaction_history_idor import _login_customer
+
+    _login_customer(client, "bob02", bob_secret)
+
+    def fail_flush_with_duplicate_open_dispute(_objects=None):
+        raise IntegrityError("duplicate open dispute", {}, Exception("fake duplicate"))
+
+    monkeypatch.setattr("app.web.routes.db.session.flush", fail_flush_with_duplicate_open_dispute)
+
+    response = client.post(
+        f"/transactions/{txn.id}/dispute",
+        data={"issue_type": "other", "reason": "Concurrent duplicate report"},
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert b"already exists" in response.data
+
+    disputes = (
+        db.session.execute(
+            db.select(TransactionDispute).where(TransactionDispute.transaction_id == txn.id)
+        )
+        .scalars()
+        .all()
+    )
+    assert disputes == []
 
 
 def test_dispute_create_rejects_missing_csrf_free_fields(client):

--- a/tests/test_transfer_limits.py
+++ b/tests/test_transfer_limits.py
@@ -146,6 +146,7 @@ def test_transfer_limit_resolver_accepts_bounded_values(choice, custom_value, ex
         ("custom", "99.99"),
         ("custom", "10000.01"),
         ("custom", "750.001"),
+        ("custom", "not-a-number"),
         ("custom", "NaN"),
         ("custom", "Infinity"),
         ("bogus", "750.00"),


### PR DESCRIPTION
Summary
---

Resolve the current main-branch Sonar findings without changing customer banking behavior, dispute routing behavior, or deployment settings.

Why
---

After PR #432 merged and the main workflow passed, Sonar still reported three open findings on `main`: duplicated `web.transaction_detail` literals, cognitive complexity in the PayUp transfer-limit resolver, and low contrast for the auth intro notice icon.

What changed
---

* Centralized transaction-detail redirect endpoint usage behind `_TRANSACTION_DETAIL_ENDPOINT`.
* Extracted custom PayUp transfer-limit parsing and bounds checks into `_resolve_custom_transfer_limit` while preserving existing validation messages.
* Changed the auth intro notice icon to primary text on a solid white surface and added a CSS regression test for the contrast-sensitive rule.

Security impact
---

No authentication, authorization, CSRF, MFA, session, audit, secret, deployment, or database policy is weakened. PayUp limit validation remains fail-closed with the same bounds and error messages, and transaction dispute redirects still resolve to the same owned transaction detail route.

Deployment impact
---

No EC2 bootstrap, staging deployment, production deployment, database migration, or secret changes required. Normal CI/deploy validation is sufficient.

Verification
---

* `git diff --check`
* `.\.venv\Scripts\python.exe -m pytest -q tests/test_transfer_limits.py tests/test_transaction_dispute_flow.py tests/test_transaction_history_idor.py tests/test_authenticated_portal_ui.py -n 4`
* `.\.venv\Scripts\python.exe -m pytest -q -n 4`
* `.\.venv\Scripts\python.exe -m pytest -q -n 4 --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term`

Notes
---

Follow-up only if SonarCloud reports a fresh issue after the PR analysis reruns.
