### PR TITLE
Redesign the monthly statement page

### DIFF
--- a/app/banking/routes.py
+++ b/app/banking/routes.py
@@ -948,6 +948,11 @@ def _csv_safe(value: str) -> str:
     return text
 
 
+def _adjacent_period(year: int, month: int, *, delta: int) -> tuple[int, int]:
+    zero_based = (year * 12 + (month - 1)) + delta
+    return zero_based // 12, zero_based % 12 + 1
+
+
 @banking_bp.get("/statement")
 @web_login_required
 @web_not_frozen_required
@@ -958,7 +963,22 @@ def statement():
     except AuthError as exc:
         flash(exc.message, "error")
         data = None
-    return render_template(_STATEMENT_TEMPLATE, user=g.current_user, statement=data, year=year, month=month)
+    now_sgt = datetime.now(timezone.utc).astimezone(_SGT_STATEMENT_OFFSET)
+    prev_year, prev_month = _adjacent_period(year, month, delta=-1)
+    next_year, next_month = _adjacent_period(year, month, delta=1)
+    has_next_period = (year, month) < (now_sgt.year, now_sgt.month)
+    return render_template(
+        _STATEMENT_TEMPLATE,
+        user=g.current_user,
+        statement=data,
+        year=year,
+        month=month,
+        prev_year=prev_year,
+        prev_month=prev_month,
+        next_year=next_year,
+        next_month=next_month,
+        has_next_period=has_next_period,
+    )
 
 
 @banking_bp.get("/statement/download")

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1944,6 +1944,180 @@ th {
 
 /* ── End banking dashboard ─────────────────────────── */
 
+/* ── Monthly statement ──────────────────────────────── */
+
+.statement-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-5);
+  flex-wrap: wrap;
+}
+
+.statement-period-form {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+}
+
+.statement-period-field {
+  display: grid;
+  gap: var(--space-1);
+}
+
+.statement-period-field label {
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.statement-period-field input,
+.statement-period-field select {
+  min-height: 44px;
+}
+
+.statement-period-field input[type="number"] {
+  width: 9ch;
+}
+
+.statement-period-nav {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.statement-period-nav .icon {
+  width: 16px;
+  height: 16px;
+}
+
+.statement-summary {
+  display: grid;
+  gap: var(--space-6);
+  border-radius: var(--radius);
+  background: linear-gradient(135deg, var(--primary) 0%, var(--accent) 100%);
+  padding: var(--space-7);
+  box-shadow: var(--shadow);
+  -webkit-print-color-adjust: exact;
+  print-color-adjust: exact;
+}
+
+.statement-summary-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+}
+
+.statement-summary-eyebrow {
+  margin: 0 0 var(--space-1);
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.statement-summary-period {
+  color: #ffffff;
+  font-size: 1.4rem;
+}
+
+.statement-flow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-6);
+  flex-wrap: wrap;
+}
+
+.statement-balance-block {
+  display: grid;
+  gap: var(--space-1);
+}
+
+.statement-balance-amount {
+  margin: 0;
+  color: #ffffff;
+  font-size: 1.9rem;
+  font-weight: 700;
+  line-height: 1.1;
+}
+
+.statement-balance-block.is-closing .statement-balance-amount {
+  font-size: 2.4rem;
+}
+
+.statement-flow-arrow {
+  display: inline-flex;
+  flex: 0 0 auto;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.statement-flow-arrow .icon {
+  width: 26px;
+  height: 26px;
+}
+
+.statement-delta {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  border-radius: 999px;
+  padding: 3px 10px;
+  background: rgba(255, 255, 255, 0.18);
+  color: #ffffff;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.statement-delta.is-negative {
+  background: rgba(0, 0, 0, 0.2);
+}
+
+.statement-txn-not-counted {
+  opacity: 0.55;
+}
+
+@media (max-width: 640px) {
+  .statement-flow {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-4);
+  }
+
+  .statement-flow-arrow {
+    transform: rotate(90deg);
+  }
+
+  .statement-period-form {
+    width: 100%;
+  }
+
+  .statement-period-field input[type="number"] {
+    width: 100%;
+  }
+}
+
+@media print {
+  .site-header,
+  .site-footer,
+  .statement-toolbar,
+  .statement-summary-header .button {
+    display: none;
+  }
+
+  .statement-summary {
+    box-shadow: none;
+  }
+}
+
+/* ── End monthly statement ──────────────────────────── */
+
 /* Admin dashboard */
 .admin-page {
   display: grid;

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -94,6 +94,16 @@
         <path d="M20 12a8 8 0 0 1-13.7 5.7"></path>
         <path d="M6 21v-5h5"></path>
       </symbol>
+      <symbol id="icon-arrow-right" viewBox="0 0 24 24">
+        <path d="M5 12h14"></path>
+        <path d="m13 5 7 7-7 7"></path>
+      </symbol>
+      <symbol id="icon-chevron-left" viewBox="0 0 24 24">
+        <path d="m15 18-6-6 6-6"></path>
+      </symbol>
+      <symbol id="icon-chevron-right" viewBox="0 0 24 24">
+        <path d="m9 18 6-6-6-6"></path>
+      </symbol>
       <symbol id="icon-user" viewBox="0 0 24 24">
         <circle cx="12" cy="8" r="4"></circle>
         <path d="M4.5 21a7.5 7.5 0 0 1 15 0"></path>

--- a/app/templates/statement.html
+++ b/app/templates/statement.html
@@ -1,5 +1,8 @@
 {% extends "base.html" %}
 
+{% set month_names = ["January", "February", "March", "April", "May", "June",
+                       "July", "August", "September", "October", "November", "December"] %}
+
 {% block title %}Monthly Statement | SITBank{% endblock %}
 
 {% block content %}
@@ -8,46 +11,75 @@
     <div class="page-heading">
       <p class="eyebrow">Account</p>
       <h1>Monthly Statement</h1>
+      <p class="muted">Opening balance is what you had at the start of the period; closing balance is what's left after that period's transactions.</p>
     </div>
     <div class="button-row">
       <a class="button secondary" href="{{ url_for('web.dashboard') }}">Back to Dashboard</a>
     </div>
   </div>
 
-  <div class="panel">
-    <form method="get" action="{{ url_for('banking.statement') }}" class="button-row">
-      <div class="form-group">
+  <div class="panel statement-toolbar">
+    <form method="get" action="{{ url_for('banking.statement') }}" class="statement-period-form">
+      <div class="statement-period-field">
         <label for="statement-year">Year</label>
-        <input id="statement-year" type="number" name="year" value="{{ year }}" min="2000" max="{{ year }}">
+        <input id="statement-year" type="number" name="year" value="{{ year }}" min="2000" max="{{ year }}" inputmode="numeric">
       </div>
-      <div class="form-group">
+      <div class="statement-period-field">
         <label for="statement-month">Month</label>
         <select id="statement-month" name="month">
           {% for m in range(1, 13) %}
-          <option value="{{ m }}" {% if m == month %}selected{% endif %}>{{ "%02d"|format(m) }}</option>
+          <option value="{{ m }}" {% if m == month %}selected{% endif %}>{{ month_names[m - 1] }}</option>
           {% endfor %}
         </select>
       </div>
       <button class="button" type="submit">View Statement</button>
     </form>
+    <nav class="statement-period-nav" aria-label="Adjacent statement periods">
+      <a class="button-quiet button small" href="{{ url_for('banking.statement', year=prev_year, month=prev_month) }}">
+        <svg class="icon" focusable="false" aria-hidden="true"><use href="#icon-chevron-left"></use></svg>
+        {{ month_names[prev_month - 1][:3] }} {{ prev_year }}
+      </a>
+      {% if has_next_period %}
+      <a class="button-quiet button small" href="{{ url_for('banking.statement', year=next_year, month=next_month) }}">
+        {{ month_names[next_month - 1][:3] }} {{ next_year }}
+        <svg class="icon" focusable="false" aria-hidden="true"><use href="#icon-chevron-right"></use></svg>
+      </a>
+      {% endif %}
+    </nav>
   </div>
 
   {% if statement %}
-  <div class="panel">
-    <div class="section-header">
-      <h2>{{ year }}-{{ "%02d"|format(month) }}</h2>
+  {% set net_change = statement.closing_balance - statement.opening_balance %}
+  <div class="statement-summary">
+    <div class="statement-summary-header">
+      <div>
+        <p class="statement-summary-eyebrow">Statement period</p>
+        <h2 class="statement-summary-period">{{ month_names[month - 1] }} {{ year }}</h2>
+      </div>
       <a class="button secondary small" href="{{ url_for('banking.statement_download', year=year, month=month) }}">Download CSV</a>
     </div>
-    <dl class="profile-detail-list">
-      <div>
-        <dt>Opening Balance (SGD)</dt>
-        <dd>{{ statement.opening_balance }}</dd>
+    <div class="statement-flow">
+      <div class="statement-balance-block">
+        <p class="statement-summary-eyebrow">Opening balance</p>
+        <p class="statement-balance-amount">SGD {{ "%.2f"|format(statement.opening_balance) }}</p>
       </div>
-      <div>
-        <dt>Closing Balance (SGD)</dt>
-        <dd>{{ statement.closing_balance }}</dd>
+      <span class="statement-flow-arrow" aria-hidden="true">
+        <svg class="icon" focusable="false"><use href="#icon-arrow-right"></use></svg>
+      </span>
+      <div class="statement-balance-block is-closing">
+        <p class="statement-summary-eyebrow">Closing balance</p>
+        <p class="statement-balance-amount">SGD {{ "%.2f"|format(statement.closing_balance) }}</p>
+        <span class="statement-delta {{ 'is-negative' if net_change < 0 else '' }}">
+          {{ "+" if net_change >= 0 else "−" }}{{ "%.2f"|format(net_change|abs) }} this period
+        </span>
       </div>
-    </dl>
+    </div>
+  </div>
+
+  <div class="panel">
+    <div class="section-header">
+      <h2>Transactions</h2>
+    </div>
     {% if statement.transactions %}
     <div class="table-wrap">
       <table aria-label="Statement transactions">
@@ -63,7 +95,7 @@
         </thead>
         <tbody>
           {% for txn in statement.transactions %}
-          <tr>
+          <tr class="{{ 'statement-txn-not-counted' if txn.status != 'completed' else '' }}">
             <td>
               {% if txn.sender_id == user.id %}
               <span class="badge neutral">Sent</span>
@@ -86,7 +118,13 @@
               +{{ txn.amount }}
               {% endif %}
             </td>
-            <td>{{ txn.status|capitalize }}{% if txn.status != "completed" %} (not counted){% endif %}</td>
+            <td>
+              {% if txn.status == "completed" %}
+              <span class="badge">Completed</span>
+              {% else %}
+              <span class="badge neutral" title="Not counted toward opening/closing balance">Failed</span>
+              {% endif %}
+            </td>
             <td><time datetime="{{ txn.created_at.isoformat() }}">{{ (txn.created_at | sgt).strftime('%d %b %Y, %H:%M') }} SGT</time></td>
           </tr>
           {% endfor %}
@@ -94,7 +132,9 @@
       </table>
     </div>
     {% else %}
-    <p class="muted">No transactions for this period.</p>
+    <div class="empty-state">
+      <p class="muted">No transactions for this period.</p>
+    </div>
     {% endif %}
   </div>
   {% endif %}

--- a/app/templates/transaction_detail.html
+++ b/app/templates/transaction_detail.html
@@ -15,7 +15,7 @@
   </div>
 
   <div class="panel">
-    <dl class="profile-detail-list">
+    <dl class="detail-list">
       <div>
         <dt>Type</dt>
         <dd>

--- a/tests/test_statement_download_security.py
+++ b/tests/test_statement_download_security.py
@@ -21,6 +21,27 @@ def test_statement_view_shows_current_month_by_default(client):
     assert "Monthly Statement" in response.data.decode("utf-8")
 
 
+def test_statement_view_shows_balance_summary_and_period_nav(client):
+    login_with_mfa(client)
+    markup = client.get("/banking/statement").data.decode("utf-8")
+    assert "statement-summary" in markup
+    assert "Opening balance" in markup
+    assert "Closing balance" in markup
+    assert "statement-period-nav" in markup
+
+
+def test_statement_view_rejects_invalid_period_without_crashing(client):
+    login_with_mfa(client)
+    # A period well before the account's creation date always triggers the
+    # rejection path deterministically (unlike a "future month," which would
+    # need date-relative logic since `year` is clamped server-side).
+    response = client.get("/banking/statement?year=2020&month=1")
+    assert response.status_code == 200
+    markup = response.data.decode("utf-8")
+    assert "did not exist yet" in markup
+    assert "statement-summary" not in markup
+
+
 def test_statement_download_returns_csv_with_safe_headers(client):
     alice = login_with_mfa(client)
     client.post("/logout")


### PR DESCRIPTION
## Summary

Gives the Monthly Statement page, merged in #433 with a plain layout, its own visual design pass and adds previous/next month navigation.

## Why

The statement page reused the dashboard’s account-card gradient for the balance display but never received its own layout pass.

Also, both `statement.html` and `transaction_detail.html` referenced a `profile-detail-list` CSS class that was never defined in `app.css`, so those detail lists rendered as unstyled browser-default `<dl>` elements.

## What changed

* Statement summary now shows opening → closing balance as a single flow, with an arrow between them and a net-change pill.
* Uses the same red-gradient card treatment as the dashboard balance so money displays stay visually consistent across the app.
* Adds previous/next month links, computed server-side, so browsing statements no longer requires manually typing `year` and `month`.
* Hides the next-month link once it would point to a future period.
* Dims failed transactions in the table instead of appending a text suffix.
* Fixes the `profile-detail-list` typo in both `statement.html` and `transaction_detail.html` by rendering the existing `detail-list` class.
* Adds print-friendly rules:

  * hides chrome/toolbars,
  * keeps summary colors,
  * improves PDF/save-to-print readability.

## Security impact

Template/CSS only.

No changes to routes, authentication, CSRF, rate limiting, or audit logging beyond passing new read-only template variables computed server-side in the existing `banking.statement` view:

* `prev_year`
* `prev_month`
* `next_year`
* `next_month`
* `has_next_period`

## Deployment impact

No deployment action expected.

This change does not require:

* EC2 bootstrap changes
* database migration
* secret changes
* provider setting changes

## Verification

* `git diff --check` passes.
* `.\.venv\Scripts\python.exe -m pytest -q -n auto`

  * 1478 passed
  * 32 skipped
  * run against current `main` after #433
* Manually verified in a real browser via Playwright on desktop and mobile viewports:

  * balance flow card renders correctly,
  * failed transactions are dimmed correctly,
  * previous/next month navigation works,
  * “account did not exist yet” error path renders correctly.

## Notes

This commit was originally pushed onto the `add-transaction-history-disputes-statement` branch, but PR #433 was merged before this commit landed.

It has therefore been cherry-picked onto a fresh branch off current `main`.
