### PR TITLE
Expand private observability dashboards

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -203,6 +203,17 @@ def register_error_handlers(app: Flask) -> None:
             json.dumps(
                 {
                     "message": "system_error",
+                    "event": "system_error",
+                    "environment": app.config.get("APP_ENV") or "unknown",
+                    "service": (
+                        "sitbank-admin"
+                        if app.config.get("APP_MODE") == "admin"
+                        else "sitbank-app"
+                    ),
+                    "result": "failure",
+                    "reason": type(original_error).__name__,
+                    "route": request.path,
+                    "status": 500,
                     "correlation_id": getattr(g, "correlation_id", ""),
                     "path": request.path,
                     "method": request.method,

--- a/app/security/alerts.py
+++ b/app/security/alerts.py
@@ -221,7 +221,7 @@ def build_security_alert_report(
                     "delivered": True,
                     "deduped": True,
                 }
-    return {
+    report = {
         "message": "security_alert_report",
         "generated_at": _utc_iso(current_time),
         "alert_count": len(alerts),
@@ -232,6 +232,14 @@ def build_security_alert_report(
         "dedupe": dedupe,
         "delivery": delivery,
     }
+    report.update(
+        _security_report_observability_fields(
+            alerts=alerts,
+            audit_chain_status=audit_chain_status,
+            database_integrity_status=database_integrity_status,
+        )
+    )
+    return report
 
 
 def deliver_security_alerts(
@@ -643,6 +651,63 @@ def _database_integrity_alerts(
         "table_count": len(current_state["tables"]),
         "tables": current_state["tables"],
     }
+
+
+def _security_report_observability_fields(
+    *,
+    alerts: list[dict[str, Any]],
+    audit_chain_status: Mapping[str, Any],
+    database_integrity_status: Mapping[str, Any],
+) -> dict[str, Any]:
+    tables = database_integrity_status.get("tables")
+    if not isinstance(tables, Mapping):
+        tables = {}
+    audit_table = _database_table_metrics(tables, "security_audit_events")
+    users_table = _database_table_metrics(tables, "users")
+    alerting = bool(alerts)
+    return {
+        "event": "security_alert_report",
+        "environment": _current_observability_environment(),
+        "service": "sitbank-security-alerts",
+        "result": "active_alerts" if alerting else "success",
+        "status": "alerting" if alerting else "healthy",
+        "audit_chain_valid": audit_chain_status.get("valid"),
+        "audit_chain_anchor_status": _safe_text(
+            audit_chain_status.get("anchor_status"),
+            80,
+        ),
+        "audit_chain_anchor_refresh_required": bool(
+            audit_chain_status.get("anchor_refresh_required")
+        ),
+        "audit_chain_anchor_stale": bool(audit_chain_status.get("anchor_stale")),
+        "audit_chain_error_count": int(audit_chain_status.get("error_count") or 0),
+        "database_integrity_valid": database_integrity_status.get("valid"),
+        "database_integrity_security_audit_events_count": audit_table["count"],
+        "database_integrity_security_audit_events_max_id": audit_table["max_id"],
+        "database_integrity_users_count": users_table["count"],
+        "database_integrity_users_max_id": users_table["max_id"],
+    }
+
+
+def _database_table_metrics(
+    tables: Mapping[str, Any],
+    table_name: str,
+) -> dict[str, int | None]:
+    metrics = tables.get(table_name)
+    if not isinstance(metrics, Mapping):
+        return {"count": None, "max_id": None}
+    return {
+        "count": _state_optional_int(metrics.get("count")),
+        "max_id": _state_optional_int(metrics.get("max_id")),
+    }
+
+
+def _current_observability_environment() -> str:
+    if has_app_context():
+        value = current_app.config.get("APP_ENV")
+    else:
+        value = os.environ.get("APP_ENV")
+    return _safe_text(value or "unknown", 40)
 
 
 def _database_integrity_snapshot(current_time: datetime) -> dict[str, Any]:

--- a/app/security/audit.py
+++ b/app/security/audit.py
@@ -930,8 +930,16 @@ def _set_critical_anchor_errors(
 
 
 def _log_audit_record(event: SecurityAuditEvent, *, path: str | None, method: str | None) -> None:
+    reason = _metadata_reason(event.event_metadata or {})
     payload = {
         "message": "security_audit_event",
+        "event": event.event_type,
+        "environment": _current_environment(),
+        "service": _current_service(),
+        "result": event.outcome,
+        "reason": reason,
+        "route": path,
+        "status": "recorded",
         "event_id": event.id,
         "event_type": event.event_type,
         "outcome": event.outcome,
@@ -968,6 +976,14 @@ def _log_audit_write_failed(
 ) -> None:
     payload = {
         "message": "security_audit_write_failed",
+        "event": "security_audit_write_failed",
+        "environment": _current_environment(),
+        "service": _current_service(),
+        "result": "failure",
+        "reason": _clean_audit_text(error_type, 80),
+        "route": path,
+        "status": "audit_write_failed",
+        "target_event": event_type,
         "event_type": event_type,
         "outcome": outcome,
         "user_id": user_id,
@@ -982,6 +998,26 @@ def _log_audit_write_failed(
         "metadata": _sanitize_metadata(metadata),
     }
     current_app.logger.warning(json.dumps(payload, separators=(",", ":"), sort_keys=True))
+
+
+def _current_environment() -> str:
+    return _clean_audit_text(current_app.config.get("APP_ENV") or "unknown", 40)
+
+
+def _current_service() -> str:
+    app_mode = str(current_app.config.get("APP_MODE") or "").casefold()
+    if app_mode == "admin":
+        return "sitbank-admin"
+    if app_mode == "customer":
+        return "sitbank-app"
+    return "sitbank"
+
+
+def _metadata_reason(metadata: Mapping[str, Any]) -> str | None:
+    reason = metadata.get("reason")
+    if isinstance(reason, bool | int | float | str):
+        return _clean_audit_text(reason, 80) or None
+    return None
 
 
 def _utc_iso(value: datetime) -> str:

--- a/docs/runbooks/private-observability-grafana-loki.md
+++ b/docs/runbooks/private-observability-grafana-loki.md
@@ -1,19 +1,22 @@
-# Private Grafana Loki Observability Runbook
+# Private Grafana Loki Prometheus Observability Runbook
 
-Use this runbook to install and operate the private SITBank Grafana, Loki, and
-Grafana Alloy stack from `ops/observability/`.
+Use this runbook to install and operate the private SITBank Grafana, Loki,
+Grafana Alloy, Prometheus, and node exporter stack from `ops/observability/`.
 
 ## Access Model
 
 - Grafana binds to `127.0.0.1:3000` on the EC2 host.
 - Loki binds to `127.0.0.1:3100` on the EC2 host.
 - Alloy does not publish a host port.
+- Prometheus and node exporter do not publish host ports; they are reachable
+  only inside the internal `sitbank-observability` Docker network.
 - Grafana and Loki also join `sitbank-observability-loopback`.
   `sitbank-observability-loopback` is a bridge network used only for Docker's
   host-loopback port publishing. The private boundary is the explicit
   `127.0.0.1` host binding plus no public Nginx/Tailscale Funnel route.
 - `sitbank-observability` remains an internal service network for
-  container-to-container traffic.
+  container-to-container traffic between Grafana, Loki, Alloy, Prometheus, and
+  node exporter.
 - Normal operator access uses the private Tailscale path
   `https://admin-sitbank.tailca101b.ts.net/grafana/` mapped to local Grafana.
 - SSH local port forwarding is allowed only for bootstrap or break-glass
@@ -42,13 +45,18 @@ approved private Grafana subpath URL:
 GRAFANA_IMAGE=example.invalid/grafana@sha256:<reviewed-digest>
 LOKI_IMAGE=example.invalid/loki@sha256:<reviewed-digest>
 ALLOY_IMAGE=example.invalid/alloy@sha256:<reviewed-digest>
+PROMETHEUS_IMAGE=example.invalid/prometheus@sha256:<reviewed-digest>
+NODE_EXPORTER_IMAGE=example.invalid/node-exporter@sha256:<reviewed-digest>
+OBSERVABILITY_ENVIRONMENT=production
 GRAFANA_PRIVATE_ROOT_URL=https://admin-sitbank.tailca101b.ts.net/grafana/
 GRAFANA_SERVE_FROM_SUB_PATH=true
 ```
 
-Do not put passwords, tokens, API keys, webhook URLs, cookies, database URLs, or
-SMTP credentials in `observability.env`. Secret files must be `root:root` mode
-`0600`. The protected live verifier accepts only
+`OBSERVABILITY_ENVIRONMENT` must be `production` or `staging` for the target
+host so dashboard variables keep environments separated. Do not put passwords,
+tokens, API keys, webhook URLs, cookies, database URLs, or SMTP credentials in
+`observability.env`. Secret files must be `root:root` mode `0600`. The
+protected live verifier accepts only
 `https://admin-sitbank.tailca101b.ts.net/grafana/`; do not point it at an
 alternate hostname, root path, query string, custom port, or credential-bearing
 URL.
@@ -146,11 +154,15 @@ sudo docker network inspect sitbank-observability-loopback --format '{{.Internal
 sudo docker inspect sitbank-grafana --format '{{json .NetworkSettings.Networks}}'
 sudo docker inspect sitbank-loki --format '{{json .NetworkSettings.Networks}}'
 sudo docker inspect sitbank-alloy --format '{{json .NetworkSettings.Networks}}'
+sudo docker inspect sitbank-prometheus --format '{{json .NetworkSettings.Networks}}'
+sudo docker inspect sitbank-node-exporter --format '{{json .NetworkSettings.Networks}}'
 sudo docker port sitbank-grafana 3000/tcp
 sudo docker port sitbank-loki 3100/tcp
 test -z "$(sudo docker port sitbank-alloy)"
+test -z "$(sudo docker port sitbank-prometheus)"
+test -z "$(sudo docker port sitbank-node-exporter)"
 sudo ss -ltnp | grep -E '127\.0\.0\.1:(3000|3100)([[:space:]]|$)'
-sudo ss -ltnp | grep -E '0\.0\.0\.0:(3000|3100)|\[::\]:(3000|3100)|\*:(3000|3100)' && exit 1 || true
+sudo ss -ltnp | grep -E '0\.0\.0\.0:(3000|3100|9090|9100)|\[::\]:(3000|3100|9090|9100)|\*:(3000|3100|9090|9100)' && exit 1 || true
 curl -fsSI http://127.0.0.1:3000/login
 curl -fsS http://127.0.0.1:3100/ready
 sudo nginx -T | grep -iE 'grafana|loki' && exit 1 || true
@@ -166,9 +178,12 @@ Expected:
   attaches only to the internal `sitbank-observability` network.
 - Grafana listens only on `127.0.0.1:3000`.
 - Loki listens only on `127.0.0.1:3100`.
-- Alloy publishes no host listener.
+- Alloy, Prometheus, and node exporter publish no host listener.
 - Public SITBank Nginx configs contain no Grafana or Loki route.
 - The private Tailscale URL reaches Grafana only for approved operators.
+- The Grafana `SITBank Prometheus` datasource points to
+  `http://prometheus:9090` and the Prometheus `sitbank-node` job targets only
+  `node-exporter:9100`.
 
 ### Private Tailscale Serve Browser Access Plan
 
@@ -285,6 +300,21 @@ Alloy collects only:
 The collector labels are coarse and non-secret: `service`, `environment`,
 `host_role`, and `source`.
 
+Production and staging Nginx access logs use the reviewed
+`sitbank_access_json` format from `ops/nginx/sitbank-default.conf`. It records
+`message`, `event`, `service`, `result`, `status`, `method`, query-free
+`route`, upstream status, and timing fields. It deliberately uses `$uri`
+instead of `$request_uri` and does not log bodies, query strings, cookies,
+authorization headers, CSRF values, session IDs, client IP addresses, or raw
+request metadata.
+
+Application audit and error logs expose stable dashboard fields
+`event`, `environment`, `service`, `result`, `reason`, `route`, and `status`.
+Use those fields for Grafana/Loki queries instead of fragile free-text
+matching where structured records are available. Do not promote user IDs,
+emails, IPs, request IDs, account numbers, transaction references, or session
+references into labels.
+
 Alloy reads each allowlisted systemd unit through its own
 `loki.source.journal` block with a single exact `_SYSTEMD_UNIT=<unit>` match.
 The journal sources read the mounted `/var/log/journal` path. Do not use `OR`
@@ -337,14 +367,41 @@ matching activity occurs. Systemd streams are limited to
 
 ## Dashboard And Operational Alerts
 
-The provisioned `SITBank Operational Overview` dashboard uses readable
-time-series and log panels for log ingestion, Nginx 4xx/5xx trends, recent
-Nginx requests, app/admin container failures, monitored systemd failures, and
-deployment or rollback signals. Each panel describes what it shows, when to
-worry, and what to check next. Variables are limited to coarse `environment`,
-`service`, and `source` selectors; do not add high-cardinality labels such as
-full paths, IP addresses, request IDs, account IDs, user IDs, session IDs, or
-free-text values.
+The provisioned dashboard set is:
+
+- `SITBank Operational Overview` for log ingestion, Nginx 4xx/5xx trends,
+  recent Nginx requests, app/admin container failures, monitored systemd
+  failures, and deployment or rollback signals.
+- `SITBank Security Operations` for security alert count, deliverable alert
+  count, last successful `security_alert_report`, audit chain validity, audit
+  anchor status, audit anchor refresh-required/stale status, audit chain error
+  count, database integrity validity, tracked `security_audit_events` count and
+  max ID, and tracked `users` count and max ID.
+- `SITBank HTTP Health` for status classes, 429 rate-limit responses, 403/404,
+  500/502/503/504, route groups from the query-free route field, Nginx
+  upstream/backend errors, and login/register/MFA route volume.
+- `SITBank Infrastructure And Deployment Health` for EC2 CPU, memory, disk
+  usage and disk pressure, container restart or OOM events, PostgreSQL
+  connectivity/storage/connection-pressure log signals, Nginx/app/admin
+  readiness checks, last deployment time and target environment, deployment
+  guard failures, and deployment start/completion/rollback annotations.
+
+Normal values are zero active alerts, zero audit-chain errors, valid database
+integrity, no unexpected 5xx/502/503/504 spikes, 429s only during abusive
+bursts, CPU below 80% sustained, memory below 85%, filesystems below 80%, no
+repeated container restarts, and no deployment guard failures. Treat sustained
+CPU above 80%, memory above 85%, disk above 80% or rapidly increasing, any
+invalid audit/database integrity state, unexpected 5xx or backend errors,
+readiness failures, missing deployment completion, or guard failures as
+investigation triggers.
+
+Container CPU/memory and PostgreSQL connection-count exporter metrics are not
+enabled here. Those panels remain log-derived until a separate reviewed
+least-privilege exporter design is implemented. Each panel describes what it
+shows, when to worry, and what to check next. Variables are limited to coarse
+selectors; do not add high-cardinality labels such as full paths, IP
+addresses, request IDs, account IDs, user IDs, session IDs, or free-text
+values.
 
 Grafana-native alerts remain an operational follow-up until notification
 contact points can be provisioned without committed webhook URLs, tokens, or

--- a/docs/security/assurance/operational-observability.md
+++ b/docs/security/assurance/operational-observability.md
@@ -1,10 +1,13 @@
-# Operational Observability With Grafana And Loki
+# Operational Observability With Grafana Loki And Prometheus
 
 SITBank separates operational log search from the banking admin application.
-Grafana, Loki, and Grafana Alloy are implemented as a private host-side
-observability deployment for Nginx, container, deployment, systemd, and
-host-operation evidence. The SITBank admin app remains a purpose-built viewer
-for `SecurityAuditEvent` rows and sanitized security alert summaries only.
+Grafana, Loki, and Grafana Alloy are implemented alongside Prometheus and node
+exporter inside the private host-side observability boundary.
+Grafana, Loki, Grafana Alloy, Prometheus, and node exporter are implemented as
+a private host-side observability deployment for Nginx, container, deployment,
+systemd, host-resource, and host-operation evidence. The SITBank admin app
+remains a purpose-built viewer for `SecurityAuditEvent` rows and sanitized
+security alert summaries only.
 
 Category: [Security assurance](../README.md#assurance).
 
@@ -16,7 +19,11 @@ The reviewed deployment files are:
 - `ops/observability/loki/loki.yml`;
 - `ops/observability/alloy/config.alloy`;
 - `ops/observability/grafana/provisioning/datasources/loki.yml`;
+- `ops/observability/prometheus/prometheus.yml`;
 - `ops/observability/grafana/dashboards/sitbank-operational-overview.json`;
+- `ops/observability/grafana/dashboards/sitbank-security-operations.json`;
+- `ops/observability/grafana/dashboards/sitbank-http-health.json`;
+- `ops/observability/grafana/dashboards/sitbank-infrastructure-deployment-health.json`;
 - `ops/deploy/bootstrap-observability-ec2`;
 - `docs/runbooks/private-observability-grafana-loki.md`.
 
@@ -26,6 +33,8 @@ Use Grafana and Loki for operational evidence such as:
 - container stdout/stderr for the customer and admin runtimes;
 - deployment wrapper, bootstrap, rollback, and migration wrapper logs;
 - systemd status for SITBank services, timers, and deployment-adjacent units;
+- EC2 CPU, memory, filesystem usage, and disk pressure from the private node
+  exporter through Prometheus;
 - host-side Tailscale, Cloudflare verification, Certbot, and Nginx checks when
   the collected record is sanitized and operator-approved.
 
@@ -37,7 +46,8 @@ credentials.
 ## Access Model
 
 Grafana is private to approved operators. The Compose deployment binds Grafana
-to `127.0.0.1:3000`, Loki to `127.0.0.1:3100`, and publishes no Alloy port.
+to `127.0.0.1:3000`, Loki to `127.0.0.1:3100`, and publishes no Alloy,
+Prometheus, or node-exporter host port.
 Normal access uses the private Tailscale path
 `https://admin-sitbank.tailca101b.ts.net/grafana/`, mapped to Grafana's
 loopback subpath at `http://127.0.0.1:3000/grafana`. SSH local port forwarding
@@ -49,6 +59,9 @@ That bridge is not the ingress security boundary. The private boundary is the
 explicit `127.0.0.1` host binding, no public Nginx route, no Tailscale Funnel,
 no public firewall opening, and protected tailnet access. Alloy attaches only
 to the internal `sitbank-observability` network and publishes no host port.
+Prometheus and node exporter also attach only to that internal network; Grafana
+reaches Prometheus over `http://prometheus:9090`, and Prometheus reaches node
+exporter over `node-exporter:9100`.
 
 Live Grafana/Loki evidence is collected only by
 `.github/workflows/observability-private-verify.yml`, a manually dispatched
@@ -94,6 +107,22 @@ SITBank Nginx access/error logs, Docker logs only from containers labelled
 arbitrary home directories, shell history, environment dumps, raw command
 transcripts, or secret files.
 
+The production and staging Nginx access logs use the committed
+`sitbank_access_json` format. It records stable JSON fields such as `event`,
+`service`, `result`, `status`, `method`, `route`, `upstream_status`, and
+timing values. The `route` field uses Nginx `$uri`, not `$request_uri`, so
+query strings are not written to the dashboard source. The format does not log
+request or response bodies, cookies, authorization headers, CSRF values,
+session identifiers, client IP addresses, or raw query strings.
+
+Application audit and error logs use the same dashboard-friendly field names:
+`event`, `environment`, `service`, `result`, `reason`, `route`, and `status`.
+Existing safe audit fields remain available for investigation, and sensitive
+metadata continues to be redacted before logging. Dashboard queries should use
+stable `event`/`message` names and coarse labels; do not promote user IDs,
+emails, IP addresses, request IDs, account numbers, session references, or
+transaction references into Loki labels.
+
 Container log discovery currently keeps the read-only host Docker socket so
 Alloy can preserve label-based opt-in collection. This is an accepted residual
 risk, not a claim that the raw Docker socket is least privilege. Compensating
@@ -124,6 +153,14 @@ raw request bodies.
 Loki retention is bounded in `ops/observability/loki/loki.yml` with
 `retention_enabled: true` and `retention_period: 168h`.
 
+Prometheus stores private host metrics for the same 168-hour window. The
+committed Prometheus config scrapes only node exporter with the
+`OBSERVABILITY_ENVIRONMENT` label. Container CPU/memory and PostgreSQL
+connection-count exporter metrics are not enabled by this repository change;
+the current container and PostgreSQL panels use log-derived restart,
+connectivity, storage-pressure, and connection-pressure signals until a
+separate least-privilege exporter design is reviewed.
+
 ## Dashboards And Alerts
 
 Grafana dashboards should focus on operational questions:
@@ -134,12 +171,38 @@ Grafana dashboards should focus on operational questions:
 - Certbot renewal status and TLS edge verification failures;
 - Cloudflare/Tailscale verification command outcomes without raw tokens.
 
-The provisioned `SITBank Operational Overview` dashboard contains described
-panels for log ingestion, Nginx 4xx/5xx trends, recent Nginx requests,
-app/admin container failures, monitored systemd failures, and deployment or
-rollback signals. Variables stay coarse (`environment`, `service`, `source`);
-do not add full paths, IP addresses, request IDs, account IDs, user IDs,
-session IDs, or free-text values as Loki labels.
+The provisioned dashboard set is:
+
+- `SITBank Operational Overview`: log ingestion, Nginx 4xx/5xx trends, recent
+  structured Nginx requests, app/admin container failures, monitored systemd
+  failures, and deployment or rollback signals.
+- `SITBank Security Operations`: security alert count, deliverable alert
+  count, last successful `security_alert_report`, audit chain validity, audit
+  anchor status/stale/refresh-required state, audit chain error count,
+  database integrity validity, and tracked `security_audit_events`/`users`
+  count and max ID.
+- `SITBank HTTP Health`: requests by `2xx`/`3xx`/`4xx`/`5xx`, 429 rate-limit
+  responses, 403/404 responses, 500/502/503/504 responses, route groups from
+  the query-free `route` field, Nginx upstream/backend errors, and
+  login/register/MFA route volume.
+- `SITBank Infrastructure And Deployment Health`: EC2 CPU, memory, disk usage
+  and pressure from node exporter; container restart or OOM signals;
+  PostgreSQL connectivity/storage/connection-pressure log signals; Nginx,
+  app, and admin readiness failures; last deployment time and target
+  environment; deployment guard failures; and deployment annotations.
+
+Normal healthy values are zero active security alerts, zero audit-chain errors,
+valid database integrity, no sustained 5xx/502/503/504 responses, expected
+429s only under abusive bursts, CPU below 80% sustained, memory below 85%,
+filesystems below 80% usage, no repeated container restarts, and no deployment
+guard failures. Investigate sustained CPU above 80%, memory above 85%, disk
+above 80% or rapidly growing, any audit/database invalidity, any unexpected
+5xx spike, repeated 429s on auth paths, stale audit anchors without a verified
+append-only explanation, readiness failures, or missing deployment completion.
+
+Variables stay coarse (`environment`, `service`, `source`, and status class
+where present); do not add full paths, IP addresses, request IDs, account IDs,
+user IDs, session IDs, or free-text values as Loki labels.
 
 Grafana alerts may notify operators about operational failure patterns, but
 contact points are intentionally deferred until they can be provisioned without

--- a/ops/deploy/bootstrap-observability-ec2
+++ b/ops/deploy/bootstrap-observability-ec2
@@ -99,11 +99,13 @@ install -d -o root -g root -m 0755 "${OBS_ROOT}/grafana/provisioning/dashboards"
 install -d -o root -g root -m 0755 "${OBS_ROOT}/grafana/dashboards"
 install -d -o root -g root -m 0755 "${OBS_ROOT}/loki"
 install -d -o root -g root -m 0755 "${OBS_ROOT}/alloy"
+install -d -o root -g root -m 0755 "${OBS_ROOT}/prometheus"
 install -d -o root -g root -m 0700 "${OBS_ROOT}/secrets"
 install -d -o root -g root -m 0755 "${OBS_DATA_ROOT}"
 install -d -o 472 -g 472 -m 0750 "${OBS_DATA_ROOT}/grafana"
 install -d -o 10001 -g 10001 -m 0750 "${OBS_DATA_ROOT}/loki"
 install -d -o root -g root -m 0750 "${OBS_DATA_ROOT}/alloy"
+install -d -o 65534 -g 65534 -m 0750 "${OBS_DATA_ROOT}/prometheus"
 
 install -o root -g root -m 0644 \
     "${repo_root}/ops/observability/compose.observability.yml" \
@@ -114,15 +116,24 @@ install -o root -g root -m 0644 \
 install -o root -g root -m 0644 \
     "${repo_root}/ops/observability/grafana/provisioning/dashboards/sitbank.yml" \
     "${OBS_ROOT}/grafana/provisioning/dashboards/sitbank.yml"
-install -o root -g root -m 0644 \
-    "${repo_root}/ops/observability/grafana/dashboards/sitbank-operational-overview.json" \
-    "${OBS_ROOT}/grafana/dashboards/sitbank-operational-overview.json"
+for dashboard_path in "${repo_root}"/ops/observability/grafana/dashboards/*.json; do
+    if [[ ! -f "${dashboard_path}" ]]; then
+        echo "Missing committed Grafana dashboard JSON files" >&2
+        exit 1
+    fi
+    install -o root -g root -m 0644 \
+        "${dashboard_path}" \
+        "${OBS_ROOT}/grafana/dashboards/$(basename "${dashboard_path}")"
+done
 install -o root -g root -m 0644 \
     "${repo_root}/ops/observability/loki/loki.yml" \
     "${OBS_ROOT}/loki/loki.yml"
 install -o root -g root -m 0644 \
     "${repo_root}/ops/observability/alloy/config.alloy" \
     "${OBS_ROOT}/alloy/config.alloy"
+install -o root -g root -m 0644 \
+    "${repo_root}/ops/observability/prometheus/prometheus.yml" \
+    "${OBS_ROOT}/prometheus/prometheus.yml"
 
 for secret_file in "${GRAFANA_ADMIN_USER_FILE}" "${GRAFANA_ADMIN_PASSWORD_FILE}"; do
     if [[ ! -f "${secret_file}" ]]; then
@@ -140,7 +151,7 @@ for secret_file in "${GRAFANA_ADMIN_USER_FILE}" "${GRAFANA_ADMIN_PASSWORD_FILE}"
 done
 
 if [[ ! -f "${OBS_ENV_FILE}" ]]; then
-    echo "Missing ${OBS_ENV_FILE}; create it with GRAFANA_IMAGE, LOKI_IMAGE, ALLOY_IMAGE, and GRAFANA_PRIVATE_ROOT_URL." >&2
+    echo "Missing ${OBS_ENV_FILE}; create it with GRAFANA_IMAGE, LOKI_IMAGE, ALLOY_IMAGE, PROMETHEUS_IMAGE, NODE_EXPORTER_IMAGE, OBSERVABILITY_ENVIRONMENT, and GRAFANA_PRIVATE_ROOT_URL." >&2
     exit 1
 fi
 if grep -Eiq '(password|token|secret|key)[[:space:]]*=' "${OBS_ENV_FILE}"; then

--- a/ops/nginx/sitbank-default.conf
+++ b/ops/nginx/sitbank-default.conf
@@ -1,3 +1,19 @@
+log_format sitbank_access_json escape=json
+    '{"message":"nginx_access",'
+    '"event":"http_request",'
+    '"service":"nginx",'
+    '"result":"$status",'
+    '"status":$status,'
+    '"method":"$request_method",'
+    '"route":"$uri",'
+    '"host":"$host",'
+    '"body_bytes_sent":$body_bytes_sent,'
+    '"request_length":$request_length,'
+    '"request_time":"$request_time",'
+    '"upstream_status":"$upstream_status",'
+    '"upstream_response_time":"$upstream_response_time",'
+    '"logged_at":"$time_iso8601"}';
+
 server {
     listen __SITBANK_PUBLIC_BIND_ADDRESS__:80 default_server;
     server_name _;

--- a/ops/nginx/sitbank-production.conf
+++ b/ops/nginx/sitbank-production.conf
@@ -47,7 +47,7 @@ server {
     server_name sitbank.pp.ua;
 
     server_tokens off;
-    access_log /var/log/nginx/sitbank.access.log;
+    access_log /var/log/nginx/sitbank.access.log sitbank_access_json;
     error_log /var/log/nginx/sitbank.error.log warn;
 
     ssl_certificate /etc/letsencrypt/live/sitbank.pp.ua/fullchain.pem;

--- a/ops/nginx/sitbank-staging.conf
+++ b/ops/nginx/sitbank-staging.conf
@@ -53,7 +53,7 @@ server {
     server_name staging-sitbank.pp.ua;
 
     server_tokens off;
-    access_log /var/log/nginx/sitbank-staging.access.log;
+    access_log /var/log/nginx/sitbank-staging.access.log sitbank_access_json;
     error_log /var/log/nginx/sitbank-staging.error.log warn;
 
     ssl_certificate /etc/letsencrypt/live/staging-sitbank.pp.ua/fullchain.pem;

--- a/ops/observability/compose.observability.yml
+++ b/ops/observability/compose.observability.yml
@@ -57,6 +57,93 @@ services:
       - observability
     depends_on:
       - loki
+      - prometheus
+
+  prometheus:
+    image: ${PROMETHEUS_IMAGE:?PROMETHEUS_IMAGE must be an immutable digest reference}
+    container_name: sitbank-prometheus
+    user: "65534:65534"
+    read_only: true
+    init: true
+    restart: unless-stopped
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --config.expand-env
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=168h
+      - --web.listen-address=0.0.0.0:9090
+    environment:
+      OBSERVABILITY_ENVIRONMENT: ${OBSERVABILITY_ENVIRONMENT:?OBSERVABILITY_ENVIRONMENT must be staging or production}
+    volumes:
+      - type: bind
+        source: /etc/sitbank-observability/prometheus/prometheus.yml
+        target: /etc/prometheus/prometheus.yml
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: /var/lib/sitbank-observability/prometheus
+        target: /prometheus
+        read_only: false
+        bind:
+          create_host_path: false
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,nodev,size=64m,uid=65534,gid=65534,mode=1770
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 256
+    mem_limit: 512m
+    networks:
+      - observability
+    depends_on:
+      - node-exporter
+
+  node-exporter:
+    image: ${NODE_EXPORTER_IMAGE:?NODE_EXPORTER_IMAGE must be an immutable digest reference}
+    container_name: sitbank-node-exporter
+    user: "65534:65534"
+    pid: host
+    read_only: true
+    init: true
+    restart: unless-stopped
+    command:
+      - --path.procfs=/host/proc
+      - --path.sysfs=/host/sys
+      - --path.rootfs=/host/root
+      - --web.listen-address=:9100
+      - --collector.filesystem.mount-points-exclude=^/(dev|proc|run/credentials/.+|sys|var/lib/docker/.+)($|/)
+      - --collector.netdev.device-exclude=^(veth.*|docker.*|br-.*|lo)$
+    volumes:
+      - type: bind
+        source: /proc
+        target: /host/proc
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: /sys
+        target: /host/sys
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: /
+        target: /host/root
+        read_only: true
+        bind:
+          create_host_path: false
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,nodev,size=64m,uid=65534,gid=65534,mode=1770
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 256
+    mem_limit: 128m
+    networks:
+      - observability
 
   loki:
     image: ${LOKI_IMAGE:?LOKI_IMAGE must be an immutable digest reference}

--- a/ops/observability/grafana/dashboards/sitbank-http-health.json
+++ b/ops/observability/grafana/dashboards/sitbank-http-health.json
@@ -1,0 +1,220 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sitbank-loki"
+      },
+      "description": "Counts structured Nginx access records by status class. Worry about sustained 5xx growth or unexpected 4xx spikes; check route and upstream panels next.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "targets": [
+        {
+          "expr": "sum(count_over_time({source=\"nginx_access\", environment=~\"$environment\"} | json | status=~\"2..\" [$__interval]))",
+          "legendFormat": "2xx",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(count_over_time({source=\"nginx_access\", environment=~\"$environment\"} | json | status=~\"3..\" [$__interval]))",
+          "legendFormat": "3xx",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(count_over_time({source=\"nginx_access\", environment=~\"$environment\"} | json | status=~\"4..\" [$__interval]))",
+          "legendFormat": "4xx",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(count_over_time({source=\"nginx_access\", environment=~\"$environment\"} | json | status=~\"5..\" [$__interval]))",
+          "legendFormat": "5xx",
+          "refId": "D"
+        }
+      ],
+      "title": "Requests by status class",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sitbank-loki"
+      },
+      "description": "Shows 429 responses separately from other 4xx traffic. Worry about bursts on auth, registration, MFA, or password-reset routes; check rate-limit controls before changing limits.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "targets": [
+        {
+          "expr": "sum by (environment) (count_over_time({source=\"nginx_access\", environment=~\"$environment\"} | json | status=\"429\" [$__interval]))",
+          "refId": "A"
+        }
+      ],
+      "title": "429 rate-limit responses",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sitbank-loki"
+      },
+      "description": "Separates forbidden and missing-route responses. Worry when 403/404 spikes follow deploys or direct-origin probes; check Cloudflare, Nginx, and route inventory boundaries.",
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "targets": [
+        {
+          "expr": "sum(count_over_time({source=\"nginx_access\", environment=~\"$environment\"} | json | status=~\"403|404\" [$__interval]))",
+          "refId": "A"
+        }
+      ],
+      "title": "403 and 404 responses",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sitbank-loki"
+      },
+      "description": "Tracks user-visible server and upstream failures. Worry about any sustained 500/502/503/504 value; check app readiness, container health, and deployment events next.",
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 8
+      },
+      "id": 4,
+      "targets": [
+        {
+          "expr": "sum(count_over_time({source=\"nginx_access\", environment=~\"$environment\"} | json | status=~\"500|502|503|504\" [$__interval]))",
+          "refId": "A"
+        }
+      ],
+      "title": "500 502 503 504 responses",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sitbank-loki"
+      },
+      "description": "Lists recent routes from the structured `$uri` field, which excludes query strings. Worry about sensitive routes appearing with unexpected statuses; check copied evidence remains sanitized.",
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 8
+      },
+      "id": 5,
+      "options": {
+        "showLabels": false,
+        "sortOrder": "Descending"
+      },
+      "targets": [
+        {
+          "expr": "{source=\"nginx_access\", environment=~\"$environment\"} | json | line_format \"{{.method}} {{.route}} {{.status}} upstream={{.upstream_status}}\"",
+          "refId": "A"
+        }
+      ],
+      "title": "Top requested paths or route groups",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sitbank-loki"
+      },
+      "description": "Shows upstream/backend errors from structured Nginx access records and Nginx error logs. Worry about connection refused, timeout, bad gateway, or upstream 5xx patterns; check app readiness next.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
+      "id": 6,
+      "options": {
+        "showLabels": true,
+        "sortOrder": "Descending"
+      },
+      "targets": [
+        {
+          "expr": "{source=\"nginx_access\", environment=~\"$environment\"} | json | upstream_status=~\"5..|502|503|504\"",
+          "refId": "A"
+        },
+        {
+          "expr": "{source=\"nginx_error\", environment=~\"$environment\"} |~ \"(?i)(upstream|connect\\(\\)|timed out|bad gateway|connection refused)\"",
+          "refId": "B"
+        }
+      ],
+      "title": "Nginx upstream and backend errors",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sitbank-loki"
+      },
+      "description": "Shows safe route volume for login, register, and MFA endpoints without body data, sensitive headers, or query strings. Worry about unusual bursts or 429 concentration; check rate-limit context next.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "id": 7,
+      "targets": [
+        {
+          "expr": "sum by (route, status) (count_over_time({source=\"nginx_access\", environment=~\"$environment\"} | json | route=~\"/(login|register|mfa/verify|auth/login|auth/register|auth/mfa/verify)\" [$__interval]))",
+          "refId": "A"
+        }
+      ],
+      "title": "Login register and MFA route volume",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [
+    "sitbank",
+    "http",
+    "operations"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "production|staging",
+          "value": "production|staging"
+        },
+        "hide": 0,
+        "label": "Environment",
+        "name": "environment",
+        "options": [],
+        "query": "production|staging",
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "title": "SITBank HTTP Health",
+  "uid": "sitbank-http-health",
+  "version": 1
+}

--- a/ops/observability/grafana/dashboards/sitbank-infrastructure-deployment-health.json
+++ b/ops/observability/grafana/dashboards/sitbank-infrastructure-deployment-health.json
@@ -1,0 +1,249 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "datasource": {
+          "type": "loki",
+          "uid": "sitbank-loki"
+        },
+        "enable": true,
+        "expr": "{environment=~\"$environment\", source=~\"container|systemd\"} |~ \"(?i)(deploy|deployment|bootstrap|rollback|migration)\"",
+        "iconColor": "rgba(87, 148, 242, 1)",
+        "name": "Deployment start completion and rollback signals"
+      }
+    ]
+  },
+  "editable": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "sitbank-prometheus"
+      },
+      "description": "Shows EC2 CPU usage from the private node exporter. Worry about sustained high CPU; check deployment events, container failures, and host process evidence next.",
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "targets": [
+        {
+          "expr": "100 - (avg by (instance, environment) (rate(node_cpu_seconds_total{mode=\"idle\", environment=~\"$environment\"}[$__rate_interval])) * 100)",
+          "refId": "A"
+        }
+      ],
+      "title": "EC2 CPU usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "sitbank-prometheus"
+      },
+      "description": "Shows EC2 memory usage from host metrics. Worry about sustained pressure or sudden jumps after deploys; check container memory and restart signals next.",
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 2,
+      "targets": [
+        {
+          "expr": "(1 - (node_memory_MemAvailable_bytes{environment=~\"$environment\"} / node_memory_MemTotal_bytes{environment=~\"$environment\"})) * 100",
+          "refId": "A"
+        }
+      ],
+      "title": "EC2 memory usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "sitbank-prometheus"
+      },
+      "description": "Shows EC2 filesystem usage while excluding pseudo-filesystems and Docker internals. Worry above the documented threshold; check Loki retention and application storage next.",
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 3,
+      "targets": [
+        {
+          "expr": "100 - ((node_filesystem_avail_bytes{environment=~\"$environment\", fstype!~\"tmpfs|overlay|squashfs|proc|sysfs\"} / node_filesystem_size_bytes{environment=~\"$environment\", fstype!~\"tmpfs|overlay|squashfs|proc|sysfs\"}) * 100)",
+          "refId": "A"
+        }
+      ],
+      "title": "EC2 disk usage and pressure",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sitbank-loki"
+      },
+      "description": "Shows container restart, stop, OOM, and crash-like events from Docker/systemd and SITBank container logs. Worry about repeated restarts or OOM messages; check host resources next.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 7
+      },
+      "id": 4,
+      "options": {
+        "showLabels": true,
+        "sortOrder": "Descending"
+      },
+      "targets": [
+        {
+          "expr": "{environment=~\"$environment\", source=~\"container|systemd\"} |~ \"(?i)(restart|restarted|oom|out of memory|killed|exited|unhealthy)\"",
+          "refId": "A"
+        }
+      ],
+      "title": "Container restart count and recent restart events",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sitbank-loki"
+      },
+      "description": "Shows PostgreSQL connectivity, storage, and connection-pressure warnings when they appear in app/admin/deployment logs. Worry about connection refused, too many connections, or storage pressure; check deployment state next.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 7
+      },
+      "id": 5,
+      "options": {
+        "showLabels": true,
+        "sortOrder": "Descending"
+      },
+      "targets": [
+        {
+          "expr": "{environment=~\"$environment\", source=~\"container|systemd\"} |~ \"(?i)(postgres|database|sqlalchemy|connection refused|too many connections|storage|disk full|db upgrade)\"",
+          "refId": "A"
+        }
+      ],
+      "title": "PostgreSQL connectivity storage and connection health",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sitbank-loki"
+      },
+      "description": "Shows readiness and health check failures for Nginx, app, and admin paths. Worry about readiness failures after deploys; use local readiness on protected staging origins.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
+      "id": 6,
+      "options": {
+        "showLabels": true,
+        "sortOrder": "Descending"
+      },
+      "targets": [
+        {
+          "expr": "{environment=~\"$environment\", source=~\"nginx_access|container|systemd\"} | json | route=~\"/health/(ready|live)\" | status!~\"2..\"",
+          "refId": "A"
+        },
+        {
+          "expr": "{environment=~\"$environment\", source=~\"container|systemd\"} |~ \"(?i)(readiness|health check|/health/ready|/health/live)\" |~ \"(?i)(failed|failure|timeout|unhealthy|refused)\"",
+          "refId": "B"
+        }
+      ],
+      "title": "Nginx app and admin readiness check status",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sitbank-loki"
+      },
+      "description": "Lists deployment start/completion, target environment, migration, bootstrap, and rollback lines. Worry about missing completion after start or rollback signals; check the deployment runbook.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "id": 7,
+      "options": {
+        "showLabels": true,
+        "sortOrder": "Descending"
+      },
+      "targets": [
+        {
+          "expr": "{environment=~\"$environment\", source=~\"container|systemd\"} |~ \"(?i)(deploy|deployment|target=|environment=|completed|started|bootstrap|migration|rollback)\"",
+          "refId": "A"
+        }
+      ],
+      "title": "Last deployment time and target environment",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sitbank-loki"
+      },
+      "description": "Highlights production and staging deployment guard failures. Worry about any nonzero value; do not bypass Cloudflare, Tailscale, cosign, readiness, database privilege, or production checks.",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 8,
+      "options": {
+        "showLabels": true,
+        "sortOrder": "Descending"
+      },
+      "targets": [
+        {
+          "expr": "{environment=~\"$environment\", source=~\"container|systemd\"} |~ \"(?i)(production-check|verify-runtime-db-privileges|cloudflare|tailscale|cosign|origin pull|authenticated origin|readiness|guard)\" |~ \"(?i)(failed|failure|denied|refused|invalid|mismatch|rollback)\"",
+          "refId": "A"
+        }
+      ],
+      "title": "Production staging deployment guard failures",
+      "type": "logs"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [
+    "sitbank",
+    "infrastructure",
+    "deployment"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "production|staging",
+          "value": "production|staging"
+        },
+        "hide": 0,
+        "label": "Environment",
+        "name": "environment",
+        "options": [],
+        "query": "production|staging",
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "title": "SITBank Infrastructure And Deployment Health",
+  "uid": "sitbank-infrastructure-deployment-health",
+  "version": 1
+}

--- a/ops/observability/grafana/dashboards/sitbank-security-operations.json
+++ b/ops/observability/grafana/dashboards/sitbank-security-operations.json
@@ -1,0 +1,278 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sitbank-loki"
+      },
+      "description": "Shows active security alerts reported by the scheduled security alert job. Worry when this rises above zero; check the alert type panel and the admin audit viewer next.",
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "targets": [
+        {
+          "expr": "max_over_time({service=\"sitbank-security-alerts\", environment=~\"$environment\"} | json | message=\"security_alert_report\" | unwrap alert_count [$__interval])",
+          "refId": "A"
+        }
+      ],
+      "title": "Security alert count",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sitbank-loki"
+      },
+      "description": "Shows alerts that remain after dedupe and delivery filtering. Worry when deliverable alerts stay nonzero; check webhook configuration and dedupe status next.",
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "targets": [
+        {
+          "expr": "max_over_time({service=\"sitbank-security-alerts\", environment=~\"$environment\"} | json | message=\"security_alert_report\" | unwrap deliverable_alert_count [$__interval])",
+          "refId": "A"
+        }
+      ],
+      "title": "Deliverable alert count",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sitbank-loki"
+      },
+      "description": "Shows the most recent healthy security alert report. Worry when no success appears in the selected window; check the systemd timer and journal unit next.",
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "showLabels": true,
+        "sortOrder": "Descending"
+      },
+      "targets": [
+        {
+          "expr": "{service=\"sitbank-security-alerts\", environment=~\"$environment\"} | json | message=\"security_alert_report\" | result=\"success\" | line_format \"{{.generated_at}} result={{.result}} alerts={{.alert_count}}\"",
+          "refId": "A"
+        }
+      ],
+      "title": "Last successful security_alert_report",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sitbank-loki"
+      },
+      "description": "Counts reports where the audit hash chain is invalid. Worry about any nonzero value; check the alert report JSON and audit verification runbook next.",
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 6
+      },
+      "id": 4,
+      "targets": [
+        {
+          "expr": "sum(count_over_time({service=\"sitbank-security-alerts\", environment=~\"$environment\"} | json | message=\"security_alert_report\" | audit_chain_valid=\"false\" [$__interval]))",
+          "refId": "A"
+        }
+      ],
+      "title": "Audit chain validity",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sitbank-loki"
+      },
+      "description": "Lists audit anchor status from the security report. Worry about critical, malformed, mismatch, or unexpected not-configured states; check the anchor file and refresh procedure next.",
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 6
+      },
+      "id": 5,
+      "options": {
+        "showLabels": true,
+        "sortOrder": "Descending"
+      },
+      "targets": [
+        {
+          "expr": "{service=\"sitbank-security-alerts\", environment=~\"$environment\"} | json | message=\"security_alert_report\" | line_format \"{{.generated_at}} anchor={{.audit_chain_anchor_status}} stale={{.audit_chain_anchor_stale}} refresh_required={{.audit_chain_anchor_refresh_required}}\"",
+          "refId": "A"
+        }
+      ],
+      "title": "Audit anchor status",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sitbank-loki"
+      },
+      "description": "Counts stale anchors or anchor refresh requirements. Worry when the value is nonzero outside expected append-only activity; check the chain before refreshing.",
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 6
+      },
+      "id": 6,
+      "targets": [
+        {
+          "expr": "sum(count_over_time({service=\"sitbank-security-alerts\", environment=~\"$environment\"} | json | message=\"security_alert_report\" | audit_chain_anchor_refresh_required=\"true\" [$__interval])) + sum(count_over_time({service=\"sitbank-security-alerts\", environment=~\"$environment\"} | json | message=\"security_alert_report\" | audit_chain_anchor_stale=\"true\" [$__interval]))",
+          "refId": "A"
+        }
+      ],
+      "title": "Audit anchor refresh required",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sitbank-loki"
+      },
+      "description": "Shows audit chain error counts from the structured report. Worry about any nonzero value; check only sanitized report fields and admin audit context next.",
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 6
+      },
+      "id": 7,
+      "targets": [
+        {
+          "expr": "max_over_time({service=\"sitbank-security-alerts\", environment=~\"$environment\"} | json | message=\"security_alert_report\" | unwrap audit_chain_error_count [$__interval])",
+          "refId": "A"
+        }
+      ],
+      "title": "Audit chain error count",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sitbank-loki"
+      },
+      "description": "Counts database integrity report failures. Worry about any nonzero value; check tracked table count and max ID panels before any rebaseline.",
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 12
+      },
+      "id": 8,
+      "targets": [
+        {
+          "expr": "sum(count_over_time({service=\"sitbank-security-alerts\", environment=~\"$environment\"} | json | message=\"security_alert_report\" | database_integrity_valid=\"false\" [$__interval]))",
+          "refId": "A"
+        }
+      ],
+      "title": "Database integrity validity",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sitbank-loki"
+      },
+      "description": "Shows tracked security_audit_events count and max ID from the security report. Worry when either value moves backward; check the database integrity runbook.",
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 12
+      },
+      "id": 9,
+      "targets": [
+        {
+          "expr": "max_over_time({service=\"sitbank-security-alerts\", environment=~\"$environment\"} | json | message=\"security_alert_report\" | unwrap database_integrity_security_audit_events_count [$__interval])",
+          "legendFormat": "count",
+          "refId": "A"
+        },
+        {
+          "expr": "max_over_time({service=\"sitbank-security-alerts\", environment=~\"$environment\"} | json | message=\"security_alert_report\" | unwrap database_integrity_security_audit_events_max_id [$__interval])",
+          "legendFormat": "max_id",
+          "refId": "B"
+        }
+      ],
+      "title": "Tracked security_audit_events count and max ID",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "sitbank-loki"
+      },
+      "description": "Shows tracked users count and max ID from the security report. Worry when either value moves backward; check for possible database rewind evidence.",
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 12
+      },
+      "id": 10,
+      "targets": [
+        {
+          "expr": "max_over_time({service=\"sitbank-security-alerts\", environment=~\"$environment\"} | json | message=\"security_alert_report\" | unwrap database_integrity_users_count [$__interval])",
+          "legendFormat": "count",
+          "refId": "A"
+        },
+        {
+          "expr": "max_over_time({service=\"sitbank-security-alerts\", environment=~\"$environment\"} | json | message=\"security_alert_report\" | unwrap database_integrity_users_max_id [$__interval])",
+          "legendFormat": "max_id",
+          "refId": "B"
+        }
+      ],
+      "title": "Tracked users count and max ID",
+      "type": "stat"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [
+    "sitbank",
+    "security",
+    "operations"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "production|staging",
+          "value": "production|staging"
+        },
+        "hide": 0,
+        "label": "Environment",
+        "name": "environment",
+        "options": [],
+        "query": "production|staging",
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "title": "SITBank Security Operations",
+  "uid": "sitbank-security-operations",
+  "version": 1
+}

--- a/ops/observability/grafana/provisioning/datasources/loki.yml
+++ b/ops/observability/grafana/provisioning/datasources/loki.yml
@@ -10,3 +10,11 @@ datasources:
     editable: false
     jsonData:
       maxLines: 1000
+  - name: SITBank Prometheus
+    uid: sitbank-prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    editable: false
+    jsonData:
+      timeInterval: 30s

--- a/ops/observability/prometheus/prometheus.yml
+++ b/ops/observability/prometheus/prometheus.yml
@@ -1,0 +1,16 @@
+global:
+  scrape_interval: 30s
+  evaluation_interval: 30s
+  external_labels:
+    environment: "${OBSERVABILITY_ENVIRONMENT}"
+    service: sitbank-observability
+
+scrape_configs:
+  - job_name: sitbank-node
+    static_configs:
+      - targets:
+          - node-exporter:9100
+        labels:
+          environment: "${OBSERVABILITY_ENVIRONMENT}"
+          service: ec2-node
+          host_role: edge

--- a/tests/test_audit_alerting.py
+++ b/tests/test_audit_alerting.py
@@ -58,6 +58,12 @@ def test_structured_audit_log_output_is_sanitized(app, caplog):
 
     assert payload["path"] == "/audit/hygiene"
     assert payload["method"] == "POST"
+    assert payload["event"] == "audit_hygiene"
+    assert payload["environment"]
+    assert payload["service"] == "sitbank-app"
+    assert payload["result"] == "success"
+    assert payload["route"] == "/audit/hygiene"
+    assert payload["status"] == "recorded"
     assert payload["session_ref"] != raw_session_id
     assert len(payload["session_ref"]) == 16
     assert payload["hash_algorithm"] == "hmac-sha256-v1"
@@ -104,6 +110,12 @@ def test_audit_write_failure_warning_is_sanitized(app, caplog, monkeypatch):
     payload = log_payloads(caplog, "security_audit_write_failed")[-1]
 
     assert payload["event_type"] == "audit_failure"
+    assert payload["event"] == "security_audit_write_failed"
+    assert payload["target_event"] == "audit_failure"
+    assert payload["result"] == "failure"
+    assert payload["route"] == "/audit/fail"
+    assert payload["status"] == "audit_write_failed"
+    assert payload["service"] == "sitbank-app"
     assert payload["error_type"] == "RuntimeError"
     assert payload["metadata"]["password"] == "[redacted]"
     assert payload["metadata"]["token"] == "[redacted]"
@@ -135,6 +147,10 @@ def test_required_audit_write_failure_raises_and_logs_sanitized_warning(app, cap
     payload = log_payloads(caplog, "security_audit_write_failed")[-1]
 
     assert payload["event_type"] == "banking_transaction_authorization"
+    assert payload["event"] == "security_audit_write_failed"
+    assert payload["target_event"] == "banking_transaction_authorization"
+    assert payload["result"] == "failure"
+    assert payload["status"] == "audit_write_failed"
     assert payload["metadata"]["authorization"] == "[redacted]"
     assert "database password leaked" not in logs
     assert "token-secret" not in logs
@@ -808,7 +824,14 @@ def test_security_alert_evaluator_cli_and_output_are_sanitized(app):
         assert forbidden not in serialized_alerts
         assert forbidden not in report_only.output
     assert report_only.exit_code == 0, report_only.output
-    assert json.loads(report_only.output)["alert_count"] >= len(alert_types)
+    report_payload = json.loads(report_only.output)
+    assert report_payload["alert_count"] >= len(alert_types)
+    assert report_payload["event"] == "security_alert_report"
+    assert report_payload["service"] == "sitbank-security-alerts"
+    assert report_payload["result"] == "active_alerts"
+    assert report_payload["audit_chain_error_count"] == 0
+    assert "database_integrity_security_audit_events_count" in report_payload
+    assert "database_integrity_users_max_id" in report_payload
     assert strict.exit_code != 0
 
 def test_security_alert_webhook_delivery_is_sanitized(monkeypatch):
@@ -1200,6 +1223,12 @@ def test_500_handler_logs_sanitized_context(mutable_app, caplog):
     assert response.status_code == 500
     assert payload["path"] == "/explode"
     assert payload["method"] == "POST"
+    assert payload["event"] == "system_error"
+    assert payload["service"] == "sitbank-app"
+    assert payload["result"] == "failure"
+    assert payload["reason"] == "RuntimeError"
+    assert payload["route"] == "/explode"
+    assert payload["status"] == 500
     assert payload["exception_type"] == "RuntimeError"
     assert payload["correlation_id"]
     for forbidden in (

--- a/tests/test_operational_observability_deployment.py
+++ b/tests/test_operational_observability_deployment.py
@@ -157,11 +157,13 @@ def test_private_grafana_loki_alloy_deployment_files_exist_and_are_private():
     compose = yaml.safe_load(compose_path.read_text(encoding="utf-8"))
     services = compose["services"]
 
-    assert set(services) == {"grafana", "loki", "alloy"}
+    assert set(services) == {"grafana", "loki", "alloy", "prometheus", "node-exporter"}
     alloy = services["alloy"]
     assert services["grafana"]["ports"] == ["127.0.0.1:3000:3000"]
     assert services["loki"]["ports"] == ["127.0.0.1:3100:3100"]
     assert "ports" not in alloy
+    assert "ports" not in services["prometheus"]
+    assert "ports" not in services["node-exporter"]
     assert alloy["command"] == [
         "run",
         "--server.http.listen-addr=127.0.0.1:12345",
@@ -175,6 +177,8 @@ def test_private_grafana_loki_alloy_deployment_files_exist_and_are_private():
     assert services["grafana"]["networks"] == ["host-loopback", "observability"]
     assert services["loki"]["networks"] == ["host-loopback", "observability"]
     assert alloy["networks"] == ["observability"]
+    assert services["prometheus"]["networks"] == ["observability"]
+    assert services["node-exporter"]["networks"] == ["observability"]
     assert compose["networks"]["host-loopback"] == {
         "name": "sitbank-observability-loopback",
         "driver": "bridge",
@@ -209,6 +213,7 @@ def test_private_grafana_loki_alloy_deployment_files_exist_and_are_private():
     assert grafana["environment"]["GF_SECURITY_ADMIN_PASSWORD__FILE"] == (
         "/run/secrets/grafana_admin_password"
     )
+    assert "prometheus" in grafana["depends_on"]
     assert compose["secrets"]["grafana_admin_user"]["file"] == (
         "/etc/sitbank-observability/secrets/grafana_admin_user"
     )
@@ -240,6 +245,23 @@ def test_private_grafana_loki_alloy_deployment_files_exist_and_are_private():
         "read_only": True,
         "bind": {"create_host_path": False},
     }
+    prometheus = services["prometheus"]
+    assert prometheus["environment"]["OBSERVABILITY_ENVIRONMENT"] == (
+        "${OBSERVABILITY_ENVIRONMENT:?OBSERVABILITY_ENVIRONMENT must be staging or production}"
+    )
+    assert "--config.expand-env" in prometheus["command"]
+    assert "--storage.tsdb.retention.time=168h" in prometheus["command"]
+    assert prometheus["depends_on"] == ["node-exporter"]
+    assert "password" not in json.dumps(prometheus).casefold()
+    assert "token" not in json.dumps(prometheus).casefold()
+
+    node_exporter = services["node-exporter"]
+    assert node_exporter["pid"] == "host"
+    assert "--path.procfs=/host/proc" in node_exporter["command"]
+    assert "--path.sysfs=/host/sys" in node_exporter["command"]
+    assert "--path.rootfs=/host/root" in node_exporter["command"]
+    assert all(volume["read_only"] is True for volume in node_exporter["volumes"])
+    assert "docker.sock" not in json.dumps(node_exporter)
 
 
 def test_loki_retention_and_grafana_datasource_are_configured_without_credentials():
@@ -253,14 +275,12 @@ def test_loki_retention_and_grafana_datasource_are_configured_without_credential
             / "loki.yml"
         ).read_text(encoding="utf-8")
     )
-    dashboard = json.loads(
-        (
-            OBS_ROOT
-            / "grafana"
-            / "dashboards"
-            / "sitbank-operational-overview.json"
-        ).read_text(encoding="utf-8")
-    )
+    dashboard_dir = OBS_ROOT / "grafana" / "dashboards"
+    dashboards = {
+        path.name: json.loads(path.read_text(encoding="utf-8"))
+        for path in dashboard_dir.glob("*.json")
+    }
+    dashboard = dashboards["sitbank-operational-overview.json"]
 
     assert loki["compactor"]["retention_enabled"] is True
     assert loki["limits_config"]["retention_period"] == "168h"
@@ -271,8 +291,24 @@ def test_loki_retention_and_grafana_datasource_are_configured_without_credential
     assert loki_datasource["type"] == "loki"
     assert loki_datasource["url"] == "http://loki:3100"
     assert loki_datasource["access"] == "proxy"
-    assert "password" not in str(loki_datasource).casefold()
-    assert "token" not in str(loki_datasource).casefold()
+    prometheus_datasource = datasource["datasources"][1]
+    assert prometheus_datasource["type"] == "prometheus"
+    assert prometheus_datasource["uid"] == "sitbank-prometheus"
+    assert prometheus_datasource["url"] == "http://prometheus:9090"
+    assert "password" not in str(datasource).casefold()
+    assert "token" not in str(datasource).casefold()
+    assert set(dashboards) == {
+        "sitbank-operational-overview.json",
+        "sitbank-security-operations.json",
+        "sitbank-http-health.json",
+        "sitbank-infrastructure-deployment-health.json",
+    }
+    assert {item["uid"] for item in dashboards.values()} == {
+        "sitbank-operational-overview",
+        "sitbank-security-operations",
+        "sitbank-http-health",
+        "sitbank-infrastructure-deployment-health",
+    }
     assert dashboard["uid"] == "sitbank-operational-overview"
     assert dashboard["version"] >= 2
     assert "Recent operational errors" not in json.dumps(dashboard)
@@ -299,6 +335,102 @@ def test_loki_retention_and_grafana_datasource_are_configured_without_credential
     assert "session_id" not in dashboard_text
     assert "request_id" not in dashboard_text
     assert "ip_address" not in dashboard_text
+
+
+def test_observability_dashboards_cover_security_http_and_infrastructure_health():
+    dashboard_dir = OBS_ROOT / "grafana" / "dashboards"
+    dashboards = {
+        path.name: json.loads(path.read_text(encoding="utf-8"))
+        for path in dashboard_dir.glob("*.json")
+    }
+    security = dashboards["sitbank-security-operations.json"]
+    http = dashboards["sitbank-http-health.json"]
+    infrastructure = dashboards["sitbank-infrastructure-deployment-health.json"]
+
+    assert {panel["title"] for panel in security["panels"]} >= {
+        "Security alert count",
+        "Deliverable alert count",
+        "Last successful security_alert_report",
+        "Audit chain validity",
+        "Audit anchor status",
+        "Audit anchor refresh required",
+        "Audit chain error count",
+        "Database integrity validity",
+        "Tracked security_audit_events count and max ID",
+        "Tracked users count and max ID",
+    }
+    assert {panel["title"] for panel in http["panels"]} >= {
+        "Requests by status class",
+        "429 rate-limit responses",
+        "403 and 404 responses",
+        "500 502 503 504 responses",
+        "Top requested paths or route groups",
+        "Nginx upstream and backend errors",
+        "Login register and MFA route volume",
+    }
+    assert {panel["title"] for panel in infrastructure["panels"]} >= {
+        "EC2 CPU usage",
+        "EC2 memory usage",
+        "EC2 disk usage and pressure",
+        "Container restart count and recent restart events",
+        "PostgreSQL connectivity storage and connection health",
+        "Nginx app and admin readiness check status",
+        "Last deployment time and target environment",
+        "Production staging deployment guard failures",
+    }
+    assert infrastructure["annotations"]["list"][0]["name"] == (
+        "Deployment start completion and rollback signals"
+    )
+    for dashboard in dashboards.values():
+        for panel in dashboard["panels"]:
+            assert panel.get("description")
+            assert "Worry" in panel["description"]
+            assert "check" in panel["description"].casefold()
+        dashboard_text = json.dumps(dashboard).casefold()
+        for forbidden in (
+            "authorization",
+            "cookie",
+            "csrf",
+            "session_id",
+            "totp",
+            "recovery_code",
+            "password=",
+            "token=",
+            "request_body",
+            "response_body",
+        ):
+            assert forbidden not in dashboard_text
+
+
+def test_nginx_structured_access_logs_omit_sensitive_request_data():
+    default_nginx = Path("ops/nginx/sitbank-default.conf").read_text(encoding="utf-8")
+    production_nginx = Path("ops/nginx/sitbank-production.conf").read_text(encoding="utf-8")
+    staging_nginx = Path("ops/nginx/sitbank-staging.conf").read_text(encoding="utf-8")
+    log_format = default_nginx.split("server {", 1)[0]
+
+    assert "log_format sitbank_access_json escape=json" in log_format
+    for required in (
+        '"message":"nginx_access"',
+        '"event":"http_request"',
+        '"service":"nginx"',
+        '"status":$status',
+        '"method":"$request_method"',
+        '"route":"$uri"',
+        '"upstream_status":"$upstream_status"',
+    ):
+        assert required in log_format
+    for forbidden in (
+        "$request_uri",
+        "$args",
+        "$query_string",
+        "$http_authorization",
+        "$http_cookie",
+        "$remote_addr",
+        "$request_body",
+    ):
+        assert forbidden not in log_format
+    assert "access_log /var/log/nginx/sitbank.access.log sitbank_access_json;" in production_nginx
+    assert "access_log /var/log/nginx/sitbank-staging.access.log sitbank_access_json;" in staging_nginx
 
 
 def test_alloy_collects_only_approved_sources_and_redacts_sensitive_patterns():
@@ -478,6 +610,10 @@ def test_observability_bootstrap_and_docs_keep_credentials_out_of_repo():
         "docker compose --env-file",
         "Grafana listens only on `127.0.0.1:3000`",
         "Loki listens only on `127.0.0.1:3100`",
+        "Prometheus and node exporter do not publish host ports",
+        "PROMETHEUS_IMAGE=example.invalid/prometheus@sha256:<reviewed-digest>",
+        "NODE_EXPORTER_IMAGE=example.invalid/node-exporter@sha256:<reviewed-digest>",
+        "OBSERVABILITY_ENVIRONMENT=production",
         "GRAFANA_PRIVATE_ROOT_URL=https://admin-sitbank.tailca101b.ts.net/grafana/",
         "GRAFANA_SERVE_FROM_SUB_PATH=true",
         "Private Tailscale Serve Browser Access Plan",
@@ -489,6 +625,10 @@ def test_observability_bootstrap_and_docs_keep_credentials_out_of_repo():
         "GF_SERVER_SERVE_FROM_SUB_PATH",
         "explicit HTTP `200` status validation",
         "https://sitbank.pp.ua/grafana",
+        "http://prometheus:9090",
+        "node-exporter:9100",
+        "sitbank_access_json",
+        "`route`, upstream status, and timing fields",
         "Nginx log files remain `0640` and group-readable by `adm`",
         "Journal files remain group-readable by `systemd-journal`",
         "`sitbank-observability-loopback` is a bridge network used only for "
@@ -497,7 +637,12 @@ def test_observability_bootstrap_and_docs_keep_credentials_out_of_repo():
         "Container log discovery currently uses the read-only host Docker socket",
         "accepted residual risk",
         "header-style, JSON-field, quoted logfmt, and unquoted key/value",
-        "The provisioned `SITBank Operational Overview` dashboard",
+        "`SITBank Operational Overview`",
+        "`SITBank Security Operations`",
+        "`SITBank HTTP Health`",
+        "`SITBank Infrastructure And Deployment Health`",
+        "Application audit and error logs expose stable dashboard fields",
+        "Container CPU/memory and PostgreSQL connection-count exporter metrics are not",
         "Grafana-native alerts remain an operational follow-up",
         "Alloy keeps only its runtime state under `/var/lib/alloy`",
         "The admin audit viewer remains backed by `SecurityAuditEvent`, not Loki",


### PR DESCRIPTION
Summary
---
Adds private observability coverage for the open Grafana/logging issues by expanding SITBank dashboards, structured logs, and private host metrics.

Why
---
The existing dashboard mostly showed log volume and a few operational errors. Operators needed safer Grafana panels for security operations, HTTP status health, infrastructure pressure, readiness, and deployment guard failures without exposing secrets or weakening private observability boundaries.

What changed
---
- Added committed Grafana dashboards for security operations, HTTP health, and infrastructure/deployment health.
- Added private Prometheus and node-exporter wiring for EC2 CPU, memory, and disk panels while keeping both off host ports.
- Standardized safe dashboard fields on audit, security alert, and system error logs.
- Switched production and staging Nginx access logs to query-free structured JSON using `$uri` instead of full request URIs.
- Updated observability runbooks, assurance docs, and regression tests for dashboards, datasource safety, bootstrap behavior, and redaction boundaries.

Security impact
---
Strengthens observability without exposing Grafana, Loki, Prometheus, or node exporter publicly. Nginx access logs exclude query strings, request bodies, client IPs, cookies, authorization headers, CSRF values, and session identifiers. Existing Cloudflare, Tailscale, Nginx, audit, alerting, and deployment guard semantics are preserved.

Deployment impact
---
EC2 observability bootstrap must be rerun so `/etc/sitbank-observability` receives the new Compose services, Prometheus config, datasource, and dashboards. Operators must add non-secret `PROMETHEUS_IMAGE`, `NODE_EXPORTER_IMAGE`, and `OBSERVABILITY_ENVIRONMENT` values to `observability.env`. Production and staging Nginx/bootstrap deployment is required to apply the structured access-log format. No database migration or application secret change is expected.

Verification
---
- `git diff --check`
- `.\.venv\Scripts\python.exe -m pytest -q tests/test_operational_observability_deployment.py tests/test_audit_alerting.py -n 4`
- `.\.venv\Scripts\python.exe -m pytest -q tests/test_deployment.py -n 4`
- `.\.venv\Scripts\python.exe -m pytest -q -n 4`
- `.\.venv\Scripts\python.exe -m pytest -q -n 4 --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term` with total coverage at 91%

Notes
---
Closes #424.
Closes #425.
Closes #426.
Closes #427.
Refs #398: the refreshed baseline already wires `GF_SERVER_SERVE_FROM_SUB_PATH` and keeps the runbook/tests aligned, so no extra code change was needed for that issue.