### PR TITLE
Fix statement delta badge contrast

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -2069,14 +2069,15 @@ th {
   width: fit-content;
   border-radius: 999px;
   padding: 3px 10px;
-  background: rgba(255, 255, 255, 0.18);
-  color: #ffffff;
+  background: #ffffff;
+  color: #8f1024;
   font-size: 0.82rem;
   font-weight: 700;
 }
 
 .statement-delta.is-negative {
-  background: rgba(0, 0, 0, 0.2);
+  background: #111111;
+  color: #ffffff;
 }
 
 .statement-txn-not-counted {

--- a/tests/test_authenticated_portal_ui.py
+++ b/tests/test_authenticated_portal_ui.py
@@ -76,6 +76,18 @@ def test_auth_intro_notice_icon_uses_contrasting_solid_surface():
     assert "rgba(255, 255, 255, 0.14)" not in notice_icon_rule
 
 
+def test_statement_delta_badge_uses_contrasting_solid_surfaces():
+    stylesheet = Path("app/static/css/app.css").read_text(encoding="utf-8")
+    delta_rule = stylesheet.split(".statement-delta {", 1)[1].split("}", 1)[0]
+    negative_delta_rule = stylesheet.split(".statement-delta.is-negative {", 1)[1].split("}", 1)[0]
+
+    assert "background: #ffffff;" in delta_rule
+    assert "color: #8f1024;" in delta_rule
+    assert "rgba(255, 255, 255, 0.18)" not in delta_rule
+    assert "background: #111111;" in negative_delta_rule
+    assert "color: #ffffff;" in negative_delta_rule
+
+
 def test_authenticated_layout_contains_working_profile_menu_destinations(client):
     register(client)
     login(client)


### PR DESCRIPTION
Summary
---
Resolve the post-merge Sonar CSS contrast finding for the monthly statement delta badge.

Why
---
Sonar reported css:S7924 on app/static/css/app.css because the badge used white text on a translucent white surface. That made the badge depend on the surrounding gradient instead of having an explicit accessible foreground/background pair.

What changed
---
- Replaced the regular statement delta badge with a solid white background and dark red text.
- Replaced the negative delta badge with a solid near-black background and white text.
- Added a focused stylesheet regression assertion for the statement delta badge surfaces.

Security impact
---
No auth, session, authorization, secret, logging, or deployment trust-boundary behavior changes. This improves accessibility/readability for an authenticated banking statement UI and resolves the current main-branch Sonar finding without weakening security controls.

Deployment impact
---
No EC2 bootstrap, database migration, or secret changes. Normal staging and production deployment will apply the static CSS update through the existing workflow.

Verification
---
- git diff --check
- .\.venv\Scripts\python.exe -m pytest -q tests/test_authenticated_portal_ui.py -n 4
- .\.venv\Scripts\python.exe -m pytest -q -n 4
- .\.venv\Scripts\python.exe -m pytest -q -n 4 --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term

Notes
---
Follow-up for the main-branch Sonar issue AZ8t-Qc9zhkku3m0zLmy.