### PR TITLE
Harden release attestation and SBOM path validation

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -744,6 +744,7 @@ jobs:
             --source-digest "${RELEASE_SHA}" \
             --cert-oidc-issuer "https://token.actions.githubusercontent.com" \
             --deny-self-hosted-runners \
+            --no-public-good \
             >/dev/null
 
       - name: Validate production and staging Compose models for the exact digest

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -266,12 +266,14 @@ attestation, pushed by the trusted publish job to the image registry, for the
 exact `ghcr.io/koon-kiat/sitbank@sha256:<digest>` subject. The verifier requires
 repository `Koon-Kiat/SITBank`, source ref `refs/heads/main`, the resolved
 release commit, exact signer workflow `.github/workflows/ci-deploy.yml`,
-GitHub's OIDC issuer, and the same digest passed to deployment. A missing,
-wrong-subject, wrong-ref, wrong-workflow, or unverifiable attestation fails
-closed. This is SLSA Build L1/L2-aligned release evidence, not a claim of
-formal SLSA certification. Repository files do not prove live GHCR state,
-branch protection, or GitHub Environment settings; preserve sanitized
-release/provider evidence separately.
+GitHub's OIDC issuer, a non-self-hosted runner, and the same digest passed to
+deployment. The `--no-public-good` option intentionally selects the GitHub
+artifact attestation rather than trusting or being confused by independent
+Sigstore public-good BuildKit provenance. A missing, wrong-subject, wrong-ref,
+wrong-workflow, or unverifiable attestation fails closed. This is SLSA Build
+L1/L2-aligned release evidence, not a claim of formal SLSA certification.
+Repository files do not prove live GHCR state, branch protection, or GitHub
+Environment settings; preserve sanitized release/provider evidence separately.
 
 Production deployment runs from the trusted `main` workflow only after release
 verification, staging deployment, and the post-deployment staging TLS scan all

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -15,9 +15,12 @@ The publish job also creates a GitHub artifact attestation whose subject is the
 exact GHCR image name and Buildx digest, and pushes that attestation to the
 image registry. Release verification checks the registry-backed attestation
 against this repository, the exact `ci-deploy.yml` signer workflow, the trusted
-`main` source ref, and the resolved release commit before any staging
-deployment. Cosign signature and certificate-identity verification, Trivy,
-SBOM, and provenance checks remain independent required layers.
+`main` source ref, the resolved release commit, GitHub's OIDC issuer, and a
+non-self-hosted runner before any staging deployment. The verifier uses
+`--no-public-good` intentionally so it selects the GitHub artifact attestation
+instead of trusting or being confused by separate Sigstore public-good
+BuildKit provenance. Cosign signature and certificate-identity verification,
+Trivy, SBOM, and provenance checks remain independent required layers.
 
 ## Workflow And Check Display Names
 
@@ -558,8 +561,10 @@ evidence artifacts and must not be committed.
 
 The job summary is a bounded preview: it reports counts by package-URL
 ecosystem and lists at most 10 `pkg:pypi/` components in a dedicated Python
-section. The artifact remains the complete inventory. Inspect all Python
-entries without printing the whole document:
+section. Its renderer accepts only relative regular-file paths contained by the
+current workspace and rejects traversal and symlink escapes before reading the
+SBOM. The artifact remains the complete inventory. Inspect all Python entries
+without printing the whole document:
 
 ```bash
 jq -r '(.components // [])[] | select((.purl // "") | startswith("pkg:pypi/")) | [.name, .version, .purl] | @tsv' sitbank-source-sbom-cyclonedx.json

--- a/docs/security/assurance/test-automation-and-dependencies.md
+++ b/docs/security/assurance/test-automation-and-dependencies.md
@@ -58,7 +58,7 @@ applicable unless a frontend package manager is added.
 | Semgrep | `.github/workflows/semgrep.yml` | Runs `p/python`, `p/flask`, `p/security-audit`, `p/owasp-top-ten`, and `p/github-actions` locally with `--metrics=off` and blocks ERROR severity |
 | Action hygiene | `.github/workflows/ci-deploy.yml` | Runs actionlint and zizmor; tests require actions to be SHA-pinned |
 | Image and artifact signing | `.github/workflows/ci-deploy.yml`, `.github/workflows/bootstrap-ec2.yml`, `ops/deploy/sitbank-container-deploy` | Uses cosign to sign/verify images and deployment artifacts |
-| Release provenance | `.github/workflows/ci-deploy.yml` | Creates and verifies a GitHub artifact attestation for the exact release image digest, trusted repository, main ref, release commit, signer workflow, and GitHub OIDC issuer before staging; this is SLSA Build L1/L2-aligned evidence, not formal certification |
+| Release provenance | `.github/workflows/ci-deploy.yml` | Creates and verifies a GitHub artifact attestation for the exact release image digest, trusted repository, main ref, release commit, signer workflow, GitHub OIDC issuer, and non-self-hosted runner before staging; `--no-public-good` excludes separate Sigstore public-good BuildKit provenance; this is SLSA Build L1/L2-aligned evidence, not formal certification |
 
 Tests for this automation include:
 
@@ -364,8 +364,9 @@ and retains the `sitbank-source-sbom` CycloneDX JSON artifact for 30 days. It
 runs without secrets on pull requests, pushes to `main`, and manual dispatch.
 Its summary is a bounded preview with package-URL ecosystem counts and at most
 10 `pkg:pypi/` rows in a dedicated Python section; zero Python components is
-reported explicitly. The full artifact remains authoritative. Inspect its
-Python inventory with
+reported explicitly. The renderer reads only relative regular-file paths
+contained by the current workspace and rejects traversal and symlink escapes.
+The full artifact remains authoritative. Inspect its Python inventory with
 `jq -r '(.components // [])[] | select((.purl // "") | startswith("pkg:pypi/")) | [.name, .version, .purl] | @tsv' sitbank-source-sbom-cyclonedx.json`.
 It is separate from Buildx image attestation and is not vulnerability scanning.
 The existing Buildx `sbom: true` attestation remains required; an explicit

--- a/ops/security/render_sbom_summary.py
+++ b/ops/security/render_sbom_summary.py
@@ -119,11 +119,36 @@ def render_summary(document: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def _validated_input_path(
+    input_path: Path, *, input_root: Path | None = None
+) -> Path:
+    root = (input_root if input_root is not None else Path.cwd()).resolve(
+        strict=True
+    )
+    if input_path.is_absolute() or ".." in input_path.parts:
+        raise ValueError(
+            "CycloneDX input must be a relative path within the working directory"
+        )
+
+    candidate = root / input_path
+    resolved_candidate = candidate.resolve(strict=True)
+    try:
+        resolved_candidate.relative_to(root)
+    except ValueError as error:
+        raise ValueError(
+            "CycloneDX input must be within the working directory"
+        ) from error
+    if not resolved_candidate.is_file():
+        raise ValueError("CycloneDX input must be a regular file")
+    return resolved_candidate
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("cyclonedx_json", type=Path)
     args = parser.parse_args()
-    document = json.loads(args.cyclonedx_json.read_text(encoding="utf-8"))
+    input_path = _validated_input_path(args.cyclonedx_json)
+    document = json.loads(input_path.read_text(encoding="utf-8"))
     if not isinstance(document, dict):
         raise ValueError("CycloneDX root must be an object")
     print(render_summary(document))

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -2444,6 +2444,15 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
         if step["name"] == "Verify signed SLSA provenance for the exact digest"
     )
     assert "--signer-workflow" in attestation_command
+    assert "--repo \"${GITHUB_REPOSITORY}\"" in attestation_command
+    assert "--source-ref \"refs/heads/main\"" in attestation_command
+    assert "--source-digest \"${RELEASE_SHA}\"" in attestation_command
+    assert (
+        '--cert-oidc-issuer "https://token.actions.githubusercontent.com"'
+        in attestation_command
+    )
+    assert "--deny-self-hosted-runners" in attestation_command
+    assert "--no-public-good" in attestation_command
     assert "--cert-identity" not in attestation_command
     release_steps = [
         step["name"] for step in workflow["jobs"]["release-verify"]["steps"]

--- a/tests/test_sbom_workflow.py
+++ b/tests/test_sbom_workflow.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import re
 import runpy
+import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
 
@@ -164,3 +166,57 @@ def test_sbom_summary_explicitly_reports_no_python_and_sanitizes_markdown():
     assert "No PyPI package URLs were detected" in summary
     assert "<unsafe>" not in summary
     assert "|`name`" not in summary
+
+
+def test_sbom_summary_input_path_is_confined_to_workspace(tmp_path):
+    validate_input_path = _summary_renderer()["_validated_input_path"]
+    workspace = tmp_path / "workspace"
+    nested = workspace / "evidence"
+    nested.mkdir(parents=True)
+    sbom_path = nested / "source.json"
+    sbom_path.write_text('{"components": []}', encoding="utf-8")
+
+    assert validate_input_path(
+        Path("evidence/source.json"), input_root=workspace
+    ) == sbom_path.resolve()
+
+    with pytest.raises(ValueError, match="relative path"):
+        validate_input_path(sbom_path, input_root=workspace)
+    with pytest.raises(ValueError, match="relative path"):
+        validate_input_path(Path("../source.json"), input_root=workspace)
+    with pytest.raises(ValueError, match="regular file"):
+        validate_input_path(Path("evidence"), input_root=workspace)
+
+
+def test_sbom_summary_input_path_rejects_symlink_escape(tmp_path):
+    validate_input_path = _summary_renderer()["_validated_input_path"]
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside.json"
+    outside.write_text('{"components": []}', encoding="utf-8")
+    link = workspace / "source.json"
+    try:
+        link.symlink_to(outside)
+    except OSError as error:
+        pytest.skip(f"Symlink creation is unavailable: {error}")
+
+    with pytest.raises(ValueError, match="within the working directory"):
+        validate_input_path(Path("source.json"), input_root=workspace)
+
+
+def test_sbom_summary_main_reads_validated_relative_input(
+    tmp_path, monkeypatch, capsys
+):
+    main = _summary_renderer()["main"]
+    sbom_path = tmp_path / "source.json"
+    sbom_path.write_text(
+        '{"components": [{"name": "flask", "purl": "pkg:pypi/flask@3.1.2"}]}',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        sys, "argv", ["render_sbom_summary.py", "source.json"]
+    )
+
+    assert main() == 0
+    assert "| PyPI | 1 |" in capsys.readouterr().out


### PR DESCRIPTION
Summary
---
Hardens release attestation selection and confines the SBOM summary renderer's CLI input to the checked-out workspace.

Why
---
Release verification could inspect independent Sigstore public-good BuildKit provenance and fail on the unexpected issuer instead of selecting the GitHub artifact attestation. SonarQube issue `AZ8wg28avs9BZkREfsBI` also identified the direct CLI-controlled filesystem read as a path-escape risk.

What changed
---
- Added `--no-public-good` while preserving repository, signer workflow, source ref, source digest, GitHub OIDC issuer, and non-self-hosted-runner constraints.
- Validated SBOM inputs as relative regular files contained by the current workspace, including resolved symlink containment.
- Added negative regression tests and updated deployment, Actions, and assurance documentation.

Security impact
---
Release verification remains digest-pinned and repository-scoped, while excluding unrelated public-good attestations. SBOM rendering now fails closed for absolute paths, traversal, directory inputs, and symlink escapes. No permissions or secret handling were weakened.

Deployment impact
---
The GitHub Actions release-verification behavior changes after merge. No EC2 bootstrap, database migration, secret change, provider setting change, or manual deployment action is required.

Verification
---
- `git diff --check`
- `.\.venv\Scripts\python.exe -m pytest -q -n 4` — 1,527 passed, 35 skipped
- `.\.venv\Scripts\python.exe -m pytest -q -n 4 --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term --durations=30 --durations-min=0.5` — 91% total coverage; 93% for the modified renderer
- `.\.venv\Scripts\python.exe -m bandit -q -ll -r app ops config.py wsgi.py admin_wsgi.py`
- `.\.venv\Scripts\python.exe ops/security/scan_repository_secrets.py --history`
- `.\.venv\Scripts\python.exe -m pip check`

Notes
---
Local `actionlint` was unavailable; the repository workflow-security job and workflow regression tests provide that validation in CI.