### PR TITLE
Allow public repository artifact attestations

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -744,7 +744,6 @@ jobs:
             --source-digest "${RELEASE_SHA}" \
             --cert-oidc-issuer "https://token.actions.githubusercontent.com" \
             --deny-self-hosted-runners \
-            --no-public-good \
             >/dev/null
 
       - name: Validate production and staging Compose models for the exact digest

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -267,13 +267,16 @@ exact `ghcr.io/koon-kiat/sitbank@sha256:<digest>` subject. The verifier requires
 repository `Koon-Kiat/SITBank`, source ref `refs/heads/main`, the resolved
 release commit, exact signer workflow `.github/workflows/ci-deploy.yml`,
 GitHub's OIDC issuer, a non-self-hosted runner, and the same digest passed to
-deployment. The `--no-public-good` option intentionally selects the GitHub
-artifact attestation rather than trusting or being confused by independent
-Sigstore public-good BuildKit provenance. A missing, wrong-subject, wrong-ref,
-wrong-workflow, or unverifiable attestation fails closed. This is SLSA Build
-L1/L2-aligned release evidence, not a claim of formal SLSA certification.
-Repository files do not prove live GHCR state, branch protection, or GitHub
-Environment settings; preserve sanitized release/provider evidence separately.
+deployment. Because public GitHub repositories sign GitHub artifact
+attestations with Sigstore's Public Good instance, verification intentionally
+does not use `--no-public-good`. It uses the repository-scoped GitHub
+attestation API lookup rather than `--bundle-from-oci`, so independent BuildKit
+provenance stored in the OCI registry is not selected. A missing, wrong-subject,
+wrong-ref, wrong-workflow, or unverifiable attestation fails closed. This is
+SLSA Build L1/L2-aligned release evidence, not a claim of formal SLSA
+certification. Repository files do not prove live GHCR state, branch
+protection, or GitHub Environment settings; preserve sanitized release/provider
+evidence separately.
 
 Production deployment runs from the trusted `main` workflow only after release
 verification, staging deployment, and the post-deployment staging TLS scan all

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -13,14 +13,17 @@ main push -> Publish container image -> Release verification -> Deploy staging
 The tested, scanned, signed, and deployed digest must be identical. Deployments never use `latest`.
 The publish job also creates a GitHub artifact attestation whose subject is the
 exact GHCR image name and Buildx digest, and pushes that attestation to the
-image registry. Release verification checks the registry-backed attestation
-against this repository, the exact `ci-deploy.yml` signer workflow, the trusted
-`main` source ref, the resolved release commit, GitHub's OIDC issuer, and a
-non-self-hosted runner before any staging deployment. The verifier uses
-`--no-public-good` intentionally so it selects the GitHub artifact attestation
-instead of trusting or being confused by separate Sigstore public-good
-BuildKit provenance. Cosign signature and certificate-identity verification,
-Trivy, SBOM, and provenance checks remain independent required layers.
+image registry. Release verification uses the GitHub attestation API's
+repository-scoped lookup for that exact image digest, rather than
+`--bundle-from-oci`, and checks the exact `ci-deploy.yml` signer workflow, the
+trusted `main` source ref, the resolved release commit, GitHub's OIDC issuer,
+and a non-self-hosted runner before any staging deployment. Public GitHub
+repositories use Sigstore's Public Good instance for GitHub artifact
+attestations, so the verifier must not use `--no-public-good`; the identity and
+source constraints remain mandatory. The API lookup also avoids selecting the
+separate BuildKit provenance stored in the OCI registry. Cosign signature and
+certificate-identity verification, Trivy, SBOM, and provenance checks remain
+independent required layers.
 
 ## Workflow And Check Display Names
 

--- a/docs/security/assurance/test-automation-and-dependencies.md
+++ b/docs/security/assurance/test-automation-and-dependencies.md
@@ -58,7 +58,7 @@ applicable unless a frontend package manager is added.
 | Semgrep | `.github/workflows/semgrep.yml` | Runs `p/python`, `p/flask`, `p/security-audit`, `p/owasp-top-ten`, and `p/github-actions` locally with `--metrics=off` and blocks ERROR severity |
 | Action hygiene | `.github/workflows/ci-deploy.yml` | Runs actionlint and zizmor; tests require actions to be SHA-pinned |
 | Image and artifact signing | `.github/workflows/ci-deploy.yml`, `.github/workflows/bootstrap-ec2.yml`, `ops/deploy/sitbank-container-deploy` | Uses cosign to sign/verify images and deployment artifacts |
-| Release provenance | `.github/workflows/ci-deploy.yml` | Creates and verifies a GitHub artifact attestation for the exact release image digest, trusted repository, main ref, release commit, signer workflow, GitHub OIDC issuer, and non-self-hosted runner before staging; `--no-public-good` excludes separate Sigstore public-good BuildKit provenance; this is SLSA Build L1/L2-aligned evidence, not formal certification |
+| Release provenance | `.github/workflows/ci-deploy.yml` | Creates and verifies a GitHub artifact attestation for the exact release image digest, trusted repository, main ref, release commit, signer workflow, GitHub OIDC issuer, and non-self-hosted runner before staging; public repositories allow Sigstore Public Good because GitHub artifact attestations use it, while the default GitHub API lookup avoids independent OCI BuildKit provenance; this is SLSA Build L1/L2-aligned evidence, not formal certification |
 
 Tests for this automation include:
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -2452,7 +2452,8 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
         in attestation_command
     )
     assert "--deny-self-hosted-runners" in attestation_command
-    assert "--no-public-good" in attestation_command
+    assert "--no-public-good" not in attestation_command
+    assert "--bundle-from-oci" not in attestation_command
     assert "--cert-identity" not in attestation_command
     release_steps = [
         step["name"] for step in workflow["jobs"]["release-verify"]["steps"]


### PR DESCRIPTION
Summary
---
Restores release verification for the GitHub artifact attestations generated by this public repository.

Why
---
Run `28730078541` failed because `--no-public-good` rejected the Public Good bundle created by `actions/attest`. GitHub documents that public repositories use Sigstore's Public Good instance for GitHub artifact attestations.

What changed
---
- Removed `--no-public-good` from `gh attestation verify`.
- Preserved repository, signer workflow, source ref, source digest, GitHub OIDC issuer, and hosted-runner verification constraints.
- Kept the default repository-scoped GitHub attestation API lookup and added a regression assertion against `--bundle-from-oci`, preventing OCI-only BuildKit provenance from being selected.
- Corrected the Actions, deployment, and assurance documentation.

Security impact
---
The verifier now accepts the trust root required by public-repository GitHub artifact attestations while retaining the specific signer and source identity policy. Digest pinning, Cosign verification, BuildKit provenance, SBOM, and staging-first deployment controls are unchanged.

Deployment impact
---
The release-verification workflow changes after merge. No EC2 bootstrap, database migration, secret change, provider setting change, or manual deployment action is required.

Verification
---
- `git diff --check`
- `.\.venv\Scripts\python.exe -m pytest -q tests/test_deployment.py tests/test_documentation_consistency.py` — 87 passed, 2 skipped
- `.\.venv\Scripts\python.exe -m pytest -q -n 4` — 1,527 passed, 35 skipped
- `.\.venv\Scripts\python.exe -m pytest -q -n 4 --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term --durations=30 --durations-min=0.5` — 91% total coverage
- `.\.venv\Scripts\python.exe ops/security/scan_repository_secrets.py --history`
- `.\.venv\Scripts\python.exe -m pip check`

Notes
---
The failed release run confirms the incompatible flag was the immediate failure. Local `actionlint` was unavailable; the workflow-security CI job performs actionlint and zizmor validation.