### PR TITLE
Use scheme-free attestation signer identity

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -739,7 +739,7 @@ jobs:
         run: |
           gh attestation verify "oci://${IMAGE}" \
             --repo "${GITHUB_REPOSITORY}" \
-            --signer-workflow "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/.github/workflows/ci-deploy.yml" \
+            --signer-workflow "github.com/${GITHUB_REPOSITORY}/.github/workflows/ci-deploy.yml" \
             --source-ref "refs/heads/main" \
             --source-digest "${RELEASE_SHA}" \
             --cert-oidc-issuer "https://token.actions.githubusercontent.com" \

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -265,9 +265,11 @@ Before staging, release verification also verifies a GitHub artifact
 attestation, pushed by the trusted publish job to the image registry, for the
 exact `ghcr.io/koon-kiat/sitbank@sha256:<digest>` subject. The verifier requires
 repository `Koon-Kiat/SITBank`, source ref `refs/heads/main`, the resolved
-release commit, exact signer workflow `.github/workflows/ci-deploy.yml`,
-GitHub's OIDC issuer, a non-self-hosted runner, and the same digest passed to
-deployment. Because public GitHub repositories sign GitHub artifact
+release commit, exact scheme-free signer workflow identity
+`github.com/Koon-Kiat/SITBank/.github/workflows/ci-deploy.yml`, GitHub's OIDC
+issuer, a non-self-hosted runner, and the same digest passed to deployment.
+GitHub CLI accepts `[host/]owner/repository/path` for `--signer-workflow`, not
+an `https://` URL. Because public GitHub repositories sign GitHub artifact
 attestations with Sigstore's Public Good instance, verification intentionally
 does not use `--no-public-good`. It uses the repository-scoped GitHub
 attestation API lookup rather than `--bundle-from-oci`, so independent BuildKit

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -15,15 +15,17 @@ The publish job also creates a GitHub artifact attestation whose subject is the
 exact GHCR image name and Buildx digest, and pushes that attestation to the
 image registry. Release verification uses the GitHub attestation API's
 repository-scoped lookup for that exact image digest, rather than
-`--bundle-from-oci`, and checks the exact `ci-deploy.yml` signer workflow, the
-trusted `main` source ref, the resolved release commit, GitHub's OIDC issuer,
-and a non-self-hosted runner before any staging deployment. Public GitHub
-repositories use Sigstore's Public Good instance for GitHub artifact
-attestations, so the verifier must not use `--no-public-good`; the identity and
-source constraints remain mandatory. The API lookup also avoids selecting the
-separate BuildKit provenance stored in the OCI registry. Cosign signature and
-certificate-identity verification, Trivy, SBOM, and provenance checks remain
-independent required layers.
+`--bundle-from-oci`, and checks the exact scheme-free signer identity
+`github.com/Koon-Kiat/SITBank/.github/workflows/ci-deploy.yml`, the trusted
+`main` source ref, the resolved release commit, GitHub's OIDC issuer, and a
+non-self-hosted runner before any staging deployment. GitHub CLI requires
+`--signer-workflow` in `[host/]owner/repository/path` form; an `https://`
+prefix is not valid. Public GitHub repositories use Sigstore's Public Good
+instance for GitHub artifact attestations, so the verifier must not use
+`--no-public-good`; the identity and source constraints remain mandatory. The
+API lookup also avoids selecting the separate BuildKit provenance stored in the
+OCI registry. Cosign signature and certificate-identity verification, Trivy,
+SBOM, and provenance checks remain independent required layers.
 
 ## Workflow And Check Display Names
 

--- a/docs/security/assurance/test-automation-and-dependencies.md
+++ b/docs/security/assurance/test-automation-and-dependencies.md
@@ -58,7 +58,7 @@ applicable unless a frontend package manager is added.
 | Semgrep | `.github/workflows/semgrep.yml` | Runs `p/python`, `p/flask`, `p/security-audit`, `p/owasp-top-ten`, and `p/github-actions` locally with `--metrics=off` and blocks ERROR severity |
 | Action hygiene | `.github/workflows/ci-deploy.yml` | Runs actionlint and zizmor; tests require actions to be SHA-pinned |
 | Image and artifact signing | `.github/workflows/ci-deploy.yml`, `.github/workflows/bootstrap-ec2.yml`, `ops/deploy/sitbank-container-deploy` | Uses cosign to sign/verify images and deployment artifacts |
-| Release provenance | `.github/workflows/ci-deploy.yml` | Creates and verifies a GitHub artifact attestation for the exact release image digest, trusted repository, main ref, release commit, signer workflow, GitHub OIDC issuer, and non-self-hosted runner before staging; public repositories allow Sigstore Public Good because GitHub artifact attestations use it, while the default GitHub API lookup avoids independent OCI BuildKit provenance; this is SLSA Build L1/L2-aligned evidence, not formal certification |
+| Release provenance | `.github/workflows/ci-deploy.yml` | Creates and verifies a GitHub artifact attestation for the exact release image digest, trusted repository, main ref, release commit, scheme-free `github.com/owner/repository/workflow` signer identity, GitHub OIDC issuer, and non-self-hosted runner before staging; public repositories allow Sigstore Public Good because GitHub artifact attestations use it, while the default GitHub API lookup avoids independent OCI BuildKit provenance; this is SLSA Build L1/L2-aligned evidence, not formal certification |
 
 Tests for this automation include:
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -2434,7 +2434,7 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
     assert "--repo \"${GITHUB_REPOSITORY}\"" in workflow_text
     assert (
         "--signer-workflow "
-        "\"${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/.github/workflows/ci-deploy.yml\""
+        "\"github.com/${GITHUB_REPOSITORY}/.github/workflows/ci-deploy.yml\""
     ) in workflow_text
     assert "--source-ref \"refs/heads/main\"" in workflow_text
     assert "--source-digest \"${RELEASE_SHA}\"" in workflow_text
@@ -2443,7 +2443,12 @@ def test_workflow_builds_scans_signs_and_deploys_only_an_immutable_digest():
         for step in workflow["jobs"]["release-verify"]["steps"]
         if step["name"] == "Verify signed SLSA provenance for the exact digest"
     )
-    assert "--signer-workflow" in attestation_command
+    assert (
+        '--signer-workflow '
+        '"github.com/${GITHUB_REPOSITORY}/.github/workflows/ci-deploy.yml"'
+        in attestation_command
+    )
+    assert '--signer-workflow "https://' not in attestation_command
     assert "--repo \"${GITHUB_REPOSITORY}\"" in attestation_command
     assert "--source-ref \"refs/heads/main\"" in attestation_command
     assert "--source-digest \"${RELEASE_SHA}\"" in attestation_command


### PR DESCRIPTION
Summary
---
Corrects the release attestation signer-workflow identity so GitHub CLI can enforce it successfully.

Why
---
Release run `28730559100` still failed with `verifying with issuer "sigstore.dev"`. Reproduction against its exact image digest showed that every policy constraint passes except the `https://github.com/...` signer value. GitHub CLI requires `[host/]owner/repository/path` form for `--signer-workflow`.

What changed
---
- Changed the signer identity to `github.com/${GITHUB_REPOSITORY}/.github/workflows/ci-deploy.yml`.
- Added regression coverage requiring the scheme-free identity and rejecting an `https://` signer value.
- Documented the exact GitHub CLI signer-workflow format in Actions, deployment, and assurance guidance.

Security impact
---
No trust constraint was removed. Verification still enforces the exact repository, signer workflow, main source ref, release commit digest, GitHub OIDC issuer, non-self-hosted runner, and repository-scoped GitHub attestation API lookup.

Deployment impact
---
The release-verification workflow changes after merge. No EC2 bootstrap, database migration, secret change, provider setting change, or manual deployment action is required.

Verification
---
- Live `gh attestation verify` with all workflow policy flags passed for `ghcr.io/koon-kiat/sitbank@sha256:61bee1f313c1d0bbfe7375dc2bab10326dda9369fc592e18c98e313ed9325d70` and release `4b751b6dad36ea2276b34077aa132d2d0b13b1e8`.
- `git diff --check`
- `.\.venv\Scripts\python.exe -m pytest -q tests/test_deployment.py tests/test_documentation_consistency.py` — 87 passed, 2 skipped
- `.\.venv\Scripts\python.exe -m pytest -q -n 4` — 1,527 passed, 35 skipped
- `.\.venv\Scripts\python.exe -m pytest -q -n 4 --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term --durations=30 --durations-min=0.5` — 91% total coverage
- `.\.venv\Scripts\python.exe ops/security/scan_repository_secrets.py --history`
- `.\.venv\Scripts\python.exe -m pip check`

Notes
---
The correction is specific to GitHub CLI input formatting; Public Good trust-root handling and OCI/API attestation selection remain unchanged.