### PR TITLE
Harden DAST, SBOM, and Prometheus workflows

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -35,8 +35,18 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          python_manifest_dir="$(mktemp -d sbom-python-manifests.XXXXXX)"
+          cleanup() {
+            rm -rf -- "${python_manifest_dir}"
+          }
+          trap cleanup EXIT
+          install -m 0600 requirements.lock \
+            "${python_manifest_dir}/runtime-requirements.txt"
+          install -m 0600 requirements-dev.lock \
+            "${python_manifest_dir}/development-requirements.txt"
           "${{ steps.syft.outputs.cmd }}" \
             dir:. \
+            --select-catalogers=-python-installed-package-cataloger \
             --output cyclonedx-json=sitbank-source-sbom-cyclonedx.json
           jq empty sitbank-source-sbom-cyclonedx.json
 
@@ -59,6 +69,8 @@ jobs:
               echo "- Services: \`$(jq '(.services // []) | length' sitbank-source-sbom-cyclonedx.json)\`"
               echo
               python ops/security/render_sbom_summary.py \
+                --python-manifest requirements.lock \
+                --python-manifest requirements-dev.lock \
                 sitbank-source-sbom-cyclonedx.json
             else
               echo "- Counts: unavailable because valid SBOM output was not produced."

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -494,7 +494,12 @@ recorded in `docs/security/governance/github-branch-protection-evidence.md`.
 Synthetic DAST users remain the only authenticated scan identities. The smoke
 helper writes the authenticated session cookie and ZAP replacer configuration to
 temporary `0600` files created under `umask 077`; the DAST cookie is not passed
-as a raw process argument. Release smoke enables
+as a raw process argument. Session bootstrap fails closed unless the app runtime
+reports `DEPLOYMENT_TARGET=smoke`, the user has the helper's exact synthetic
+`zap<12-lowercase-hex>` customer identity, and the session base URL is loopback
+or the allowlisted `sitbank-smoke` container. Real customers and all staff,
+admin, and root-admin identities are rejected before session issuance. Release
+smoke enables
 `DEPLOYMENT_TARGET=smoke` and `TURNSTILE_ALLOW_TEST_ACTION=true` only on the
 isolated smoke app container so Cloudflare's official dummy-token response can
 authenticate the synthetic DAST user with the official test keys; production
@@ -564,19 +569,31 @@ the `sitbank-source-sbom` CycloneDX JSON artifact for 30 days with
 `contents: read` and checkout credentials disabled. Generated SBOM files are
 evidence artifacts and must not be committed.
 
-The job summary is a bounded preview: it reports counts by package-URL
-ecosystem and lists at most 10 `pkg:pypi/` components in a dedicated Python
-section. Its renderer accepts only relative regular-file paths contained by the
-current workspace and rejects traversal and symlink escapes before reading the
-SBOM. The artifact remains the complete inventory. Inspect all Python entries
-without printing the whole document:
+The workflow copies the source-controlled `requirements.lock` and
+`requirements-dev.lock` into temporary `*requirements*.txt` paths so Syft's
+declared-package cataloger can recognize them, and explicitly disables Syft's
+installed-Python-package cataloger. Runner-global packages, runner
+`site-packages`, and a local `.venv` are therefore not source dependency
+evidence. The temporary copies are removed even if generation fails.
+
+The job summary is a bounded preview: its Python section comes first and lists
+at most 10 unique `pkg:pypi/` components that match pinned packages in those
+reviewed source-controlled manifests. The ecosystem table follows at the
+bottom. If manifests exist but no matching PyPI PURLs are emitted, the summary
+reports a generator/PURL detection limitation instead of implying that the
+repository has no Python dependencies. Its renderer accepts only relative
+regular-file paths contained by the current workspace and rejects traversal
+and symlink escapes. The full `sitbank-source-sbom` artifact remains the source
+of truth. Inspect all Python entries without printing the whole document:
 
 ```bash
 jq -r '(.components // [])[] | select((.purl // "") | startswith("pkg:pypi/")) | [.name, .version, .purl] | @tsv' sitbank-source-sbom-cyclonedx.json
 ```
 
 This source artifact complements the existing Docker Buildx `sbom: true`
-release-image attestation. An explicit image SBOM artifact remains deferred
+release-image attestation. Packages actually installed in the runtime belong
+to image/container SBOM scope, not the source SBOM summary. An explicit image
+SBOM artifact remains deferred
 until the exact digest-verified release image can be supplied to Syft without
 adding registry write privileges or untrusted-PR credentials. SBOM generation
 is inventory evidence, not vulnerability scanning; dependency audit and Trivy

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1121,6 +1121,11 @@ artifacts, job summaries, chat, screenshots, or issue comments. If a DAST cookie
 or full replacer config is exposed, cancel the run, remove the artifact, treat
 the synthetic session as compromised until the run cleanup completes, and review
 the workflow/script change before retrying.
+The session bootstrap itself is available only when
+`DEPLOYMENT_TARGET=smoke`; it validates the helper's exact synthetic customer
+identity and the loopback or `sitbank-smoke` session host before issuing a
+cookie. It is not available for staging, production, real customers, staff,
+admins, or root admins.
 
 Pull requests additionally run a 12-minute local-only DAST smoke against an
 ephemeral image and database. Its two-minute unauthenticated ZAP baseline

--- a/docs/runbooks/private-observability-grafana-loki.md
+++ b/docs/runbooks/private-observability-grafana-loki.md
@@ -53,7 +53,11 @@ GRAFANA_SERVE_FROM_SUB_PATH=true
 ```
 
 `OBSERVABILITY_ENVIRONMENT` must be `production` or `staging` for the target
-host so dashboard variables keep environments separated. Do not put passwords,
+host so dashboard variables keep environments separated. The trusted bootstrap
+renders this allowlisted value into Prometheus's root-owned config and fails
+closed on missing, invalid, duplicate, or unresolved placeholders before
+starting the stack. Prometheus is not started with the unsupported
+`--config.expand-env` flag. Do not put passwords,
 tokens, API keys, webhook URLs, cookies, database URLs, or SMTP credentials in
 `observability.env`. Secret files must be `root:root` mode `0600`. The
 protected live verifier accepts only
@@ -194,6 +198,9 @@ sudo ss -ltnp | grep -E '127\.0\.0\.1:(3000|3100)([[:space:]]|$)'
 sudo ss -ltnp | grep -E '0\.0\.0\.0:(3000|3100|9090|9100)|\[::\]:(3000|3100|9090|9100)|\*:(3000|3100|9090|9100)' && exit 1 || true
 curl -fsSI http://127.0.0.1:3000/login
 curl -fsS http://127.0.0.1:3100/ready
+sudo docker inspect sitbank-prometheus --format '{{.State.Status}} {{.RestartCount}}'
+sudo docker logs --tail 50 sitbank-prometheus
+sudo docker exec sitbank-grafana wget -qO- http://prometheus:9090/-/ready
 sudo nginx -T | grep -iE 'grafana|loki' && exit 1 || true
 ```
 
@@ -208,6 +215,10 @@ Expected:
 - Grafana listens only on `127.0.0.1:3000`.
 - Loki listens only on `127.0.0.1:3100`.
 - Alloy, Prometheus, and node exporter publish no host listener.
+- Prometheus reports `running` with a stable restart count, not a restarting
+  loop, and its logs contain no unsupported-flag or config-expansion error.
+- From inside Grafana, `http://prometheus:9090/-/ready` returns the Prometheus
+  ready response over the internal Docker network.
 - Public SITBank Nginx configs contain no Grafana or Loki route.
 - The private Tailscale URL reaches Grafana only for approved operators.
 - The Grafana `SITBank Prometheus` datasource points to

--- a/docs/security/assurance/operational-observability.md
+++ b/docs/security/assurance/operational-observability.md
@@ -155,7 +155,11 @@ Loki retention is bounded in `ops/observability/loki/loki.yml` with
 
 Prometheus stores private host metrics for the same 168-hour window. The
 committed Prometheus config scrapes only node exporter with the
-`OBSERVABILITY_ENVIRONMENT` label. Container CPU/memory and PostgreSQL
+`OBSERVABILITY_ENVIRONMENT` label. The trusted observability bootstrap accepts
+only `staging` or `production`, renders that label into the root-owned
+Prometheus config before container startup, and rejects missing or unresolved
+placeholders. Prometheus does not depend on runtime environment expansion.
+Container CPU/memory and PostgreSQL
 connection-count exporter metrics are not enabled by this repository change;
 the current container and PostgreSQL panels use log-derived restart,
 connectivity, storage-pressure, and connection-pressure signals until a

--- a/docs/security/assurance/test-automation-and-dependencies.md
+++ b/docs/security/assurance/test-automation-and-dependencies.md
@@ -299,6 +299,8 @@ Authenticated DAST session creation is handled by
 | Control | Evidence |
 | --- | --- |
 | Target host restricted to loopback or explicit smoke host | `tests/test_deployment.py::test_dast_session_creator_requires_loopback_or_explicit_smoke_host` |
+| Session bootstrap restricted to `DEPLOYMENT_TARGET=smoke` | `tests/test_dast_helper_security.py::test_issue_dast_session_cookie_rejects_non_smoke_runtime` |
+| Session bootstrap rejects non-synthetic and privileged users | `tests/test_dast_helper_security.py::test_issue_dast_session_cookie_rejects_non_synthetic_or_privileged_users` |
 | Synthetic account registration follows the real registration contract | `tests/test_deployment.py::test_dast_session_creator_matches_registration_contract` |
 | Generated credentials are synthetic and random | `ops/container/create_dast_session.py` |
 | The script emits an authenticated session cookie for ZAP rather than real user credentials | `ops/container/create_dast_session.py` |
@@ -309,6 +311,12 @@ Authenticated DAST session creation is handled by
 `ops/container/dast-smoke.sh` provides a local smoke-oriented DAST path using
 synthetic secrets and a synthetic local test user. No real customer, admin, or
 staff credentials are required by the DAST scripts in the repository.
+The server-side session primitive fails before issuance unless the runtime
+target is exactly `smoke`, the customer matches the helper's complete
+`zap<12-lowercase-hex>` identity contract, MFA is already enabled, and the
+session host is loopback or `sitbank-smoke`. Existing-username collisions,
+stale or malformed synthetic records, real customers, and staff, admin, and
+root-admin identities fail closed.
 
 The authenticated release/scheduled DAST path stores `auth-cookie` and
 `zap-replacer.properties` only in the smoke-test temporary directory. The helper
@@ -362,13 +370,23 @@ The source SBOM workflow at `.github/workflows/sbom.yml` uses pinned Syft
 1.46.0 to create `sitbank-source-sbom-cyclonedx.json`, validates it as JSON,
 and retains the `sitbank-source-sbom` CycloneDX JSON artifact for 30 days. It
 runs without secrets on pull requests, pushes to `main`, and manual dispatch.
-Its summary is a bounded preview with package-URL ecosystem counts and at most
-10 `pkg:pypi/` rows in a dedicated Python section; zero Python components is
-reported explicitly. The renderer reads only relative regular-file paths
-contained by the current workspace and rejects traversal and symlink escapes.
-The full artifact remains authoritative. Inspect its Python inventory with
+Before scanning, the workflow copies the source-controlled
+`requirements.lock` and `requirements-dev.lock` to temporary
+`*requirements*.txt` names recognized by Syft and disables the installed
+Python package cataloger. This keeps runner-global packages, runner
+`site-packages`, and local `.venv` contents out of the source dependency
+count. Its bounded summary puts the Python section first, matches emitted
+`pkg:pypi/` PURLs to pinned packages in those reviewed source-controlled
+manifests, limits the preview to 10 rows, and places the all-component
+ecosystem table last. If manifests exist but no matching PyPI PURLs are
+emitted, zero is described as a generator/PURL detection limitation rather
+than proof of no Python dependencies. The renderer reads only relative
+regular-file paths contained by the current workspace and rejects traversal
+and symlink escapes. The full `sitbank-source-sbom` artifact remains the source
+of truth. Inspect its Python inventory with
 `jq -r '(.components // [])[] | select((.purl // "") | startswith("pkg:pypi/")) | [.name, .version, .purl] | @tsv' sitbank-source-sbom-cyclonedx.json`.
-It is separate from Buildx image attestation and is not vulnerability scanning.
+Installed runtime packages belong to image/container SBOM scope. The source
+artifact is separate from Buildx image attestation and is not vulnerability scanning.
 The existing Buildx `sbom: true` attestation remains required; an explicit
 image SBOM artifact remains deferred until the exact digest-verified release
 image is safely available to the evidence job.

--- a/ops/container/create_dast_session.py
+++ b/ops/container/create_dast_session.py
@@ -17,13 +17,18 @@ from sqlalchemy.exc import IntegrityError
 DAST_COOKIE_RE = re.compile(r"^__Host-sitbank_session=[A-Za-z0-9._~-]+$")
 DAST_FORWARDED_FOR = "127.0.0.1"
 DAST_FORWARDED_PROTO = "https"
+DAST_SMOKE_CONTAINER_HOSTS = frozenset({"sitbank-smoke"})
+DAST_SYNTHETIC_USERNAME_RE = re.compile(r"^zap([0-9a-f]{12})$")
 DAST_USER_AGENT = "sitbank-dast-session"
 
 
 class DastClient:
     def __init__(self, base_url: str, *, allowed_hosts: set[str] | None = None) -> None:
         parsed = urllib.parse.urlsplit(base_url)
-        permitted_hosts = {"127.0.0.1", "localhost"} | (allowed_hosts or set())
+        requested_hosts = allowed_hosts or set()
+        if not requested_hosts.issubset(DAST_SMOKE_CONTAINER_HOSTS):
+            raise ValueError("DAST base URL host is not allowed")
+        permitted_hosts = {"127.0.0.1", "localhost"} | requested_hosts
         if (
             parsed.scheme != "http"
             or parsed.hostname not in permitted_hosts
@@ -140,12 +145,14 @@ def issue_dast_session_cookie(*, user_id: int, session_base_url: str) -> str:
     from app.security.sessions import establish_authenticated_session
 
     app = create_app()
+    if str(app.config.get("DEPLOYMENT_TARGET") or "").strip().casefold() != "smoke":
+        raise RuntimeError("DAST session bootstrap requires the smoke runtime")
+    _validate_session_base_url(session_base_url)
     with app.app_context():
         user = db.session.get(User, int(user_id))
         if user is None:
             raise RuntimeError("Synthetic DAST user was not found")
-        user.mfa_enabled = True
-        db.session.commit()
+        _validate_synthetic_dast_user(user)
         with app.test_request_context(
             "/",
             base_url=session_base_url,
@@ -163,6 +170,41 @@ def issue_dast_session_cookie(*, user_id: int, session_base_url: str) -> str:
     if not cookie:
         raise RuntimeError("Authenticated DAST session cookie was not issued")
     return cookie
+
+
+def _validate_session_base_url(session_base_url: str) -> None:
+    parsed = urllib.parse.urlsplit(session_base_url)
+    if (
+        parsed.scheme != DAST_FORWARDED_PROTO
+        or parsed.hostname
+        not in {"127.0.0.1", "localhost", *DAST_SMOKE_CONTAINER_HOSTS}
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+        or parsed.path not in {"", "/"}
+    ):
+        raise RuntimeError("DAST session base URL is not an approved smoke host")
+
+
+def _validate_synthetic_dast_user(user: object) -> None:
+    username = str(getattr(user, "username", ""))
+    match = DAST_SYNTHETIC_USERNAME_RE.fullmatch(username)
+    suffix = match.group(1) if match else ""
+    expected_email = f"{username}@sit.singaporetech.edu.sg"
+    expected_name = f"DAST User {suffix}"
+    if (
+        not match
+        or str(getattr(user, "email", "")) != expected_email
+        or str(getattr(user, "full_name", "")) != expected_name
+        or getattr(user, "account_type", None) != "customer"
+        or getattr(user, "account_status", None) != "active"
+        or getattr(user, "staff_personal_email", None) is not None
+        or getattr(user, "workplace_email_verified_at", None) is not None
+        or getattr(user, "registration_email_canonical", None) is not None
+        or getattr(user, "mfa_enabled", None) is not True
+    ):
+        raise RuntimeError("DAST session bootstrap requires a synthetic customer")
 
 
 def _cookie_value_from_headers(headers: list[str]) -> str:
@@ -200,7 +242,7 @@ def create_dast_user(
     with app.app_context():
         existing = db.session.execute(db.select(User).where(User.username == username)).scalar_one_or_none()
         if existing:
-            return int(existing.id)
+            raise RuntimeError("Synthetic DAST username collision")
         for attempt in range(20):
             candidate_phone = phone_number if attempt == 0 else _generate_synthetic_phone_number()
             if db.session.execute(db.select(User).where(User.phone_number == candidate_phone)).scalar_one_or_none():

--- a/ops/container/smoke-test.sh
+++ b/ops/container/smoke-test.sh
@@ -536,6 +536,7 @@ if [[ "${RUN_ZAP_DAST:-false}" == "true" ]]; then
     chmod_host_path 0777 "${work_dir}/dast"
     dast_mount_source="$(docker_bind_source "${work_dir}/dast")"
     docker run --rm "${docker_args[@]}" \
+        --env DEPLOYMENT_TARGET=smoke \
         --volume "${create_dast_session_source}:/app/create_dast_session.py:ro" \
         --volume "${dast_mount_source}:/run/dast:rw" \
         "${IMAGE}" \

--- a/ops/deploy/bootstrap-observability-ec2
+++ b/ops/deploy/bootstrap-observability-ec2
@@ -66,6 +66,23 @@ set_observability_env_value() {
     mv -f "${tmp}" "${OBS_ENV_FILE}"
 }
 
+read_observability_env_value() {
+    local key="$1"
+    local count value
+
+    count="$(grep -Ec "^${key}=" "${OBS_ENV_FILE}" || true)"
+    if [[ "${count}" != "1" ]]; then
+        echo "${OBS_ENV_FILE} must contain exactly one ${key} setting" >&2
+        exit 1
+    fi
+    value="$(sed -n "s/^${key}=//p" "${OBS_ENV_FILE}")"
+    if [[ -z "${value}" || "${value}" == *$'\r'* || "${value}" == *$'\n'* ]]; then
+        echo "${OBS_ENV_FILE} contains an invalid ${key} setting" >&2
+        exit 1
+    fi
+    printf '%s' "${value}"
+}
+
 if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
     usage
     exit 0
@@ -131,9 +148,6 @@ install -o root -g root -m 0644 \
 install -o root -g root -m 0644 \
     "${repo_root}/ops/observability/alloy/config.alloy" \
     "${OBS_ROOT}/alloy/config.alloy"
-install -o root -g root -m 0644 \
-    "${repo_root}/ops/observability/prometheus/prometheus.yml" \
-    "${OBS_ROOT}/prometheus/prometheus.yml"
 
 for secret_file in "${GRAFANA_ADMIN_USER_FILE}" "${GRAFANA_ADMIN_PASSWORD_FILE}"; do
     if [[ ! -f "${secret_file}" ]]; then
@@ -158,6 +172,30 @@ if grep -Eiq '(password|token|secret|key)[[:space:]]*=' "${OBS_ENV_FILE}"; then
     echo "${OBS_ENV_FILE} must contain non-secret image references and private URL settings only." >&2
     exit 1
 fi
+observability_environment="$(read_observability_env_value OBSERVABILITY_ENVIRONMENT)"
+if [[ "${observability_environment}" != "staging" \
+    && "${observability_environment}" != "production" ]]; then
+    echo "OBSERVABILITY_ENVIRONMENT must be staging or production" >&2
+    exit 1
+fi
+
+prometheus_renderer="${repo_root}/ops/observability/render_prometheus_config.py"
+prometheus_template="${repo_root}/ops/observability/prometheus/prometheus.yml"
+if [[ ! -f "${prometheus_renderer}" || -L "${prometheus_renderer}" \
+    || ! -f "${prometheus_template}" || -L "${prometheus_template}" ]]; then
+    echo "Trusted Prometheus renderer or template is missing or unsafe" >&2
+    exit 1
+fi
+prometheus_config_tmp="$(mktemp)"
+trap 'rm -f -- "${prometheus_config_tmp:-}"' EXIT
+python3 "${prometheus_renderer}" \
+    "${prometheus_template}" \
+    "${observability_environment}" >"${prometheus_config_tmp}"
+install -o root -g root -m 0644 \
+    "${prometheus_config_tmp}" \
+    "${OBS_ROOT}/prometheus/prometheus.yml"
+rm -f -- "${prometheus_config_tmp}"
+trap - EXIT
 
 alloy_nginx_log_gid="$(host_group_gid adm "Nginx log files")"
 alloy_journal_gid="$(host_group_gid systemd-journal "systemd journal files")"

--- a/ops/observability/compose.observability.yml
+++ b/ops/observability/compose.observability.yml
@@ -68,12 +68,9 @@ services:
     restart: unless-stopped
     command:
       - --config.file=/etc/prometheus/prometheus.yml
-      - --config.expand-env
       - --storage.tsdb.path=/prometheus
       - --storage.tsdb.retention.time=168h
       - --web.listen-address=0.0.0.0:9090
-    environment:
-      OBSERVABILITY_ENVIRONMENT: ${OBSERVABILITY_ENVIRONMENT:?OBSERVABILITY_ENVIRONMENT must be staging or production}
     volumes:
       - type: bind
         source: /etc/sitbank-observability/prometheus/prometheus.yml

--- a/ops/observability/render_prometheus_config.py
+++ b/ops/observability/render_prometheus_config.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Render the non-secret Prometheus environment label for host deployment."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+ENVIRONMENT_PLACEHOLDER = "${OBSERVABILITY_ENVIRONMENT}"
+UNRESOLVED_PLACEHOLDER_RE = re.compile(r"\$\{[^}]+\}")
+VALID_ENVIRONMENTS = frozenset({"production", "staging"})
+
+
+def render_prometheus_config(template: str, environment: str) -> str:
+    normalized_environment = environment.strip().casefold()
+    if environment != normalized_environment or normalized_environment not in VALID_ENVIRONMENTS:
+        raise ValueError("Prometheus environment must be staging or production")
+    if ENVIRONMENT_PLACEHOLDER not in template:
+        raise ValueError("Prometheus template is missing its environment placeholder")
+
+    rendered = template.replace(ENVIRONMENT_PLACEHOLDER, normalized_environment)
+    if UNRESOLVED_PLACEHOLDER_RE.search(rendered):
+        raise ValueError("Prometheus template contains an unresolved placeholder")
+    return rendered
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("template", type=Path)
+    parser.add_argument("environment")
+    args = parser.parse_args()
+
+    if args.template.is_symlink() or not args.template.is_file():
+        raise ValueError("Prometheus template must be a regular non-symlink file")
+    print(
+        render_prometheus_config(
+            args.template.read_text(encoding="utf-8"),
+            args.environment,
+        ),
+        end="",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/security/render_sbom_summary.py
+++ b/ops/security/render_sbom_summary.py
@@ -13,6 +13,7 @@ from typing import Any
 
 
 PYTHON_COMPONENT_LIMIT = 10
+PYPI_PURL_PREFIX = "pkg:pypi/"
 SYSTEM_PURL_PREFIXES = (
     "pkg:alpm/",
     "pkg:apk/",
@@ -51,9 +52,13 @@ def _normalized_python_name(name: str) -> str:
 
 def _python_purl_identity(component: dict[str, Any]) -> tuple[str, str] | None:
     purl = _component_purl(component)
-    if not purl.startswith("pkg:pypi/"):
+    if not purl.startswith(PYPI_PURL_PREFIX):
         return None
-    package = purl.removeprefix("pkg:pypi/").split("?", 1)[0].split("#", 1)[0]
+    package = (
+        purl.removeprefix(PYPI_PURL_PREFIX)
+        .split("?", 1)[0]
+        .split("#", 1)[0]
+    )
     if "@" not in package:
         return None
     name, version = package.rsplit("@", 1)
@@ -86,7 +91,7 @@ def _read_pinned_python_dependencies(
 
 def _ecosystem(component: dict[str, Any]) -> str:
     purl = _component_purl(component)
-    if purl.startswith("pkg:pypi/"):
+    if purl.startswith(PYPI_PURL_PREFIX):
         return "PyPI"
     if purl.startswith("pkg:github/"):
         return "GitHub actions/workflows"

--- a/ops/security/render_sbom_summary.py
+++ b/ops/security/render_sbom_summary.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import argparse
 import html
 import json
+import re
+import urllib.parse
 from pathlib import Path
 from typing import Any
 
@@ -16,6 +18,10 @@ SYSTEM_PURL_PREFIXES = (
     "pkg:apk/",
     "pkg:deb/",
     "pkg:rpm/",
+)
+PINNED_REQUIREMENT_RE = re.compile(
+    r"^\s*([A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)"
+    r"(?:\[[^\]]+\])?==([^\s\\;]+)"
 )
 
 
@@ -39,6 +45,45 @@ def _component_purl(component: dict[str, Any]) -> str:
     return str(component.get("purl") or "").strip().casefold()
 
 
+def _normalized_python_name(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).casefold()
+
+
+def _python_purl_identity(component: dict[str, Any]) -> tuple[str, str] | None:
+    purl = _component_purl(component)
+    if not purl.startswith("pkg:pypi/"):
+        return None
+    package = purl.removeprefix("pkg:pypi/").split("?", 1)[0].split("#", 1)[0]
+    if "@" not in package:
+        return None
+    name, version = package.rsplit("@", 1)
+    if not name or not version:
+        return None
+    return (
+        _normalized_python_name(urllib.parse.unquote(name)),
+        urllib.parse.unquote(version).casefold(),
+    )
+
+
+def _read_pinned_python_dependencies(
+    manifest_paths: list[Path],
+) -> set[tuple[str, str]]:
+    dependencies: set[tuple[str, str]] = set()
+    for manifest_path in manifest_paths:
+        for line in manifest_path.read_text(encoding="utf-8").splitlines():
+            match = PINNED_REQUIREMENT_RE.match(line)
+            if match:
+                dependencies.add(
+                    (
+                        _normalized_python_name(match.group(1)),
+                        match.group(2).casefold(),
+                    )
+                )
+    if not dependencies:
+        raise ValueError("Reviewed Python manifests contain no pinned dependencies")
+    return dependencies
+
+
 def _ecosystem(component: dict[str, Any]) -> str:
     purl = _component_purl(component)
     if purl.startswith("pkg:pypi/"):
@@ -54,7 +99,12 @@ def _ecosystem(component: dict[str, Any]) -> str:
     return "Other PURL"
 
 
-def render_summary(document: dict[str, Any]) -> str:
+def render_summary(
+    document: dict[str, Any],
+    *,
+    declared_python_dependencies: set[tuple[str, str]] | None = None,
+    python_manifest_count: int = 0,
+) -> str:
     raw_components = document.get("components") or []
     if not isinstance(raw_components, list):
         raise ValueError("CycloneDX components must be a list")
@@ -75,26 +125,43 @@ def render_summary(document: dict[str, Any]) -> str:
         )
         for ecosystem in ecosystem_order
     }
-    python_components = [
-        component
-        for component in components
-        if _component_purl(component).startswith("pkg:pypi/")
-    ]
+    python_by_identity: dict[tuple[str, str], dict[str, Any]] = {}
+    for component in components:
+        identity = _python_purl_identity(component)
+        if identity is not None:
+            python_by_identity.setdefault(identity, component)
+    all_python_components = list(python_by_identity.values())
+    if declared_python_dependencies is None:
+        python_components = all_python_components
+    else:
+        python_components = [
+            component
+            for identity, component in python_by_identity.items()
+            if identity in declared_python_dependencies
+        ]
+    unmatched_python_count = len(all_python_components) - len(python_components)
 
     lines = [
-        "### Ecosystem breakdown",
-        "",
-        "| Ecosystem | Components |",
-        "| --- | ---: |",
-        *(
-            f"| {ecosystem} | {counts[ecosystem]} |"
-            for ecosystem in ecosystem_order
-        ),
-        "",
         "### Python components",
         "",
-        f"- Python components detected: `{len(python_components)}`",
+        (
+            "- Reviewed source-controlled Python manifests: "
+            f"`{python_manifest_count}`"
+        ),
+        (
+            "- Declared pinned Python packages: "
+            f"`{len(declared_python_dependencies or set())}`"
+        ),
+        (
+            "- Python components detected from reviewed manifests: "
+            f"`{len(python_components)}`"
+        ),
     ]
+    if unmatched_python_count:
+        lines.append(
+            "- PyPI components excluded because they were not matched to reviewed "
+            f"manifests: `{unmatched_python_count}`"
+        )
     if python_components:
         lines.extend(
             (
@@ -113,9 +180,23 @@ def render_summary(document: dict[str, Any]) -> str:
             )
     else:
         lines.append(
-            "- No PyPI package URLs were detected; inspect the full artifact "
-            "before concluding that the source has no Python dependencies."
+            "- No matching `pkg:pypi/` package URLs were emitted. This is a "
+            "generator/PURL detection limitation, not evidence that the source "
+            "has no Python dependencies."
         )
+    lines.extend(
+        (
+            "",
+            "### Ecosystem breakdown",
+            "",
+            "| Ecosystem | Components |",
+            "| --- | ---: |",
+            *(
+                f"| {ecosystem} | {counts[ecosystem]} |"
+                for ecosystem in ecosystem_order
+            ),
+        )
+    )
     return "\n".join(lines)
 
 
@@ -146,12 +227,31 @@ def _validated_input_path(
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("cyclonedx_json", type=Path)
+    parser.add_argument(
+        "--python-manifest",
+        action="append",
+        required=True,
+        type=Path,
+        help="reviewed source-controlled pinned Python dependency manifest",
+    )
     args = parser.parse_args()
     input_path = _validated_input_path(args.cyclonedx_json)
+    manifest_paths = [
+        _validated_input_path(manifest_path)
+        for manifest_path in args.python_manifest
+    ]
     document = json.loads(input_path.read_text(encoding="utf-8"))
     if not isinstance(document, dict):
         raise ValueError("CycloneDX root must be an object")
-    print(render_summary(document))
+    print(
+        render_summary(
+            document,
+            declared_python_dependencies=_read_pinned_python_dependencies(
+                manifest_paths
+            ),
+            python_manifest_count=len(manifest_paths),
+        )
+    )
     return 0
 
 

--- a/tests/test_dast_helper_security.py
+++ b/tests/test_dast_helper_security.py
@@ -91,6 +91,11 @@ def test_dast_secret_files_are_restricted_and_cleaned_up_by_contract():
     assert "the cookie and ZAP config files inside remain 0600" in smoke_test
     assert "--output /run/dast/auth-cookie" in smoke_test
     assert "--zap-replacer-config-output /run/dast/zap-replacer.properties" in smoke_test
+    assert (
+        'docker run --rm "${docker_args[@]}" \\\n'
+        "        --env DEPLOYMENT_TARGET=smoke \\\n"
+        '        --volume "${create_dast_session_source}:/app/create_dast_session.py:ro"'
+    ) in smoke_test
     assert "os.umask(0o077)" in creator
     assert "os.open(path, flags, 0o600)" in creator
     assert "path.chmod(0o600)" in creator
@@ -355,7 +360,9 @@ def test_create_authenticated_cookie_requires_issued_session_cookie(monkeypatch)
         module.create_authenticated_cookie("http://localhost:5000")
 
 
-def test_create_dast_user_persists_mfa_user_and_reuses_username(app, monkeypatch):
+def test_create_dast_user_persists_mfa_user_and_rejects_username_collision(
+    app, monkeypatch
+):
     module = _load_create_dast_session_module()
     import app as app_module
 
@@ -387,15 +394,14 @@ def test_create_dast_user_persists_mfa_user_and_reuses_username(app, monkeypatch
         user.password_hash,
     )
 
-    reused_id = module.create_dast_user(
-        username="zapreal",
-        email="other@sit.singaporetech.edu.sg",
-        password="DAST-Other-Correct-Horse-Battery-Staple-2026-A9!",
-        full_name="Other DAST User",
-        phone_number="91234568",
-    )
-
-    assert reused_id == user_id
+    with pytest.raises(RuntimeError, match="username collision"):
+        module.create_dast_user(
+            username="zapreal",
+            email="other@sit.singaporetech.edu.sg",
+            password="DAST-Other-Correct-Horse-Battery-Staple-2026-A9!",
+            full_name="Other DAST User",
+            phone_number="91234568",
+        )
     assert db.session.query(User).filter_by(username="zapreal").count() == 1
 
 
@@ -447,21 +453,22 @@ def test_issue_dast_session_cookie_persists_mfa_session(app, monkeypatch):
     from app.security.sessions import session_lookup_hash
 
     monkeypatch.setattr(app_module, "create_app", lambda: app)
+    app.config["DEPLOYMENT_TARGET"] = "smoke"
     user = User(
-        username="dastuser",
-        email="dastuser@sit.singaporetech.edu.sg",
+        username="zapabcdef123456",
+        email="zapabcdef123456@sit.singaporetech.edu.sg",
         password_hash="not-used-by-dast-session-test",
-        full_name="DAST User",
+        full_name="DAST User abcdef123456",
         phone_number="91234567",
         account_number="123456789012",
-        mfa_enabled=False,
+        mfa_enabled=True,
     )
     db.session.add(user)
     db.session.commit()
 
     cookie_value = module.issue_dast_session_cookie(
         user_id=user.id,
-        session_base_url="https://smoke:5000/",
+        session_base_url="https://sitbank-smoke:5000/",
     )
 
     assert module.DAST_COOKIE_RE.fullmatch(
@@ -528,11 +535,154 @@ def test_issue_dast_session_cookie_rejects_missing_synthetic_user(app, monkeypat
     import app as app_module
 
     monkeypatch.setattr(app_module, "create_app", lambda: app)
+    app.config["DEPLOYMENT_TARGET"] = "smoke"
 
     with pytest.raises(RuntimeError, match="Synthetic DAST user was not found"):
         module.issue_dast_session_cookie(
             user_id=999,
-            session_base_url="https://smoke:5000/",
+            session_base_url="https://sitbank-smoke:5000/",
+        )
+
+
+@pytest.mark.parametrize(
+    "deployment_target",
+    ("", "testing", "staging", "production", "admin"),
+)
+def test_issue_dast_session_cookie_rejects_non_smoke_runtime(
+    app, monkeypatch, deployment_target
+):
+    module = _load_create_dast_session_module()
+    import app as app_module
+
+    monkeypatch.setattr(app_module, "create_app", lambda: app)
+    app.config["DEPLOYMENT_TARGET"] = deployment_target
+
+    with pytest.raises(RuntimeError, match="requires the smoke runtime"):
+        module.issue_dast_session_cookie(
+            user_id=1,
+            session_base_url="https://sitbank-smoke:5000/",
+        )
+
+
+@pytest.mark.parametrize(
+    ("username", "email", "full_name", "account_type"),
+    (
+        (
+            "realcustomer",
+            "realcustomer@sit.singaporetech.edu.sg",
+            "Real Customer",
+            "customer",
+        ),
+        (
+            "zapabcdef123456",
+            "different@sit.singaporetech.edu.sg",
+            "DAST User abcdef123456",
+            "customer",
+        ),
+        (
+            "zapabcdef123456",
+            "zapabcdef123456@sit.singaporetech.edu.sg",
+            "DAST User abcdef123456",
+            "staff",
+        ),
+        (
+            "zapabcdef123456",
+            "zapabcdef123456@sit.singaporetech.edu.sg",
+            "DAST User abcdef123456",
+            "admin",
+        ),
+        (
+            "zapabcdef123456",
+            "zapabcdef123456@sit.singaporetech.edu.sg",
+            "DAST User abcdef123456",
+            "root_admin",
+        ),
+    ),
+)
+def test_issue_dast_session_cookie_rejects_non_synthetic_or_privileged_users(
+    app,
+    monkeypatch,
+    username,
+    email,
+    full_name,
+    account_type,
+):
+    module = _load_create_dast_session_module()
+    import app as app_module
+
+    from app.extensions import db
+    from app.models import User
+
+    monkeypatch.setattr(app_module, "create_app", lambda: app)
+    app.config["DEPLOYMENT_TARGET"] = "smoke"
+    user = User(
+        username=username,
+        email=email,
+        password_hash="not-used-by-dast-session-test",
+        full_name=full_name,
+        phone_number="91234567",
+        account_number="123456789012",
+        account_type=account_type,
+        mfa_enabled=True,
+    )
+    db.session.add(user)
+    db.session.commit()
+
+    with pytest.raises(RuntimeError, match="requires a synthetic customer"):
+        module.issue_dast_session_cookie(
+            user_id=user.id,
+            session_base_url="https://sitbank-smoke:5000/",
+        )
+
+
+@pytest.mark.parametrize(
+    ("account_status", "mfa_enabled"),
+    (("locked", True), ("active", False)),
+)
+def test_issue_dast_session_cookie_rejects_stale_synthetic_users(
+    app, monkeypatch, account_status, mfa_enabled
+):
+    module = _load_create_dast_session_module()
+    import app as app_module
+
+    from app.extensions import db
+    from app.models import User
+
+    monkeypatch.setattr(app_module, "create_app", lambda: app)
+    app.config["DEPLOYMENT_TARGET"] = "smoke"
+    user = User(
+        username="zapabcdef123456",
+        email="zapabcdef123456@sit.singaporetech.edu.sg",
+        password_hash="not-used-by-dast-session-test",
+        full_name="DAST User abcdef123456",
+        phone_number="91234567",
+        account_number="123456789012",
+        account_status=account_status,
+        mfa_enabled=mfa_enabled,
+    )
+    db.session.add(user)
+    db.session.commit()
+
+    with pytest.raises(RuntimeError, match="requires a synthetic customer"):
+        module.issue_dast_session_cookie(
+            user_id=user.id,
+            session_base_url="https://sitbank-smoke:5000/",
+        )
+
+
+def test_issue_dast_session_cookie_rejects_unapproved_session_host(
+    app, monkeypatch
+):
+    module = _load_create_dast_session_module()
+    import app as app_module
+
+    monkeypatch.setattr(app_module, "create_app", lambda: app)
+    app.config["DEPLOYMENT_TARGET"] = "smoke"
+
+    with pytest.raises(RuntimeError, match="approved smoke host"):
+        module.issue_dast_session_cookie(
+            user_id=1,
+            session_base_url="https://customer.example.test/",
         )
 
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -569,7 +569,7 @@ def test_dast_session_creator_requires_loopback_or_explicit_smoke_host():
     with pytest.raises(ValueError, match="host is not allowed"):
         create_dast_session.DastClient(
             "http://unexpected-smoke:5000",
-            allowed_hosts={"sitbank-smoke"},
+            allowed_hosts={"unexpected-smoke"},
         )
 
 

--- a/tests/test_operational_observability_deployment.py
+++ b/tests/test_operational_observability_deployment.py
@@ -246,11 +246,14 @@ def test_private_grafana_loki_alloy_deployment_files_exist_and_are_private():
         "bind": {"create_host_path": False},
     }
     prometheus = services["prometheus"]
-    assert prometheus["environment"]["OBSERVABILITY_ENVIRONMENT"] == (
-        "${OBSERVABILITY_ENVIRONMENT:?OBSERVABILITY_ENVIRONMENT must be staging or production}"
-    )
-    assert "--config.expand-env" in prometheus["command"]
-    assert "--storage.tsdb.retention.time=168h" in prometheus["command"]
+    assert "environment" not in prometheus
+    assert prometheus["command"] == [
+        "--config.file=/etc/prometheus/prometheus.yml",
+        "--storage.tsdb.path=/prometheus",
+        "--storage.tsdb.retention.time=168h",
+        "--web.listen-address=0.0.0.0:9090",
+    ]
+    assert "--config.expand-env" not in prometheus["command"]
     assert prometheus["depends_on"] == ["node-exporter"]
     assert "password" not in json.dumps(prometheus).casefold()
     assert "token" not in json.dumps(prometheus).casefold()
@@ -262,6 +265,44 @@ def test_private_grafana_loki_alloy_deployment_files_exist_and_are_private():
     assert "--path.rootfs=/host/root" in node_exporter["command"]
     assert all(volume["read_only"] is True for volume in node_exporter["volumes"])
     assert "docker.sock" not in json.dumps(node_exporter)
+
+
+def test_prometheus_config_is_rendered_fail_closed_before_container_start():
+    renderer = runpy.run_path(
+        "ops/observability/render_prometheus_config.py",
+        run_name="_prometheus_config_renderer",
+    )
+    template = (OBS_ROOT / "prometheus" / "prometheus.yml").read_text(
+        encoding="utf-8"
+    )
+    render = renderer["render_prometheus_config"]
+
+    rendered = render(template, "production")
+
+    assert "${OBSERVABILITY_ENVIRONMENT}" not in rendered
+    assert 'environment: "production"' in rendered
+    assert rendered.count('environment: "production"') == 2
+    for invalid_environment in ("", "Production", "testing", "admin"):
+        with pytest.raises(ValueError, match="staging or production"):
+            render(template, invalid_environment)
+    with pytest.raises(ValueError, match="missing its environment placeholder"):
+        render(template.replace("${OBSERVABILITY_ENVIRONMENT}", "production"), "production")
+    with pytest.raises(ValueError, match="unresolved placeholder"):
+        render(template + "\nunsafe: ${UNREVIEWED_VALUE}\n", "production")
+
+    bootstrap = Path("ops/deploy/bootstrap-observability-ec2").read_text(
+        encoding="utf-8"
+    )
+    assert "read_observability_env_value OBSERVABILITY_ENVIRONMENT" in bootstrap
+    assert "OBSERVABILITY_ENVIRONMENT must be staging or production" in bootstrap
+    assert "render_prometheus_config.py" in bootstrap
+    assert 'python3 "${prometheus_renderer}"' in bootstrap
+    assert '"${prometheus_config_tmp}"' in bootstrap
+    runbook = Path(
+        "docs/runbooks/private-observability-grafana-loki.md"
+    ).read_text(encoding="utf-8")
+    assert "`--config.expand-env` flag" in runbook
+    assert "http://prometheus:9090/-/ready" in runbook
 
 
 def test_loki_retention_and_grafana_datasource_are_configured_without_credentials():

--- a/tests/test_sbom_workflow.py
+++ b/tests/test_sbom_workflow.py
@@ -47,6 +47,10 @@ def test_source_sbom_is_cyclonedx_json_with_predictable_retention():
     assert "--output cyclonedx-json=sitbank-source-sbom-cyclonedx.json" in (
         generate["run"]
     )
+    assert "runtime-requirements.txt" in generate["run"]
+    assert "development-requirements.txt" in generate["run"]
+    assert "--select-catalogers=-python-installed-package-cataloger" in generate["run"]
+    assert 'rm -rf -- "${python_manifest_dir}"' in generate["run"]
     assert "jq empty sitbank-source-sbom-cyclonedx.json" in generate["run"]
     assert upload["with"] == {
         "name": "sitbank-source-sbom",
@@ -56,6 +60,8 @@ def test_source_sbom_is_cyclonedx_json_with_predictable_retention():
     }
     summary = next(step for step in steps if step["name"] == "Summarize source SBOM")
     assert "python ops/security/render_sbom_summary.py" in summary["run"]
+    assert "--python-manifest requirements.lock" in summary["run"]
+    assert "--python-manifest requirements-dev.lock" in summary["run"]
     assert "sitbank-source-sbom-cyclonedx.json" in summary["run"]
 
 
@@ -96,10 +102,12 @@ def test_sbom_documentation_distinguishes_artifact_attestation_and_scanning():
         "30 days",
         "Buildx",
         "attestation",
-        "explicit image SBOM artifact remains deferred",
+        "explicit image\nSBOM artifact remains deferred",
         "not vulnerability scanning",
         "bounded preview",
         "pkg:pypi/",
+        "source-controlled",
+        "image/container SBOM",
     ):
         assert required in docs
 
@@ -132,17 +140,34 @@ def test_sbom_summary_reports_ecosystems_and_bounds_python_preview():
         ]
     )
 
-    summary = render_summary({"components": components})
+    declared = {
+        (f"python-package-{index}", str(index))
+        for index in range(12)
+    }
+    summary = render_summary(
+        {"components": components},
+        declared_python_dependencies=declared,
+        python_manifest_count=2,
+    )
 
     assert "### Ecosystem breakdown" in summary
+    assert summary.index("### Python components") < summary.index(
+        "### Ecosystem breakdown"
+    )
     assert "| PyPI | 12 |" in summary
     assert "| GitHub actions/workflows | 1 |" in summary
     assert "| npm | 1 |" in summary
     assert "| OS/system | 1 |" in summary
     assert "| Unknown/no PURL | 1 |" in summary
     assert "| Other PURL | 1 |" in summary
-    assert "Python components detected: `12`" in summary
+    assert "Python components detected from reviewed manifests: `12`" in summary
     assert "Preview limit: `10` components" in summary
+    assert (
+        "- Reviewed source-controlled Python manifests: `2`\n"
+        "- Declared pinned Python packages: `12`\n"
+        "- Python components detected from reviewed manifests: `12`\n"
+        "- Preview limit: `10` components"
+    ) in summary
     assert summary.count("| python-package-") == 10
     assert "python-package-10" not in summary
 
@@ -159,13 +184,43 @@ def test_sbom_summary_explicitly_reports_no_python_and_sanitizes_markdown():
                     "purl": "pkg:npm/unsafe@1",
                 }
             ]
-        }
+        },
+        declared_python_dependencies={("flask", "3.1.2")},
+        python_manifest_count=1,
     )
 
-    assert "Python components detected: `0`" in summary
-    assert "No PyPI package URLs were detected" in summary
+    assert "Python components detected from reviewed manifests: `0`" in summary
+    assert "No matching `pkg:pypi/` package URLs were emitted" in summary
+    assert "not evidence that the source has no Python dependencies" in summary
     assert "<unsafe>" not in summary
     assert "|`name`" not in summary
+
+
+def test_sbom_summary_excludes_runner_python_packages_not_in_manifests():
+    render_summary = _summary_renderer()["render_summary"]
+    summary = render_summary(
+        {
+            "components": [
+                {
+                    "name": "flask",
+                    "version": "3.1.2",
+                    "purl": "pkg:pypi/Flask@3.1.2",
+                },
+                {
+                    "name": "runner-only",
+                    "version": "99.0",
+                    "purl": "pkg:pypi/runner_only@99.0",
+                },
+            ]
+        },
+        declared_python_dependencies={("flask", "3.1.2")},
+        python_manifest_count=2,
+    )
+
+    assert "Python components detected from reviewed manifests: `1`" in summary
+    assert "PyPI components excluded because they were not matched" in summary
+    assert "| flask | 3.1.2 |" in summary
+    assert "| runner-only |" not in summary
 
 
 def test_sbom_summary_input_path_is_confined_to_workspace(tmp_path):
@@ -213,9 +268,18 @@ def test_sbom_summary_main_reads_validated_relative_input(
         '{"components": [{"name": "flask", "purl": "pkg:pypi/flask@3.1.2"}]}',
         encoding="utf-8",
     )
+    manifest_path = tmp_path / "requirements.lock"
+    manifest_path.write_text("flask==3.1.2 \\\n    --hash=sha256:fake\n", encoding="utf-8")
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(
-        sys, "argv", ["render_sbom_summary.py", "source.json"]
+        sys,
+        "argv",
+        [
+            "render_sbom_summary.py",
+            "--python-manifest",
+            "requirements.lock",
+            "source.json",
+        ],
     )
 
     assert main() == 0


### PR DESCRIPTION
Summary
---
Hardens the DAST session bootstrap, source SBOM Python reporting, and Prometheus observability startup contract.

Why
---
The DAST helper could mint a server-side session from a bare user ID, the source SBOM summary did not tie PyPI results to reviewed manifests, and Prometheus restarted on an unsupported environment-expansion flag.

What changed
---

- Require the exact smoke runtime, approved session hosts, and complete synthetic customer identity before DAST session issuance; reject collisions, stale identities, real customers, and privileged users.
- Stage reviewed lockfiles under Syft-recognized manifest names, disable installed-Python cataloging, and filter the bounded summary against pinned source dependencies.
- Remove the unsupported Prometheus flag and render allowlisted environment labels through the trusted bootstrap with unresolved-placeholder rejection.
- Update security, CI, operations, and observability documentation plus positive and fail-closed regression tests.

Security impact
---
The change narrows the DAST session-minting boundary without changing public login, MFA, CSRF, Turnstile, or session-risk controls. SBOM generation remains read-only and secret-free, and Prometheus, node exporter, and Grafana retain immutable images, internal networking, restricted mounts, and no public metrics ports.

Deployment impact
---
Observability EC2 bootstrap and staging/production observability redeployment are required for affected hosts. No database migration, application secret change, Cloudflare/Tailscale provider change, or customer/admin application deployment is required.

Verification
---

- `git diff --check`
- `.\.venv\Scripts\python.exe -m pytest -q -n 4` — 1,542 passed, 35 skipped
- `.\.venv\Scripts\python.exe -m pytest -q -n auto --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term --durations=30 --durations-min=0.5` — 91% total coverage
- Git Bash `bash -n` for both modified shell scripts
- Pinned Syft 1.46.0 source-manifest scan — 117 PyPI records emitted before renderer deduplication/filtering

Notes
---
Closes #456

Closes #452

Closes #441

After observability redeployment, verify `sitbank-prometheus` is stable and that `http://prometheus:9090/-/ready` succeeds from inside the Grafana container without exposing port 9090.