### PR TITLE
Refresh provisioned Grafana dashboards

### DIFF
--- a/docs/security/assurance/operational-observability.md
+++ b/docs/security/assurance/operational-observability.md
@@ -195,6 +195,12 @@ The provisioned dashboard set is:
   app, and admin readiness failures; last deployment time and target
   environment; deployment guard failures; and deployment annotations.
 
+Dashboard files use the Grafana v2 Kubernetes resource envelope with
+`apiVersion: dashboard.grafana.app/v2beta1`, `kind: Dashboard`, and a stable
+`metadata.name` matching the file name. Export dashboard changes as a complete
+V2 Resource, not as a bare `spec`, so file provisioning preserves dashboard
+identity and can validate every layout reference against its panel element.
+
 Normal healthy values are zero active security alerts, zero audit-chain errors,
 valid database integrity, no sustained 5xx/502/503/504 responses, expected
 429s only under abusive bursts, CPU below 80% sustained, memory below 85%,

--- a/ops/observability/grafana/dashboards/sitbank-http-health.json
+++ b/ops/observability/grafana/dashboards/sitbank-http-health.json
@@ -1,220 +1,880 @@
 {
-  "annotations": {
-    "list": []
+  "apiVersion": "dashboard.grafana.app/v2beta1",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "sitbank-http-health"
   },
-  "editable": false,
-  "panels": [
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "sitbank-loki"
-      },
-      "description": "Counts structured Nginx access records by status class. Worry about sustained 5xx growth or unexpected 4xx spikes; check route and upstream panels next.",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 0
-      },
-      "id": 1,
-      "targets": [
-        {
-          "expr": "sum(count_over_time({source=\"nginx_access\", environment=~\"$environment\"} | json | status=~\"2..\" [$__interval]))",
-          "legendFormat": "2xx",
-          "refId": "A"
-        },
-        {
-          "expr": "sum(count_over_time({source=\"nginx_access\", environment=~\"$environment\"} | json | status=~\"3..\" [$__interval]))",
-          "legendFormat": "3xx",
-          "refId": "B"
-        },
-        {
-          "expr": "sum(count_over_time({source=\"nginx_access\", environment=~\"$environment\"} | json | status=~\"4..\" [$__interval]))",
-          "legendFormat": "4xx",
-          "refId": "C"
-        },
-        {
-          "expr": "sum(count_over_time({source=\"nginx_access\", environment=~\"$environment\"} | json | status=~\"5..\" [$__interval]))",
-          "legendFormat": "5xx",
-          "refId": "D"
-        }
-      ],
-      "title": "Requests by status class",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "sitbank-loki"
-      },
-      "description": "Shows 429 responses separately from other 4xx traffic. Worry about bursts on auth, registration, MFA, or password-reset routes; check rate-limit controls before changing limits.",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 0
-      },
-      "id": 2,
-      "targets": [
-        {
-          "expr": "sum by (environment) (count_over_time({source=\"nginx_access\", environment=~\"$environment\"} | json | status=\"429\" [$__interval]))",
-          "refId": "A"
-        }
-      ],
-      "title": "429 rate-limit responses",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "sitbank-loki"
-      },
-      "description": "Separates forbidden and missing-route responses. Worry when 403/404 spikes follow deploys or direct-origin probes; check Cloudflare, Nginx, and route inventory boundaries.",
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 0,
-        "y": 8
-      },
-      "id": 3,
-      "targets": [
-        {
-          "expr": "sum(count_over_time({source=\"nginx_access\", environment=~\"$environment\"} | json | status=~\"403|404\" [$__interval]))",
-          "refId": "A"
-        }
-      ],
-      "title": "403 and 404 responses",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "sitbank-loki"
-      },
-      "description": "Tracks user-visible server and upstream failures. Worry about any sustained 500/502/503/504 value; check app readiness, container health, and deployment events next.",
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 8,
-        "y": 8
-      },
-      "id": 4,
-      "targets": [
-        {
-          "expr": "sum(count_over_time({source=\"nginx_access\", environment=~\"$environment\"} | json | status=~\"500|502|503|504\" [$__interval]))",
-          "refId": "A"
-        }
-      ],
-      "title": "500 502 503 504 responses",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "sitbank-loki"
-      },
-      "description": "Lists recent routes from the structured `$uri` field, which excludes query strings. Worry about sensitive routes appearing with unexpected statuses; check copied evidence remains sanitized.",
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 16,
-        "y": 8
-      },
-      "id": 5,
-      "options": {
-        "showLabels": false,
-        "sortOrder": "Descending"
-      },
-      "targets": [
-        {
-          "expr": "{source=\"nginx_access\", environment=~\"$environment\"} | json | line_format \"{{.method}} {{.route}} {{.status}} upstream={{.upstream_status}}\"",
-          "refId": "A"
-        }
-      ],
-      "title": "Top requested paths or route groups",
-      "type": "logs"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "sitbank-loki"
-      },
-      "description": "Shows upstream/backend errors from structured Nginx access records and Nginx error logs. Worry about connection refused, timeout, bad gateway, or upstream 5xx patterns; check app readiness next.",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 15
-      },
-      "id": 6,
-      "options": {
-        "showLabels": true,
-        "sortOrder": "Descending"
-      },
-      "targets": [
-        {
-          "expr": "{source=\"nginx_access\", environment=~\"$environment\"} | json | upstream_status=~\"5..|502|503|504\"",
-          "refId": "A"
-        },
-        {
-          "expr": "{source=\"nginx_error\", environment=~\"$environment\"} |~ \"(?i)(upstream|connect\\(\\)|timed out|bad gateway|connection refused)\"",
-          "refId": "B"
-        }
-      ],
-      "title": "Nginx upstream and backend errors",
-      "type": "logs"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "sitbank-loki"
-      },
-      "description": "Shows safe route volume for login, register, and MFA endpoints without body data, sensitive headers, or query strings. Worry about unusual bursts or 429 concentration; check rate-limit context next.",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 15
-      },
-      "id": 7,
-      "targets": [
-        {
-          "expr": "sum by (route, status) (count_over_time({source=\"nginx_access\", environment=~\"$environment\"} | json | route=~\"/(login|register|mfa/verify|auth/login|auth/register|auth/mfa/verify)\" [$__interval]))",
-          "refId": "A"
-        }
-      ],
-      "title": "Login register and MFA route volume",
-      "type": "timeseries"
-    }
-  ],
-  "schemaVersion": 39,
-  "tags": [
-    "sitbank",
-    "http",
-    "operations"
-  ],
-  "templating": {
-    "list": [
+  "spec": {
+    "annotations": [
       {
-        "current": {
-          "selected": true,
-          "text": "production|staging",
-          "value": "production|staging"
-        },
-        "hide": 0,
-        "label": "Environment",
-        "name": "environment",
-        "options": [],
-        "query": "production|staging",
-        "type": "textbox"
+        "kind": "AnnotationQuery",
+        "spec": {
+          "builtIn": true,
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "query": {
+            "datasource": {
+              "name": "-- Grafana --"
+            },
+            "group": "grafana",
+            "kind": "DataQuery",
+            "spec": {},
+            "version": "v0"
+          }
+        }
+      }
+    ],
+    "cursorSync": "Off",
+    "editable": true,
+    "elements": {
+      "panel-1": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "sum(\r\n  count_over_time(\r\n    {source=\"nginx_access\", environment=~\"$environment\"}\r\n    | json\r\n    | status=~\"2..\"\r\n    [$__interval]\r\n  )\r\n) or vector(0)",
+                        "legendFormat": "2xx",
+                        "queryType": "range"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "sum(\r\n  count_over_time(\r\n    {source=\"nginx_access\", environment=~\"$environment\"}\r\n    | json\r\n    | status=~\"3..\"\r\n    [$__interval]\r\n  )\r\n) or vector(0)",
+                        "legendFormat": "3xx",
+                        "queryType": "range"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "sum(\r\n  count_over_time(\r\n    {source=\"nginx_access\", environment=~\"$environment\"}\r\n    | json\r\n    | status=~\"4..\"\r\n    [$__interval]\r\n  )\r\n) or vector(0)",
+                        "legendFormat": "4xx",
+                        "queryType": "range"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "C"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "sum(\r\n  count_over_time(\r\n    {source=\"nginx_access\", environment=~\"$environment\"}\r\n    | json\r\n    | status=~\"5..\"\r\n    [$__interval]\r\n  )\r\n) or vector(0)",
+                        "legendFormat": "5xx",
+                        "queryType": "range"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "D"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Counts structured Nginx access records by status class. Worry about sustained 5xx growth or unexpected 4xx spikes; check route and upstream panels next.",
+          "id": 1,
+          "links": [],
+          "title": "Requests by status class",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.8,
+                    "drawStyle": "bars",
+                    "fillOpacity": 40,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-2": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "sum(\r\n  count_over_time(\r\n    {source=\"nginx_access\", environment=~\"$environment\"}\r\n    | json\r\n    | __error__=\"\"\r\n    | status=\"429\"\r\n    [$__range]\r\n  )\r\n) or vector(0)",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Shows 429 responses separately from other 4xx traffic. Worry about bursts on auth, registration, MFA, or password-reset routes; check rate-limit controls before changing limits.",
+          "id": 2,
+          "links": [],
+          "title": "429 rate-limit responses",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-3": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "sum(\r\n  count_over_time(\r\n    {source=\"nginx_access\", environment=~\"$environment\"}\r\n    | json\r\n    | __error__=\"\"\r\n    | status=~\"40[34]\"\r\n    [$__range]\r\n  )\r\n) or vector(0)",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Separates forbidden and missing-route responses. Worry when 403/404 spikes follow deploys or direct-origin probes; check Cloudflare, Nginx, and route inventory boundaries.",
+          "id": 3,
+          "links": [],
+          "title": "403 and 404 responses",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-4": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "sum(\r\n  count_over_time(\r\n    {source=\"nginx_access\", environment=~\"$environment\"}\r\n    | json\r\n    | __error__=\"\"\r\n    | status=~\"50[0234]\"\r\n    [$__range]\r\n  )\r\n) or vector(0)",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Tracks user-visible server and upstream failures. Worry about any sustained 500/502/503/504 value; check app readiness, container health, and deployment events next.",
+          "id": 4,
+          "links": [],
+          "title": "500 502 503 504 responses",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-5": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "{source=\"nginx_access\", environment=~\"$environment\"} | json | line_format \"{{.method}} {{.route}} {{.status}} upstream={{.upstream_status}}\"",
+                        "queryType": "range"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Lists recent routes from the structured `$uri` field, which excludes query strings. Worry about sensitive routes appearing with unexpected statuses; check copied evidence remains sanitized.",
+          "id": 5,
+          "links": [],
+          "title": "Top requested paths or route groups",
+          "vizConfig": {
+            "group": "logs",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "dedupStrategy": "none",
+                "enableInfiniteScrolling": false,
+                "enableLogDetails": true,
+                "prettifyLogMessage": true,
+                "showControls": false,
+                "showFieldSelector": false,
+                "showLabels": false,
+                "showLevel": true,
+                "showTime": true,
+                "sortOrder": "Descending",
+                "syntaxHighlighting": true,
+                "timestampResolution": "ms",
+                "unwrappedColumns": false,
+                "wrapLogMessage": false
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-6": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "{source=\"nginx_access\", environment=~\"$environment\"}\r\n| json\r\n| __error__=\"\"\r\n| upstream_status=~\"(^|.*, *)5[0-9][0-9]( *,.*|$)\"",
+                        "queryType": "range"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "{source=\"nginx_error\", environment=~\"$environment\"}\r\n|~ \"(?i)(upstream|connect\\\\(\\\\)|timed out|bad gateway|connection refused|no live upstreams|upstream prematurely closed)\"",
+                        "queryType": "range"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Shows upstream/backend errors from structured Nginx access records and Nginx error logs. Worry about connection refused, timeout, bad gateway, or upstream 5xx patterns; check app readiness next.",
+          "id": 6,
+          "links": [],
+          "title": "Nginx upstream and backend errors",
+          "vizConfig": {
+            "group": "logs",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "dedupStrategy": "none",
+                "enableInfiniteScrolling": false,
+                "enableLogDetails": true,
+                "prettifyLogMessage": true,
+                "showControls": false,
+                "showFieldSelector": false,
+                "showLabels": true,
+                "showLevel": true,
+                "showTime": true,
+                "sortOrder": "Descending",
+                "syntaxHighlighting": true,
+                "timestampResolution": "ms",
+                "unwrappedColumns": false,
+                "wrapLogMessage": false
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-7": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "sum by (route, status) (\r\n  count_over_time(\r\n    {source=\"nginx_access\", environment=~\"$environment\"}\r\n    | json\r\n    | __error__=\"\"\r\n    | route=~\"^/(login|register|mfa/verify|auth/login|auth/register|auth/mfa/verify)$\"\r\n    [$__interval]\r\n  )\r\n)",
+                        "legendFormat": "{{route}} {{status}}",
+                        "queryType": "range"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Shows safe route volume for login, register, and MFA endpoints without body data, sensitive headers, or query strings. Worry about unusual bursts or 429 concentration; check rate-limit context next.",
+          "id": 7,
+          "links": [],
+          "title": "Login register and MFA route volume",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "bars",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "GridLayout",
+      "spec": {
+        "items": [
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-1"
+              },
+              "height": 14,
+              "width": 24,
+              "x": 0,
+              "y": 0
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-3"
+              },
+              "height": 10,
+              "width": 12,
+              "x": 0,
+              "y": 14
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-2"
+              },
+              "height": 10,
+              "width": 12,
+              "x": 12,
+              "y": 14
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-4"
+              },
+              "height": 10,
+              "width": 12,
+              "x": 0,
+              "y": 24
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-7"
+              },
+              "height": 10,
+              "width": 12,
+              "x": 12,
+              "y": 24
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-5"
+              },
+              "height": 11,
+              "width": 24,
+              "x": 0,
+              "y": 34
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-6"
+              },
+              "height": 11,
+              "width": 24,
+              "x": 0,
+              "y": 45
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preload": false,
+    "tags": [
+      "sitbank",
+      "http",
+      "operations"
+    ],
+    "timeSettings": {
+      "autoRefresh": "",
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "fiscalYearStartMonth": 0,
+      "from": "now-6h",
+      "hideTimepicker": false,
+      "timezone": "browser",
+      "to": "now"
+    },
+    "title": "SITBank HTTP Health",
+    "variables": [
+      {
+        "kind": "TextVariable",
+        "spec": {
+          "current": {
+            "text": "production|staging",
+            "value": "production|staging"
+          },
+          "hide": "dontHide",
+          "label": "Environment",
+          "name": "environment",
+          "query": "production|staging",
+          "skipUrlSync": false
+        }
       }
     ]
-  },
-  "time": {
-    "from": "now-6h",
-    "to": "now"
-  },
-  "title": "SITBank HTTP Health",
-  "uid": "sitbank-http-health",
-  "version": 1
+  }
 }

--- a/ops/observability/grafana/dashboards/sitbank-infrastructure-deployment-health.json
+++ b/ops/observability/grafana/dashboards/sitbank-infrastructure-deployment-health.json
@@ -1,249 +1,916 @@
 {
-  "annotations": {
-    "list": [
+  "apiVersion": "dashboard.grafana.app/v2beta1",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "sitbank-infrastructure-deployment-health"
+  },
+  "spec": {
+    "annotations": [
       {
-        "datasource": {
-          "type": "loki",
-          "uid": "sitbank-loki"
-        },
-        "enable": true,
-        "expr": "{environment=~\"$environment\", source=~\"container|systemd\"} |~ \"(?i)(deploy|deployment|bootstrap|rollback|migration)\"",
-        "iconColor": "rgba(87, 148, 242, 1)",
-        "name": "Deployment start completion and rollback signals"
+        "kind": "AnnotationQuery",
+        "spec": {
+          "builtIn": true,
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "query": {
+            "datasource": {
+              "name": "-- Grafana --"
+            },
+            "group": "grafana",
+            "kind": "DataQuery",
+            "spec": {},
+            "version": "v0"
+          }
+        }
+      },
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "enable": true,
+          "hide": false,
+          "iconColor": "rgba(87, 148, 242, 1)",
+          "legacyOptions": {
+            "expr": "{environment=~\"$environment\", source=~\"container|systemd\"} |~ \"(?i)(deploy|deployment|bootstrap|rollback|migration)\""
+          },
+          "name": "Deployment start completion and rollback signals",
+          "query": {
+            "datasource": {
+              "name": "sitbank-loki"
+            },
+            "group": "loki",
+            "kind": "DataQuery",
+            "spec": {},
+            "version": "v0"
+          }
+        }
+      }
+    ],
+    "cursorSync": "Off",
+    "editable": true,
+    "elements": {
+      "panel-1": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-prometheus"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "100 * (\r\n  1 - avg by (instance, environment) (\r\n    rate(node_cpu_seconds_total{\r\n      mode=\"idle\",\r\n      environment=~\"$environment\",\r\n      service=\"ec2-node\"\r\n    }[$__rate_interval])\r\n  )\r\n)",
+                        "instant": false,
+                        "legendFormat": "EC2 CPU",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Shows EC2 CPU usage from the private node exporter. Worry about sustained high CPU; check deployment events, container failures, and host process evidence next.",
+          "id": 1,
+          "links": [],
+          "title": "EC2 CPU usage",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-2": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-prometheus"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "100 * (\r\n  1 -\r\n  (\r\n    avg by (instance, environment) (\r\n      node_memory_MemAvailable_bytes{\r\n        environment=~\"$environment\",\r\n        service=\"ec2-node\"\r\n      }\r\n    )\r\n    /\r\n    avg by (instance, environment) (\r\n      node_memory_MemTotal_bytes{\r\n        environment=~\"$environment\",\r\n        service=\"ec2-node\"\r\n      }\r\n    )\r\n  )\r\n)",
+                        "legendFormat": "EC2 memory",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Shows EC2 memory usage from host metrics. Worry about sustained pressure or sudden jumps after deploys; check container memory and restart signals next.",
+          "id": 2,
+          "links": [],
+          "title": "EC2 memory usage",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-3": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-prometheus"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "100 * (\r\n  1 -\r\n  (\r\n    node_filesystem_avail_bytes{\r\n      environment=~\"$environment\",\r\n      service=\"ec2-node\",\r\n      mountpoint=\"/\",\r\n      fstype!~\"tmpfs|overlay|squashfs|proc|sysfs\"\r\n    }\r\n    /\r\n    node_filesystem_size_bytes{\r\n      environment=~\"$environment\",\r\n      service=\"ec2-node\",\r\n      mountpoint=\"/\",\r\n      fstype!~\"tmpfs|overlay|squashfs|proc|sysfs\"\r\n    }\r\n  )\r\n)",
+                        "legendFormat": "Root disk usage",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Shows EC2 filesystem usage while excluding pseudo-filesystems and Docker internals. Worry above the documented threshold; check Loki retention and application storage next.",
+          "id": 3,
+          "links": [],
+          "title": "EC2 disk usage and pressure",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-4": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "{environment=~\"$environment\", source=~\"container|systemd\"}\r\n|~ \"(?i)(restart|restarted|restarting|oom|out of memory|killed|exited|unhealthy|stopped|crash|fatal)\"",
+                        "queryType": "range"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Shows container restart, stop, OOM, and crash-like events from Docker/systemd and SITBank container logs. Worry about repeated restarts or OOM messages; check host resources next.",
+          "id": 4,
+          "links": [],
+          "title": "Container restart count and recent restart events",
+          "vizConfig": {
+            "group": "logs",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "dedupStrategy": "none",
+                "detailsMode": "inline",
+                "enableInfiniteScrolling": false,
+                "enableLogDetails": true,
+                "prettifyLogMessage": true,
+                "showControls": false,
+                "showFieldSelector": false,
+                "showLabels": true,
+                "showLevel": true,
+                "showTime": false,
+                "sortOrder": "Descending",
+                "syntaxHighlighting": true,
+                "timestampResolution": "ms",
+                "unwrappedColumns": false,
+                "wrapLogMessage": false
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-5": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "{environment=~\"$environment\", source=~\"container|systemd\"}\r\n|~ \"(?i)(postgres|postgresql|database|sqlalchemy|psycopg|connection refused|too many connections|remaining connection slots|could not connect|connection timed out|storage|disk full|no space left|db upgrade|migration)\"\r\n!~ \"(?i)(health check passed|ready|readiness passed|connection health ok)\"",
+                        "queryType": "range"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Shows PostgreSQL connectivity, storage, and connection-pressure warnings when they appear in app/admin/deployment logs. Worry about connection refused, too many connections, or storage pressure; check deployment state next.",
+          "id": 5,
+          "links": [],
+          "title": "PostgreSQL connectivity storage and connection health",
+          "vizConfig": {
+            "group": "logs",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "dedupStrategy": "none",
+                "enableInfiniteScrolling": false,
+                "enableLogDetails": true,
+                "prettifyLogMessage": true,
+                "showControls": false,
+                "showFieldSelector": false,
+                "showLabels": true,
+                "showLevel": true,
+                "showTime": false,
+                "sortOrder": "Descending",
+                "timestampResolution": "ms",
+                "unwrappedColumns": false,
+                "wrapLogMessage": false
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-6": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "{source=\"nginx_access\", environment=~\"$environment\"}\r\n| json\r\n| __error__=\"\"\r\n| route=~\"^/health/(ready|live)$\"\r\n| status!~\"2..\"",
+                        "queryType": "range"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "{environment=~\"$environment\", source=~\"container|systemd\"}\r\n|~ \"(?i)(readiness|health check|/health/(ready|live)|health/ready|health/live)\"\r\n|~ \"(?i)(failed|failure|timeout|timed out|unhealthy|refused|connection refused|not ready)\"",
+                        "queryType": "range"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Shows readiness and health check failures for Nginx, app, and admin paths. Worry about readiness failures after deploys; use local readiness on protected staging origins.",
+          "id": 6,
+          "links": [],
+          "title": "Nginx app and admin readiness check status",
+          "vizConfig": {
+            "group": "logs",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "dedupStrategy": "none",
+                "enableInfiniteScrolling": false,
+                "enableLogDetails": true,
+                "prettifyLogMessage": true,
+                "showControls": false,
+                "showFieldSelector": false,
+                "showLabels": true,
+                "showLevel": true,
+                "showTime": false,
+                "sortOrder": "Descending",
+                "timestampResolution": "ms",
+                "unwrappedColumns": false,
+                "wrapLogMessage": false
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-7": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "{environment=~\"$environment\", source=~\"container|systemd\"}\r\n|~ \"(?i)(sitbank-container-deploy|sitbank-container-bootstrap|sitbank-container-runtime|bootstrap-container-ec2|deployment|deploy|bootstrap|migration|db upgrade|database cutover|rollback)\"\r\n|~ \"(?i)(started|completed|failed|failure|rollback|target=|environment=)\"",
+                        "queryType": "range"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Lists deployment start/completion, target environment, migration, bootstrap, and rollback lines. Worry about missing completion after start or rollback signals; check the deployment runbook.",
+          "id": 7,
+          "links": [],
+          "title": "Last deployment time and target environment",
+          "vizConfig": {
+            "group": "logs",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "dedupStrategy": "none",
+                "enableInfiniteScrolling": false,
+                "enableLogDetails": true,
+                "prettifyLogMessage": true,
+                "showControls": false,
+                "showFieldSelector": false,
+                "showLabels": true,
+                "showLevel": true,
+                "showTime": false,
+                "sortOrder": "Descending",
+                "timestampResolution": "ms",
+                "unwrappedColumns": false,
+                "wrapLogMessage": false
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-8": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "{environment=~\"$environment\", source=~\"container|systemd\"}\r\n|~ \"(?i)(production-check|verify-runtime-db-privileges|apply-runtime-db-privileges|verify-cloudflare-origin-pull-ca|verify-production-nginx-boundary|verify-staging-edge-boundary|sitbank-verify-tailscale-admin|cloudflare|tailscale|cosign|origin pull|authenticated origin|readiness|production readiness|deployment guard|guard)\"\r\n|~ \"(?i)(failed|failure|denied|refused|invalid|mismatch|rollback|required|missing|stale|unauthorized|forbidden|blocked)\"",
+                        "queryType": "range"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Highlights production and staging deployment guard failures. Worry about any nonzero value; do not bypass Cloudflare, Tailscale, cosign, readiness, database privilege, or production checks.",
+          "id": 8,
+          "links": [],
+          "title": "Production staging deployment guard failures",
+          "vizConfig": {
+            "group": "logs",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "dedupStrategy": "none",
+                "enableInfiniteScrolling": false,
+                "enableLogDetails": true,
+                "prettifyLogMessage": true,
+                "showControls": false,
+                "showFieldSelector": false,
+                "showLabels": true,
+                "showLevel": true,
+                "showTime": false,
+                "sortOrder": "Descending",
+                "timestampResolution": "ms",
+                "unwrappedColumns": false,
+                "wrapLogMessage": false
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "GridLayout",
+      "spec": {
+        "items": [
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-1"
+              },
+              "height": 7,
+              "width": 8,
+              "x": 0,
+              "y": 0
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-2"
+              },
+              "height": 7,
+              "width": 8,
+              "x": 8,
+              "y": 0
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-3"
+              },
+              "height": 7,
+              "width": 8,
+              "x": 16,
+              "y": 0
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-4"
+              },
+              "height": 10,
+              "width": 24,
+              "x": 0,
+              "y": 7
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-5"
+              },
+              "height": 10,
+              "width": 24,
+              "x": 0,
+              "y": 17
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-6"
+              },
+              "height": 8,
+              "width": 24,
+              "x": 0,
+              "y": 27
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-7"
+              },
+              "height": 9,
+              "width": 24,
+              "x": 0,
+              "y": 35
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-8"
+              },
+              "height": 8,
+              "width": 24,
+              "x": 0,
+              "y": 44
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preload": false,
+    "tags": [
+      "sitbank",
+      "infrastructure",
+      "deployment"
+    ],
+    "timeSettings": {
+      "autoRefresh": "",
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "fiscalYearStartMonth": 0,
+      "from": "now-6h",
+      "hideTimepicker": false,
+      "timezone": "browser",
+      "to": "now"
+    },
+    "title": "SITBank Infrastructure And Deployment Health",
+    "variables": [
+      {
+        "kind": "TextVariable",
+        "spec": {
+          "current": {
+            "text": "production|staging",
+            "value": "production|staging"
+          },
+          "hide": "dontHide",
+          "label": "Environment",
+          "name": "environment",
+          "query": "production|staging",
+          "skipUrlSync": false
+        }
       }
     ]
-  },
-  "editable": false,
-  "panels": [
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "sitbank-prometheus"
-      },
-      "description": "Shows EC2 CPU usage from the private node exporter. Worry about sustained high CPU; check deployment events, container failures, and host process evidence next.",
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 0,
-        "y": 0
-      },
-      "id": 1,
-      "targets": [
-        {
-          "expr": "100 - (avg by (instance, environment) (rate(node_cpu_seconds_total{mode=\"idle\", environment=~\"$environment\"}[$__rate_interval])) * 100)",
-          "refId": "A"
-        }
-      ],
-      "title": "EC2 CPU usage",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "sitbank-prometheus"
-      },
-      "description": "Shows EC2 memory usage from host metrics. Worry about sustained pressure or sudden jumps after deploys; check container memory and restart signals next.",
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 8,
-        "y": 0
-      },
-      "id": 2,
-      "targets": [
-        {
-          "expr": "(1 - (node_memory_MemAvailable_bytes{environment=~\"$environment\"} / node_memory_MemTotal_bytes{environment=~\"$environment\"})) * 100",
-          "refId": "A"
-        }
-      ],
-      "title": "EC2 memory usage",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "sitbank-prometheus"
-      },
-      "description": "Shows EC2 filesystem usage while excluding pseudo-filesystems and Docker internals. Worry above the documented threshold; check Loki retention and application storage next.",
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 16,
-        "y": 0
-      },
-      "id": 3,
-      "targets": [
-        {
-          "expr": "100 - ((node_filesystem_avail_bytes{environment=~\"$environment\", fstype!~\"tmpfs|overlay|squashfs|proc|sysfs\"} / node_filesystem_size_bytes{environment=~\"$environment\", fstype!~\"tmpfs|overlay|squashfs|proc|sysfs\"}) * 100)",
-          "refId": "A"
-        }
-      ],
-      "title": "EC2 disk usage and pressure",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "sitbank-loki"
-      },
-      "description": "Shows container restart, stop, OOM, and crash-like events from Docker/systemd and SITBank container logs. Worry about repeated restarts or OOM messages; check host resources next.",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 7
-      },
-      "id": 4,
-      "options": {
-        "showLabels": true,
-        "sortOrder": "Descending"
-      },
-      "targets": [
-        {
-          "expr": "{environment=~\"$environment\", source=~\"container|systemd\"} |~ \"(?i)(restart|restarted|oom|out of memory|killed|exited|unhealthy)\"",
-          "refId": "A"
-        }
-      ],
-      "title": "Container restart count and recent restart events",
-      "type": "logs"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "sitbank-loki"
-      },
-      "description": "Shows PostgreSQL connectivity, storage, and connection-pressure warnings when they appear in app/admin/deployment logs. Worry about connection refused, too many connections, or storage pressure; check deployment state next.",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 7
-      },
-      "id": 5,
-      "options": {
-        "showLabels": true,
-        "sortOrder": "Descending"
-      },
-      "targets": [
-        {
-          "expr": "{environment=~\"$environment\", source=~\"container|systemd\"} |~ \"(?i)(postgres|database|sqlalchemy|connection refused|too many connections|storage|disk full|db upgrade)\"",
-          "refId": "A"
-        }
-      ],
-      "title": "PostgreSQL connectivity storage and connection health",
-      "type": "logs"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "sitbank-loki"
-      },
-      "description": "Shows readiness and health check failures for Nginx, app, and admin paths. Worry about readiness failures after deploys; use local readiness on protected staging origins.",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 15
-      },
-      "id": 6,
-      "options": {
-        "showLabels": true,
-        "sortOrder": "Descending"
-      },
-      "targets": [
-        {
-          "expr": "{environment=~\"$environment\", source=~\"nginx_access|container|systemd\"} | json | route=~\"/health/(ready|live)\" | status!~\"2..\"",
-          "refId": "A"
-        },
-        {
-          "expr": "{environment=~\"$environment\", source=~\"container|systemd\"} |~ \"(?i)(readiness|health check|/health/ready|/health/live)\" |~ \"(?i)(failed|failure|timeout|unhealthy|refused)\"",
-          "refId": "B"
-        }
-      ],
-      "title": "Nginx app and admin readiness check status",
-      "type": "logs"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "sitbank-loki"
-      },
-      "description": "Lists deployment start/completion, target environment, migration, bootstrap, and rollback lines. Worry about missing completion after start or rollback signals; check the deployment runbook.",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 15
-      },
-      "id": 7,
-      "options": {
-        "showLabels": true,
-        "sortOrder": "Descending"
-      },
-      "targets": [
-        {
-          "expr": "{environment=~\"$environment\", source=~\"container|systemd\"} |~ \"(?i)(deploy|deployment|target=|environment=|completed|started|bootstrap|migration|rollback)\"",
-          "refId": "A"
-        }
-      ],
-      "title": "Last deployment time and target environment",
-      "type": "logs"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "sitbank-loki"
-      },
-      "description": "Highlights production and staging deployment guard failures. Worry about any nonzero value; do not bypass Cloudflare, Tailscale, cosign, readiness, database privilege, or production checks.",
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 23
-      },
-      "id": 8,
-      "options": {
-        "showLabels": true,
-        "sortOrder": "Descending"
-      },
-      "targets": [
-        {
-          "expr": "{environment=~\"$environment\", source=~\"container|systemd\"} |~ \"(?i)(production-check|verify-runtime-db-privileges|cloudflare|tailscale|cosign|origin pull|authenticated origin|readiness|guard)\" |~ \"(?i)(failed|failure|denied|refused|invalid|mismatch|rollback)\"",
-          "refId": "A"
-        }
-      ],
-      "title": "Production staging deployment guard failures",
-      "type": "logs"
-    }
-  ],
-  "schemaVersion": 39,
-  "tags": [
-    "sitbank",
-    "infrastructure",
-    "deployment"
-  ],
-  "templating": {
-    "list": [
-      {
-        "current": {
-          "selected": true,
-          "text": "production|staging",
-          "value": "production|staging"
-        },
-        "hide": 0,
-        "label": "Environment",
-        "name": "environment",
-        "options": [],
-        "query": "production|staging",
-        "type": "textbox"
-      }
-    ]
-  },
-  "time": {
-    "from": "now-6h",
-    "to": "now"
-  },
-  "title": "SITBank Infrastructure And Deployment Health",
-  "uid": "sitbank-infrastructure-deployment-health",
-  "version": 1
+  }
 }

--- a/ops/observability/grafana/dashboards/sitbank-operational-overview.json
+++ b/ops/observability/grafana/dashboards/sitbank-operational-overview.json
@@ -1,221 +1,690 @@
 {
-  "annotations": {
-    "list": []
+  "apiVersion": "dashboard.grafana.app/v2beta1",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "sitbank-operational-overview"
   },
-  "editable": false,
-  "panels": [
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "sitbank-loki"
-      },
-      "description": "Shows whether expected operational log streams are still arriving. Worry when an environment or service drops to zero outside a planned stop; check Alloy health, container labels, and Loki ingestion next.",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 0
-      },
-      "id": 1,
-      "options": {},
-      "targets": [
-        {
-          "expr": "sum by (service, environment, source) (count_over_time({environment=~\"$environment\", service=~\"$service\", source=~\"$source\"}[$__interval]))",
-          "refId": "A"
-        }
-      ],
-      "title": "Log ingestion by service and source",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "sitbank-loki"
-      },
-      "description": "Counts Nginx 4xx and 5xx responses by environment. Worry about sustained 5xx or unexpected 4xx spikes; check recent request table, deployment events, and upstream readiness next.",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 0
-      },
-      "id": 2,
-      "options": {},
-      "targets": [
-        {
-          "expr": "sum by (environment) (count_over_time({source=\"nginx_access\", environment=~\"$environment\"} |~ \"\\\\s[45][0-9][0-9]\\\\s\" [$__interval]))",
-          "refId": "A"
-        }
-      ],
-      "title": "Nginx 4xx and 5xx trend",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "sitbank-loki"
-      },
-      "description": "Lists recent edge requests without promoting path, IP, request ID, user, account, or session values to Loki labels. Worry about failed readiness, blocked origin checks, or repeated suspicious paths; keep copied evidence sanitized.",
-      "gridPos": {
-        "h": 9,
-        "w": 24,
-        "x": 0,
-        "y": 8
-      },
-      "id": 3,
-      "options": {
-        "showLabels": false,
-        "sortOrder": "Descending"
-      },
-      "targets": [
-        {
-          "expr": "{source=\"nginx_access\", environment=~\"$environment\"}",
-          "refId": "A"
-        }
-      ],
-      "title": "Recent Nginx requests",
-      "type": "logs"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "sitbank-loki"
-      },
-      "description": "Shows application and admin container lines that look like real failures while ignoring harmless counters such as error_count: 0. Worry about repeated exceptions, tracebacks, failed migrations, or readiness failures; check the deployment window and app health next.",
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 0,
-        "y": 17
-      },
-      "id": 4,
-      "options": {
-        "showLabels": true,
-        "sortOrder": "Descending"
-      },
-      "targets": [
-        {
-          "expr": "{source=\"container\", environment=~\"$environment\", service=~\"sitbank-app|sitbank-admin\"} |~ \"(?i)(\\\\berror\\\\b|\\\\bfailed\\\\b|traceback|exception)\" != \"error_count: 0\"",
-          "refId": "A"
-        }
-      ],
-      "title": "App and admin container failures",
-      "type": "logs"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "sitbank-loki"
-      },
-      "description": "Shows failures from approved systemd units only: security alerts, Docker, and Certbot. Worry about failed timers, failed cert renewals, Docker restarts, or alert jobs exiting nonzero; check systemd status and sanitized host evidence next.",
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 17
-      },
-      "id": 5,
-      "options": {
-        "showLabels": true,
-        "sortOrder": "Descending"
-      },
-      "targets": [
-        {
-          "expr": "{source=\"systemd\", service=~\"sitbank-security-alerts|docker|certbot\"} |~ \"(?i)(failed|failure|error|exited|timeout)\"",
-          "refId": "A"
-        }
-      ],
-      "title": "Systemd failures for monitored units",
-      "type": "logs"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "sitbank-loki"
-      },
-      "description": "Highlights deployment, bootstrap, migration, and rollback lines when they are present in collected container or systemd logs. Worry about rollback, failed upgrade, privilege verification failure, or readiness failure; check the deployment runbook for the next command.",
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 26
-      },
-      "id": 6,
-      "options": {
-        "showLabels": true,
-        "sortOrder": "Descending"
-      },
-      "targets": [
-        {
-          "expr": "{environment=~\"$environment\", source=~\"container|systemd\"} |~ \"(?i)(deploy|bootstrap|rollback|migration|db upgrade|readiness|runtime privileges)\"",
-          "refId": "A"
-        }
-      ],
-      "title": "Deployment and rollback signals",
-      "type": "logs"
-    }
-  ],
-  "schemaVersion": 39,
-  "tags": [
-    "sitbank",
-    "operations"
-  ],
-  "templating": {
-    "list": [
+  "spec": {
+    "annotations": [
       {
-        "current": {
-          "selected": true,
-          "text": "production|staging",
-          "value": "production|staging"
-        },
-        "hide": 0,
-        "label": "Environment",
-        "name": "environment",
-        "options": [],
-        "query": "production|staging",
-        "type": "textbox"
+        "kind": "AnnotationQuery",
+        "spec": {
+          "builtIn": true,
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "query": {
+            "datasource": {
+              "name": "-- Grafana --"
+            },
+            "group": "grafana",
+            "kind": "DataQuery",
+            "spec": {},
+            "version": "v0"
+          }
+        }
+      }
+    ],
+    "cursorSync": "Off",
+    "editable": true,
+    "elements": {
+      "panel-1": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "sum by (environment, service, source) (\r\n  count_over_time(\r\n    {environment=~\"$environment\", service=~\"$service\", source=~\"$source\"}\r\n    [$__interval]\r\n  )\r\n)",
+                        "legendFormat": "{{environment}} / {{service}} / {{source}}",
+                        "queryType": "range"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Shows whether expected operational log streams are still arriving. Worry when an environment or service drops to zero outside a planned stop; check Alloy health, container labels, and Loki ingestion next.",
+          "id": 1,
+          "links": [],
+          "title": "Log ingestion by service and source",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "bars",
+                    "fillOpacity": 25,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-2": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "sum by (environment) (\r\n  count_over_time(\r\n    {source=\"nginx_access\", environment=~\"$environment\"}\r\n    | json\r\n    | __error__=\"\"\r\n    | status=~\"^[45][0-9][0-9]$\"\r\n    [$__interval]\r\n  )\r\n)",
+                        "legendFormat": "{{environment}} 4xx/5xx",
+                        "queryType": "range"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Counts Nginx 4xx and 5xx responses by environment. Worry about sustained 5xx or unexpected 4xx spikes; check recent request table, deployment events, and upstream readiness next.",
+          "id": 2,
+          "links": [],
+          "title": "Nginx 4xx and 5xx trend",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "bars",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-3": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "{source=\"nginx_access\", environment=~\"$environment\"}\r\n| json\r\n| __error__=\"\"\r\n| line_format \"{{.method}} {{.route}} {{.status}} host={{.host}} result={{.result}} upstream={{.upstream_status}} bytes={{.body_bytes_sent}}\"",
+                        "queryType": "range"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Lists recent edge requests without promoting path, IP, request ID, user, account, or session values to Loki labels. Worry about failed readiness, blocked origin checks, or repeated suspicious paths; keep copied evidence sanitized.",
+          "id": 3,
+          "links": [],
+          "title": "Recent Nginx requests",
+          "vizConfig": {
+            "group": "logs",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "dedupStrategy": "none",
+                "enableInfiniteScrolling": false,
+                "enableLogDetails": true,
+                "prettifyLogMessage": true,
+                "showControls": false,
+                "showFieldSelector": false,
+                "showLabels": false,
+                "showLevel": true,
+                "showTime": true,
+                "sortOrder": "Descending",
+                "syntaxHighlighting": true,
+                "timestampResolution": "ms",
+                "unwrappedColumns": false,
+                "wrapLogMessage": false
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-4": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "{source=\"container\", environment=~\"$environment\", service=~\"^(sitbank-app|sitbank-admin)$\"}\r\n|~ \"(?i)(\\\\berror\\\\b|\\\\bfailed\\\\b|traceback|exception)\"\r\n!~ \"(?i)(error_count[:=][[:space:]]*0|errors[:=][[:space:]]*0|failed_count[:=][[:space:]]*0)\"",
+                        "queryType": "range"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Shows application and admin container lines that look like real failures while ignoring harmless counters such as error_count: 0. Worry about repeated exceptions, tracebacks, failed migrations, or readiness failures; check the deployment window and app health next.",
+          "id": 4,
+          "links": [],
+          "title": "App and admin container failures",
+          "vizConfig": {
+            "group": "logs",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "dedupStrategy": "none",
+                "enableInfiniteScrolling": false,
+                "enableLogDetails": true,
+                "prettifyLogMessage": true,
+                "showControls": false,
+                "showFieldSelector": false,
+                "showLabels": true,
+                "showLevel": true,
+                "showTime": false,
+                "sortOrder": "Descending",
+                "timestampResolution": "ms",
+                "unwrappedColumns": false,
+                "wrapLogMessage": false
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-5": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "{source=\"systemd\", environment=~\"$environment\", service=~\"^(sitbank-security-alerts|docker|certbot)$\"}\r\n|~ \"(?i)(failed|failure|error|exited|timeout|timed out|start request repeated too quickly|dependency failed|unit entered failed state)\"\r\n!~ \"(?i)(error=0|no error|ignored|ignore)\"",
+                        "queryType": "range"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Shows failures from approved systemd units only: security alerts, Docker, and Certbot. Worry about failed timers, failed cert renewals, Docker restarts, or alert jobs exiting nonzero; check systemd status and sanitized host evidence next.",
+          "id": 5,
+          "links": [],
+          "title": "Systemd failures for monitored units",
+          "vizConfig": {
+            "group": "logs",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "dedupStrategy": "none",
+                "enableInfiniteScrolling": false,
+                "enableLogDetails": true,
+                "prettifyLogMessage": true,
+                "showControls": false,
+                "showFieldSelector": false,
+                "showLabels": true,
+                "showLevel": true,
+                "showTime": false,
+                "sortOrder": "Descending",
+                "timestampResolution": "ms",
+                "unwrappedColumns": false,
+                "wrapLogMessage": false
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-6": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "{environment=~\"$environment\", source=~\"container|systemd\"}\r\n|~ \"(?i)(sitbank-container-deploy|sitbank-container-bootstrap|sitbank-container-runtime|deploy|deployment|bootstrap|rollback|migration|db upgrade|database cutover|readiness|runtime privileges|verify-runtime-db-privileges|apply-runtime-db-privileges)\"",
+                        "queryType": "range"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Highlights deployment, bootstrap, migration, and rollback lines when they are present in collected container or systemd logs. Worry about rollback, failed upgrade, privilege verification failure, or readiness failure; check the deployment runbook for the next command.",
+          "id": 6,
+          "links": [],
+          "title": "Deployment and rollback signals",
+          "vizConfig": {
+            "group": "logs",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "dedupStrategy": "none",
+                "enableInfiniteScrolling": false,
+                "enableLogDetails": true,
+                "prettifyLogMessage": true,
+                "showControls": false,
+                "showFieldSelector": false,
+                "showLabels": true,
+                "showLevel": true,
+                "showTime": false,
+                "sortOrder": "Descending",
+                "timestampResolution": "ms",
+                "unwrappedColumns": false,
+                "wrapLogMessage": false
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "GridLayout",
+      "spec": {
+        "items": [
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-1"
+              },
+              "height": 12,
+              "width": 24,
+              "x": 0,
+              "y": 0
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-2"
+              },
+              "height": 11,
+              "width": 24,
+              "x": 0,
+              "y": 12
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-3"
+              },
+              "height": 11,
+              "width": 24,
+              "x": 0,
+              "y": 23
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-5"
+              },
+              "height": 12,
+              "width": 24,
+              "x": 0,
+              "y": 34
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-4"
+              },
+              "height": 10,
+              "width": 24,
+              "x": 0,
+              "y": 46
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-6"
+              },
+              "height": 9,
+              "width": 24,
+              "x": 0,
+              "y": 56
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preload": false,
+    "tags": [
+      "sitbank",
+      "operations"
+    ],
+    "timeSettings": {
+      "autoRefresh": "",
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "fiscalYearStartMonth": 0,
+      "from": "now-6h",
+      "hideTimepicker": false,
+      "timezone": "browser",
+      "to": "now"
+    },
+    "title": "SITBank Operational Overview",
+    "variables": [
+      {
+        "kind": "TextVariable",
+        "spec": {
+          "current": {
+            "text": "production|staging",
+            "value": "production|staging"
+          },
+          "hide": "dontHide",
+          "label": "Environment",
+          "name": "environment",
+          "query": "production|staging",
+          "skipUrlSync": false
+        }
       },
       {
-        "current": {
-          "selected": true,
-          "text": "nginx|sitbank-app|sitbank-admin|sitbank-security-alerts|docker|certbot",
-          "value": "nginx|sitbank-app|sitbank-admin|sitbank-security-alerts|docker|certbot"
-        },
-        "hide": 0,
-        "label": "Service",
-        "name": "service",
-        "options": [],
-        "query": "nginx|sitbank-app|sitbank-admin|sitbank-security-alerts|docker|certbot",
-        "type": "textbox"
+        "kind": "TextVariable",
+        "spec": {
+          "current": {
+            "text": "nginx|sitbank-app|sitbank-admin|sitbank-security-alerts|docker|certbot",
+            "value": "nginx|sitbank-app|sitbank-admin|sitbank-security-alerts|docker|certbot"
+          },
+          "hide": "dontHide",
+          "label": "Service",
+          "name": "service",
+          "query": "nginx|sitbank-app|sitbank-admin|sitbank-security-alerts|docker|certbot",
+          "skipUrlSync": false
+        }
       },
       {
-        "current": {
-          "selected": true,
-          "text": "nginx_access|nginx_error|container|systemd",
-          "value": "nginx_access|nginx_error|container|systemd"
-        },
-        "hide": 0,
-        "label": "Source",
-        "name": "source",
-        "options": [],
-        "query": "nginx_access|nginx_error|container|systemd",
-        "type": "textbox"
+        "kind": "TextVariable",
+        "spec": {
+          "current": {
+            "text": "nginx_access|nginx_error|container|systemd",
+            "value": "nginx_access|nginx_error|container|systemd"
+          },
+          "hide": "dontHide",
+          "label": "Source",
+          "name": "source",
+          "query": "nginx_access|nginx_error|container|systemd",
+          "skipUrlSync": false
+        }
       }
     ]
-  },
-  "time": {
-    "from": "now-6h",
-    "to": "now"
-  },
-  "title": "SITBank Operational Overview",
-  "uid": "sitbank-operational-overview",
-  "version": 2
+  }
 }

--- a/ops/observability/grafana/dashboards/sitbank-security-operations.json
+++ b/ops/observability/grafana/dashboards/sitbank-security-operations.json
@@ -1,278 +1,1184 @@
 {
-  "annotations": {
-    "list": []
+  "apiVersion": "dashboard.grafana.app/v2beta1",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "sitbank-security-operations"
   },
-  "editable": false,
-  "panels": [
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "sitbank-loki"
-      },
-      "description": "Shows active security alerts reported by the scheduled security alert job. Worry when this rises above zero; check the alert type panel and the admin audit viewer next.",
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 0,
-        "y": 0
-      },
-      "id": 1,
-      "targets": [
-        {
-          "expr": "max_over_time({service=\"sitbank-security-alerts\", environment=~\"$environment\"} | json | message=\"security_alert_report\" | unwrap alert_count [$__interval])",
-          "refId": "A"
-        }
-      ],
-      "title": "Security alert count",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "sitbank-loki"
-      },
-      "description": "Shows alerts that remain after dedupe and delivery filtering. Worry when deliverable alerts stay nonzero; check webhook configuration and dedupe status next.",
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 6,
-        "y": 0
-      },
-      "id": 2,
-      "targets": [
-        {
-          "expr": "max_over_time({service=\"sitbank-security-alerts\", environment=~\"$environment\"} | json | message=\"security_alert_report\" | unwrap deliverable_alert_count [$__interval])",
-          "refId": "A"
-        }
-      ],
-      "title": "Deliverable alert count",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "sitbank-loki"
-      },
-      "description": "Shows the most recent healthy security alert report. Worry when no success appears in the selected window; check the systemd timer and journal unit next.",
-      "gridPos": {
-        "h": 6,
-        "w": 12,
-        "x": 12,
-        "y": 0
-      },
-      "id": 3,
-      "options": {
-        "showLabels": true,
-        "sortOrder": "Descending"
-      },
-      "targets": [
-        {
-          "expr": "{service=\"sitbank-security-alerts\", environment=~\"$environment\"} | json | message=\"security_alert_report\" | result=\"success\" | line_format \"{{.generated_at}} result={{.result}} alerts={{.alert_count}}\"",
-          "refId": "A"
-        }
-      ],
-      "title": "Last successful security_alert_report",
-      "type": "logs"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "sitbank-loki"
-      },
-      "description": "Counts reports where the audit hash chain is invalid. Worry about any nonzero value; check the alert report JSON and audit verification runbook next.",
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 0,
-        "y": 6
-      },
-      "id": 4,
-      "targets": [
-        {
-          "expr": "sum(count_over_time({service=\"sitbank-security-alerts\", environment=~\"$environment\"} | json | message=\"security_alert_report\" | audit_chain_valid=\"false\" [$__interval]))",
-          "refId": "A"
-        }
-      ],
-      "title": "Audit chain validity",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "sitbank-loki"
-      },
-      "description": "Lists audit anchor status from the security report. Worry about critical, malformed, mismatch, or unexpected not-configured states; check the anchor file and refresh procedure next.",
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 6,
-        "y": 6
-      },
-      "id": 5,
-      "options": {
-        "showLabels": true,
-        "sortOrder": "Descending"
-      },
-      "targets": [
-        {
-          "expr": "{service=\"sitbank-security-alerts\", environment=~\"$environment\"} | json | message=\"security_alert_report\" | line_format \"{{.generated_at}} anchor={{.audit_chain_anchor_status}} stale={{.audit_chain_anchor_stale}} refresh_required={{.audit_chain_anchor_refresh_required}}\"",
-          "refId": "A"
-        }
-      ],
-      "title": "Audit anchor status",
-      "type": "logs"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "sitbank-loki"
-      },
-      "description": "Counts stale anchors or anchor refresh requirements. Worry when the value is nonzero outside expected append-only activity; check the chain before refreshing.",
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 12,
-        "y": 6
-      },
-      "id": 6,
-      "targets": [
-        {
-          "expr": "sum(count_over_time({service=\"sitbank-security-alerts\", environment=~\"$environment\"} | json | message=\"security_alert_report\" | audit_chain_anchor_refresh_required=\"true\" [$__interval])) + sum(count_over_time({service=\"sitbank-security-alerts\", environment=~\"$environment\"} | json | message=\"security_alert_report\" | audit_chain_anchor_stale=\"true\" [$__interval]))",
-          "refId": "A"
-        }
-      ],
-      "title": "Audit anchor refresh required",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "sitbank-loki"
-      },
-      "description": "Shows audit chain error counts from the structured report. Worry about any nonzero value; check only sanitized report fields and admin audit context next.",
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 18,
-        "y": 6
-      },
-      "id": 7,
-      "targets": [
-        {
-          "expr": "max_over_time({service=\"sitbank-security-alerts\", environment=~\"$environment\"} | json | message=\"security_alert_report\" | unwrap audit_chain_error_count [$__interval])",
-          "refId": "A"
-        }
-      ],
-      "title": "Audit chain error count",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "sitbank-loki"
-      },
-      "description": "Counts database integrity report failures. Worry about any nonzero value; check tracked table count and max ID panels before any rebaseline.",
-      "gridPos": {
-        "h": 6,
-        "w": 8,
-        "x": 0,
-        "y": 12
-      },
-      "id": 8,
-      "targets": [
-        {
-          "expr": "sum(count_over_time({service=\"sitbank-security-alerts\", environment=~\"$environment\"} | json | message=\"security_alert_report\" | database_integrity_valid=\"false\" [$__interval]))",
-          "refId": "A"
-        }
-      ],
-      "title": "Database integrity validity",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "sitbank-loki"
-      },
-      "description": "Shows tracked security_audit_events count and max ID from the security report. Worry when either value moves backward; check the database integrity runbook.",
-      "gridPos": {
-        "h": 6,
-        "w": 8,
-        "x": 8,
-        "y": 12
-      },
-      "id": 9,
-      "targets": [
-        {
-          "expr": "max_over_time({service=\"sitbank-security-alerts\", environment=~\"$environment\"} | json | message=\"security_alert_report\" | unwrap database_integrity_security_audit_events_count [$__interval])",
-          "legendFormat": "count",
-          "refId": "A"
-        },
-        {
-          "expr": "max_over_time({service=\"sitbank-security-alerts\", environment=~\"$environment\"} | json | message=\"security_alert_report\" | unwrap database_integrity_security_audit_events_max_id [$__interval])",
-          "legendFormat": "max_id",
-          "refId": "B"
-        }
-      ],
-      "title": "Tracked security_audit_events count and max ID",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "sitbank-loki"
-      },
-      "description": "Shows tracked users count and max ID from the security report. Worry when either value moves backward; check for possible database rewind evidence.",
-      "gridPos": {
-        "h": 6,
-        "w": 8,
-        "x": 16,
-        "y": 12
-      },
-      "id": 10,
-      "targets": [
-        {
-          "expr": "max_over_time({service=\"sitbank-security-alerts\", environment=~\"$environment\"} | json | message=\"security_alert_report\" | unwrap database_integrity_users_count [$__interval])",
-          "legendFormat": "count",
-          "refId": "A"
-        },
-        {
-          "expr": "max_over_time({service=\"sitbank-security-alerts\", environment=~\"$environment\"} | json | message=\"security_alert_report\" | unwrap database_integrity_users_max_id [$__interval])",
-          "legendFormat": "max_id",
-          "refId": "B"
-        }
-      ],
-      "title": "Tracked users count and max ID",
-      "type": "stat"
-    }
-  ],
-  "schemaVersion": 39,
-  "tags": [
-    "sitbank",
-    "security",
-    "operations"
-  ],
-  "templating": {
-    "list": [
+  "spec": {
+    "annotations": [
       {
-        "current": {
-          "selected": true,
-          "text": "production|staging",
-          "value": "production|staging"
-        },
-        "hide": 0,
-        "label": "Environment",
-        "name": "environment",
-        "options": [],
-        "query": "production|staging",
-        "type": "textbox"
+        "kind": "AnnotationQuery",
+        "spec": {
+          "builtIn": true,
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "query": {
+            "datasource": {
+              "name": "-- Grafana --"
+            },
+            "group": "grafana",
+            "kind": "DataQuery",
+            "spec": {},
+            "version": "v0"
+          }
+        }
+      }
+    ],
+    "cursorSync": "Off",
+    "editable": true,
+    "elements": {
+      "panel-1": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "max(\r\n  max_over_time(\r\n    {service=\"sitbank-security-alerts\", environment=~\"$environment\"}\r\n    | json\r\n    | message=\"security_alert_report\"\r\n    | unwrap alert_count [$__range]\r\n  )\r\n) or vector(0)",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Shows active security alerts reported by the scheduled security alert job. Worry when this rises above zero; check the alert type panel and the admin audit viewer next.",
+          "id": 1,
+          "links": [],
+          "title": "Security alert count",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "mappings": [
+                    {
+                      "options": {
+                        "0": {
+                          "index": 0,
+                          "text": "None"
+                        }
+                      },
+                      "type": "value"
+                    },
+                    {
+                      "options": {
+                        "from": 1,
+                        "result": {
+                          "index": 1,
+                          "text": "Alerts"
+                        }
+                      },
+                      "type": "range"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-10": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "max(\r\n  max_over_time(\r\n    {service=\"sitbank-security-alerts\", environment=~\"$environment\"}\r\n    | json\r\n    | message=\"security_alert_report\"\r\n    | unwrap database_integrity_users_count [$__range]\r\n  )\r\n)",
+                        "legendFormat": "users_count",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "max(\r\n  max_over_time(\r\n    {service=\"sitbank-security-alerts\", environment=~\"$environment\"}\r\n    | json\r\n    | message=\"security_alert_report\"\r\n    | unwrap database_integrity_users_max_id [$__range]\r\n  )\r\n)",
+                        "legendFormat": "users_max_id",
+                        "queryType": "instant",
+                        "step": ""
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Shows tracked users count and max ID from the security report. Worry when either value moves backward; check for possible database rewind evidence.",
+          "id": 10,
+          "links": [],
+          "title": "Tracked users count and max ID",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #A",
+                      "scope": "series"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "users_count"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #B",
+                      "scope": "series"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "users_max_id"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-12": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "max(\r\n  max_over_time(\r\n    {service=\"sitbank-security-alerts\", environment=~\"$environment\"}\r\n    | json\r\n    | message=\"security_alert_report\"\r\n    | unwrap database_integrity_security_audit_events_count\r\n    [$__range]\r\n  )\r\n)",
+                        "legendFormat": "count",
+                        "queryType": "range"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "max(\r\n  max_over_time(\r\n    {service=\"sitbank-security-alerts\", environment=~\"$environment\"}\r\n    | json\r\n    | message=\"security_alert_report\"\r\n    | unwrap database_integrity_security_audit_events_max_id\r\n    [$__range]\r\n  )\r\n)",
+                        "legendFormat": "max_id",
+                        "queryType": "range"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Shows tracked security_audit_events count and max ID from the security report. Worry when either value moves backward; check the database integrity runbook.",
+          "id": 12,
+          "links": [],
+          "title": "Tracked security_audit_events count and max ID",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-2": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "max(\r\n  max_over_time(\r\n    {service=\"sitbank-security-alerts\", environment=~\"$environment\"}\r\n    | json\r\n    | message=\"security_alert_report\"\r\n    | unwrap deliverable_alert_count [$__range]\r\n  )\r\n) or vector(0)",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Shows alerts that remain after dedupe and delivery filtering. Worry when deliverable alerts stay nonzero; check webhook configuration and dedupe status next.",
+          "id": 2,
+          "links": [],
+          "title": "Deliverable alert count",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "mappings": [
+                    {
+                      "options": {
+                        "0": {
+                          "index": 0,
+                          "text": "None"
+                        }
+                      },
+                      "type": "value"
+                    },
+                    {
+                      "options": {
+                        "from": 1,
+                        "result": {
+                          "index": 1,
+                          "text": "Deliverable alerts"
+                        }
+                      },
+                      "type": "range"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-3": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "{service=\"sitbank-security-alerts\", environment=~\"$environment\"} | json | message=\"security_alert_report\" | result=\"success\" | line_format \"{{.generated_at}} result={{.result}} alerts={{.alert_count}}\""
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Shows the most recent healthy security alert report. Worry when no success appears in the selected window; check the systemd timer and journal unit next.",
+          "id": 3,
+          "links": [],
+          "title": "Last successful security_alert_report",
+          "vizConfig": {
+            "group": "logs",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "dedupStrategy": "none",
+                "enableInfiniteScrolling": false,
+                "enableLogDetails": true,
+                "prettifyLogMessage": true,
+                "showControls": false,
+                "showFieldSelector": false,
+                "showLabels": true,
+                "showLevel": true,
+                "showTime": false,
+                "sortOrder": "Descending",
+                "timestampResolution": "ms",
+                "unwrappedColumns": false,
+                "wrapLogMessage": false
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-4": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "sum(\r\n  count_over_time(\r\n    {service=\"sitbank-security-alerts\", environment=~\"$environment\"}\r\n    | json\r\n    | message=\"security_alert_report\"\r\n    | audit_chain_valid=\"false\"\r\n    [$__range]\r\n  )\r\n) or vector(0)",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Counts reports where the audit hash chain is invalid. Worry about any nonzero value; check the alert report JSON and audit verification runbook next.",
+          "id": 4,
+          "links": [],
+          "title": "Audit chain validity",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "mappings": [
+                    {
+                      "options": {
+                        "0": {
+                          "index": 0,
+                          "text": "Valid"
+                        }
+                      },
+                      "type": "value"
+                    },
+                    {
+                      "options": {
+                        "from": 1,
+                        "result": {
+                          "index": 1,
+                          "text": "Invalid"
+                        }
+                      },
+                      "type": "range"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-5": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "{service=\"sitbank-security-alerts\", environment=~\"$environment\"} | json | message=\"security_alert_report\" | line_format \"{{.generated_at}} anchor={{.audit_chain_anchor_status}} stale={{.audit_chain_anchor_stale}} refresh_required={{.audit_chain_anchor_refresh_required}}\""
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Lists audit anchor status from the security report. Worry about critical, malformed, mismatch, or unexpected not-configured states; check the anchor file and refresh procedure next.",
+          "id": 5,
+          "links": [],
+          "title": "Audit anchor status",
+          "vizConfig": {
+            "group": "logs",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "dedupStrategy": "none",
+                "enableInfiniteScrolling": false,
+                "enableLogDetails": true,
+                "prettifyLogMessage": true,
+                "showControls": false,
+                "showFieldSelector": false,
+                "showLabels": true,
+                "showLevel": true,
+                "showTime": false,
+                "sortOrder": "Descending",
+                "timestampResolution": "ms",
+                "unwrappedColumns": false,
+                "wrapLogMessage": false
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-6": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "sum(\r\n  count_over_time(\r\n    {service=\"sitbank-security-alerts\", environment=~\"$environment\"}\r\n    | json\r\n    | message=\"security_alert_report\"\r\n    | audit_chain_anchor_refresh_required=\"true\"\r\n    [$__range]\r\n  )\r\n) or vector(0)",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Counts stale anchors or anchor refresh requirements. Worry when the value is nonzero outside expected append-only activity; check the chain before refreshing.",
+          "id": 6,
+          "links": [],
+          "title": "Audit anchor refresh required",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "mappings": [
+                    {
+                      "options": {
+                        "0": {
+                          "index": 0,
+                          "text": "No refresh needed"
+                        }
+                      },
+                      "type": "value"
+                    },
+                    {
+                      "options": {
+                        "from": 1,
+                        "result": {
+                          "index": 1,
+                          "text": "Refresh required"
+                        }
+                      },
+                      "type": "range"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-7": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "max(\r\n  max_over_time(\r\n    {service=\"sitbank-security-alerts\", environment=~\"$environment\"}\r\n    | json\r\n    | message=\"security_alert_report\"\r\n    | unwrap audit_chain_error_count [$__range]\r\n  )\r\n) or vector(0)",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Shows audit chain error counts from the structured report. Worry about any nonzero value; check only sanitized report fields and admin audit context next.",
+          "id": 7,
+          "links": [],
+          "title": "Audit chain error count",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "mappings": [
+                    {
+                      "options": {
+                        "0": {
+                          "index": 0,
+                          "text": "No errors"
+                        }
+                      },
+                      "type": "value"
+                    },
+                    {
+                      "options": {
+                        "from": 1,
+                        "result": {
+                          "index": 1,
+                          "text": "Errors"
+                        }
+                      },
+                      "type": "range"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      },
+      "panel-8": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "sitbank-loki"
+                      },
+                      "group": "loki",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "sum(\r\n  count_over_time(\r\n    {service=\"sitbank-security-alerts\", environment=~\"$environment\"}\r\n    | json\r\n    | message=\"security_alert_report\"\r\n    | database_integrity_valid=\"false\"\r\n    [$__range]\r\n  )\r\n) or vector(0)",
+                        "queryType": "instant"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Counts database integrity report failures. Worry about any nonzero value; check tracked table count and max ID panels before any rebaseline.",
+          "id": 8,
+          "links": [],
+          "title": "Database integrity validity",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "mappings": [
+                    {
+                      "options": {
+                        "0": {
+                          "index": 0,
+                          "text": "Valid"
+                        }
+                      },
+                      "type": "value"
+                    },
+                    {
+                      "options": {
+                        "from": 1,
+                        "result": {
+                          "index": 1,
+                          "text": "Invalid"
+                        }
+                      },
+                      "type": "range"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "#C4162A",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "13.0.2"
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "GridLayout",
+      "spec": {
+        "items": [
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-8"
+              },
+              "height": 7,
+              "width": 12,
+              "x": 0,
+              "y": 0
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-4"
+              },
+              "height": 7,
+              "width": 12,
+              "x": 12,
+              "y": 0
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-10"
+              },
+              "height": 7,
+              "width": 12,
+              "x": 0,
+              "y": 7
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-12"
+              },
+              "height": 7,
+              "width": 12,
+              "x": 12,
+              "y": 7
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-1"
+              },
+              "height": 7,
+              "width": 6,
+              "x": 0,
+              "y": 14
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-2"
+              },
+              "height": 7,
+              "width": 6,
+              "x": 6,
+              "y": 14
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-6"
+              },
+              "height": 7,
+              "width": 6,
+              "x": 12,
+              "y": 14
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-7"
+              },
+              "height": 7,
+              "width": 6,
+              "x": 18,
+              "y": 14
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-3"
+              },
+              "height": 8,
+              "width": 24,
+              "x": 0,
+              "y": 21
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-5"
+              },
+              "height": 8,
+              "width": 24,
+              "x": 0,
+              "y": 29
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preload": false,
+    "tags": [
+      "sitbank",
+      "security",
+      "operations"
+    ],
+    "timeSettings": {
+      "autoRefresh": "",
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "fiscalYearStartMonth": 0,
+      "from": "now-24h",
+      "hideTimepicker": false,
+      "timezone": "browser",
+      "to": "now"
+    },
+    "title": "SITBank Security Operations",
+    "variables": [
+      {
+        "kind": "TextVariable",
+        "spec": {
+          "current": {
+            "text": "production|staging",
+            "value": "production|staging"
+          },
+          "hide": "dontHide",
+          "label": "Environment",
+          "name": "environment",
+          "query": "production|staging",
+          "skipUrlSync": false
+        }
       }
     ]
-  },
-  "time": {
-    "from": "now-24h",
-    "to": "now"
-  },
-  "title": "SITBank Security Operations",
-  "uid": "sitbank-security-operations",
-  "version": 1
+  }
 }

--- a/tests/test_operational_observability_deployment.py
+++ b/tests/test_operational_observability_deployment.py
@@ -15,6 +15,30 @@ OBS_ROOT = Path("ops/observability")
 VERIFIER_PATH = OBS_ROOT / "verify-private-observability"
 PRIVATE_GRAFANA_URL = "https://admin-sitbank.tailca101b.ts.net/grafana"
 FAKE_GRAFANA_TOKEN = "fake-grafana-health-token"
+DASHBOARD_API_VERSION = "dashboard.grafana.app/v2beta1"
+
+
+def _dashboard_spec(resource: dict, expected_name: str) -> dict:
+    assert resource["apiVersion"] == DASHBOARD_API_VERSION
+    assert resource["kind"] == "Dashboard"
+    assert resource["metadata"]["name"] == expected_name
+
+    spec = resource["spec"]
+    elements = spec["elements"]
+    layout_items = spec["layout"]["spec"]["items"]
+    layout_names = [
+        item["spec"]["element"]["name"]
+        for item in layout_items
+        if item["spec"]["element"]["kind"] == "ElementReference"
+    ]
+    assert len(layout_names) == len(set(layout_names))
+    assert set(layout_names) == set(elements)
+    assert all(element["kind"] == "Panel" for element in elements.values())
+    return spec
+
+
+def _dashboard_panels(spec: dict) -> list[dict]:
+    return [element["spec"] for element in spec["elements"].values()]
 
 
 def _read_observability_files() -> str:
@@ -317,9 +341,21 @@ def test_loki_retention_and_grafana_datasource_are_configured_without_credential
         ).read_text(encoding="utf-8")
     )
     dashboard_dir = OBS_ROOT / "grafana" / "dashboards"
-    dashboards = {
+    dashboard_resources = {
         path.name: json.loads(path.read_text(encoding="utf-8"))
         for path in dashboard_dir.glob("*.json")
+    }
+    expected_names = {
+        "sitbank-operational-overview.json": "sitbank-operational-overview",
+        "sitbank-security-operations.json": "sitbank-security-operations",
+        "sitbank-http-health.json": "sitbank-http-health",
+        "sitbank-infrastructure-deployment-health.json": (
+            "sitbank-infrastructure-deployment-health"
+        ),
+    }
+    dashboards = {
+        filename: _dashboard_spec(dashboard_resources[filename], name)
+        for filename, name in expected_names.items()
     }
     dashboard = dashboards["sitbank-operational-overview.json"]
 
@@ -338,23 +374,11 @@ def test_loki_retention_and_grafana_datasource_are_configured_without_credential
     assert prometheus_datasource["url"] == "http://prometheus:9090"
     assert "password" not in str(datasource).casefold()
     assert "token" not in str(datasource).casefold()
-    assert set(dashboards) == {
-        "sitbank-operational-overview.json",
-        "sitbank-security-operations.json",
-        "sitbank-http-health.json",
-        "sitbank-infrastructure-deployment-health.json",
-    }
-    assert {item["uid"] for item in dashboards.values()} == {
-        "sitbank-operational-overview",
-        "sitbank-security-operations",
-        "sitbank-http-health",
-        "sitbank-infrastructure-deployment-health",
-    }
-    assert dashboard["uid"] == "sitbank-operational-overview"
-    assert dashboard["version"] >= 2
+    assert set(dashboard_resources) == set(expected_names)
     assert "Recent operational errors" not in json.dumps(dashboard)
     assert "SecurityAuditEvent" not in json.dumps(dashboard)
-    panel_titles = {panel["title"] for panel in dashboard["panels"]}
+    panels = _dashboard_panels(dashboard)
+    panel_titles = {panel["title"] for panel in panels}
     assert panel_titles >= {
         "Log ingestion by service and source",
         "Nginx 4xx and 5xx trend",
@@ -363,11 +387,11 @@ def test_loki_retention_and_grafana_datasource_are_configured_without_credential
         "Systemd failures for monitored units",
         "Deployment and rollback signals",
     }
-    for panel in dashboard["panels"]:
+    for panel in panels:
         assert panel.get("description")
         assert "Worry" in panel["description"]
         assert "check" in panel["description"].casefold()
-    variables = {entry["name"] for entry in dashboard["templating"]["list"]}
+    variables = {entry["spec"]["name"] for entry in dashboard["variables"]}
     assert variables == {"environment", "service", "source"}
     dashboard_text = json.dumps(dashboard).casefold()
     assert "error_count: 0" in dashboard_text
@@ -380,15 +404,24 @@ def test_loki_retention_and_grafana_datasource_are_configured_without_credential
 
 def test_observability_dashboards_cover_security_http_and_infrastructure_health():
     dashboard_dir = OBS_ROOT / "grafana" / "dashboards"
-    dashboards = {
+    dashboard_resources = {
         path.name: json.loads(path.read_text(encoding="utf-8"))
         for path in dashboard_dir.glob("*.json")
     }
-    security = dashboards["sitbank-security-operations.json"]
-    http = dashboards["sitbank-http-health.json"]
-    infrastructure = dashboards["sitbank-infrastructure-deployment-health.json"]
+    dashboards = {
+        filename: _dashboard_spec(resource, filename.removesuffix(".json"))
+        for filename, resource in dashboard_resources.items()
+    }
+    security = _dashboard_panels(
+        dashboards["sitbank-security-operations.json"]
+    )
+    http = _dashboard_panels(dashboards["sitbank-http-health.json"])
+    infrastructure_dashboard = dashboards[
+        "sitbank-infrastructure-deployment-health.json"
+    ]
+    infrastructure = _dashboard_panels(infrastructure_dashboard)
 
-    assert {panel["title"] for panel in security["panels"]} >= {
+    assert {panel["title"] for panel in security} >= {
         "Security alert count",
         "Deliverable alert count",
         "Last successful security_alert_report",
@@ -400,7 +433,24 @@ def test_observability_dashboards_cover_security_http_and_infrastructure_health(
         "Tracked security_audit_events count and max ID",
         "Tracked users count and max ID",
     }
-    assert {panel["title"] for panel in http["panels"]} >= {
+    tracked_audit_events = next(
+        panel
+        for panel in security
+        if panel["title"] == "Tracked security_audit_events count and max ID"
+    )
+    tracked_queries = {
+        query["spec"]["refId"]: query["spec"]["query"]["spec"]
+        for query in tracked_audit_events["data"]["spec"]["queries"]
+    }
+    assert tracked_queries["A"]["legendFormat"] == "count"
+    assert "database_integrity_security_audit_events_count" in (
+        tracked_queries["A"]["expr"]
+    )
+    assert tracked_queries["B"]["legendFormat"] == "max_id"
+    assert "database_integrity_security_audit_events_max_id" in (
+        tracked_queries["B"]["expr"]
+    )
+    assert {panel["title"] for panel in http} >= {
         "Requests by status class",
         "429 rate-limit responses",
         "403 and 404 responses",
@@ -409,7 +459,7 @@ def test_observability_dashboards_cover_security_http_and_infrastructure_health(
         "Nginx upstream and backend errors",
         "Login register and MFA route volume",
     }
-    assert {panel["title"] for panel in infrastructure["panels"]} >= {
+    assert {panel["title"] for panel in infrastructure} >= {
         "EC2 CPU usage",
         "EC2 memory usage",
         "EC2 disk usage and pressure",
@@ -419,11 +469,31 @@ def test_observability_dashboards_cover_security_http_and_infrastructure_health(
         "Last deployment time and target environment",
         "Production staging deployment guard failures",
     }
-    assert infrastructure["annotations"]["list"][0]["name"] == (
-        "Deployment start completion and rollback signals"
-    )
+    infrastructure_queries = {
+        panel["title"]: panel["data"]["spec"]["queries"][0]["spec"]["query"]["spec"][
+            "expr"
+        ]
+        for panel in infrastructure
+    }
+    restart_query = infrastructure_queries[
+        "Container restart count and recent restart events"
+    ].casefold()
+    for signal in ("restart", "oom", "out of memory", "killed", "unhealthy"):
+        assert signal in restart_query
+    for title in (
+        "Container restart count and recent restart events",
+        "PostgreSQL connectivity storage and connection health",
+        "Last deployment time and target environment",
+        "Production staging deployment guard failures",
+    ):
+        assert "| logfmt" not in infrastructure_queries[title]
+    annotation_names = {
+        annotation["spec"]["name"]
+        for annotation in infrastructure_dashboard["annotations"]
+    }
+    assert "Deployment start completion and rollback signals" in annotation_names
     for dashboard in dashboards.values():
-        for panel in dashboard["panels"]:
+        for panel in _dashboard_panels(dashboard):
             assert panel.get("description")
             assert "Worry" in panel["description"]
             assert "check" in panel["description"].casefold()


### PR DESCRIPTION
Summary
---
Refreshes the four provisioned Grafana dashboards using the v2 resource model and strengthens their deployment validation.

Why
---
The exported dashboard bodies used Grafana's v2 schema but lacked the resource envelope required by file provisioning, which would lose stable dashboard identity. Review also found crossed security audit count/max-ID queries and logfmt-only infrastructure filters that could miss JSON or plain systemd/container signals.

What changed
---

- Wrap each dashboard in a `dashboard.grafana.app/v2beta1` resource with a stable `metadata.name`, refreshed panel definitions, and complete layout references.
- Correct the security audit-events count/max-ID query mapping and keep infrastructure incident queries format-agnostic across JSON, logfmt, and plain logs.
- Update focused regression tests and operational observability documentation for the v2 provisioning contract.

Security impact
---
Private Grafana, Loki, Prometheus, Tailscale, credential, and datasource boundaries are unchanged. Dashboard queries remain limited to sanitized operational fields and regression tests continue rejecting sensitive log fields.

Deployment impact
---
Observability EC2 bootstrap and staging/production observability redeployment are required for affected hosts. No customer/admin application deployment, database migration, secret change, Cloudflare change, or Tailscale change is required.

Verification
---

- `git diff --check`
- `.\.venv\Scripts\python.exe -m pytest -q tests/test_operational_observability_deployment.py` — 41 passed
- `.\.venv\Scripts\python.exe -m pytest -q -n 4` — 1,542 passed, 35 skipped
- `.\.venv\Scripts\python.exe -m pytest -q -n auto --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term --durations=50 --durations-min=0.1` — 1,542 passed, 35 skipped, 91% total coverage

Notes
---
After observability redeployment, verify Grafana provisions all four stable dashboard names and renders the refreshed Loki and Prometheus panels. Live provider validation was not run from this local checkout.