### PR TITLE
Clarify SonarQube credential log output

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -40,7 +40,8 @@ jobs:
             exit 0
           fi
           if [[ -z "${SONAR_TOKEN}" ]]; then
-            echo "::error::SONAR_TOKEN is not configured. Add the SonarQube Cloud analysis token as a GitHub Actions repository or organization secret."
+            annotation_type=error
+            printf '::%s::SONAR_TOKEN is not configured. Add the SonarQube Cloud analysis token as a GitHub Actions repository or organization secret.\n' "${annotation_type}"
             exit 1
           fi
           echo "should_scan=true" >> "${GITHUB_OUTPUT}"

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -531,6 +531,9 @@ Actions secret `SONAR_TOKEN`; it does not use production environments,
 deployment credentials, or `SONAR_HOST_URL`. Scheduled CI runs skip the
 SonarQube job. Coverage retrieval uses the SHA-pinned
 `actions/download-artifact` v8.0.1 Node.js 24 action.
+The token check constructs the GitHub error annotation at runtime so successful
+logs do not show a misleading literal `::error::SONAR_TOKEN...` command; a
+trusted run with no token still fails closed with an error annotation.
 
 The initial SonarQube quality gate is reporting-only and is not a release or
 deployment dependency. After a successful trusted internal pull-request scan,

--- a/docs/security/assurance/sonarqube.md
+++ b/docs/security/assurance/sonarqube.md
@@ -107,6 +107,12 @@ fall back to a legacy owner or project. Scanner evidence is valid only when the
 same run imports both `coverage.xml` and `coverage/lcov.info` for the resolved
 source commit.
 
+The reusable workflow builds the missing-token GitHub error annotation at
+runtime, so successful logs do not display a misleading literal
+`::error::SONAR_TOKEN...` command while showing the checked-in shell script. If
+`SONAR_TOKEN` is actually absent on a trusted run, the job still fails closed
+with a clear GitHub error annotation.
+
 The reviewed main-branch cleartext-protocol finding in
 `ops/container/smoke-test.sh` is an intentional private-only exception: the
 URL and its ZAP baseline sink address only a named container on the isolated

--- a/tests/test_sonarqube_workflow.py
+++ b/tests/test_sonarqube_workflow.py
@@ -150,6 +150,9 @@ def test_sonarqube_workflow_handles_token_without_deployment_secrets():
 
     assert "SONAR_TOKEN" in credential_step["env"]
     assert "is not configured" in credential_step["run"]
+    assert "::error::SONAR_TOKEN" not in text
+    assert "annotation_type=error" in credential_step["run"]
+    assert "printf '::%s::SONAR_TOKEN is not configured" in credential_step["run"]
     assert "fork or Dependabot PRs" in credential_step["run"]
     assert "PR comment are skipped" in credential_step["run"]
     assert "dependabot[bot]" in text


### PR DESCRIPTION
Summary
---
Clarifies the SonarQube credential preflight so successful workflow logs do not display a literal GitHub `::error::SONAR_TOKEN...` annotation command.

Why
---
Issue #469 identified that the successful SonarQube job prints the checked-in shell script, including a literal error annotation command that can look like a CLI failure even when the token is configured and the scan succeeds.

What changed
---
- Builds the missing-token annotation at runtime while preserving fail-closed behavior.
- Adds workflow regression assertions that the literal `::error::SONAR_TOKEN` string is absent from checked-in workflow text.
- Documents the credential-log behavior in GitHub Actions and SonarQube assurance docs.

Security impact
---
Preserves existing SonarQube secret handling and fail-closed behavior for trusted runs. No deployment secrets, permissions, auth, or runtime banking controls changed.

Deployment impact
---
No deployment action required. No EC2 bootstrap, staging deployment, production deployment, database migration, or secret changes are required.

Verification
---
- `git diff --check`
- `.\.venv\Scripts\python.exe -m pytest -q tests/test_sonarqube_workflow.py tests/test_sonarqube_pr_comment_workflow.py tests/test_workflow_display_names.py`
- `.\.venv\Scripts\python.exe -m pytest -q tests/test_github_actions_workflows.py`
- `.\.venv\Scripts\python.exe -m pytest -q -n 4`
- `.\.venv\Scripts\python.exe -m pytest -q -n 4 --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term` (91% total coverage)

Notes
---
Closes #469.