### PR TITLE
Resolve main Sonar findings after PayUp merge

### DIFF
--- a/app/admin/services.py
+++ b/app/admin/services.py
@@ -2328,20 +2328,40 @@ def _admin_action_user_summary(user: User | None, user_id: int | None) -> str:
 def _admin_action_target_summary(request_record: AdminActionRequest) -> str:
     target_type = str(request_record.target_type or "")
     target_id = str(request_record.target_id or "")
-    if target_type in {"staff_user", "customer_user"} and target_id.isdigit():
-        target = db.session.get(User, int(target_id))
-        if target is not None:
-            label = target.username or target.full_name or f"User {target.id}"
-            if target_type == "staff_user":
-                return f"{label} ({role_label(target.account_type)}, {target.email})"
-            return f"{label} (customer)"
-    if target_type == "manual_recovery_request" and target_id.isdigit():
-        request_record_target = db.session.get(ManualRecoveryRequest, int(target_id))
-        if request_record_target is not None:
-            customer = db.session.get(User, request_record_target.user_id) if request_record_target.user_id else None
-            customer_label = f" for {customer.username}" if customer else ""
-            return f"Manual recovery request #{request_record_target.id}{customer_label} ({request_record_target.status})"
+    if target_id.isdigit():
+        summary = _admin_action_known_target_summary(target_type, int(target_id))
+        if summary:
+            return summary
     return _admin_action_target_ref(request_record) or "Unknown target"
+
+
+def _admin_action_known_target_summary(target_type: str, target_id: int) -> str | None:
+    if target_type == "staff_user":
+        return _admin_action_user_target_summary(target_id, include_role=True)
+    if target_type == "customer_user":
+        return _admin_action_user_target_summary(target_id, include_role=False)
+    if target_type == "manual_recovery_request":
+        return _admin_action_manual_recovery_target_summary(target_id)
+    return None
+
+
+def _admin_action_user_target_summary(target_id: int, *, include_role: bool) -> str | None:
+    target = db.session.get(User, target_id)
+    if target is None:
+        return None
+    label = target.username or target.full_name or f"User {target.id}"
+    if include_role:
+        return f"{label} ({role_label(target.account_type)}, {target.email})"
+    return f"{label} (customer)"
+
+
+def _admin_action_manual_recovery_target_summary(target_id: int) -> str | None:
+    request_record_target = db.session.get(ManualRecoveryRequest, target_id)
+    if request_record_target is None:
+        return None
+    customer = db.session.get(User, request_record_target.user_id) if request_record_target.user_id else None
+    customer_label = f" for {customer.username}" if customer else ""
+    return f"Manual recovery request #{request_record_target.id}{customer_label} ({request_record_target.status})"
 
 
 def _create_admin_action_request(

--- a/app/auth/forms.py
+++ b/app/auth/forms.py
@@ -14,6 +14,8 @@ _PASSWORDS_MUST_MATCH_MESSAGE = "Passwords do not match. Please re-enter your pa
 _AUTHENTICATOR_CODE_LABEL = "Authenticator code"
 _MFA_CODE_ERROR = "MFA code must be exactly 6 digits"
 _VERIFICATION_CODE_ERROR = "Verification code must be exactly 6 digits"
+_PHONE_NUMBER_LABEL = "Phone number"
+_PHONE_NUMBER_ERROR = "Enter a valid Singapore phone number (8 digits starting with 8 or 9)"
 
 
 def password_length(*, minimum: int | None = None):
@@ -47,10 +49,10 @@ class RegisterForm(FlaskForm):
         ],
     )
     phone_number = StringField(
-        "Phone number",
+        _PHONE_NUMBER_LABEL,
         validators=[
             InputRequired(),
-            Regexp(PHONE_RE, message="Enter a valid Singapore phone number (8 digits starting with 8 or 9)"),
+            Regexp(PHONE_RE, message=_PHONE_NUMBER_ERROR),
         ],
     )
     email = StringField("Email", validators=[InputRequired(), Email(), Length(max=255)])
@@ -83,10 +85,10 @@ class RegisterDetailsForm(FlaskForm):
         ],
     )
     phone_number = StringField(
-        "Phone number",
+        _PHONE_NUMBER_LABEL,
         validators=[
             InputRequired(),
-            Regexp(PHONE_RE, message="Enter a valid Singapore phone number (8 digits starting with 8 or 9)"),
+            Regexp(PHONE_RE, message=_PHONE_NUMBER_ERROR),
         ],
     )
     password = PasswordField("Password", validators=[InputRequired(), password_length()])
@@ -149,10 +151,10 @@ class ProfileForm(FlaskForm):
     )
     email = StringField("Email address", validators=[InputRequired(), Email(), Length(max=255)])
     phone_number = StringField(
-        "Phone number",
+        _PHONE_NUMBER_LABEL,
         validators=[
             InputRequired(),
-            Regexp(PHONE_RE, message="Enter a valid Singapore phone number (8 digits starting with 8 or 9)"),
+            Regexp(PHONE_RE, message=_PHONE_NUMBER_ERROR),
         ],
     )
     email_verification_code = StringField(

--- a/app/auth/services.py
+++ b/app/auth/services.py
@@ -31,7 +31,7 @@ from app.auth.mfa_policy import (
     PASSWORD_BOOTSTRAP_AUTH_CONTEXT,
     has_enrolled_mfa_method,
 )
-from app.security.audit import AuditWriteError, audit_event, audit_event_required, audit_reference, principal_reference
+from app.security.audit import audit_event, audit_event_required, audit_reference, principal_reference
 from app.security.crypto import decrypt_mfa_secret, encrypt_mfa_secret
 from app.security.email import send_security_email
 from app.security.identity_policy import (
@@ -107,6 +107,7 @@ PROFILE_EMAIL_PENDING_USERNAME_KEY = "profile_email_pending_username"
 PROFILE_EMAIL_PENDING_PHONE_HMAC_KEY = "profile_email_pending_phone_hmac"
 PROFILE_EMAIL_PENDING_CODE_HMAC_KEY = "profile_email_pending_code_hmac"
 PROFILE_EMAIL_PENDING_EXPIRES_AT_KEY = "profile_email_pending_expires_at"
+PROFILE_EMAIL_CHANGE_EXPIRED_MESSAGE = "Email verification expired. Request a new code."
 REGISTRATION_WELCOME_CREDIT_AMOUNT = Decimal("100.00")
 
 
@@ -288,7 +289,7 @@ def register_user(data: dict[str, Any]) -> tuple[User, list[str]]:
         db.session.rollback()
         audit_event("registration", "failure", metadata={"reason": "integrity_error"})
         raise AuthError("Registration could not be completed with those details", 400) from exc
-    except (AuditWriteError, RuntimeError) as exc:
+    except RuntimeError as exc:
         db.session.rollback()
         current_app.logger.warning("registration_welcome_credit_failed error=%s", type(exc).__name__)
         audit_event("registration", "failure", metadata={"reason": "welcome_credit_unavailable"})
@@ -865,7 +866,7 @@ def _profile_update_values(user: User, username: str, email: str, phone_number: 
     username_lookup = _normalize(normalized_username)
     submitted_email = email.strip().lower()
     normalized_phone = str(phone_number or "").strip()
-    if re.fullmatch(r"[89][0-9]{7}", normalized_phone) is None:
+    if re.fullmatch(r"[89]\d{7}", normalized_phone) is None:
         audit_event("profile_update", "blocked", user=user, metadata={"reason": "invalid_phone"})
         raise AuthError(PROFILE_UPDATE_ERROR, 400)
 
@@ -928,19 +929,19 @@ def _validate_profile_email_change_code(
         _reject_profile_email_change(
             user,
             reason="missing_or_expired_challenge",
-            message="Email verification expired. Request a new code.",
+            message=PROFILE_EMAIL_CHANGE_EXPIRED_MESSAGE,
         )
     if pending_change["email"] != normalized_email:
         _reject_profile_email_change(
             user,
             reason="superseded_challenge",
-            message="Email verification expired. Request a new code.",
+            message=PROFILE_EMAIL_CHANGE_EXPIRED_MESSAGE,
         )
     if pending_change["phone_hmac"] != _profile_phone_hmac(user, normalized_phone):
         _reject_profile_email_change(
             user,
             reason="superseded_challenge",
-            message="Email verification expired. Request a new code.",
+            message=PROFILE_EMAIL_CHANGE_EXPIRED_MESSAGE,
         )
     expected_hmac = str(pending_change["code_hmac"])
     submitted_hmac = _profile_email_code_hmac(


### PR DESCRIPTION
Summary
---
Resolves the six open Sonar findings reported on `main` after PR #480 merged.

Why
---
The quality gate passed, but Sonar still reported maintainability issues in the newly merged PayUp/profile/admin readability changes. Keeping the open issue count at zero avoids leaving cleanup debt on `main`.

What changed
---
- Split admin action target summary formatting into smaller helpers to reduce cognitive complexity.
- Centralized repeated phone field label and Singapore phone validation message constants.
- Centralized the repeated profile email-change expiry message.
- Simplified the welcome-credit exception catch and changed the profile phone regex to concise digit syntax.

Security impact
---
No security controls are weakened. The registration welcome-credit rollback behavior still catches `RuntimeError`, including audit write failures, and the phone validation pattern remains equivalent.

Deployment impact
---
No deployment action required beyond the normal application rollout. No database migration, EC2 bootstrap, or secret changes required.

Verification
---
- `git diff --check`
- `.\.venv\Scripts\python.exe -m pytest -q tests/test_admin_maker_checker.py tests/test_auth_registration_login.py tests/test_account_security_actions.py tests/test_transaction_integrity.py` (139 passed)
- `.\.venv\Scripts\python.exe -m pytest -q -n 4` (1620 passed, 36 skipped, 4 existing SQLite reflection warnings)
- `.\.venv\Scripts\python.exe -m pytest -q -n auto --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term --durations=50 --durations-min=0.1` (1620 passed, 36 skipped, 4 existing SQLite reflection warnings, TOTAL 90%)

Notes
---
Follow-up to #480. No follow-up required if Sonar confirms the six findings are resolved.