### PR TITLE
Align admin and staff console design with the customer site

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -2137,12 +2137,6 @@ th {
   gap: var(--space-6);
 }
 
-.admin-identity-card {
-  background:
-    linear-gradient(135deg, rgba(76, 29, 149, 0.96), rgba(109, 40, 217, 0.92)),
-    var(--surface-strong);
-}
-
 .admin-summary-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -2186,26 +2180,35 @@ th {
 
 .admin-table-wrap {
   overflow-x: auto;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
 }
 
 .admin-table {
   width: 100%;
-  border-collapse: collapse;
   min-width: 760px;
+  border-collapse: collapse;
+  background: var(--surface);
 }
 
 .admin-table th,
 .admin-table td {
   border-bottom: 1px solid var(--line);
-  padding: var(--space-3);
+  padding: var(--space-4);
   text-align: left;
   vertical-align: top;
 }
 
+.admin-table tr:last-child td {
+  border-bottom: 0;
+}
+
 .admin-table th {
-  color: var(--muted);
+  background: var(--surface-strong);
+  color: var(--muted-strong);
   font-size: 0.78rem;
   font-weight: 800;
+  letter-spacing: 0;
   text-transform: uppercase;
 }
 

--- a/app/templates/admin/action_requests.html
+++ b/app/templates/admin/action_requests.html
@@ -3,112 +3,153 @@
 {% block title %}Admin approvals - SITBank Admin{% endblock %}
 
 {% block content %}
-<section class="dashboard-section" aria-labelledby="admin-action-requests-heading">
-  <div class="section-heading">
-    <h1 id="admin-action-requests-heading">Admin approvals</h1>
+<section class="dashboard admin-dashboard">
+  <div class="dashboard-header">
+    <div class="page-heading">
+      <p class="eyebrow">Maker-checker</p>
+      <h1 id="admin-action-requests-heading">Admin approvals</h1>
+      <p class="muted">Approve, reject, or cancel pending high-risk admin action requests.</p>
+    </div>
   </div>
-  <div class="table-wrap">
-    <table>
-      <thead>
-        <tr>
-          <th scope="col">Request</th>
-          <th scope="col">Operation</th>
-          <th scope="col">Requester</th>
-          <th scope="col">Target</th>
-          <th scope="col">Status</th>
-          <th scope="col">Expires</th>
-          <th scope="col">Action</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for item in requests %}
-        <tr>
-          <td>#{{ item.id }}</td>
-          <td>{{ item.operation_label }}</td>
-          <td>{{ item.requester_summary }}</td>
-          <td>{{ item.target_summary }}</td>
-          <td>{{ item.status }}</td>
-          <td>{{ item.expires_at_display or "n/a" }}</td>
-          <td><a class="button secondary small" href="{{ url_for('admin.admin_action_request_detail', request_id=item.id) }}">Review</a></td>
-        </tr>
-        {% else %}
-        <tr>
-          <td colspan="7">No admin approval requests.</td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
-</section>
 
-{% if selected_request %}
-<section class="dashboard-section" aria-labelledby="admin-action-request-detail-heading">
-  <div class="section-heading">
-    <h2 id="admin-action-request-detail-heading">Request #{{ selected_request.id }}</h2>
-  </div>
-  <dl class="detail-list">
-    <dt>Operation</dt>
-    <dd>{{ selected_request.operation_label }}</dd>
-    <dt>Target</dt>
-    <dd>{{ selected_request.target_summary }}</dd>
-    <dt>Requester</dt>
-    <dd>{{ selected_request.requester_summary }}</dd>
-    <dt>Approver</dt>
-    <dd>{{ selected_request.approver_summary or "not decided" }}</dd>
-    <dt>Status</dt>
-    <dd>{{ selected_request.status }}</dd>
-    <dt>Created</dt>
-    <dd>{{ selected_request.created_at_display or "n/a" }}</dd>
-    <dt>Expires</dt>
-    <dd>{{ selected_request.expires_at_display or "n/a" }}</dd>
-    <dt>Reason metadata</dt>
-    <dd>{% if selected_request.reason_present %}present, {{ selected_request.reason_length }} characters{% else %}not provided{% endif %}</dd>
-  </dl>
-  <details>
-    <summary>Technical details</summary>
+  <section class="panel" aria-labelledby="admin-action-requests-heading">
+    <div class="admin-table-wrap">
+      <table class="admin-table">
+        <thead>
+          <tr>
+            <th scope="col">Request</th>
+            <th scope="col">Operation</th>
+            <th scope="col">Requester</th>
+            <th scope="col">Target</th>
+            <th scope="col">Status</th>
+            <th scope="col">Expires</th>
+            <th scope="col">Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for item in requests %}
+          <tr>
+            <td>#{{ item.id }}</td>
+            <td>{{ item.operation_label }}</td>
+            <td>{{ item.requester_summary }}</td>
+            <td>{{ item.target_summary }}</td>
+            <td>{{ item.status }}</td>
+            <td>{{ item.expires_at_display or "n/a" }}</td>
+            <td><a class="button secondary small" href="{{ url_for('admin.admin_action_request_detail', request_id=item.id) }}">Review</a></td>
+          </tr>
+          {% else %}
+          <tr>
+            <td colspan="7">No admin approval requests.</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  {% if selected_request %}
+  <section class="panel" aria-labelledby="admin-action-request-detail-heading">
+    <div class="section-header">
+      <h2 id="admin-action-request-detail-heading">Request #{{ selected_request.id }}</h2>
+    </div>
     <dl class="detail-list">
-      <dt>Operation type</dt>
-      <dd>{{ selected_request.operation_type }}</dd>
-      <dt>Target reference</dt>
-      <dd>{{ selected_request.target_ref or "unavailable" }}</dd>
-      <dt>Requester reference</dt>
-      <dd>{{ selected_request.requester_ref or "unavailable" }}</dd>
-      <dt>Approver reference</dt>
-      <dd>{{ selected_request.approver_ref or "not decided" }}</dd>
-      <dt>Created UTC</dt>
-      <dd>{{ selected_request.created_at or "n/a" }}</dd>
-      <dt>Expires UTC</dt>
-      <dd>{{ selected_request.expires_at or "n/a" }}</dd>
-      <dt>Decided UTC</dt>
-      <dd>{{ selected_request.decided_at or "not decided" }}</dd>
-      <dt>Executed UTC</dt>
-      <dd>{{ selected_request.executed_at or "not executed" }}</dd>
-      <dt>Payload</dt>
-      <dd><code>{{ selected_request.payload }}</code></dd>
+      <div>
+        <dt>Operation</dt>
+        <dd>{{ selected_request.operation_label }}</dd>
+      </div>
+      <div>
+        <dt>Target</dt>
+        <dd>{{ selected_request.target_summary }}</dd>
+      </div>
+      <div>
+        <dt>Requester</dt>
+        <dd>{{ selected_request.requester_summary }}</dd>
+      </div>
+      <div>
+        <dt>Approver</dt>
+        <dd>{{ selected_request.approver_summary or "not decided" }}</dd>
+      </div>
+      <div>
+        <dt>Status</dt>
+        <dd>{{ selected_request.status }}</dd>
+      </div>
+      <div>
+        <dt>Created</dt>
+        <dd>{{ selected_request.created_at_display or "n/a" }}</dd>
+      </div>
+      <div>
+        <dt>Expires</dt>
+        <dd>{{ selected_request.expires_at_display or "n/a" }}</dd>
+      </div>
+      <div>
+        <dt>Reason metadata</dt>
+        <dd>{% if selected_request.reason_present %}present, {{ selected_request.reason_length }} characters{% else %}not provided{% endif %}</dd>
+      </div>
     </dl>
-  </details>
-  {% if selected_request.status == "pending" %}
-  <div class="action-grid">
-    <form method="post" action="{{ url_for('admin.admin_action_request_approve', request_id=selected_request.id) }}">
-      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-      <label for="approve-totp-code">Authenticator code</label>
-      <input id="approve-totp-code" name="totp_code" inputmode="numeric" autocomplete="one-time-code" pattern="[0-9]{6}" maxlength="6" required>
-      <button class="button" type="submit">Approve</button>
-    </form>
-    <form method="post" action="{{ url_for('admin.admin_action_request_reject', request_id=selected_request.id) }}">
-      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-      <label for="reject-totp-code">Authenticator code</label>
-      <input id="reject-totp-code" name="totp_code" inputmode="numeric" autocomplete="one-time-code" pattern="[0-9]{6}" maxlength="6" required>
-      <button class="button secondary" type="submit">Reject</button>
-    </form>
-    <form method="post" action="{{ url_for('admin.admin_action_request_cancel', request_id=selected_request.id) }}">
-      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-      <label for="cancel-totp-code">Authenticator code</label>
-      <input id="cancel-totp-code" name="totp_code" inputmode="numeric" autocomplete="one-time-code" pattern="[0-9]{6}" maxlength="6" required>
-      <button class="button secondary" type="submit">Cancel</button>
-    </form>
-  </div>
+    <details>
+      <summary>Technical details</summary>
+      <dl class="detail-list">
+        <div>
+          <dt>Operation type</dt>
+          <dd>{{ selected_request.operation_type }}</dd>
+        </div>
+        <div>
+          <dt>Target reference</dt>
+          <dd>{{ selected_request.target_ref or "unavailable" }}</dd>
+        </div>
+        <div>
+          <dt>Requester reference</dt>
+          <dd>{{ selected_request.requester_ref or "unavailable" }}</dd>
+        </div>
+        <div>
+          <dt>Approver reference</dt>
+          <dd>{{ selected_request.approver_ref or "not decided" }}</dd>
+        </div>
+        <div>
+          <dt>Created UTC</dt>
+          <dd>{{ selected_request.created_at or "n/a" }}</dd>
+        </div>
+        <div>
+          <dt>Expires UTC</dt>
+          <dd>{{ selected_request.expires_at or "n/a" }}</dd>
+        </div>
+        <div>
+          <dt>Decided UTC</dt>
+          <dd>{{ selected_request.decided_at or "not decided" }}</dd>
+        </div>
+        <div>
+          <dt>Executed UTC</dt>
+          <dd>{{ selected_request.executed_at or "not executed" }}</dd>
+        </div>
+        <div>
+          <dt>Payload</dt>
+          <dd><code>{{ selected_request.payload }}</code></dd>
+        </div>
+      </dl>
+    </details>
+    {% if selected_request.status == "pending" %}
+    <div class="action-grid">
+      <form method="post" action="{{ url_for('admin.admin_action_request_approve', request_id=selected_request.id) }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <label for="approve-totp-code">Authenticator code</label>
+        <input id="approve-totp-code" name="totp_code" inputmode="numeric" autocomplete="one-time-code" pattern="[0-9]{6}" maxlength="6" required>
+        <button class="button" type="submit">Approve</button>
+      </form>
+      <form method="post" action="{{ url_for('admin.admin_action_request_reject', request_id=selected_request.id) }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <label for="reject-totp-code">Authenticator code</label>
+        <input id="reject-totp-code" name="totp_code" inputmode="numeric" autocomplete="one-time-code" pattern="[0-9]{6}" maxlength="6" required>
+        <button class="button secondary" type="submit">Reject</button>
+      </form>
+      <form method="post" action="{{ url_for('admin.admin_action_request_cancel', request_id=selected_request.id) }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <label for="cancel-totp-code">Authenticator code</label>
+        <input id="cancel-totp-code" name="totp_code" inputmode="numeric" autocomplete="one-time-code" pattern="[0-9]{6}" maxlength="6" required>
+        <button class="button secondary" type="submit">Cancel</button>
+      </form>
+    </div>
+    {% endif %}
+  </section>
   {% endif %}
 </section>
-{% endif %}
 {% endblock %}

--- a/app/templates/admin/alerts.html
+++ b/app/templates/admin/alerts.html
@@ -4,8 +4,12 @@
 
 {% block content %}
 <section class="dashboard admin-dashboard">
-  <div class="section-header">
-    <h1>Security Alerts</h1>
+  <div class="dashboard-header">
+    <div class="page-heading">
+      <p class="eyebrow">Security monitoring</p>
+      <h1>Security Alerts</h1>
+      <p class="muted">Review active alert findings and confirm audit chain and database integrity.</p>
+    </div>
   </div>
   <section class="panel">
     <dl class="admin-metadata-grid">

--- a/app/templates/admin/audit_log_detail.html
+++ b/app/templates/admin/audit_log_detail.html
@@ -4,9 +4,15 @@
 
 {% block content %}
 <section class="dashboard admin-dashboard">
-  <div class="section-header">
-    <h1>Audit Event {{ event.id }}</h1>
-    <a class="button secondary" href="{{ url_for('admin.audit_logs') }}">Back</a>
+  <div class="dashboard-header">
+    <div class="page-heading">
+      <p class="eyebrow">Audit event</p>
+      <h1>Audit Event {{ event.id }}</h1>
+      <p class="muted">Full investigation detail for a single recorded security event.</p>
+    </div>
+    <div class="button-row">
+      <a class="button secondary" href="{{ url_for('admin.audit_logs') }}">Back to audit logs</a>
+    </div>
   </div>
   <section class="panel" aria-labelledby="audit-investigation-summary-heading">
     <div class="section-header">

--- a/app/templates/admin/audit_logs.html
+++ b/app/templates/admin/audit_logs.html
@@ -4,8 +4,12 @@
 
 {% block content %}
 <section class="dashboard admin-dashboard">
-  <div class="section-header">
-    <h1>Audit Logs</h1>
+  <div class="dashboard-header">
+    <div class="page-heading">
+      <p class="eyebrow">Security review</p>
+      <h1>Audit Logs</h1>
+      <p class="muted">Search and filter every recorded security event across customer, staff, and admin activity.</p>
+    </div>
   </div>
   <section class="panel">
     {% set advanced_open = filters.event_type or filters.actor or filters.target or filters.severity or filters.outcome or filters.role or filters.request_id or filters.ip_address or filters.from or filters.to or sort != "timestamp" or direction != "desc" or page != 1 %}

--- a/app/templates/admin/base.html
+++ b/app/templates/admin/base.html
@@ -5,26 +5,65 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}SITBank Admin{% endblock %}</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
-    <script src="{{ url_for('static', filename='js/theme.js') }}" defer></script>
     {% if g.current_user %}
     <meta name="csrf-token" content="{{ csrf_token() }}">
     {% endif %}
   </head>
   <body class="admin-shell">
     <svg class="icon-sprite" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg">
-      <symbol id="icon-theme-sun" viewBox="0 0 24 24">
-        <circle cx="12" cy="12" r="4"></circle>
-        <path d="M12 2v2"></path>
-        <path d="M12 20v2"></path>
-        <path d="m4.93 4.93 1.41 1.41"></path>
-        <path d="m17.66 17.66 1.41 1.41"></path>
-        <path d="M2 12h2"></path>
-        <path d="M20 12h2"></path>
-        <path d="m6.34 17.66-1.41 1.41"></path>
-        <path d="m19.07 4.93-1.41 1.41"></path>
+      <symbol id="icon-controls" viewBox="0 0 24 24">
+        <path d="M4 6h9"></path>
+        <path d="M17 6h3"></path>
+        <circle cx="15" cy="6" r="2"></circle>
+        <path d="M4 12h3"></path>
+        <path d="M11 12h9"></path>
+        <circle cx="9" cy="12" r="2"></circle>
+        <path d="M4 18h11"></path>
+        <path d="M19 18h1"></path>
+        <circle cx="17" cy="18" r="2"></circle>
       </symbol>
-      <symbol id="icon-theme-moon" viewBox="0 0 24 24">
-        <path d="M21 12.8A8.5 8.5 0 1 1 11.2 3a6.8 6.8 0 0 0 9.8 9.8Z"></path>
+      <symbol id="icon-alert" viewBox="0 0 24 24">
+        <path d="m12 3 10 18H2L12 3Z"></path>
+        <path d="M12 9v5"></path>
+        <path d="M12 17h.01"></path>
+      </symbol>
+      <symbol id="icon-reference" viewBox="0 0 24 24">
+        <path d="M10 13a5 5 0 0 0 7.1 0l2-2a5 5 0 0 0-7.1-7.1l-1.1 1.1"></path>
+        <path d="M14 11a5 5 0 0 0-7.1 0l-2 2a5 5 0 0 0 7.1 7.1l1.1-1.1"></path>
+      </symbol>
+      <symbol id="icon-user" viewBox="0 0 24 24">
+        <circle cx="12" cy="8" r="4"></circle>
+        <path d="M4.5 21a7.5 7.5 0 0 1 15 0"></path>
+      </symbol>
+      <symbol id="icon-education" viewBox="0 0 24 24">
+        <path d="M4 5.5A2.5 2.5 0 0 1 6.5 3H20v17H6.5A2.5 2.5 0 0 1 4 17.5Z"></path>
+        <path d="M4 17.5A2.5 2.5 0 0 0 6.5 20"></path>
+        <path d="M8 7h8"></path>
+        <path d="M8 11h6"></path>
+      </symbol>
+      <symbol id="icon-refresh" viewBox="0 0 24 24">
+        <path d="M4 12a8 8 0 0 1 13.7-5.7"></path>
+        <path d="M18 3v5h-5"></path>
+        <path d="M20 12a8 8 0 0 1-13.7 5.7"></path>
+        <path d="M6 21v-5h5"></path>
+      </symbol>
+      <symbol id="icon-lock" viewBox="0 0 24 24">
+        <rect x="5" y="11" width="14" height="10" rx="2"></rect>
+        <path d="M8 11V8a4 4 0 0 1 8 0v3"></path>
+        <path d="M12 15v2"></path>
+      </symbol>
+      <symbol id="icon-check-circle" viewBox="0 0 24 24">
+        <circle cx="12" cy="12" r="9"></circle>
+        <path d="m8.5 12.5 2.5 2.5 5.5-6"></path>
+      </symbol>
+      <symbol id="icon-info" viewBox="0 0 24 24">
+        <circle cx="12" cy="12" r="9"></circle>
+        <path d="M12 11v5"></path>
+        <path d="M12 8h.01"></path>
+      </symbol>
+      <symbol id="icon-mail" viewBox="0 0 24 24">
+        <rect x="3" y="5" width="18" height="14" rx="2"></rect>
+        <path d="m4 7 8 6 8-6"></path>
       </symbol>
     </svg>
     <a class="skip-link" href="#main-content">Skip to main content</a>
@@ -44,12 +83,6 @@
             {% endfor %}
           </div>
           <div class="nav-actions">
-            <button class="theme-toggle icon-button" type="button" data-theme-toggle aria-pressed="false" aria-label="Switch to dark mode" title="Switch to dark mode">
-              <span class="theme-icon" aria-hidden="true" data-theme-toggle-icon>
-                <svg class="icon" focusable="false"><use href="#icon-theme-moon"></use></svg>
-              </span>
-              <span class="sr-only" data-theme-toggle-label>Switch to dark mode</span>
-            </button>
             {% if g.current_user %}
             <form class="admin-logout-form" method="post" action="{{ url_for('admin.logout') }}">
               <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">

--- a/app/templates/admin/customer_security_locks.html
+++ b/app/templates/admin/customer_security_locks.html
@@ -3,54 +3,58 @@
 {% block title %}Customer security locks - SITBank Admin{% endblock %}
 
 {% block content %}
-<section class="dashboard-section" aria-labelledby="customer-security-locks-heading">
-  <div class="section-heading">
-    <div>
+<section class="dashboard admin-dashboard">
+  <div class="dashboard-header">
+    <div class="page-heading">
+      <p class="eyebrow">Account security</p>
       <h1 id="customer-security-locks-heading">Customer security locks</h1>
       <p class="muted">Only automatic password or authenticator lockouts are shown. A different root admin must approve every unlock.</p>
     </div>
   </div>
-  <div class="table-wrap">
-    <table>
-      <thead>
-        <tr>
-          <th scope="col">Customer</th>
-          <th scope="col">Reference</th>
-          <th scope="col">Automatic lock</th>
-          <th scope="col">Locked at</th>
-          <th scope="col">Request unlock</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for customer in customers %}
-        <tr>
-          <td>{{ customer.username }}</td>
-          <td>
-            <details>
-              <summary>Technical details</summary>
-              <code>{{ customer.customer_ref }}</code>
-            </details>
-          </td>
-          <td>{{ customer.lock_reason|replace("_", " ") }}</td>
-          <td><time datetime="{{ customer.locked_at }}">{{ customer.locked_at_display }}</time></td>
-          <td>
-            <form method="post" action="{{ url_for('admin.customer_security_unlock_request', user_id=customer.id) }}">
-              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-              <label for="reason-{{ customer.id }}">Reviewed support reason</label>
-              <input id="reason-{{ customer.id }}" name="reason" type="text" maxlength="512" required>
-              <label for="totp-{{ customer.id }}">Authenticator code</label>
-              <input id="totp-{{ customer.id }}" name="totp_code" inputmode="numeric" autocomplete="one-time-code" pattern="[0-9]{6}" maxlength="6" required>
-              <button class="button small" type="submit">Request unlock</button>
-            </form>
-          </td>
-        </tr>
-        {% else %}
-        <tr>
-          <td colspan="5">No eligible automatic customer lockouts.</td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
+
+  <section class="panel" aria-labelledby="customer-security-locks-heading">
+    <div class="admin-table-wrap">
+      <table class="admin-table">
+        <thead>
+          <tr>
+            <th scope="col">Customer</th>
+            <th scope="col">Reference</th>
+            <th scope="col">Automatic lock</th>
+            <th scope="col">Locked at</th>
+            <th scope="col">Request unlock</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for customer in customers %}
+          <tr>
+            <td>{{ customer.username }}</td>
+            <td>
+              <details>
+                <summary>Technical details</summary>
+                <code>{{ customer.customer_ref }}</code>
+              </details>
+            </td>
+            <td>{{ customer.lock_reason|replace("_", " ") }}</td>
+            <td><time datetime="{{ customer.locked_at }}">{{ customer.locked_at_display }}</time></td>
+            <td>
+              <form method="post" action="{{ url_for('admin.customer_security_unlock_request', user_id=customer.id) }}">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <label for="reason-{{ customer.id }}">Reviewed support reason</label>
+                <input id="reason-{{ customer.id }}" name="reason" type="text" maxlength="512" required>
+                <label for="totp-{{ customer.id }}">Authenticator code</label>
+                <input id="totp-{{ customer.id }}" name="totp_code" inputmode="numeric" autocomplete="one-time-code" pattern="[0-9]{6}" maxlength="6" required>
+                <button class="button small" type="submit">Request unlock</button>
+              </form>
+            </td>
+          </tr>
+          {% else %}
+          <tr>
+            <td colspan="5">No eligible automatic customer lockouts.</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
 </section>
 {% endblock %}

--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -55,9 +55,24 @@
     <div class="section-header">
       <h2>Allowed Operations</h2>
     </div>
+    {% set nav_icons = {
+      "Dashboard": "icon-controls",
+      "Business operations": "icon-info",
+      "Disputes": "icon-reference",
+      "Audit logs": "icon-education",
+      "Alerts": "icon-alert",
+      "Staff/admin users": "icon-user",
+      "Staff invites": "icon-mail",
+      "Manual recovery": "icon-refresh",
+      "Customer locks": "icon-lock",
+      "Approvals": "icon-check-circle",
+    } %}
     <div class="bank-quick-grid admin-nav-grid">
       {% for item in navigation %}
       <a class="bank-quick-btn" href="{{ item.href }}">
+        <span class="bank-quick-icon" aria-hidden="true">
+          <svg class="icon" focusable="false"><use href="#{{ nav_icons.get(item.label, 'icon-controls') }}"></use></svg>
+        </span>
         <span>{{ item.label }}</span>
         <span class="badge neutral">{{ item.group }}</span>
       </a>

--- a/app/templates/admin/disputes.html
+++ b/app/templates/admin/disputes.html
@@ -3,94 +3,117 @@
 {% block title %}Transaction disputes - SITBank Admin{% endblock %}
 
 {% block content %}
-<section class="dashboard-section" aria-labelledby="disputes-heading">
-  <div class="section-heading">
-    <h1 id="disputes-heading">Transaction disputes</h1>
+<section class="dashboard admin-dashboard">
+  <div class="dashboard-header">
+    <div class="page-heading">
+      <p class="eyebrow">Dispute review</p>
+      <h1 id="disputes-heading">Transaction disputes</h1>
+      <p class="muted">Review customer-reported transaction disputes and update their status.</p>
+    </div>
   </div>
-  <div class="table-wrap">
-    <table>
-      <thead>
-        <tr>
-          <th scope="col">Dispute</th>
-          <th scope="col">Transaction</th>
-          <th scope="col">Reporter</th>
-          <th scope="col">Issue type</th>
-          <th scope="col">Status</th>
-          <th scope="col">Filed</th>
-          <th scope="col">Action</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for item in disputes %}
-        <tr>
-          <td>#{{ item.id }}</td>
-          <td>{{ item.transaction_ref or "unavailable" }}</td>
-          <td>{{ item.reporter_username or item.reporter_ref or "unavailable" }}</td>
-          <td>{{ item.issue_type }}</td>
-          <td>{{ item.status }}</td>
-          <td><time datetime="{{ item.created_at or '' }}">{{ item.created_at_display or "n/a" }}</time></td>
-          <td><a class="button secondary small" href="{{ url_for('admin.dispute_detail', dispute_id=item.id) }}">Review</a></td>
-        </tr>
-        {% else %}
-        <tr>
-          <td colspan="7">No transaction disputes.</td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
-</section>
 
-{% if selected_dispute %}
-<section class="dashboard-section" aria-labelledby="dispute-detail-heading">
-  <div class="section-heading">
-    <h2 id="dispute-detail-heading">Dispute #{{ selected_dispute.id }}</h2>
-  </div>
-  <dl class="detail-list">
-    <dt>Transaction</dt>
-    <dd>{{ selected_dispute.transaction_ref or "unavailable" }}</dd>
-    <dt>Reporter</dt>
-    <dd>{{ selected_dispute.reporter_username or selected_dispute.reporter_ref or "unavailable" }}</dd>
-    <dt>Issue type</dt>
-    <dd>{{ selected_dispute.issue_type }}</dd>
-    <dt>Reason</dt>
-    <dd>{{ selected_dispute.reason }}</dd>
-    <dt>Status</dt>
-    <dd>{{ selected_dispute.status }}</dd>
-    <dt>Filed</dt>
-    <dd><time datetime="{{ selected_dispute.created_at or '' }}">{{ selected_dispute.created_at_display or "n/a" }}</time></dd>
-    <dt>Decided</dt>
-    <dd>{{ selected_dispute.decided_at_display or "not decided" }}</dd>
-    <dt>Resolution note</dt>
-    <dd>{{ selected_dispute.resolution_note or "not provided" }}</dd>
-  </dl>
-  {% if selected_dispute.status in ("open", "under_review") %}
-  <div class="action-grid">
-    {% if selected_dispute.status == "open" %}
-    <form method="post" action="{{ url_for('admin.dispute_transition', dispute_id=selected_dispute.id) }}">
-      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-      <input type="hidden" name="status" value="under_review">
-      <label for="under-review-note">Note (optional)</label>
-      <input id="under-review-note" name="resolution_note" maxlength="1000">
-      <button class="button secondary" type="submit">Mark Under Review</button>
-    </form>
+  <section class="panel" aria-labelledby="disputes-heading">
+    <div class="admin-table-wrap">
+      <table class="admin-table">
+        <thead>
+          <tr>
+            <th scope="col">Dispute</th>
+            <th scope="col">Transaction</th>
+            <th scope="col">Reporter</th>
+            <th scope="col">Issue type</th>
+            <th scope="col">Status</th>
+            <th scope="col">Filed</th>
+            <th scope="col">Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for item in disputes %}
+          <tr>
+            <td>#{{ item.id }}</td>
+            <td>{{ item.transaction_ref or "unavailable" }}</td>
+            <td>{{ item.reporter_username or item.reporter_ref or "unavailable" }}</td>
+            <td>{{ item.issue_type }}</td>
+            <td>{{ item.status }}</td>
+            <td><time datetime="{{ item.created_at or '' }}">{{ item.created_at_display or "n/a" }}</time></td>
+            <td><a class="button secondary small" href="{{ url_for('admin.dispute_detail', dispute_id=item.id) }}">Review</a></td>
+          </tr>
+          {% else %}
+          <tr>
+            <td colspan="7">No transaction disputes.</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  {% if selected_dispute %}
+  <section class="panel" aria-labelledby="dispute-detail-heading">
+    <div class="section-header">
+      <h2 id="dispute-detail-heading">Dispute #{{ selected_dispute.id }}</h2>
+    </div>
+    <dl class="detail-list">
+      <div>
+        <dt>Transaction</dt>
+        <dd>{{ selected_dispute.transaction_ref or "unavailable" }}</dd>
+      </div>
+      <div>
+        <dt>Reporter</dt>
+        <dd>{{ selected_dispute.reporter_username or selected_dispute.reporter_ref or "unavailable" }}</dd>
+      </div>
+      <div>
+        <dt>Issue type</dt>
+        <dd>{{ selected_dispute.issue_type }}</dd>
+      </div>
+      <div>
+        <dt>Reason</dt>
+        <dd>{{ selected_dispute.reason }}</dd>
+      </div>
+      <div>
+        <dt>Status</dt>
+        <dd>{{ selected_dispute.status }}</dd>
+      </div>
+      <div>
+        <dt>Filed</dt>
+        <dd><time datetime="{{ selected_dispute.created_at or '' }}">{{ selected_dispute.created_at_display or "n/a" }}</time></dd>
+      </div>
+      <div>
+        <dt>Decided</dt>
+        <dd>{{ selected_dispute.decided_at_display or "not decided" }}</dd>
+      </div>
+      <div>
+        <dt>Resolution note</dt>
+        <dd>{{ selected_dispute.resolution_note or "not provided" }}</dd>
+      </div>
+    </dl>
+    {% if selected_dispute.status in ("open", "under_review") %}
+    <div class="action-grid">
+      {% if selected_dispute.status == "open" %}
+      <form method="post" action="{{ url_for('admin.dispute_transition', dispute_id=selected_dispute.id) }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <input type="hidden" name="status" value="under_review">
+        <label for="under-review-note">Note (optional)</label>
+        <input id="under-review-note" name="resolution_note" maxlength="1000">
+        <button class="button secondary" type="submit">Mark Under Review</button>
+      </form>
+      {% endif %}
+      <form method="post" action="{{ url_for('admin.dispute_transition', dispute_id=selected_dispute.id) }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <input type="hidden" name="status" value="resolved">
+        <label for="resolve-note">Resolution note</label>
+        <input id="resolve-note" name="resolution_note" maxlength="1000">
+        <button class="button" type="submit">Resolve</button>
+      </form>
+      <form method="post" action="{{ url_for('admin.dispute_transition', dispute_id=selected_dispute.id) }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <input type="hidden" name="status" value="rejected">
+        <label for="reject-note">Rejection note</label>
+        <input id="reject-note" name="resolution_note" maxlength="1000">
+        <button class="button secondary" type="submit">Reject</button>
+      </form>
+    </div>
     {% endif %}
-    <form method="post" action="{{ url_for('admin.dispute_transition', dispute_id=selected_dispute.id) }}">
-      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-      <input type="hidden" name="status" value="resolved">
-      <label for="resolve-note">Resolution note</label>
-      <input id="resolve-note" name="resolution_note" maxlength="1000">
-      <button class="button" type="submit">Resolve</button>
-    </form>
-    <form method="post" action="{{ url_for('admin.dispute_transition', dispute_id=selected_dispute.id) }}">
-      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-      <input type="hidden" name="status" value="rejected">
-      <label for="reject-note">Rejection note</label>
-      <input id="reject-note" name="resolution_note" maxlength="1000">
-      <button class="button secondary" type="submit">Reject</button>
-    </form>
-  </div>
+  </section>
   {% endif %}
 </section>
-{% endif %}
 {% endblock %}

--- a/app/templates/admin/invites.html
+++ b/app/templates/admin/invites.html
@@ -4,8 +4,12 @@
 
 {% block content %}
 <section class="dashboard admin-dashboard">
-  <div class="section-header">
-    <h1>Staff Invites</h1>
+  <div class="dashboard-header">
+    <div class="page-heading">
+      <p class="eyebrow">Staff onboarding</p>
+      <h1>Staff Invites</h1>
+      <p class="muted">Create workplace invites for new staff or admin accounts and track their acceptance status.</p>
+    </div>
   </div>
 
   <section class="panel">

--- a/app/templates/admin/manual_recovery_requests.html
+++ b/app/templates/admin/manual_recovery_requests.html
@@ -4,8 +4,12 @@
 
 {% block content %}
 <section class="dashboard admin-dashboard">
-  <div class="section-header">
-    <h1>Manual Recovery</h1>
+  <div class="dashboard-header">
+    <div class="page-heading">
+      <p class="eyebrow">Account recovery</p>
+      <h1>Manual Recovery</h1>
+      <p class="muted">Review and progress manual recovery requests that could not be resolved automatically.</p>
+    </div>
   </div>
 
   <section class="panel" aria-labelledby="manual-recovery-summary-heading">

--- a/app/templates/admin/staff_accounts.html
+++ b/app/templates/admin/staff_accounts.html
@@ -4,8 +4,12 @@
 
 {% block content %}
 <section class="dashboard admin-dashboard">
-  <div class="section-header">
-    <h1>Staff/Admin Users</h1>
+  <div class="dashboard-header">
+    <div class="page-heading">
+      <p class="eyebrow">Staff directory</p>
+      <h1>Staff/Admin Users</h1>
+      <p class="muted">Review workplace identities, TOTP enrollment, and lifecycle status for every staff and admin account.</p>
+    </div>
   </div>
   <section class="panel">
     <div class="admin-table-wrap">


### PR DESCRIPTION
Summary
---

Aligns the admin and staff console's visual design with the customer site. Front-end only — no routes, permissions, or backend behavior changed.

Why
---

The admin/staff console read as a visually different product from the customer site: a purple identity-card gradient instead of the Singapore-red brand, flat borderless tables, bare `<h1>` headings on most content pages (no eyebrow/description), and a leftover dark-mode toggle that no longer did anything (dark mode CSS was already fully removed).

What changed
---

* `app/static/css/app.css`: removed the `.admin-identity-card` purple gradient override (falls back to the shared red `.bank-account-card` gradient); added border + shaded-header styling to `.admin-table`/`.admin-table-wrap` to match the customer `table`/`.table-wrap` look.
* `app/templates/admin/base.html`: removed the dead dark-mode toggle button and the now-pointless `theme.js` include; added the icon symbols used by the dashboard's quick-action tiles.
* `app/templates/admin/dashboard.html`: added icons to the "Allowed Operations" tiles (label-to-icon mapping lives entirely in the template — no backend change).
* `app/templates/admin/{audit_logs,staff_accounts,invites,manual_recovery_requests,alerts,audit_log_detail}.html`: replaced the bare `<h1>` with the customer's `.dashboard-header` > `.page-heading` (eyebrow + h1 + one-line description) pattern.
* `app/templates/admin/{disputes,action_requests,customer_security_locks}.html`: same page-heading treatment, restructured from the unstyled `.dashboard-section` wrapper (zero CSS existed for that class) to `.dashboard admin-dashboard` + `.panel`, matching every other admin page; also fixed a markup bug where `.detail-list` dt/dd pairs weren't wrapped in `<div>`, so their row separators never rendered.

Security impact
---

Purely visual/template changes — no authentication, authorization, CSRF, session, or audit-logging behavior touched. No routes, permissions, or role checks were modified. Verified via the full test suite (unchanged pass count) and manual screenshot review of every affected page as both a root-admin and a plain-staff session.

Deployment impact
---

* no deployment action

Verification
---

* `.\.venv\Scripts\python.exe -m pytest -q -n auto` — 1643 passed, 35 skipped (no change in pass/skip count vs. before this PR)
* `git diff --check` — clean
* Manual: screenshotted every affected admin/staff page (dashboard, audit logs, staff accounts, invites, manual recovery, alerts, customer locks, approvals, disputes) as both a root-admin and a plain-staff test session via a throwaway Playwright script (not committed) to confirm the redesign renders correctly and matches the customer site's look.

Notes
---

Closes #485.
