### PR TITLE
Upgrade legacy customer session risk context

### DIFF
--- a/app/security/sessions.py
+++ b/app/security/sessions.py
@@ -597,6 +597,21 @@ def _session_risk_context_changes() -> set[str]:
     return changes
 
 
+def _has_matching_legacy_session_risk_fingerprint() -> bool:
+    stored = session.get(SESSION_RISK_FINGERPRINT_KEY)
+    if not stored:
+        return False
+    return matches_hmac(str(stored), _current_session_risk_message(), length=32)
+
+
+def _can_upgrade_missing_customer_session_risk_context(stored: Any) -> bool:
+    if current_app.config.get("APP_MODE") == "admin":
+        return False
+    if stored is not None:
+        return False
+    return _has_matching_legacy_session_risk_fingerprint()
+
+
 def _session_risk_severity(changes: set[str]) -> str:
     if not changes:
         return "stable"
@@ -633,6 +648,11 @@ def _touch_session_risk_context() -> None:
 
 def enforce_authenticated_session_context() -> Any:
     if not session.get("user_id") or not current_session_id():
+        return None
+
+    stored_context = session.get(SESSION_RISK_CONTEXT_KEY)
+    if _can_upgrade_missing_customer_session_risk_context(stored_context):
+        _store_current_session_risk_context(clear_reauth=True)
         return None
 
     changes = _session_risk_context_changes()

--- a/docs/security/architecture/session-management.md
+++ b/docs/security/architecture/session-management.md
@@ -214,10 +214,13 @@ names. It does not contain cookies, raw session ids, raw context values, or
 session payloads. Standard audit request columns remain governed by
 `docs/security/assurance/audit-and-alerting.md`.
 
-Sessions with missing, malformed, or unsupported structured context never use
-the old fingerprint as an authentication shortcut. Customer sessions are
-marked for full reauthentication before sensitive actions, while the stricter
-admin policy revokes the session and requires a fresh login. A subsequent
+Sessions with missing, malformed, or unsupported structured context fail closed
+unless a customer session has no structured context and its existing legacy
+fingerprint HMAC still matches the current request context. In that narrow
+migration case, the server writes the structured context before sensitive-action
+checks continue. Missing context without a matching fingerprint, malformed or
+unsupported context, and all admin sessions with missing, malformed, or
+unsupported context require full reauthentication or revocation. A subsequent
 authenticated session receives only the current versioned context.
 
 Focused coverage is in `tests/test_session_risk_binding.py`. It verifies

--- a/tests/test_account_security_actions.py
+++ b/tests/test_account_security_actions.py
@@ -502,6 +502,84 @@ def test_profile_phone_update_succeeds_without_raw_phone_audit_metadata(client, 
     assert "92345678" not in str(event.event_metadata)
 
 
+def test_profile_phone_update_accepts_matching_legacy_session_context(client, monkeypatch):
+    from app.security.sessions import SESSION_RISK_CONTEXT_KEY, SESSION_RISK_FINGERPRINT_KEY
+
+    register(client)
+    user, secret = enable_mfa_for_user()
+    password_response = login(client)
+    login_time = int(time.time())
+    monkeypatch.setattr("app.auth.services.time.time", lambda: login_time)
+    mfa_response = client.post(
+        "/auth/mfa/verify",
+        json={"totp_code": pyotp.TOTP(secret, digits=6, interval=30).at(login_time)},
+    )
+    with client.session_transaction() as sess:
+        assert sess.get(SESSION_RISK_FINGERPRINT_KEY)
+        sess.pop(SESSION_RISK_CONTEXT_KEY)
+
+    stepup_time = login_time + 1
+    monkeypatch.setattr("app.auth.services.time.time", lambda: stepup_time)
+    response = client.post(
+        "/profile",
+        data={
+            "username": "alice01",
+            "email": "alice@example.com",
+            "phone_number": "92345678",
+            "totp_code": pyotp.TOTP(secret, digits=6, interval=30).at(stepup_time),
+        },
+    )
+    db.session.refresh(user)
+
+    assert password_response.status_code == 302
+    assert mfa_response.status_code == 200
+    assert response.status_code == 302
+    assert user.phone_number == "92345678"
+    assert db.session.query(SecurityAuditEvent).filter_by(
+        event_type="session_risk",
+        outcome="reauth_required",
+    ).count() == 0
+
+
+def test_profile_phone_and_username_update_accepts_matching_legacy_session_context(
+    client,
+    monkeypatch,
+):
+    from app.security.sessions import SESSION_RISK_CONTEXT_KEY, SESSION_RISK_FINGERPRINT_KEY
+
+    register(client)
+    user, secret = enable_mfa_for_user()
+    password_response = login(client)
+    login_time = int(time.time())
+    monkeypatch.setattr("app.auth.services.time.time", lambda: login_time)
+    mfa_response = client.post(
+        "/auth/mfa/verify",
+        json={"totp_code": pyotp.TOTP(secret, digits=6, interval=30).at(login_time)},
+    )
+    with client.session_transaction() as sess:
+        assert sess.get(SESSION_RISK_FINGERPRINT_KEY)
+        sess.pop(SESSION_RISK_CONTEXT_KEY)
+
+    stepup_time = login_time + 1
+    monkeypatch.setattr("app.auth.services.time.time", lambda: stepup_time)
+    response = client.post(
+        "/profile",
+        data={
+            "username": "alice02",
+            "email": "alice@example.com",
+            "phone_number": "93456789",
+            "totp_code": pyotp.TOTP(secret, digits=6, interval=30).at(stepup_time),
+        },
+    )
+    db.session.refresh(user)
+
+    assert password_response.status_code == 302
+    assert mfa_response.status_code == 200
+    assert response.status_code == 302
+    assert user.username == "alice02"
+    assert user.phone_number == "93456789"
+
+
 def test_profile_update_rejects_invalid_phone(client):
     register(client)
     login(client)

--- a/tests/test_documentation_consistency.py
+++ b/tests/test_documentation_consistency.py
@@ -153,6 +153,7 @@ def test_auth_schema_reset_and_customer_unlock_docs_match_current_contract():
         "exactly 12 decimal digits",
         "different active\nroot admin",
         "missing, malformed, or unsupported structured context",
+        "narrow\nmigration case",
         "retired URLs are unregistered",
     ):
         assert required in docs

--- a/tests/test_local_transfer.py
+++ b/tests/test_local_transfer.py
@@ -348,6 +348,55 @@ def test_complete_transfer_route_flow(client, transfer_context, monkeypatch):
     assert Transaction.query.filter_by(reference="Coverage").count() == 1
 
 
+def test_transfer_stepup_accepts_matching_legacy_session_context(
+    client,
+    transfer_context,
+    monkeypatch,
+):
+    from app.security.sessions import SESSION_RISK_CONTEXT_KEY, SESSION_RISK_FINGERPRINT_KEY
+
+    payee = transfer_context["payee"]
+    secret = transfer_context["alice_secret"]
+    client.post("/logout")
+    password_response = login(client, identifier="alice01")
+    login_time = int(time.time())
+    monkeypatch.setattr("app.auth.services.time.time", lambda: login_time)
+    mfa_response = client.post(
+        "/auth/mfa/verify",
+        json={"totp_code": pyotp.TOTP(secret, digits=6, interval=30).at(login_time)},
+    )
+    with client.session_transaction() as sess:
+        assert sess.get(SESSION_RISK_FINGERPRINT_KEY)
+        sess.pop(SESSION_RISK_CONTEXT_KEY)
+
+    stepup_time = login_time + 1
+    monkeypatch.setattr("app.auth.services.time.time", lambda: stepup_time)
+    submit_response = client.post(
+        f"/banking/transfer/{payee.id}",
+        data={
+            "amount": "25.00",
+            "reference": "Legacy context",
+            "totp_code": pyotp.TOTP(secret, digits=6, interval=30).at(stepup_time),
+        },
+    )
+    with client.session_transaction() as sess:
+        assert sess.get("pending_transfer_token")
+
+    confirm_response = client.get(f"/banking/transfer/{payee.id}/confirm")
+    complete_response = client.post(f"/banking/transfer/{payee.id}/confirm")
+
+    assert password_response.status_code == 302
+    assert mfa_response.status_code == 200
+    assert submit_response.status_code == 302
+    assert confirm_response.status_code == 200
+    assert complete_response.status_code == 302
+    assert Transaction.query.filter_by(reference="Legacy context").count() == 1
+    assert db.session.query(SecurityAuditEvent).filter_by(
+        event_type="session_risk",
+        outcome="reauth_required",
+    ).count() == 0
+
+
 def test_transfer_route_handles_invalid_form_and_mfa_error(
     client,
     transfer_context,

--- a/tests/test_payup.py
+++ b/tests/test_payup.py
@@ -864,6 +864,52 @@ def test_complete_payup_route_flow_crossing_threshold_requires_mfa(client, payup
     assert Transaction.query.filter_by(transaction_type="payup").count() == 1
 
 
+def test_payup_confirm_accepts_matching_legacy_session_context(
+    client,
+    payup_context,
+    monkeypatch,
+):
+    from app.security.sessions import SESSION_RISK_CONTEXT_KEY, SESSION_RISK_FINGERPRINT_KEY
+
+    alice_secret = payup_context["alice_secret"]
+    client.post("/logout")
+    password_response = login(client, identifier="alice01")
+    login_time = int(time.time())
+    monkeypatch.setattr("app.auth.services.time.time", lambda: login_time)
+    mfa_response = client.post(
+        "/auth/mfa/verify",
+        json={"totp_code": _totp_code(alice_secret, login_time)},
+    )
+
+    lookup = client.post("/banking/payup", data=_payup_lookup_data(payup_context))
+    amount = client.post("/banking/payup/amount", data={"amount": "450.00"})
+    with client.session_transaction() as sess:
+        assert sess.get(SESSION_RISK_FINGERPRINT_KEY)
+        assert sess.get("pending_payup_token")
+        sess.pop(SESSION_RISK_CONTEXT_KEY)
+
+    confirm_page = client.get("/banking/payup/confirm")
+    stepup_time = login_time + 1
+    monkeypatch.setattr("app.auth.services.time.time", lambda: stepup_time)
+    confirm_submit = client.post(
+        "/banking/payup/confirm",
+        data={"totp_code": _totp_code(alice_secret, stepup_time)},
+    )
+
+    assert password_response.status_code == 302
+    assert mfa_response.status_code == 200
+    assert lookup.status_code == 302
+    assert amount.status_code == 302
+    assert confirm_page.status_code == 200
+    assert b"Authenticator code" in confirm_page.data
+    assert confirm_submit.status_code == 302
+    assert Transaction.query.filter_by(transaction_type="payup").count() == 1
+    assert db.session.query(SecurityAuditEvent).filter_by(
+        event_type="session_risk",
+        outcome="reauth_required",
+    ).count() == 0
+
+
 def test_payup_confirm_rechecks_stepup_when_usage_changes_after_amount_entry(client, payup_context):
     alice = payup_context["alice"]
     bob = payup_context["bob"]

--- a/tests/test_session_risk_binding.py
+++ b/tests/test_session_risk_binding.py
@@ -15,6 +15,7 @@ from app.security.passwords import hash_password
 from app.security.sessions import (
     AUTH_CREATED_AT_KEY,
     SESSION_RISK_CONTEXT_KEY,
+    SESSION_RISK_FINGERPRINT_KEY,
     SESSION_RISK_REAUTH_REQUIRED_KEY,
     session_lookup_hash,
 )
@@ -219,7 +220,34 @@ def test_same_context_customer_request_continues_and_checks_risk(client):
         assert not sess.get(SESSION_RISK_REAUTH_REQUIRED_KEY)
 
 
-def test_missing_session_risk_context_requires_reauthentication(
+def test_matching_legacy_customer_session_context_is_upgraded_without_reauth(
+    client,
+):
+    _login_customer(
+        client,
+        ip_address=CUSTOMER_IP,
+        user_agent=CHROME_120,
+    )
+    with client.session_transaction() as sess:
+        assert sess.get(SESSION_RISK_FINGERPRINT_KEY)
+        sess.pop(SESSION_RISK_CONTEXT_KEY)
+
+    response = client.get(
+        "/dashboard",
+        **_request_context(CUSTOMER_IP, CHROME_120),
+    )
+
+    assert response.status_code == 200
+    with client.session_transaction() as sess:
+        assert sess[SESSION_RISK_CONTEXT_KEY]["version"] == 1
+        assert not sess.get(SESSION_RISK_REAUTH_REQUIRED_KEY)
+    assert db.session.query(SecurityAuditEvent).filter_by(
+        event_type="session_risk",
+        outcome="reauth_required",
+    ).count() == 0
+
+
+def test_missing_session_risk_context_with_tampered_fingerprint_requires_reauth(
     client,
 ):
     _login_customer(
@@ -229,6 +257,7 @@ def test_missing_session_risk_context_requires_reauthentication(
     )
     with client.session_transaction() as sess:
         sess.pop(SESSION_RISK_CONTEXT_KEY)
+        sess[SESSION_RISK_FINGERPRINT_KEY] = "tampered"
 
     response = client.get(
         "/dashboard",


### PR DESCRIPTION
Summary
---
Upgrade customer session-risk handling so a session with a matching legacy risk fingerprint but missing structured context can rebuild the structured context before high-risk checks continue.

Why
---
Closes #482.
Closes #483.
Closes #484.

Valid customer TOTP step-up flows for profile phone edits, PayUp confirmation, and local transfer could be blocked after ordinary navigation marked a legacy-shaped session as requiring reauthentication because structured risk context was missing.

What changed
---
- Added a customer-only upgrade path for missing structured risk context when the existing legacy fingerprint HMAC matches the current request context.
- Kept admin sessions, malformed structured context, unsupported structured context, tampered fingerprints, and real context drift fail-closed.
- Added route regressions for profile phone-only and phone-plus-username edits, PayUp confirmation, and local transfer step-up.
- Updated session-management documentation and the stale-doc consistency check.

Security impact
---
This preserves the session-risk boundary while removing false reauthentication failures for a narrowly verified customer-session migration case. The server still rejects nonmatching fingerprints, malformed context, unsupported context, admin context gaps, replayed or invalid TOTP, stale pending transfer state, and real session-risk drift.

Deployment impact
---
No deployment action required beyond normal staging and production deployment. No EC2 bootstrap, database migration, secret change, provider setting change, or workflow change is required.

Verification
---
- `git diff --check`
- `.\.venv\Scripts\python.exe -m pytest -q tests/test_session_risk_binding.py tests/test_account_security_actions.py::test_profile_phone_update_accepts_matching_legacy_session_context tests/test_local_transfer.py::test_transfer_stepup_accepts_matching_legacy_session_context tests/test_payup.py::test_payup_confirm_accepts_matching_legacy_session_context tests/test_documentation_consistency.py::test_auth_schema_reset_and_customer_unlock_docs_match_current_contract`
- `.\.venv\Scripts\python.exe -m pytest -q tests/test_account_security_actions.py tests/test_session_risk_binding.py tests/test_payup.py tests/test_local_transfer.py tests/test_local_transfer_security.py tests/test_payee_management_security.py tests/test_transfer_limits.py`
- `.\.venv\Scripts\python.exe -m pytest -q -n 4`
- `.\.venv\Scripts\python.exe -m pytest -q -n 4 --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term`

Notes
---
Coverage stayed at 91%. The full-suite runs reported the existing SQLite/Alembic expression-index reflection warnings only.