### PR TITLE
Fix missing form spacing on admin action and delivery forms

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -2264,6 +2264,34 @@ th {
   margin: 0;
 }
 
+.action-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-4);
+  align-items: start;
+  margin-top: var(--space-5);
+}
+
+.action-grid form {
+  display: grid;
+  gap: var(--space-3);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: var(--space-4);
+  background: var(--surface-raised);
+}
+
+.form-field {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.admin-form {
+  display: grid;
+  gap: var(--space-4);
+  max-width: 480px;
+}
+
 /* End admin dashboard */
 
 /* ── Session timer indicator ───────────────────────── */

--- a/app/templates/admin/customer_security_locks.html
+++ b/app/templates/admin/customer_security_locks.html
@@ -37,12 +37,16 @@
             <td>{{ customer.lock_reason|replace("_", " ") }}</td>
             <td><time datetime="{{ customer.locked_at }}">{{ customer.locked_at_display }}</time></td>
             <td>
-              <form method="post" action="{{ url_for('admin.customer_security_unlock_request', user_id=customer.id) }}">
+              <form class="admin-form" method="post" action="{{ url_for('admin.customer_security_unlock_request', user_id=customer.id) }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                <label for="reason-{{ customer.id }}">Reviewed support reason</label>
-                <input id="reason-{{ customer.id }}" name="reason" type="text" maxlength="512" required>
-                <label for="totp-{{ customer.id }}">Authenticator code</label>
-                <input id="totp-{{ customer.id }}" name="totp_code" inputmode="numeric" autocomplete="one-time-code" pattern="[0-9]{6}" maxlength="6" required>
+                <div class="form-group">
+                  <label for="reason-{{ customer.id }}">Reviewed support reason</label>
+                  <input id="reason-{{ customer.id }}" name="reason" type="text" maxlength="512" required>
+                </div>
+                <div class="form-group">
+                  <label for="totp-{{ customer.id }}">Authenticator code</label>
+                  <input id="totp-{{ customer.id }}" name="totp_code" inputmode="numeric" autocomplete="one-time-code" pattern="[0-9]{6}" maxlength="6" required>
+                </div>
                 <button class="button small" type="submit">Request unlock</button>
               </form>
             </td>

--- a/app/templates/admin/invites.html
+++ b/app/templates/admin/invites.html
@@ -57,14 +57,14 @@
             <td><time datetime="{{ invite.expires_at }}">{{ invite.expires_at_display }}</time></td>
             <td>
               {% if invite.status in ["pending", "totp_pending"] %}
-              <form method="post" action="{{ url_for('admin.invite_revoke', invite_id=invite.id) }}">
+              <form class="admin-inline-actions" method="post" action="{{ url_for('admin.invite_revoke', invite_id=invite.id) }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <label class="sr-only" for="revoke-totp-{{ invite.id }}">Authenticator code</label>
                 <input id="revoke-totp-{{ invite.id }}" name="totp_code" inputmode="numeric" autocomplete="one-time-code" maxlength="6" required>
                 <button class="button-danger" type="submit">Revoke</button>
               </form>
               {% if invite.acceptance_locked %}
-              <form method="post" action="{{ url_for('admin.invite_reset_acceptance', invite_id=invite.id) }}">
+              <form class="admin-inline-actions" method="post" action="{{ url_for('admin.invite_reset_acceptance', invite_id=invite.id) }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <label class="sr-only" for="reset-acceptance-totp-{{ invite.id }}">Authenticator code</label>
                 <input id="reset-acceptance-totp-{{ invite.id }}" name="totp_code" inputmode="numeric" autocomplete="one-time-code" maxlength="6" required>


### PR DESCRIPTION
Summary
---

Fixes missing spacing on several admin action and delivery forms — a follow-up to #486.

Why
---

After #486 restyled the surrounding admin pages, it became obvious that several forms used CSS classes (`.action-grid`, `.form-field`, `.admin-form`) that were referenced in templates but never actually defined anywhere in `app.css`. With no layout rules, labels, inputs, and buttons rendered stacked with zero spacing — reported as "spacing and words all over the place," especially on the admin-approval request detail view.

What changed
---

* `app/static/css/app.css`: added `.action-grid` (a responsive grid of card-styled forms, used by the approve/reject/cancel controls in `disputes.html` and `action_requests.html`), `.form-field` (label+input stacking, used by `alerts.html` and `manual_recovery_requests.html`), and `.admin-form` (gap + max-width wrapper around multiple `.form-field`s, same two templates).
* `app/templates/admin/customer_security_locks.html`: the unlock-request form had no wrapper class at all — wrapped its two label/input pairs in `.form-group` (the same pattern used by every other form in the app) and gave the form the new `.admin-form` treatment.
* `app/templates/admin/invites.html`: the revoke/reset-acceptance forms were missing the `.admin-inline-actions` class already used identically by `staff_accounts.html`'s equivalent controls.

Security impact
---

Purely visual/CSS and wrapper-class changes — no form fields, actions, CSRF tokens, or validation logic were added, removed, or reordered. No routes, permissions, or authorization checks touched.

Deployment impact
---

* no deployment action

Verification
---

* `.\.venv\Scripts\python.exe -m pytest -q -n auto` — 1643 passed, 35 skipped (unchanged from before this fix)
* `git diff --check` — clean
* Manual: reproduced the exact bug using the real `app.css` against copies of the affected markup, then re-verified the fix render clean; also seeded a locked customer, a manual recovery request, and reused the existing dispute/action-request pages via a throwaway Playwright script (not committed) to confirm every affected form now shows proper label/input/button spacing.

Notes
---

Closes #489. Follow-up to #486.
