### PR TITLE
Fix admin pages stretching content when shorter than the viewport

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -2129,6 +2129,7 @@ th {
 /* Admin dashboard */
 .admin-page {
   display: grid;
+  align-content: start;
   gap: var(--space-7);
 }
 


### PR DESCRIPTION
Summary
---

Fixes admin/staff pages rendering with huge, uneven gaps whenever their real content is shorter than the viewport — most visible on the 401 error page, but present on every sparse admin page.

Why
---

Reported as "so much spacing" on the private-admin 401 status page. Investigating with real computed styles showed the eyebrow/heading/message/button rows were each 130-155px tall (vs. their natural ~17-45px) — CSS Grid was distributing all the page's leftover vertical space evenly across those rows instead of packing them at the top.

What changed
---

* `app/static/css/app.css`: added `align-content: start` to `.admin-page`, the grid container used by `admin/base.html`'s `<main>`. Without it, CSS Grid's default `align-content: normal` stretches auto-sized rows to fill any extra height in the viewport — invisible on content-rich pages (e.g. Audit Logs, which already fills the viewport) but very visible on sparse ones (empty tables, the bare error page, short settings forms).
* Confirmed `.admin-page` is referenced only in `admin/base.html` — no customer template uses this class, so this is fully scoped to the admin/staff console.

Security impact
---

Single-property CSS layout change — no authentication, authorization, routing, or content logic touched.

Deployment impact
---

* no deployment action

Verification
---

* `.\.venv\Scripts\python.exe -m pytest -q -n auto` — 1648 passed, 35 skipped (unchanged from before this fix)
* `git diff --check` — clean
* Manual: measured computed element heights via a throwaway Playwright script (not committed) before/after — row heights dropped from ~130-155px to their natural 17-45px; re-screenshotted the 401 page and several sparse admin pages (disputes, audit logs) to confirm the fix and confirm content-rich pages are visually unchanged.

Notes
---

Closes #494. Found while reviewing #486/#490.
