### PR TITLE
Improve alert review and customer MFA regressions

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from datetime import datetime, timezone
 from typing import Any
 
 from flask import Blueprint, current_app, flash, g, jsonify, redirect, render_template, request, session, url_for
@@ -22,6 +23,7 @@ from app.security.production_guard import (
     validate_production_security_prerequisites,
 )
 from app.security.rate_limits import request_principal
+from app.time_display import sgt_datetime
 from app.security.http_errors import (
     CSRF_ERROR_MESSAGE,
     rate_limit_response,
@@ -350,28 +352,38 @@ def _alert_display_report(report: dict[str, Any], selected_ref: str | None) -> d
         for index, alert in enumerate(report.get("alerts") or [])
         if isinstance(alert, dict)
     ]
-    display["alerts"] = alerts
-    display["highest_severity"] = _highest_alert_severity(alerts)
-    display["next_action"] = _alert_next_action(display)
-    display["selected_alert"] = next(
+    selected_alert = next(
         (alert for alert in alerts if alert["ref"] == selected_ref),
         alerts[0] if alerts else None,
     )
+    selected_alert_ref = selected_alert["ref"] if selected_alert else ""
+    for alert in alerts:
+        alert["selected"] = alert["ref"] == selected_alert_ref
+    display["alerts"] = alerts
+    display["highest_severity"] = _highest_alert_severity(alerts)
+    display["next_action"] = _alert_next_action(display)
+    display["selected_alert"] = selected_alert
+    display["generated_at_utc"] = _alert_time_utc(report.get("generated_at"))
+    display["generated_at_display"] = _alert_time_display(report.get("generated_at"))
     return display
 
 
 def _alert_display_item(alert: dict[str, Any], index: int) -> dict[str, Any]:
     ref = f"alert-{index + 1}"
     event_id = _alert_existing_event_id(alert.get("latest_event_id"))
+    source = _safe_alert_text(alert.get("source"), 160) or "unknown"
     return {
         "ref": ref,
         "detail_url": url_for(_ADMIN_ALERTS_ENDPOINT, alert=ref),
         "alert_type": _safe_alert_text(alert.get("alert_type"), 80),
         "severity": _safe_alert_text(alert.get("severity"), 24) or "low",
-        "source": _safe_alert_text(alert.get("source"), 160) or "unknown",
+        "source": source,
+        "source_summary": _alert_source_summary(source),
         "count": int(alert.get("count") or 0),
         "window_seconds": int(alert.get("window_seconds") or 0),
         "generated_at": _safe_alert_text(alert.get("generated_at"), 40),
+        "generated_at_utc": _alert_time_utc(alert.get("generated_at")),
+        "generated_at_display": _alert_time_display(alert.get("generated_at")),
         "event_id": event_id,
         "event_url": url_for("admin.audit_log_detail", event_id=event_id) if event_id else "",
         "status": _safe_alert_text(alert.get("status"), 80),
@@ -379,6 +391,57 @@ def _alert_display_item(alert: dict[str, Any], index: int) -> dict[str, Any]:
         "error_type": _safe_alert_text(alert.get("error_type"), 80),
         "recommended_action": _alert_recommended_action(alert),
     }
+
+
+def _alert_time_utc(value: Any) -> str:
+    return _safe_alert_text(value, 64)
+
+
+def _alert_time_display(value: Any) -> str:
+    parsed = _parse_alert_time(value)
+    if parsed is not None:
+        return sgt_datetime(parsed)
+    return _safe_alert_text(value, 40) or "unknown"
+
+
+def _parse_alert_time(value: Any) -> datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _alert_source_summary(source: Any) -> str:
+    raw = _safe_alert_text(source, 160)
+    if not raw:
+        return "Unknown source"
+    normalized = raw.casefold()
+    if normalized.startswith("principal_ref:"):
+        return "Principal reference"
+    if normalized.startswith("table:"):
+        table_name = raw.split(":", 1)[1].replace("_", " ").strip()
+        if table_name:
+            return f"{table_name.title()} table"
+        return "Database table"
+    source_labels = {
+        "audit_chain": "Audit chain",
+        "database_integrity": "Database integrity",
+        "manual_security_alert": "Manual security alert",
+    }
+    if normalized in source_labels:
+        return source_labels[normalized]
+    summary = " ".join(re.sub(r"[_:]+", " ", raw).split())
+    if not summary:
+        return "Unknown source"
+    return f"{summary[:77]}..." if len(summary) > 80 else summary[:1].upper() + summary[1:]
 
 
 def _alert_existing_event_id(value: Any) -> int | None:

--- a/app/static/js/admin-alerts.js
+++ b/app/static/js/admin-alerts.js
@@ -1,0 +1,42 @@
+(() => {
+  function showDetail(ref, link, links, panels) {
+    const panel = document.getElementById(`alert-detail-${ref}`);
+    if (!panel) return;
+
+    panels.forEach((item) => {
+      item.hidden = item.dataset.alertRef !== ref;
+    });
+    links.forEach((item) => {
+      item.setAttribute("aria-expanded", item.dataset.alertRef === ref ? "true" : "false");
+    });
+
+    if (window.history && typeof window.history.replaceState === "function") {
+      window.history.replaceState(null, "", link.href);
+    }
+    panel.focus({ preventScroll: true });
+    if (typeof panel.scrollIntoView === "function") {
+      panel.scrollIntoView({ block: "nearest" });
+    }
+  }
+
+  function initAlertDetails() {
+    const links = Array.from(document.querySelectorAll("[data-alert-detail-link]"));
+    const panels = Array.from(document.querySelectorAll("[data-alert-detail-panel]"));
+    if (!links.length || !panels.length) return;
+
+    links.forEach((link) => {
+      link.addEventListener("click", (event) => {
+        const ref = link.dataset.alertRef || "";
+        if (!ref || !document.getElementById(`alert-detail-${ref}`)) return;
+        event.preventDefault();
+        showDetail(ref, link, links, panels);
+      });
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initAlertDetails);
+  } else {
+    initAlertDetails();
+  }
+})();

--- a/app/static/js/admin-alerts.js
+++ b/app/static/js/admin-alerts.js
@@ -10,8 +10,9 @@
       item.setAttribute("aria-expanded", item.dataset.alertRef === ref ? "true" : "false");
     });
 
-    if (window.history && typeof window.history.replaceState === "function") {
-      window.history.replaceState(null, "", link.href);
+    const browserHistory = globalThis.history;
+    if (browserHistory && typeof browserHistory.replaceState === "function") {
+      browserHistory.replaceState(null, "", link.href);
     }
     panel.focus({ preventScroll: true });
     if (typeof panel.scrollIntoView === "function") {

--- a/app/templates/add_payee.html
+++ b/app/templates/add_payee.html
@@ -39,9 +39,9 @@
         </div>
         <div class="form-group">
           <label for="{{ form.account_number.id }}">Account number</label>
-          {{ form.account_number(autocomplete="off", maxlength="12", placeholder="9- or 12-digit account number", inputmode="numeric") }}
+          {{ form.account_number(autocomplete="off", maxlength="12", placeholder="12-digit account number", inputmode="numeric") }}
           {% for error in form.account_number.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
-          <p class="hint">The 9- or 12-digit SITBank account number of the recipient.</p>
+          <p class="hint">Enter exactly 12 digits. Do not include hyphens or spaces.</p>
         </div>
         <div class="form-group">
           <label for="{{ form.totp_code.id }}">Authenticator code</label>

--- a/app/templates/admin/alerts.html
+++ b/app/templates/admin/alerts.html
@@ -13,7 +13,7 @@
   </div>
   <section class="panel">
     <dl class="admin-metadata-grid">
-      <div><dt>Generated</dt><dd>{{ report.generated_at }}</dd></div>
+      <div><dt>Generated</dt><dd><time datetime="{{ report.generated_at_utc }}">{{ report.generated_at_display }}</time></dd></div>
       <div><dt>Active alerts</dt><dd>{{ report.alert_count }}</dd></div>
       <div><dt>Highest severity</dt><dd>{{ report.highest_severity }}</dd></div>
       <div><dt>Audit chain</dt><dd>{% if report.audit_chain.valid %}Valid{% else %}Attention required{% endif %}</dd></div>
@@ -57,8 +57,14 @@
             <td>{{ alert.alert_type }}</td>
             <td>{{ alert.severity }}</td>
             <td>{{ alert.count }}</td>
-            <td>{{ alert.source }}</td>
-            <td><a href="{{ alert.detail_url }}">Open</a></td>
+            <td>{{ alert.source_summary }}</td>
+            <td>
+              <a href="{{ alert.detail_url }}"
+                 data-alert-detail-link
+                 data-alert-ref="{{ alert.ref }}"
+                 aria-controls="alert-detail-{{ alert.ref }}"
+                 aria-expanded="{{ 'true' if alert.selected else 'false' }}">Open</a>
+            </td>
           </tr>
           {% else %}
           <tr>
@@ -69,27 +75,33 @@
       </table>
     </div>
   </section>
-  {% if report.selected_alert %}
-  <section class="panel">
+  {% for alert in report.alerts %}
+  <section class="panel alert-detail-panel"
+           id="alert-detail-{{ alert.ref }}"
+           data-alert-detail-panel
+           data-alert-ref="{{ alert.ref }}"
+           tabindex="-1"
+           {% if not alert.selected %}hidden{% endif %}>
     <div class="section-header">
       <h2>Alert Detail</h2>
     </div>
     <dl class="admin-metadata-grid">
-      <div><dt>Type</dt><dd>{{ report.selected_alert.alert_type }}</dd></div>
-      <div><dt>Severity</dt><dd>{{ report.selected_alert.severity }}</dd></div>
-      <div><dt>Source</dt><dd>{{ report.selected_alert.source }}</dd></div>
-      <div><dt>Count</dt><dd>{{ report.selected_alert.count }}</dd></div>
-      <div><dt>Window seconds</dt><dd>{{ report.selected_alert.window_seconds }}</dd></div>
-      <div><dt>Generated</dt><dd>{{ report.selected_alert.generated_at }}</dd></div>
-      <div><dt>Status</dt><dd>{{ report.selected_alert.status or "reported" }}</dd></div>
-      <div><dt>Reason</dt><dd>{{ report.selected_alert.reason or "not specified" }}</dd></div>
-      <div><dt>Error type</dt><dd>{{ report.selected_alert.error_type or "none" }}</dd></div>
-      <div><dt>Recommended action</dt><dd>{{ report.selected_alert.recommended_action }}</dd></div>
+      <div><dt>Type</dt><dd>{{ alert.alert_type }}</dd></div>
+      <div><dt>Severity</dt><dd>{{ alert.severity }}</dd></div>
+      <div><dt>Source summary</dt><dd>{{ alert.source_summary }}</dd></div>
+      <div><dt>Technical source</dt><dd>{{ alert.source }}</dd></div>
+      <div><dt>Count</dt><dd>{{ alert.count }}</dd></div>
+      <div><dt>Window seconds</dt><dd>{{ alert.window_seconds }}</dd></div>
+      <div><dt>Generated</dt><dd><time datetime="{{ alert.generated_at_utc }}">{{ alert.generated_at_display }}</time></dd></div>
+      <div><dt>Status</dt><dd>{{ alert.status or "reported" }}</dd></div>
+      <div><dt>Reason</dt><dd>{{ alert.reason or "not specified" }}</dd></div>
+      <div><dt>Error type</dt><dd>{{ alert.error_type or "none" }}</dd></div>
+      <div><dt>Recommended action</dt><dd>{{ alert.recommended_action }}</dd></div>
       <div>
         <dt>Related audit event</dt>
         <dd>
-          {% if report.selected_alert.event_url %}
-          <a href="{{ report.selected_alert.event_url }}">Open audit event {{ report.selected_alert.event_id }}</a>
+          {% if alert.event_url %}
+          <a href="{{ alert.event_url }}">Open audit event {{ alert.event_id }}</a>
           {% else %}
           No related audit event ID in this alert.
           {% endif %}
@@ -97,6 +109,10 @@
       </div>
     </dl>
   </section>
-  {% endif %}
+  {% endfor %}
 </section>
+{% endblock %}
+
+{% block scripts %}
+<script src="{{ url_for('static', filename='js/admin-alerts.js') }}" defer></script>
 {% endblock %}

--- a/app/templates/admin/base.html
+++ b/app/templates/admin/base.html
@@ -121,5 +121,6 @@
         </section>
       </div>
     </footer>
+    {% block scripts %}{% endblock %}
   </body>
 </html>

--- a/docs/security/architecture/session-management.md
+++ b/docs/security/architecture/session-management.md
@@ -223,6 +223,14 @@ unsupported context, and all admin sessions with missing, malformed, or
 unsupported context require full reauthentication or revocation. A subsequent
 authenticated session receives only the current versioned context.
 
+Current clean customer password-plus-TOTP sessions are expected to use the same
+stable structured context for later profile update, Local Transfer, and PayUp
+step-up decisions. If a deployed browser session still sees false
+`sign in again` failures after the current session-risk code is live, use a
+normal redeploy or bounded customer reauthentication to clear stale pre-upgrade
+session payloads; do not relax TOTP replay checks, pending-transfer verifiers,
+CSRF, or risk-drift fail-closed behavior.
+
 Focused coverage is in `tests/test_session_risk_binding.py`. It verifies
 customer/admin context creation, low/medium/high handling, strict admin
 revocation, lifetime precedence, CSRF behavior, audit safety, and runtime/key

--- a/docs/security/assurance/audit-and-alerting.md
+++ b/docs/security/assurance/audit-and-alerting.md
@@ -217,10 +217,15 @@ without copying secrets into issues, pull requests, screenshots, or chat.
 Authorized admin/root users can review current security alert report output at
 `GET /alerts`. This dashboard route calls `build_security_alert_report()` with
 delivery disabled; it does not send, resend, or acknowledge alerts. The browser
-view shows labeled report cards, actionable safe alert details, audit-chain and
-database-integrity status, delivery status, dedupe status, next action text,
-and links to existing authorized audit-event detail pages only when a related
-event row exists.
+view shows labeled report cards, readable SGT timestamps with UTC `datetime`
+values, friendly alert source summaries for first-pass triage, actionable safe
+alert details, audit-chain and database-integrity status, delivery status,
+dedupe status, next action text, and links to existing authorized audit-event
+detail pages only when a related event row exists. The JSON, CLI, webhook,
+dedupe, and audit-evidence report contract keeps machine-readable UTC values;
+the browser detail panel preserves sanitized technical source, status, window,
+reason, error type, related audit event, and recommended-action fields behind
+the summary view.
 
 Manual browser delivery is explicit and state-changing through
 `POST /alerts/deliver` only. The route requires the existing admin/root session

--- a/tests/js/collect-browser-coverage.mjs
+++ b/tests/js/collect-browser-coverage.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const browserScripts = [
   "app/static/js/account.js",
+  "app/static/js/admin-alerts.js",
   "app/static/js/dashboard.js",
   "app/static/js/payees.js",
   "app/static/js/session-timeout.js",
@@ -135,6 +136,10 @@ class MockElement {
     this.focused = true;
   }
 
+  scrollIntoView() {
+    this.scrolledIntoView = true;
+  }
+
   select() {
     this.selected = true;
   }
@@ -207,6 +212,12 @@ function createBrowserContext(document) {
         return { timeout_seconds: 180 };
       },
     }),
+    history: {
+      replacedUrl: "",
+      replaceState(_state, _title, url) {
+        this.replacedUrl = url;
+      },
+    },
     location: {
       href: "",
       reloadCount: 0,
@@ -378,6 +389,54 @@ async function exercisePayees() {
   for (const callback of context.__intervalCallbacks) callback();
   assert.match(badge.textContent, /Available in/);
   assert.equal(context.location.reloadCount, 1);
+}
+
+async function exerciseAdminAlerts() {
+  const document = new MockDocument();
+  const linkOne = new MockElement({
+    attributes: {
+      "data-alert-ref": "alert-1",
+      href: "/alerts?alert=alert-1",
+    },
+  });
+  linkOne.href = "/alerts?alert=alert-1";
+  const linkTwo = new MockElement({
+    attributes: {
+      "data-alert-ref": "alert-2",
+      href: "/alerts?alert=alert-2",
+    },
+  });
+  linkTwo.href = "/alerts?alert=alert-2";
+  const panelOne = new MockElement({
+    id: "alert-detail-alert-1",
+    attributes: { "data-alert-ref": "alert-1" },
+  });
+  const panelTwo = new MockElement({
+    id: "alert-detail-alert-2",
+    attributes: { "data-alert-ref": "alert-2" },
+  });
+  panelTwo.hidden = true;
+  document.idMap.set(panelOne.id, panelOne);
+  document.idMap.set(panelTwo.id, panelTwo);
+  document.selectorAllMap.set("[data-alert-detail-link]", [linkOne, linkTwo]);
+  document.selectorAllMap.set("[data-alert-detail-panel]", [panelOne, panelTwo]);
+
+  const context = createBrowserContext(document);
+  runScript("app/static/js/admin-alerts.js", context);
+  const clickEvent = await linkTwo.emit("click");
+
+  assert.equal(clickEvent.defaultPrevented, true);
+  assert.equal(panelOne.hidden, true);
+  assert.equal(panelTwo.hidden, false);
+  assert.equal(linkOne.getAttribute("aria-expanded"), "false");
+  assert.equal(linkTwo.getAttribute("aria-expanded"), "true");
+  assert.equal(context.history.replacedUrl, "/alerts?alert=alert-2");
+  assert.equal(panelTwo.focused, true);
+  assert.equal(panelTwo.scrolledIntoView, true);
+
+  const emptyDocument = new MockDocument();
+  const emptyContext = createBrowserContext(emptyDocument);
+  runScript("app/static/js/admin-alerts.js", emptyContext);
 }
 
 async function exerciseSessionTimeout() {
@@ -583,6 +642,7 @@ await post(session, "Profiler.startPreciseCoverage", {
 });
 
 await exerciseAccount();
+await exerciseAdminAlerts();
 await exerciseDashboard();
 await exercisePayees();
 await exerciseSessionTimeout();

--- a/tests/test_account_security_actions.py
+++ b/tests/test_account_security_actions.py
@@ -432,6 +432,41 @@ def test_profile_details_update_succeeds_for_authenticated_user(client, monkeypa
     assert new_username_login.headers["Location"].endswith("/mfa/verify")
     assert db.session.query(SecurityAuditEvent).filter_by(event_type="profile_update", outcome="success").count() == 1
 
+
+def test_profile_phone_update_succeeds_after_clean_password_totp_login(client, monkeypatch):
+    register(client)
+    user, secret = enable_mfa_for_user()
+    password_response = login(client)
+    login_time = int(time.time())
+    monkeypatch.setattr("app.auth.services.time.time", lambda: login_time)
+    mfa_response = client.post(
+        "/auth/mfa/verify",
+        json={"totp_code": pyotp.TOTP(secret, digits=6, interval=30).at(login_time)},
+    )
+
+    stepup_time = login_time + 31
+    monkeypatch.setattr("app.auth.services.time.time", lambda: stepup_time)
+    response = client.post(
+        "/profile",
+        data={
+            "username": "alice01",
+            "email": "alice@example.com",
+            "phone_number": "92345678",
+            "totp_code": pyotp.TOTP(secret, digits=6, interval=30).at(stepup_time),
+        },
+    )
+    db.session.refresh(user)
+
+    assert password_response.status_code == 302
+    assert mfa_response.status_code == 200
+    assert response.status_code == 302
+    assert user.phone_number == "92345678"
+    assert db.session.query(SecurityAuditEvent).filter_by(
+        event_type="session_risk",
+        outcome="reauth_required",
+    ).count() == 0
+
+
 def test_profile_email_update_requires_email_code_and_totp_stepup(client, monkeypatch):
     from app.security.email import password_reset_outbox
 

--- a/tests/test_admin_dashboard_operations.py
+++ b/tests/test_admin_dashboard_operations.py
@@ -773,11 +773,78 @@ def test_alert_review_renders_actionable_safe_detail_without_raw_logs(admin_clie
     assert "Next action" in body
     assert "Alert Detail" in body
     assert "manual_recovery_burst" in body
+    assert '<time datetime="2026-06-30T08:15:00+00:00">30 Jun 2026, 16:15:00 SGT</time>' in body
+    assert "<td>Principal reference</td>" in body
+    assert "<dt>Technical source</dt><dd>principal_ref:safe</dd>" in body
     assert f"/audit-logs/{event.id}" in body
     assert "[redacted]" in body
     assert sensitive_header not in body
     assert "authorization:" not in body.casefold()
     assert "review page is read-only" in body
+
+
+def test_alert_review_detail_links_use_loaded_panels_with_deep_link_fallback(
+    admin_client,
+    monkeypatch,
+):
+    _admin, admin_secret = _create_staff_identity(
+        username="security-admin",
+        email="security.admin@sit.singaporetech.edu.sg",
+        account_type="admin",
+        phone_number="91234568",
+    )
+
+    def fake_report(*, deliver):
+        assert deliver is False
+        return {
+            "message": "security_alert_report",
+            "generated_at": "2026-06-30T08:15:00+00:00",
+            "alert_count": 2,
+            "alerts": [
+                {
+                    "alert_type": "login_failure_burst",
+                    "severity": "medium",
+                    "count": 4,
+                    "window_seconds": 300,
+                    "source": "principal_ref:safe",
+                    "generated_at": "2026-06-30T08:15:00+00:00",
+                },
+                {
+                    "alert_type": "database_integrity_regression",
+                    "severity": "high",
+                    "count": 1,
+                    "window_seconds": 60,
+                    "source": "table:security_audit_events",
+                    "generated_at": "2026-06-30T08:16:00+00:00",
+                },
+            ],
+            "audit_chain": {"checked": True, "valid": True},
+            "database_integrity": {"checked": True, "valid": True},
+            "dedupe": {"enabled": False, "suppressed": 0},
+            "delivery": {"enabled": True},
+        }
+
+    monkeypatch.setattr("app.admin.routes.build_security_alert_report", fake_report)
+    _login_admin(admin_client, admin_secret, email="security.admin@sit.singaporetech.edu.sg")
+
+    response = admin_client.get("/alerts?alert=alert-2")
+    body = response.get_data(as_text=True)
+    script = Path("app/static/js/admin-alerts.js").read_text(encoding="utf-8")
+
+    assert response.status_code == 200
+    assert 'href="/alerts?alert=alert-1"' in body
+    assert 'data-alert-detail-link' in body
+    assert 'aria-controls="alert-detail-alert-1"' in body
+    assert 'aria-expanded="false"' in body
+    assert 'aria-controls="alert-detail-alert-2"' in body
+    assert 'aria-expanded="true"' in body
+    assert '<section class="panel alert-detail-panel"\n           id="alert-detail-alert-1"' in body
+    assert '<section class="panel alert-detail-panel"\n           id="alert-detail-alert-2"' in body
+    assert "Security Audit Events table" in body
+    assert "<dt>Technical source</dt><dd>table:security_audit_events</dd>" in body
+    assert 'js/admin-alerts.js' in body
+    assert "event.preventDefault()" in script
+    assert "window.history.replaceState" in script
 
 
 def test_alert_review_next_actions_cover_integrity_and_generic_alerts(admin_client, monkeypatch):

--- a/tests/test_admin_dashboard_operations.py
+++ b/tests/test_admin_dashboard_operations.py
@@ -844,7 +844,8 @@ def test_alert_review_detail_links_use_loaded_panels_with_deep_link_fallback(
     assert "<dt>Technical source</dt><dd>table:security_audit_events</dd>" in body
     assert 'js/admin-alerts.js' in body
     assert "event.preventDefault()" in script
-    assert "window.history.replaceState" in script
+    assert "globalThis.history" in script
+    assert "browserHistory.replaceState" in script
 
 
 def test_alert_review_next_actions_cover_integrity_and_generic_alerts(admin_client, monkeypatch):

--- a/tests/test_documentation_consistency.py
+++ b/tests/test_documentation_consistency.py
@@ -154,6 +154,8 @@ def test_auth_schema_reset_and_customer_unlock_docs_match_current_contract():
         "different active\nroot admin",
         "missing, malformed, or unsupported structured context",
         "narrow\nmigration case",
+        "normal redeploy or bounded customer reauthentication",
+        "do not relax TOTP replay checks",
         "retired URLs are unregistered",
     ):
         assert required in docs

--- a/tests/test_local_transfer.py
+++ b/tests/test_local_transfer.py
@@ -348,6 +348,47 @@ def test_complete_transfer_route_flow(client, transfer_context, monkeypatch):
     assert Transaction.query.filter_by(reference="Coverage").count() == 1
 
 
+def test_transfer_stepup_succeeds_after_clean_password_totp_login(
+    client,
+    transfer_context,
+    monkeypatch,
+):
+    payee = transfer_context["payee"]
+    secret = transfer_context["alice_secret"]
+    client.post("/logout")
+    password_response = login(client, identifier="alice01")
+    login_time = int(time.time())
+    monkeypatch.setattr("app.auth.services.time.time", lambda: login_time)
+    mfa_response = client.post(
+        "/auth/mfa/verify",
+        json={"totp_code": pyotp.TOTP(secret, digits=6, interval=30).at(login_time)},
+    )
+
+    stepup_time = login_time + 31
+    monkeypatch.setattr("app.auth.services.time.time", lambda: stepup_time)
+    submit_response = client.post(
+        f"/banking/transfer/{payee.id}",
+        data={
+            "amount": "25.00",
+            "reference": "Clean session",
+            "totp_code": pyotp.TOTP(secret, digits=6, interval=30).at(stepup_time),
+        },
+    )
+    confirm_response = client.get(f"/banking/transfer/{payee.id}/confirm")
+    complete_response = client.post(f"/banking/transfer/{payee.id}/confirm")
+
+    assert password_response.status_code == 302
+    assert mfa_response.status_code == 200
+    assert submit_response.status_code == 302
+    assert confirm_response.status_code == 200
+    assert complete_response.status_code == 302
+    assert Transaction.query.filter_by(reference="Clean session").count() == 1
+    assert db.session.query(SecurityAuditEvent).filter_by(
+        event_type="session_risk",
+        outcome="reauth_required",
+    ).count() == 0
+
+
 def test_transfer_stepup_accepts_matching_legacy_session_context(
     client,
     transfer_context,

--- a/tests/test_payee_management_security.py
+++ b/tests/test_payee_management_security.py
@@ -482,6 +482,22 @@ def test_payee_routes_cover_missing_expired_and_unauthorized_pending_state(clien
 
     add_page = client.get("/banking/payees/add")
     invalid_add = client.post("/banking/payees/add", data={})
+    nine_digit_add = client.post(
+        "/banking/payees/add",
+        data={
+            "nickname": "Short",
+            "account_number": "123456789",
+            "totp_code": "123456",
+        },
+    )
+    hyphenated_add = client.post(
+        "/banking/payees/add",
+        data={
+            "nickname": "Hyphen",
+            "account_number": "123-456-789-012",
+            "totp_code": "123456",
+        },
+    )
     missing_get = client.get("/banking/payees/confirm")
     missing_post = client.post("/banking/payees/confirm")
 
@@ -516,7 +532,15 @@ def test_payee_routes_cover_missing_expired_and_unauthorized_pending_state(clien
     self_payee = client.post("/banking/payees/confirm")
 
     assert add_page.status_code == 200
+    add_markup = add_page.get_data(as_text=True)
+    assert "9- or 12-digit" not in add_markup
+    assert 'placeholder="12-digit account number"' in add_markup
+    assert "Enter exactly 12 digits. Do not include hyphens or spaces." in add_markup
     assert invalid_add.status_code == 400
+    assert nine_digit_add.status_code == 400
+    assert hyphenated_add.status_code == 400
+    assert b"Account number must be exactly 12 digits" in nine_digit_add.data
+    assert b"Account number must be exactly 12 digits" in hyphenated_add.data
     assert missing_get.status_code == 302
     assert missing_post.status_code == 302
     assert expired.status_code == 302

--- a/tests/test_payup.py
+++ b/tests/test_payup.py
@@ -71,6 +71,20 @@ def _totp_code(secret: str, timestamp: int | None = None) -> str:
     return pyotp.TOTP(secret, digits=6, interval=30).at(timestamp or int(time.time()))
 
 
+def _complete_clean_mfa_login(client, secret: str, monkeypatch) -> int:
+    client.post("/logout")
+    password_response = login(client, identifier="alice01")
+    login_time = int(time.time())
+    monkeypatch.setattr("app.auth.services.time.time", lambda: login_time)
+    mfa_response = client.post(
+        "/auth/mfa/verify",
+        json={"totp_code": _totp_code(secret, login_time)},
+    )
+    assert password_response.status_code == 302
+    assert mfa_response.status_code == 200
+    return login_time
+
+
 def _payup_lookup_data(
     payup_context: dict,
     phone_number: str = "81234567",
@@ -862,6 +876,66 @@ def test_complete_payup_route_flow_crossing_threshold_requires_mfa(client, payup
     confirm_submit = client.post("/banking/payup/confirm", data={"totp_code": totp_code})
     assert confirm_submit.status_code == 302
     assert Transaction.query.filter_by(transaction_type="payup").count() == 1
+
+
+def test_payup_low_risk_succeeds_after_clean_password_totp_login(
+    client,
+    payup_context,
+    monkeypatch,
+):
+    _complete_clean_mfa_login(client, payup_context["alice_secret"], monkeypatch)
+
+    lookup = client.post("/banking/payup", data=_payup_lookup_data(payup_context))
+    amount = client.post(
+        "/banking/payup/amount",
+        data={"amount": "100.00", "reference": "Clean low risk"},
+    )
+    confirm_page = client.get("/banking/payup/confirm")
+    confirm_submit = client.post("/banking/payup/confirm", data={})
+
+    assert lookup.status_code == 302
+    assert amount.status_code == 302
+    assert confirm_page.status_code == 200
+    assert b"Authenticator code" not in confirm_page.data
+    assert confirm_submit.status_code == 302
+    assert Transaction.query.filter_by(reference="Clean low risk", transaction_type="payup").count() == 1
+    assert db.session.query(SecurityAuditEvent).filter_by(
+        event_type="session_risk",
+        outcome="reauth_required",
+    ).count() == 0
+
+
+def test_payup_stepup_succeeds_after_clean_password_totp_login(
+    client,
+    payup_context,
+    monkeypatch,
+):
+    alice_secret = payup_context["alice_secret"]
+    login_time = _complete_clean_mfa_login(client, alice_secret, monkeypatch)
+
+    lookup = client.post("/banking/payup", data=_payup_lookup_data(payup_context))
+    amount = client.post(
+        "/banking/payup/amount",
+        data={"amount": "450.00", "reference": "Clean stepup"},
+    )
+    confirm_page = client.get("/banking/payup/confirm")
+    stepup_time = login_time + 31
+    monkeypatch.setattr("app.auth.services.time.time", lambda: stepup_time)
+    confirm_submit = client.post(
+        "/banking/payup/confirm",
+        data={"totp_code": _totp_code(alice_secret, stepup_time)},
+    )
+
+    assert lookup.status_code == 302
+    assert amount.status_code == 302
+    assert confirm_page.status_code == 200
+    assert b"Authenticator code" in confirm_page.data
+    assert confirm_submit.status_code == 302
+    assert Transaction.query.filter_by(reference="Clean stepup", transaction_type="payup").count() == 1
+    assert db.session.query(SecurityAuditEvent).filter_by(
+        event_type="session_risk",
+        outcome="reauth_required",
+    ).count() == 0
 
 
 def test_payup_confirm_accepts_matching_legacy_session_context(


### PR DESCRIPTION
Summary
---
Improves admin alert review readability, clarifies Add Payee account-number guidance, and locks in the verified customer MFA/session behavior for profile update, Local Transfer, and PayUp. Closes #487, closes #491, and closes #493.

Why
---
Issue #487 was accurate: the admin alert page rendered raw UTC timestamps, raw technical source strings in the table, and used full-page navigation for alert detail. Issue #493 was accurate: Add Payee still advertised 9- or 12-digit account numbers even though validation is exactly 12 digits. Issue #491 was not reproducible on current main after #488, so this PR preserves the existing fail-closed session invariant and adds clean-session regressions plus operator documentation for stale deployed sessions.

What changed
---
- Render admin alert report and alert generated times as readable SGT in HTML while preserving UTC values in time datetime attributes and leaving JSON/report output unchanged.
- Show friendly alert source summaries in the alert table and keep sanitized technical source, status, window, reason, error type, related audit event, and recommended action in preloaded detail panels.
- Add a small admin alert script so JavaScript-enabled users reveal alert detail in place while the existing /alerts?alert=... deep-link fallback remains usable.
- Update Add Payee placeholder and hint to say exactly 12 digits and no hyphens or spaces, without changing strict validation.
- Add clean password-plus-TOTP regression coverage for profile update, Local Transfer, low-risk PayUp, step-up PayUp, Add Payee copy, alert detail UX, JS harness coverage, and documentation consistency.

Security impact
---
No authentication, authorization, CSRF, TOTP replay, pending-transfer verifier, transfer authorization, audit sanitization, or session-risk checks were weakened. Admin alert GET remains read-only through build_security_alert_report(deliver=False), manual alert delivery remains CSRF/TOTP-gated, and customer risk drift still fails closed before high-risk TOTP processing.

Deployment impact
---
No deployment action required. This is a source, template, static JavaScript, test, and documentation change only; no EC2 bootstrap, staging/production special operation, database migration, secret change, or provider setting change is expected.

Verification
---
- git diff --check
- .\.venv\Scripts\python.exe -m pytest -q tests/test_admin_dashboard_operations.py tests/test_payee_management_security.py tests/test_session_risk_binding.py tests/test_account_security_actions.py tests/test_local_transfer.py tests/test_payup.py tests/test_documentation_consistency.py
- .\.venv\Scripts\python.exe -m pytest -q -n 4
- .\.venv\Scripts\python.exe -m pytest -q -n 4 --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term

Notes
---
Local `node` is not installed on PATH, so `node tests/js/collect-browser-coverage.mjs` could not be run locally. The harness was updated to cover `admin-alerts.js` and should run in CI where Node is available.
