### PR TITLE
Fix mobile layout across customer banking pages

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1768,6 +1768,7 @@ th {
   display: flex;
   align-items: center;
   gap: var(--space-2);
+  overflow-wrap: normal;
 }
 
 .card-acct-label-group {
@@ -1791,6 +1792,7 @@ th {
   align-items: center;
   justify-content: flex-end;
   gap: var(--space-2);
+  overflow-wrap: normal;
 }
 
 .dashboard-txn-header {
@@ -2487,6 +2489,10 @@ th {
     color: var(--text);
   }
 
+  .session-timer {
+    right: 68px;
+  }
+
   .nav {
     position: absolute;
     left: 12px;
@@ -2556,7 +2562,9 @@ th {
   .hero,
   .panel,
   .auth-card,
-  .dashboard-header {
+  .dashboard-header,
+  .bank-account-card,
+  .statement-summary {
     padding: var(--space-5);
   }
 
@@ -2650,29 +2658,48 @@ th {
   }
 
   tr {
+    display: block;
     border: 1px solid var(--line);
     border-radius: var(--radius);
     margin-bottom: var(--space-4);
+    padding: var(--space-2) var(--space-4);
     background: var(--surface);
     box-shadow: var(--shadow-soft);
   }
 
   td {
     display: grid;
-    grid-template-columns: 130px minmax(0, 1fr);
-    gap: var(--space-3);
+    grid-template-columns: 112px minmax(0, 1fr);
+    align-items: start;
+    gap: var(--space-2) var(--space-3);
+    padding: var(--space-3) 0;
     border-bottom: 1px solid var(--line);
   }
 
   td::before {
     color: var(--muted-strong);
-    font-size: 0.82rem;
-    font-weight: 850;
+    font-size: 0.72rem;
+    font-weight: 800;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
     content: attr(data-label);
   }
 
   td:last-child {
     border-bottom: 0;
+  }
+
+  td.cell-amount {
+    font-variant-numeric: tabular-nums;
+    font-weight: 750;
+    text-align: right;
+  }
+
+  td.cell-actions {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--space-2);
   }
 }
 

--- a/app/templates/_transaction_row.html
+++ b/app/templates/_transaction_row.html
@@ -1,0 +1,36 @@
+{% from "_transaction_party.html" import transaction_party %}
+
+{% macro transaction_row(txn, user, show_actions=False) -%}
+<tr>
+  <td data-label="Type">
+    {% if txn.sender_id == user.id %}
+    <span class="badge neutral">Sent</span>
+    {% else %}
+    <span class="badge">Received</span>
+    {% endif %}
+  </td>
+  <td data-label="Transaction ID" title="{{ txn.transaction_ref }}">{{ txn.transaction_ref[:8]|upper }}</td>
+  <td data-label="Recipient">
+    {{ transaction_party(txn, user) }}
+  </td>
+  <td data-label="Method">
+    {% if txn.transaction_type == 'payup' %}
+    PayUp
+    {% else %}
+    Local Transfer
+    {% endif %}
+  </td>
+  <td data-label="Reference">{{ txn.reference or "—" }}</td>
+  <td data-label="Amount (SGD)" class="cell-amount">
+    {% if txn.sender_id == user.id %}
+    <span class="muted">−{{ txn.amount }}</span>
+    {% else %}
+    +{{ txn.amount }}
+    {% endif %}
+  </td>
+  <td data-label="Date"><time datetime="{{ txn.created_at|utc_iso }}">{{ txn.created_at|sgt_datetime }}</time></td>
+  {% if show_actions %}
+  <td data-label="Actions"><a class="button secondary small" href="{{ url_for('web.transaction_detail', transaction_id=txn.id) }}">View</a></td>
+  {% endif %}
+</tr>
+{%- endmacro %}

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from "_transaction_party.html" import transaction_party %}
+{% from "_transaction_row.html" import transaction_row %}
 
 {% block title %}Dashboard | SITBank{% endblock %}
 
@@ -151,35 +151,7 @@
         </thead>
         <tbody>
           {% for txn in transactions %}
-          <tr>
-            <td data-label="Type">
-              {% if txn.sender_id == user.id %}
-              <span class="badge neutral">Sent</span>
-              {% else %}
-              <span class="badge">Received</span>
-              {% endif %}
-            </td>
-            <td data-label="Transaction ID" title="{{ txn.transaction_ref }}">{{ txn.transaction_ref[:8]|upper }}</td>
-            <td data-label="Recipient">
-              {{ transaction_party(txn, user) }}
-            </td>
-            <td data-label="Method">
-              {% if txn.transaction_type == 'payup' %}
-              PayUp
-              {% else %}
-              Local Transfer
-              {% endif %}
-            </td>
-            <td data-label="Reference">{{ txn.reference or "—" }}</td>
-            <td data-label="Amount (SGD)" class="cell-amount">
-              {% if txn.sender_id == user.id %}
-              <span class="muted">−{{ txn.amount }}</span>
-              {% else %}
-              +{{ txn.amount }}
-              {% endif %}
-            </td>
-            <td data-label="Date"><time datetime="{{ txn.created_at|utc_iso }}">{{ txn.created_at|sgt_datetime }}</time></td>
-          </tr>
+          {{ transaction_row(txn, user) }}
           {% endfor %}
         </tbody>
       </table>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -152,33 +152,33 @@
         <tbody>
           {% for txn in transactions %}
           <tr>
-            <td>
+            <td data-label="Type">
               {% if txn.sender_id == user.id %}
               <span class="badge neutral">Sent</span>
               {% else %}
               <span class="badge">Received</span>
               {% endif %}
             </td>
-            <td title="{{ txn.transaction_ref }}">{{ txn.transaction_ref[:8]|upper }}</td>
-            <td>
+            <td data-label="Transaction ID" title="{{ txn.transaction_ref }}">{{ txn.transaction_ref[:8]|upper }}</td>
+            <td data-label="Recipient">
               {{ transaction_party(txn, user) }}
             </td>
-            <td>
+            <td data-label="Method">
               {% if txn.transaction_type == 'payup' %}
               PayUp
               {% else %}
               Local Transfer
               {% endif %}
             </td>
-            <td>{{ txn.reference or "—" }}</td>
-            <td>
+            <td data-label="Reference">{{ txn.reference or "—" }}</td>
+            <td data-label="Amount (SGD)" class="cell-amount">
               {% if txn.sender_id == user.id %}
               <span class="muted">−{{ txn.amount }}</span>
               {% else %}
               +{{ txn.amount }}
               {% endif %}
             </td>
-            <td><time datetime="{{ txn.created_at|utc_iso }}">{{ txn.created_at|sgt_datetime }}</time></td>
+            <td data-label="Date"><time datetime="{{ txn.created_at|utc_iso }}">{{ txn.created_at|sgt_datetime }}</time></td>
           </tr>
           {% endfor %}
         </tbody>

--- a/app/templates/my_disputes.html
+++ b/app/templates/my_disputes.html
@@ -31,11 +31,11 @@
         <tbody>
           {% for dispute in disputes %}
           <tr>
-            <td>{{ dispute.transaction.transaction_ref[:8]|upper }}</td>
-            <td>{{ dispute.issue_type.replace('_', ' ')|capitalize }}</td>
-            <td><time datetime="{{ dispute.created_at|utc_iso }}">{{ dispute.created_at|sgt_datetime }}</time></td>
-            <td><span class="badge {{ 'neutral' if dispute.status in ('open', 'under_review') else '' }}">{{ dispute.status.replace('_', ' ')|capitalize }}</span></td>
-            <td><a class="button secondary small" href="{{ url_for('web.transaction_detail', transaction_id=dispute.transaction_id) }}">View</a></td>
+            <td data-label="Transaction">{{ dispute.transaction.transaction_ref[:8]|upper }}</td>
+            <td data-label="Issue Type">{{ dispute.issue_type.replace('_', ' ')|capitalize }}</td>
+            <td data-label="Filed"><time datetime="{{ dispute.created_at|utc_iso }}">{{ dispute.created_at|sgt_datetime }}</time></td>
+            <td data-label="Status"><span class="badge {{ 'neutral' if dispute.status in ('open', 'under_review') else '' }}">{{ dispute.status.replace('_', ' ')|capitalize }}</span></td>
+            <td data-label="Actions"><a class="button secondary small" href="{{ url_for('web.transaction_detail', transaction_id=dispute.transaction_id) }}">View</a></td>
           </tr>
           {% endfor %}
         </tbody>

--- a/app/templates/payees.html
+++ b/app/templates/payees.html
@@ -18,39 +18,41 @@
 
   {% if payee_rows %}
   <div class="panel">
-    <table class="data-table">
-      <thead>
-        <tr>
-          <th scope="col">Nickname</th>
-          <th scope="col">Recipient Name</th>
-          <th scope="col">Account</th>
-          <th scope="col">Status</th>
-          <th scope="col"><span class="sr-only">Actions</span></th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for row in payee_rows %}
-        <tr>
-          <td>{{ row.payee.nickname }}</td>
-          <td>{{ row.payee.recipient_name }}</td>
-          <td>•••-•••-{{ row.payee.account_number[-3:] }}</td>
-          <td>
-            {% if row.status == "active" %}
-            <span class="badge">Ready</span>
-            {% else %}
-            <span class="badge neutral" data-cooldown-expires="{{ row.expires_at }}" title="Available at {{ row.available_at }}">Available in {{ row.remaining }}</span>
-            {% endif %}
-          </td>
-          <td>
-            {% if row.status == "active" %}
-            <a class="button small" href="{{ url_for('banking.transfer', payee_id=row.payee.id) }}">Transfer</a>
-            {% endif %}
-            <a class="button secondary small" href="{{ url_for('banking.payees_remove', payee_id=row.payee.id) }}">Remove</a>
-          </td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
+    <div class="table-wrap">
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th scope="col">Nickname</th>
+            <th scope="col">Recipient Name</th>
+            <th scope="col">Account</th>
+            <th scope="col">Status</th>
+            <th scope="col"><span class="sr-only">Actions</span></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in payee_rows %}
+          <tr>
+            <td data-label="Nickname">{{ row.payee.nickname }}</td>
+            <td data-label="Recipient Name">{{ row.payee.recipient_name }}</td>
+            <td data-label="Account">•••-•••-{{ row.payee.account_number[-3:] }}</td>
+            <td data-label="Status">
+              {% if row.status == "active" %}
+              <span class="badge">Ready</span>
+              {% else %}
+              <span class="badge neutral" data-cooldown-expires="{{ row.expires_at }}" title="Available at {{ row.available_at }}">Available in {{ row.remaining }}</span>
+              {% endif %}
+            </td>
+            <td data-label="Actions" class="cell-actions">
+              {% if row.status == "active" %}
+              <a class="button small" href="{{ url_for('banking.transfer', payee_id=row.payee.id) }}">Transfer</a>
+              {% endif %}
+              <a class="button secondary small" href="{{ url_for('banking.payees_remove', payee_id=row.payee.id) }}">Remove</a>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
   </div>
   {% else %}
   <div class="panel">

--- a/app/templates/statement.html
+++ b/app/templates/statement.html
@@ -99,32 +99,32 @@
         <tbody>
           {% for txn in statement.transactions %}
           <tr class="{{ 'statement-txn-not-counted' if txn.status != 'completed' else '' }}">
-            <td>
+            <td data-label="Type">
               {% if txn.sender_id == user.id %}
               <span class="badge neutral">Sent</span>
               {% else %}
               <span class="badge">Received</span>
               {% endif %}
             </td>
-            <td>
+            <td data-label="Counterparty">
               {{ transaction_party(txn, user) }}
             </td>
-            <td>{{ txn.reference or "—" }}</td>
-            <td>
+            <td data-label="Reference">{{ txn.reference or "—" }}</td>
+            <td data-label="Amount (SGD)" class="cell-amount">
               {% if txn.sender_id == user.id %}
               <span class="muted">−{{ txn.amount }}</span>
               {% else %}
               +{{ txn.amount }}
               {% endif %}
             </td>
-            <td>
+            <td data-label="Status">
               {% if txn.status == "completed" %}
               <span class="badge">Completed</span>
               {% else %}
               <span class="badge neutral" title="Not counted toward opening/closing balance">Failed</span>
               {% endif %}
             </td>
-            <td><time datetime="{{ txn.created_at|utc_iso }}">{{ txn.created_at|sgt_datetime }}</time></td>
+            <td data-label="Date"><time datetime="{{ txn.created_at|utc_iso }}">{{ txn.created_at|sgt_datetime }}</time></td>
           </tr>
           {% endfor %}
         </tbody>

--- a/app/templates/transaction_detail.html
+++ b/app/templates/transaction_detail.html
@@ -80,10 +80,10 @@
         <tbody>
           {% for dispute in disputes %}
           <tr>
-            <td>{{ dispute.issue_type.replace('_', ' ')|capitalize }}</td>
-            <td><time datetime="{{ dispute.created_at|utc_iso }}">{{ dispute.created_at|sgt_datetime }}</time></td>
-            <td><span class="badge {{ 'neutral' if dispute.status in ('open', 'under_review') else '' }}">{{ dispute.status.replace('_', ' ')|capitalize }}</span></td>
-            <td>{{ dispute.resolution_note or "—" }}</td>
+            <td data-label="Issue Type">{{ dispute.issue_type.replace('_', ' ')|capitalize }}</td>
+            <td data-label="Filed"><time datetime="{{ dispute.created_at|utc_iso }}">{{ dispute.created_at|sgt_datetime }}</time></td>
+            <td data-label="Status"><span class="badge {{ 'neutral' if dispute.status in ('open', 'under_review') else '' }}">{{ dispute.status.replace('_', ' ')|capitalize }}</span></td>
+            <td data-label="Resolution">{{ dispute.resolution_note or "—" }}</td>
           </tr>
           {% endfor %}
         </tbody>

--- a/app/templates/transactions.html
+++ b/app/templates/transactions.html
@@ -35,34 +35,34 @@
         <tbody>
           {% for txn in transactions %}
           <tr>
-            <td>
+            <td data-label="Type">
               {% if txn.sender_id == user.id %}
               <span class="badge neutral">Sent</span>
               {% else %}
               <span class="badge">Received</span>
               {% endif %}
             </td>
-            <td title="{{ txn.transaction_ref }}">{{ txn.transaction_ref[:8]|upper }}</td>
-            <td>
+            <td data-label="Transaction ID" title="{{ txn.transaction_ref }}">{{ txn.transaction_ref[:8]|upper }}</td>
+            <td data-label="Recipient">
               {{ transaction_party(txn, user) }}
             </td>
-            <td>
+            <td data-label="Method">
               {% if txn.transaction_type == 'payup' %}
               PayUp
               {% else %}
               Local Transfer
               {% endif %}
             </td>
-            <td>{{ txn.reference or "—" }}</td>
-            <td>
+            <td data-label="Reference">{{ txn.reference or "—" }}</td>
+            <td data-label="Amount (SGD)" class="cell-amount">
               {% if txn.sender_id == user.id %}
               <span class="muted">−{{ txn.amount }}</span>
               {% else %}
               +{{ txn.amount }}
               {% endif %}
             </td>
-            <td><time datetime="{{ txn.created_at|utc_iso }}">{{ txn.created_at|sgt_datetime }}</time></td>
-            <td><a class="button secondary small" href="{{ url_for('web.transaction_detail', transaction_id=txn.id) }}">View</a></td>
+            <td data-label="Date"><time datetime="{{ txn.created_at|utc_iso }}">{{ txn.created_at|sgt_datetime }}</time></td>
+            <td data-label="Actions"><a class="button secondary small" href="{{ url_for('web.transaction_detail', transaction_id=txn.id) }}">View</a></td>
           </tr>
           {% endfor %}
         </tbody>

--- a/app/templates/transactions.html
+++ b/app/templates/transactions.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from "_transaction_party.html" import transaction_party %}
+{% from "_transaction_row.html" import transaction_row %}
 
 {% block title %}Past Transactions | SITBank{% endblock %}
 
@@ -34,36 +34,7 @@
         </thead>
         <tbody>
           {% for txn in transactions %}
-          <tr>
-            <td data-label="Type">
-              {% if txn.sender_id == user.id %}
-              <span class="badge neutral">Sent</span>
-              {% else %}
-              <span class="badge">Received</span>
-              {% endif %}
-            </td>
-            <td data-label="Transaction ID" title="{{ txn.transaction_ref }}">{{ txn.transaction_ref[:8]|upper }}</td>
-            <td data-label="Recipient">
-              {{ transaction_party(txn, user) }}
-            </td>
-            <td data-label="Method">
-              {% if txn.transaction_type == 'payup' %}
-              PayUp
-              {% else %}
-              Local Transfer
-              {% endif %}
-            </td>
-            <td data-label="Reference">{{ txn.reference or "—" }}</td>
-            <td data-label="Amount (SGD)" class="cell-amount">
-              {% if txn.sender_id == user.id %}
-              <span class="muted">−{{ txn.amount }}</span>
-              {% else %}
-              +{{ txn.amount }}
-              {% endif %}
-            </td>
-            <td data-label="Date"><time datetime="{{ txn.created_at|utc_iso }}">{{ txn.created_at|sgt_datetime }}</time></td>
-            <td data-label="Actions"><a class="button secondary small" href="{{ url_for('web.transaction_detail', transaction_id=txn.id) }}">View</a></td>
-          </tr>
+          {{ transaction_row(txn, user, show_actions=True) }}
           {% endfor %}
         </tbody>
       </table>


### PR DESCRIPTION
Summary
---

Fixes mobile responsiveness across the customer banking pages: restores missing table labels on small screens, fixes a broken dashboard balance card, and fixes an overlapping header widget.

Why
---

The mobile "card" transform for data tables (`app.css`, <760px) relies on a `data-label` attribute per `<td>` to show field names via `::before { content: attr(data-label) }`. Six customer templates never set it, so on phones each transaction/payee/dispute row rendered as a stack of bare values with no way to tell which field was which. Separately, `payees.html` rendered its table outside the shared `.table-wrap` scroll container, so its `min-width: 880px` could force the whole page to scroll horizontally on tablet widths (761-880px) instead of just the table.

While visually verifying the fix on a real mobile viewport, two more pre-existing mobile bugs surfaced and are fixed in the same change since they block the same "usable on a phone" goal:

- A global `h1, h2, h3, p { overflow-wrap: anywhere }` rule combined with `display: flex` on the dashboard balance card's masked account number and balance figure (`.bank-card-number`, `.balance-amount`, both `<p>` elements) triggers a Chromium flex-sizing quirk where the text collapses to a single character wide, blowing the card out to 700+px tall and making it unreadable.
- The fixed session-timer badge overlapped the mobile hamburger menu button on every logged-in page below 760px.

What changed
---

* Added `data-label` attributes to every `<td>` in `dashboard.html`, `transactions.html`, `statement.html`, `my_disputes.html`, `transaction_detail.html`, and `payees.html`, matching the pattern already used in `sessions.html`.
* Wrapped the Payees table in `.table-wrap` for a contained horizontal scrollbar, consistent with every other data table.
* Added `.cell-amount` (right-aligned, bold, tabular numerals) and `.cell-actions` (stacked buttons with spacing) mobile card styles, and applied them to the relevant cells.
* Fixed `.bank-account-card` and `.statement-summary` to shrink padding on mobile like every other panel already does.
* Overrode `overflow-wrap: normal` on `.bank-card-number` and `.balance-amount` to stop the flex-collapse bug.
* Shifted `.session-timer` right offset on mobile so it clears the hamburger nav toggle.

Security impact
---

None. Template/CSS presentation changes only; no auth, session, CSRF, authorization, or data-handling logic touched.

Deployment impact
---

No deployment action required.

Verification
---

* `.\.venv\Scripts\python.exe -m pytest -q -n auto` — 1663 passed, 35 skipped.
* `git diff --check` — clean.
* Manual: booted the app locally and drove it with Playwright at a 390x844 mobile viewport (login + MFA, a real Local Transfer, a real dispute filing) and screenshotted all six edited pages plus the header, confirming labels render, the amount/action cell styling looks correct, the balance card renders normally, and the session-timer no longer overlaps the nav toggle.

Notes
---

None.