### PR TITLE
Fix eye-toggle buttons stretching full-width on mobile

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1827,6 +1827,7 @@ th {
   border-radius: 4px;
   transition: color 0.15s;
   flex-shrink: 0;
+  width: auto;
 }
 
 .card-eye-btn:hover {
@@ -1850,6 +1851,7 @@ th {
   border-radius: 4px;
   transition: color 0.15s;
   flex-shrink: 0;
+  width: auto;
 }
 
 .text-eye-btn:hover {
@@ -2459,8 +2461,17 @@ th {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
+  .bank-account-card-inner {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
   .bank-account-balance {
     text-align: left;
+  }
+
+  .balance-amount {
+    justify-content: flex-start;
   }
 
   :root {


### PR DESCRIPTION
Summary
---

Fixes a mobile layout bug where the dashboard balance card's account number/balance still looked squished after PR #511 — the reveal/hide eye-toggle buttons were stretching to fill the entire row width and squeezing the text next to them down to almost nothing.

Why
---

After PR #511 fixed the character-by-character text collapse, the account number still wrapped/looked cramped on real phone widths. Investigation with computed-style diagnostics (Playwright against a live-booted app) found the actual cause: the mobile button reset `.button, button { width: 100% }` also matches `<button>` elements used as small circular icon toggles (`.card-eye-btn` on the dashboard balance card, `.text-eye-btn` on the PayUp amount page). Combined with their existing `flex-shrink: 0`, each eye button claimed the full row width and starved its sibling text of space. This is the same bug class already fixed once for `.password-toggle` in this file — just missed for these two classes.

What changed
---

* Added `width: auto` to `.card-eye-btn` and `.text-eye-btn` so they keep their natural small size instead of being stretched full-width by the generic mobile button reset.
* Stacked the balance card's identity and balance sections vertically on mobile (`.bank-account-card-inner { flex-direction: column }`) instead of leaving them to compete over a wrapped flex row, giving the account number the full card width to lay out on one line.

Security impact
---

None. CSS-only presentation change; no auth, session, CSRF, authorization, or data-handling logic touched.

Deployment impact
---

No deployment action required.

Verification
---

* `.\.venv\Scripts\python.exe -m pytest -q -n auto` — 1663 passed, 35 skipped.
* `git diff --check` — clean.
* Manual: booted the app locally and used Playwright with `getBoundingClientRect`/`getComputedStyle` diagnostics plus screenshots at 320/360/375/390/414/430px widths to confirm the eye button's rendered width and the masked account number's wrap behavior before and after the fix. At 320px (smallest common phone), the account number and balance now both render on a single line.

Notes
---

Follow-up to #511. None otherwise.