### PR TITLE
Make customer username immutable after registration

### DIFF
--- a/app/auth/forms.py
+++ b/app/auth/forms.py
@@ -141,14 +141,10 @@ class ManualRecoveryForm(FlaskForm):
 
 
 class ProfileForm(FlaskForm):
-    username = StringField(
-        "Username",
-        validators=[
-            InputRequired(),
-            Length(min=3, max=64),
-            Regexp(USERNAME_RE, message=_INVALID_USERNAME_MESSAGE),
-        ],
-    )
+    # Username is intentionally not a field here: it is fixed at registration
+    # and must not be editable through the profile-update flow (see
+    # app/web/routes.py::profile_submit, which passes g.current_user.username
+    # to the service layer rather than any request-supplied value).
     email = StringField("Email address", validators=[InputRequired(), Email(), Length(max=255)])
     phone_number = StringField(
         _PHONE_NUMBER_LABEL,

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -74,9 +74,9 @@
         <form method="post" action="{{ url_for('web.profile_submit') }}" novalidate>
           {{ form.hidden_tag() }}
           <div class="form-group">
-            <label for="{{ form.username.id }}">Username</label>
-            {{ form.username(autocomplete="username", maxlength="64") }}
-            {% for error in form.username.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
+            <label>Username</label>
+            <p>{{ user.username }}</p>
+            <p class="hint">Your username is fixed and cannot be changed.</p>
           </div>
           <div class="form-group">
             <label for="{{ form.email.id }}">Email address</label>

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -852,9 +852,6 @@ def my_disputes():
 def profile():
     form = ProfileForm()
     pending_email_change = pending_profile_email_change()
-    form.username.data = (
-        pending_email_change["username"] if pending_email_change else g.current_user.username
-    )
     form.email.data = pending_email_change["email"] if pending_email_change else g.current_user.email
     form.phone_number.data = g.current_user.phone_number
     return render_template(
@@ -885,7 +882,7 @@ def profile_submit():
     try:
         result = update_profile_details(
             g.current_user,
-            form.username.data,
+            g.current_user.username,
             form.email.data,
             form.phone_number.data,
             form.totp_code.data,

--- a/tests/test_account_security_actions.py
+++ b/tests/test_account_security_actions.py
@@ -142,7 +142,7 @@ def test_authenticated_user_can_open_own_edit_profile_page(client):
     assert b"alice01" in response.data
     assert b"alice@example.com" in response.data
     assert b"91234567" in response.data
-    assert 'name="username"' in markup
+    assert 'name="username"' not in markup
     assert 'name="email"' in markup
     assert 'name="phone_number"' in markup
     assert "Update profile details" in markup
@@ -427,21 +427,21 @@ def test_profile_details_update_succeeds_for_authenticated_user(client, monkeypa
         data={
             "username": "alice02",
             "email": "alice@example.com",
-            "phone_number": "91234567",
+            "phone_number": "92345678",
             "totp_code": pyotp.TOTP(secret, digits=6, interval=30).at(stepup_time),
         },
     )
     db.session.refresh(user)
     client.post("/logout")
-    new_username_login = login(client, identifier="alice02")
+    original_username_login = login(client, identifier="alice01")
 
     assert response.status_code == 302
     assert response.headers["Location"].endswith("/profile")
-    assert user.username == "alice02"
+    assert user.username == "alice01"
     assert user.email == "alice@example.com"
-    assert user.phone_number == "91234567"
-    assert new_username_login.status_code == 302
-    assert new_username_login.headers["Location"].endswith("/mfa/verify")
+    assert user.phone_number == "92345678"
+    assert original_username_login.status_code == 302
+    assert original_username_login.headers["Location"].endswith("/mfa/verify")
     assert db.session.query(SecurityAuditEvent).filter_by(event_type="profile_update", outcome="success").count() == 1
 
 
@@ -773,35 +773,26 @@ def test_profile_update_rejects_admin_domain_customer_email(client):
     assert event.event_metadata["reason"] == "admin_email_domain"
 
 
-def test_profile_update_rejects_invalid_username(client):
-    register(client)
-    login(client)
-    user, _secret = enable_mfa_for_user()
-
-    response = client.post(
-        "/profile",
-        data={"username": "bad user", "email": "alice@example.com", "phone_number": "91234567"},
-    )
-    db.session.refresh(user)
-
-    assert response.status_code == 400
-    assert user.username == "alice01"
-
-def test_profile_update_rejects_duplicate_username(client):
+def test_profile_update_ignores_submitted_username(client):
     register(client)
     register(client, username="bob02", email="bob@example.com", full_name="Bob Test", phone_number="81234567")
     login(client)
-    user, _secret = enable_mfa_for_user()
+    user, secret = enable_mfa_for_user()
 
     response = client.post(
         "/profile",
-        data={"username": "BOB02", "email": "alice@example.com", "phone_number": "91234567"},
+        data={
+            "username": "bob02",
+            "email": "alice@example.com",
+            "phone_number": "92345678",
+            "totp_code": pyotp.TOTP(secret, digits=6, interval=30).now(),
+        },
     )
     db.session.refresh(user)
 
-    assert response.status_code == 400
+    assert response.status_code == 302
     assert user.username == "alice01"
-    assert db.session.query(SecurityAuditEvent).filter_by(event_type="profile_update", outcome="failure").count() == 1
+    assert user.phone_number == "92345678"
 
 def test_profile_update_rejects_duplicate_email(client):
     register(client)
@@ -909,7 +900,7 @@ def test_profile_submission_cannot_modify_privileged_fields(client):
     db.session.refresh(other_user)
 
     assert response.status_code == 302
-    assert user.username == "alice02"
+    assert user.username == "alice01"
     assert user.email == "alice@example.com"
     assert user.mfa_enabled is True
     assert user.is_frozen is False
@@ -927,14 +918,15 @@ def test_high_risk_action_accepts_totp_stepup(client):
         data={
             "username": "alice02",
             "email": "alice@example.com",
-            "phone_number": "91234567",
+            "phone_number": "92345678",
             "totp_code": pyotp.TOTP(secret, digits=6, interval=30).now(),
         },
     )
     db.session.refresh(user)
 
     assert response.status_code == 302
-    assert user.username == "alice02"
+    assert user.username == "alice01"
+    assert user.phone_number == "92345678"
 
 def test_totp_user_can_navigate_and_use_high_risk_forms(client):
     register(client)

--- a/tests/test_pentest_auth_bypass.py
+++ b/tests/test_pentest_auth_bypass.py
@@ -677,7 +677,7 @@ class TestProfileUpdateAuthZ:
 
         with app.app_context():
             user = db.session.get(User, uid)
-            assert user.username != "alice_hacked", \
+            assert user.email != "hacked@evil.com", \
                 "Profile updated without MFA verification!"
 
     def test_profile_update_rejects_wrong_mfa(self, app, client):
@@ -699,7 +699,7 @@ class TestProfileUpdateAuthZ:
 
         with app.app_context():
             user = db.session.get(User, uid)
-            assert user.username != "alice_hacked", \
+            assert user.email != "hacked@evil.com", \
                 "Profile updated with wrong MFA code!"
 
 


### PR DESCRIPTION
Summary
  ---

  Makes the customer username field immutable after registration — it can no longer be changed through the "Edit profile" page.

  Why
  ---

  Username was previously an editable field on the profile-update form, letting a customer change it at will after registration. A fixed
  username better matches how account identifiers should behave in a banking app (like an account number), and removes ambiguity around
  login-identifier history, audit trails, and support lookups tied to a username that could otherwise drift over time.

  What changed
  ---

  * app/auth/forms.py — removed the username field from ProfileForm entirely
  * app/web/routes.py — GET /profile no longer populates a username form field; POST /profile now always passes g.current_user.username (the
  account's real current value) to update_profile_details() instead of any request-supplied value
  * app/templates/profile.html — username is now displayed as plain read-only text with a "fixed and cannot be changed" hint, not an editable
  input
  * tests/test_account_security_actions.py — updated 5 tests that assumed username was mutable; replaced the two username-specific
  validation/duplicate tests with test_profile_update_ignores_submitted_username, which proves a submitted username (even one colliding with
  another account) is silently ignored while other fields still update normally
  * tests/test_pentest_auth_bypass.py — repointed two MFA-gating assertions from username (which can no longer change under any circumstance,
  making the assertion vacuous) to email (still the actual MFA-gated field being exercised)

  Security impact
  ---

  No new attack surface; this closes a minor "why is this even editable" gap rather than fixing an exploitable bug.
  app/auth/services.py::update_profile_details was intentionally left unchanged — since the route now always feeds it the account's own
  current username rather than a client-controlled value, the existing uniqueness re-check simply becomes a no-op for username, with no
  behavior change needed there.

  Deployment impact
  ---

  No deployment action required — this is a pure application-code change with no EC2 bootstrap, staging/production deployment, database
  migration, or secret changes.

  Verification
  ---

  * git diff --check — clean
  * Targeted run: pytest -q tests/test_account_security_actions.py tests/test_pentest_auth_bypass.py tests/test_route_inventory_security.py
  tests/test_authenticated_portal_ui.py tests/test_session_risk_binding.py — 122 passed
  * Full suite: pytest -q -n auto — 1666 passed, 31 skipped, 0 failed
  
  Notes
  ---

  No follow-up required.