### PR TITLE
Freeze TOTP verification time in profile-update tests

### DIFF
--- a/tests/test_account_security_actions.py
+++ b/tests/test_account_security_actions.py
@@ -773,11 +773,13 @@ def test_profile_update_rejects_admin_domain_customer_email(client):
     assert event.event_metadata["reason"] == "admin_email_domain"
 
 
-def test_profile_update_ignores_submitted_username(client):
+def test_profile_update_ignores_submitted_username(client, monkeypatch):
     register(client)
     register(client, username="bob02", email="bob@example.com", full_name="Bob Test", phone_number="81234567")
     login(client)
     user, secret = enable_mfa_for_user()
+    stepup_time = int(time.time())
+    monkeypatch.setattr("app.auth.services.time.time", lambda: stepup_time)
 
     response = client.post(
         "/profile",
@@ -785,7 +787,7 @@ def test_profile_update_ignores_submitted_username(client):
             "username": "bob02",
             "email": "alice@example.com",
             "phone_number": "92345678",
-            "totp_code": pyotp.TOTP(secret, digits=6, interval=30).now(),
+            "totp_code": pyotp.TOTP(secret, digits=6, interval=30).at(stepup_time),
         },
     )
     db.session.refresh(user)
@@ -874,13 +876,15 @@ def test_json_auth_post_requires_global_csrf_header_when_enabled(app, client):
     assert valid_token.status_code == 401
     assert valid_token.get_json() == {"error": "Invalid username or password"}
 
-def test_profile_submission_cannot_modify_privileged_fields(client):
+def test_profile_submission_cannot_modify_privileged_fields(client, monkeypatch):
     register(client)
     register(client, username="bob02", email="bob@example.com", full_name="Bob Test", phone_number="81234567")
     login(client)
     user, secret = enable_mfa_for_user()
     other_user = db.session.execute(db.select(User).where(User.username == "bob02")).scalar_one()
     original_password_hash = user.password_hash
+    stepup_time = int(time.time())
+    monkeypatch.setattr("app.auth.services.time.time", lambda: stepup_time)
 
     response = client.post(
         "/profile",
@@ -888,7 +892,7 @@ def test_profile_submission_cannot_modify_privileged_fields(client):
             "username": "alice02",
             "email": "alice@example.com",
             "phone_number": "91234567",
-            "totp_code": pyotp.TOTP(secret, digits=6, interval=30).now(),
+            "totp_code": pyotp.TOTP(secret, digits=6, interval=30).at(stepup_time),
             "user_id": str(other_user.id),
             "mfa_enabled": "true",
             "is_frozen": "true",
@@ -908,10 +912,12 @@ def test_profile_submission_cannot_modify_privileged_fields(client):
     assert other_user.username == "bob02"
     assert other_user.email == "bob@example.com"
 
-def test_high_risk_action_accepts_totp_stepup(client):
+def test_high_risk_action_accepts_totp_stepup(client, monkeypatch):
     register(client)
     login(client)
     user, secret = enable_mfa_for_user()
+    stepup_time = int(time.time())
+    monkeypatch.setattr("app.auth.services.time.time", lambda: stepup_time)
 
     response = client.post(
         "/profile",
@@ -919,7 +925,7 @@ def test_high_risk_action_accepts_totp_stepup(client):
             "username": "alice02",
             "email": "alice@example.com",
             "phone_number": "92345678",
-            "totp_code": pyotp.TOTP(secret, digits=6, interval=30).now(),
+            "totp_code": pyotp.TOTP(secret, digits=6, interval=30).at(stepup_time),
         },
     )
     db.session.refresh(user)


### PR DESCRIPTION
Summary
  ---

  Fixes a flaky TOTP-timing race in three profile-update tests that caused the "Test and security checks" CI job to fail on main after PR #513
  merged.

  Why
  ---

  test_profile_update_ignores_submitted_username, test_profile_submission_cannot_modify_privileged_fields, and
  test_high_risk_action_accepts_totp_stepup generated their step-up TOTP code with pyotp's .now() (real wall clock) rather than freezing time.
  Under a slower/more loaded CI runner, enough time can elapse between code generation and server-side verification to cross the 30-second
  TOTP window, causing a legitimately-correct code to be rejected as invalid (401) instead of accepted (302). This test file already has an
  established safe pattern for this exact problem (test_profile_details_update_succeeds_for_authenticated_user), which the three new/touched
  tests didn't follow.

  What changed
  ---

  * tests/test_account_security_actions.py — all three tests now freeze app.auth.services.time.time via monkeypatch and generate the TOTP code
  with .at(stepup_time) instead of .now()

  Security impact
  ---

  None — test-only change, no application code touched.

  Deployment impact
  ---

  No deployment action required.

  Verification
  ---

  * git diff --check — clean
  * Targeted run of all three affected tests — 3 passed
  * Full suite: pytest -q -n auto — 1666 passed, 31 skipped, 0 failed
  * Reproduced the failure theory by running the affected test 5x in isolation and 3x under -n auto locally — 100% pass rate, consistent with
  a CI-environment-specific timing race rather than a local, deterministic bug

  Notes
  ---

  No follow-up required.