### PR TITLE
Inform customers their username is permanent at registration

### DIFF
--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -68,6 +68,7 @@
       <div class="form-group">
         <label for="{{ form.username.id }}">Username</label>
         {{ form.username(autocomplete="username", maxlength="64") }}
+        <p class="hint">Choose carefully — your username is permanent and cannot be changed after registration.</p>
         {% for error in form.username.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
       </div>
 

--- a/tests/test_authenticated_portal_ui.py
+++ b/tests/test_authenticated_portal_ui.py
@@ -182,6 +182,7 @@ def test_authentication_pages_have_password_helpers_and_mfa_back_link(client):
     assert mfa_page.status_code == 200
     assert "data-password-toggle" in register_page.data.decode("utf-8")
     assert "data-password-strength" in register_page.data.decode("utf-8")
+    assert "username is permanent and cannot be changed" in register_page.data.decode("utf-8")
     assert "data-password-toggle" in login_page.data.decode("utf-8")
     assert "Back to login" in mfa_page.data.decode("utf-8")
 


### PR DESCRIPTION
Summary
  ---

  Adds a hint on the registration page telling customers their username is permanent and cannot be changed after registration.

  Why
  ---

  Profile-edit no longer allows changing username (prior fix), but registration itself gave no indication of that, so a customer had no way to
  know their username choice was permanent until they later tried to change it and couldn't.

  What changed
  ---

  * app/templates/register.html — added a hint under the username field: "Choose carefully — your username is permanent and cannot be changed
  after registration."
  * tests/test_authenticated_portal_ui.py — extended the existing registration-page markup test to assert this hint is present

  Security impact
  ---

  None — copy-only UI change, no application logic touched.

  Deployment impact
  ---

  No deployment action required.

  Verification
  ---

  * git diff --check — clean
  * Targeted run: pytest -q tests/test_authenticated_portal_ui.py — 14 passed

  Notes
  ---

  No follow-up required.