### PR TITLE
Remove username field from the profile-edit form

### DIFF
--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -74,11 +74,6 @@
         <form method="post" action="{{ url_for('web.profile_submit') }}" novalidate>
           {{ form.hidden_tag() }}
           <div class="form-group">
-            <label>Username</label>
-            <p>{{ user.username }}</p>
-            <p class="hint">Your username is fixed and cannot be changed.</p>
-          </div>
-          <div class="form-group">
             <label for="{{ form.email.id }}">Email address</label>
             {{ form.email(autocomplete="email", maxlength="255") }}
             {% for error in form.email.errors %}<p class="field-error">{{ error }}</p>{% endfor %}


### PR DESCRIPTION
Summary
  ---

  Removes the username field from the profile-edit form, leaving only email and phone number as editable fields in that panel.

  Why
  ---

  Username is already immutable (enforced server-side by a prior change) and shown read-only in the "Profile details" summary panel on the
  left of the edit-profile page. Showing it a second time in the editable-fields panel on the right, even as read-only text, was confusing
  next to email and phone, which are genuinely editable there.

  What changed
  ---

  * app/templates/profile.html — removed the username display block from the edit-profile form, leaving only email and phone number as
  editable fields

  Security impact
  ---

  None — template-only change, no application logic touched. Username was already server-side immutable before this change; this only removes
  a redundant read-only display from the UI.

  Deployment impact
  ---

  No deployment action required.

  Verification
  ---

  * git diff --check — clean
  * Targeted run: pytest -q tests/test_account_security_actions.py tests/test_authenticated_portal_ui.py tests/test_pentest_auth_bypass.py —
  97 passed
  * Full suite: pytest -q -n auto — 1676 passed, 31 skipped (3 unrelated transient failures on this run, not reproducible individually or on a
  clean main checkout — confirmed pre-existing flakiness, not caused by this change)

  Notes
  ---

  No follow-up required.