### PR TITLE
Reword the registration-page username notice

### DIFF
--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -68,7 +68,7 @@
       <div class="form-group">
         <label for="{{ form.username.id }}">Username</label>
         {{ form.username(autocomplete="username", maxlength="64") }}
-        <p class="hint">Choose carefully — your username is permanent and cannot be changed after registration.</p>
+        <p class="hint">Username is not allowed to be changed after registration is successful.</p>
         {% for error in form.username.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
       </div>
 

--- a/tests/test_authenticated_portal_ui.py
+++ b/tests/test_authenticated_portal_ui.py
@@ -182,7 +182,7 @@ def test_authentication_pages_have_password_helpers_and_mfa_back_link(client):
     assert mfa_page.status_code == 200
     assert "data-password-toggle" in register_page.data.decode("utf-8")
     assert "data-password-strength" in register_page.data.decode("utf-8")
-    assert "username is permanent and cannot be changed" in register_page.data.decode("utf-8")
+    assert "Username is not allowed to be changed after registration is successful" in register_page.data.decode("utf-8")
     assert "data-password-toggle" in login_page.data.decode("utf-8")
     assert "Back to login" in mfa_page.data.decode("utf-8")
 


### PR DESCRIPTION
Summary
  ---

  Rewords the registration-page username-immutability hint to a plain statement.

  Why
  ---

  PR #516 merged with the original em-dash-joined wording before this simplification was ready. Review feedback asked for plainer wording
  without a dash.

  What changed
  ---

  * app/templates/register.html — hint text changed to "Username is not allowed to be changed after registration is successful."
  * tests/test_authenticated_portal_ui.py — updated the matching markup assertion

  Security impact
  ---

  None — copy-only change.

  Deployment impact
  ---

  No deployment action required.

  Verification
  ---

  * git diff --check — clean
  * Targeted run: pytest -q tests/test_authenticated_portal_ui.py — 14 passed

  Notes
  ---

  No follow-up required.