### PR TITLE
Render generic staff invite unavailable page

### DIFF
--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -1500,8 +1500,14 @@ def manual_recovery_complete(request_id: int):
 @admin_bp.get("/invites/accept/<token>")
 @limiter.limit("20 per hour", key_func=get_remote_address)
 def invite_accept_info(token: str):
-    result = invite_info(token)
-    if _wants_json():
+    wants_json = _wants_json()
+    try:
+        result = invite_info(token)
+    except AuthError as exc:
+        if wants_json:
+            raise
+        return _render_invite_acceptance("", phase="unavailable", status_code=exc.status_code)
+    if wants_json:
         return jsonify(result)
     return _render_invite_acceptance(token, phase="start")[0]
 

--- a/app/templates/admin/invite_accept.html
+++ b/app/templates/admin/invite_accept.html
@@ -57,12 +57,15 @@
       </div>
       <button class="button full" type="submit">Activate staff access</button>
     </form>
-  {% else %}
+  {% elif phase == "complete" %}
     <h1>Staff access activated</h1>
     <p class="muted">Your workplace email and authenticator have been verified. Use the staff login with your workplace email, password, and authenticator code.</p>
     <div class="button-row">
       <a class="button" href="{{ url_for('admin.login_form') }}">Continue to staff login</a>
     </div>
+  {% else %}
+    <h1>Staff invite unavailable</h1>
+    <p class="muted">This invite link is invalid or expired. Ask a root admin to review the invite and send a new link if access is still needed.</p>
   {% endif %}
 </section>
 {% endblock %}

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -476,6 +476,9 @@ passwords, TOTP setup secrets, or workplace verification codes. If an active
 invite becomes locked by the restart cap, a root admin should use the invite
 screen's reset action with a fresh TOTP code; do not unlock it by editing
 database rows directly.
+Stale or malformed browser invite links render a generic invite-unavailable page
+instead of the private admin error page; explicit JSON clients receive only the
+minimal generic error.
 Invite creation, revoke, reset, and reissue actions use strict high-risk TOTP:
 wait for a fresh authenticator code before retrying an invite action, and do
 not reuse the same code for repeated invite operations. The invite table shows

--- a/docs/security/architecture/cryptography-and-authentication.md
+++ b/docs/security/architecture/cryptography-and-authentication.md
@@ -396,6 +396,9 @@ active invite. Staff invite password fields are length-bounded at the request
 schema before the service-level password policy runs. Repeated invalid TOTP or
 workplace-code verification attempts also lock the active invite until a root
 admin resets, revokes, or reissues it.
+Stale or malformed browser invite links render a generic invite-unavailable page
+instead of the private admin error page; explicit JSON clients receive only the
+minimal generic error.
 
 Evidence: `app/admin/routes.py`, `app/admin/services.py`,
 `app/admin/separation.py`, `admin_wsgi.py`, `config.py`, and

--- a/tests/test_admin_staff_invites.py
+++ b/tests/test_admin_staff_invites.py
@@ -120,6 +120,27 @@ def _assert_invite_acceptance_security_headers(response):
     assert response.headers.get("Referrer-Policy") == "no-referrer"
 
 
+def _assert_generic_invite_unavailable_page(response, token: str):
+    body = response.get_data(as_text=True)
+    assert response.status_code == 401
+    assert response.mimetype == "text/html"
+    assert "Staff invite unavailable" in body
+    assert "This invite link is invalid or expired" in body
+    assert "Security token expired or invalid" not in body
+    assert "Private admin request status" not in body
+    assert token not in body
+    for forbidden in (
+        "staff.person@sit.singaporetech.edu.sg",
+        "workplace_email",
+        "acceptance_",
+        "setup_user",
+        "revoked_by_user_id",
+        "used_by_user_id",
+    ):
+        assert forbidden not in body
+    _assert_invite_acceptance_security_headers(response)
+
+
 def _invite_info_json(client, token: str):
     return client.get(
         f"/invites/accept/{token}",
@@ -757,6 +778,49 @@ def test_invite_info_closed_tokens_return_generic_errors_and_no_token_audit(admi
     serialized_metadata = json.dumps([event.event_metadata for event in events], default=str)
     assert missing_token not in serialized_metadata
     assert "token" not in serialized_metadata.casefold()
+
+
+def test_browser_invite_info_closed_tokens_render_generic_recipient_page(admin_client):
+    root, _secret = _create_staff_identity(
+        username="root-admin",
+        email=ROOT_EMAIL,
+        account_type="root_admin",
+        phone_number="91234567",
+    )
+    closed_cases = [
+        ("MissingInviteToken000000000000000000000000", {}),
+        ("MalformedInviteToken", None),
+        (
+            "ExpiredInviteToken000000000000000000000000",
+            {"expires_at": datetime.now(timezone.utc) - timedelta(minutes=1)},
+        ),
+        (
+            "RevokedInviteToken000000000000000000000000",
+            {"status": "revoked", "revoked_at": datetime.now(timezone.utc)},
+        ),
+        (
+            "AcceptedInviteToken00000000000000000000000",
+            {"status": "accepted", "used_at": datetime.now(timezone.utc)},
+        ),
+        (
+            "LockedInviteToken000000000000000000000000",
+            {"acceptance_locked_at": datetime.now(timezone.utc), "acceptance_start_count": 3},
+        ),
+    ]
+
+    for token, overrides in closed_cases:
+        if overrides is not None and overrides:
+            _insert_invite_for_token(token, root, **overrides)
+
+        response = admin_client.get(f"/invites/accept/{token}")
+
+        _assert_generic_invite_unavailable_page(response, token)
+
+    events = db.session.query(SecurityAuditEvent).filter_by(event_type="staff_invite_invalid_attempt").all()
+    serialized_metadata = json.dumps([event.event_metadata for event in events], default=str)
+    for token, _overrides in closed_cases:
+        assert token not in serialized_metadata
+    assert db.session.query(User).count() == 1
 
 
 def test_invite_info_does_not_reveal_started_or_locked_acceptance_state(admin_client):

--- a/tests/test_security_docs_issue_links.py
+++ b/tests/test_security_docs_issue_links.py
@@ -290,6 +290,7 @@ def test_staff_invite_acceptance_docs_cover_minimal_metadata_and_restart_control
         "`queued` means sitbank handed the message to the configured email backend",
         "normal browser get renders the onboarding page while an explicit json client receives the minimal api response",
         "viewing the page leaves the invite pending and creates no account",
+        "stale or malformed browser invite links render a generic invite-unavailable page",
         "use the root-admin reissue action to rotate the stored invite token hash",
         "invite is moved out of active pending state so it does not block safe retry",
         "do not repair locked invites by editing production rows ad hoc",


### PR DESCRIPTION
Summary
---
Renders unusable staff/admin invite browser links through the invite acceptance page's generic unavailable state instead of the private admin error page, while preserving the minimal JSON/API error contract.

Why
---
Issue #522 reports invite recipients landing on an admin error experience instead of a recipient-safe invite flow. Valid invite links already open the onboarding page; this closes the adjacent stale, malformed, revoked, accepted, and locked browser-link path so those links fail closed without exposing invite metadata or raw token material.

What changed
---
- Browser GETs for unusable invite tokens now render a generic invite-unavailable state with the original fail-closed status code.
- JSON clients still receive the existing structured AuthError responses.
- Added regression coverage for missing, malformed, expired, revoked, accepted, and locked browser invite links, plus docs/stale-doc coverage for the browser/API split.

Security impact
---
The invite-token boundary remains fail closed. The page does not echo raw tokens, workplace email, role, setup state, counters, lock timestamps, user IDs, or private admin error copy. CSRF-protected start and verify forms, token hashing, expiry, one-time use, session binding, restart limits, verification lockout, Turnstile, TOTP setup, workplace-code verification, and safe audit metadata are preserved.

Deployment impact
---
No deployment action required beyond the normal application release. No EC2 bootstrap, database migration, secret change, or provider setting change is required.

Verification
---
- `git diff --check`
- `.\.venv\Scripts\python.exe -m pytest -q tests/test_admin_staff_invites.py tests/test_web_route_dispatch_coverage.py tests/test_security_docs_issue_links.py tests/test_documentation_consistency.py` - 83 passed
- `.\.venv\Scripts\python.exe -m pytest -q -n 4` - 1680 passed, 36 skipped
- `.\.venv\Scripts\python.exe -m pytest -q -n 4 --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term` - 1680 passed, 36 skipped, 91% total coverage

Notes
---
Closes #522
