### PR TITLE
Notify a replaced session's tab without waiting for navigation

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -120,6 +120,7 @@ def register_forced_password_change_guard(app: Flask) -> None:
             "auth.csrf_token",
             "auth.logout",
             "auth.session_extend",
+            "auth.session_status",
             "auth.password_change",
             "auth.password_reset_request",
             "auth.password_reset_exchange",

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from flask import Blueprint, current_app, g, jsonify, request
+from flask import Blueprint, current_app, g, jsonify, request, session
 from flask_limiter.util import get_remote_address
 from flask_wtf.csrf import generate_csrf
 from marshmallow import Schema, ValidationError
@@ -9,6 +9,7 @@ from app.extensions import limiter
 from app.auth.mfa_policy import has_enrolled_mfa_method
 from app.admin.services import is_customer_user
 from app.security.rate_limits import mfa_principal, request_principal
+from app.security.sessions import session_replacement_reason
 from app.security.turnstile import TurnstileError, require_turnstile
 
 from .decorators import login_required, not_frozen_required
@@ -85,6 +86,7 @@ AUTH_MFA_ONBOARDING_ALLOWED_ENDPOINTS = {
     "auth.csrf_token",
     "auth.logout",
     "auth.session_extend",
+    "auth.session_status",
     "auth.mfa_setup",
     "auth.mfa_setup_verify",
     "auth.password_reset_request",
@@ -304,6 +306,15 @@ def session_extend():
             "timeout_seconds": int(current_app.config["SESSION_INACTIVITY_SECONDS"]),
         }
     )
+
+
+@auth_bp.get("/session/status")
+def session_status():
+    if session.get("user_id") and g.current_user is not None:
+        return jsonify({"status": "active"})
+    reason = session_replacement_reason()
+    code = "replaced" if reason == "session_cap" else "ended"
+    return jsonify({"status": "signed_out", "code": code}), 401
 
 
 @auth_bp.post("/mfa/setup")

--- a/app/security/sessions.py
+++ b/app/security/sessions.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta, timezone
 from functools import wraps
 from typing import Any
 
-from flask import Flask, current_app, flash, has_request_context, jsonify, redirect, request, session, url_for
+from flask import Flask, current_app, flash, g, has_request_context, jsonify, redirect, request, session, url_for
 from flask.sessions import SessionInterface, SessionMixin, session_json_serializer
 from sqlalchemy.exc import IntegrityError
 from werkzeug.datastructures import CallbackDict
@@ -57,6 +57,10 @@ SESSION_END_REASON_LABELS = {
     "ended": "Ended",
 }
 _SESSION_STORE_LOCK = threading.RLock()
+_SESSION_REPLACED_REASON_G_KEY = "_sitbank_session_replaced_reason"
+# Polled by the client to detect a session replaced elsewhere; must not itself
+# count as activity or it would silently defeat the inactivity timeout.
+ACTIVITY_EXEMPT_ENDPOINTS = frozenset({"auth.session_status"})
 
 
 def _session_store_locked(func):
@@ -115,6 +119,7 @@ class DatabaseSessionInterface(SessionInterface):
 
         now = _utcnow()
         if record.revoked_at is not None:
+            _stash_session_replacement_reason(record.ended_reason)
             return self.session_class(sid=_new_session_id(), new=True)
         if record.expires_at is None:
             self._handle_integrity_failure(record, reason="missing_expires_at")
@@ -278,6 +283,19 @@ def current_session_id() -> str | None:
     if not has_request_context():
         return None
     return getattr(session, "sid", None)
+
+
+def _stash_session_replacement_reason(reason: str | None) -> None:
+    if has_request_context():
+        setattr(g, _SESSION_REPLACED_REASON_G_KEY, reason)
+
+
+def session_replacement_reason() -> str | None:
+    # Set only when open_session() discovers the presented cookie's session was
+    # already revoked (e.g. session_cap); unset for a request with no session at all.
+    if not has_request_context():
+        return None
+    return getattr(g, _SESSION_REPLACED_REASON_G_KEY, None)
 
 
 def session_lookup_hash(session_id: str) -> str:
@@ -1096,9 +1114,10 @@ def _enforce_session_activity():
     if context_response is not None:
         return context_response
 
-    session["last_activity_at"] = now
-    session.modified = True
-    update_session_activity()
+    if request.endpoint not in ACTIVITY_EXEMPT_ENDPOINTS:
+        session["last_activity_at"] = now
+        session.modified = True
+        update_session_activity()
     return None
 
 

--- a/app/static/js/session-timeout.js
+++ b/app/static/js/session-timeout.js
@@ -20,6 +20,9 @@
   const timerEl = document.getElementById('session-timer');
   const timerValueEl = document.getElementById('session-timer-value');
   const csrfMeta = document.querySelector('meta[name="csrf-token"]');
+  const replacedOverlayEl = document.getElementById('session-replaced-overlay');
+  const statusPollMs = 15000;
+  let sessionEnded = false;
 
   function formatTime(ms) {
     const totalSeconds = Math.max(0, Math.ceil(ms / 1000));
@@ -29,6 +32,7 @@
   }
 
   function updateTimerDisplay() {
+    if (sessionEnded) return;
     const remaining = timeoutMs - (Date.now() - lastResetTime);
     if (timerValueEl) timerValueEl.textContent = formatTime(remaining);
     if (timerEl) {
@@ -64,6 +68,31 @@
 
   function expire() {
     globalThis.location.href = '/login?session_expired=1';
+  }
+
+  function showReplacedOverlay() {
+    if (sessionEnded) return;
+    sessionEnded = true;
+    clearTimeout(expireTimer);
+    clearTimeout(warningTimer);
+    hideOverlay();
+    if (replacedOverlayEl && !replacedOverlayEl.open) replacedOverlayEl.showModal();
+  }
+
+  function pollSessionStatus() {
+    if (sessionEnded || document.hidden) return;
+    fetch('/auth/session/status', {
+      method: 'GET',
+      credentials: 'same-origin',
+      headers: { 'Accept': 'application/json' }
+    }).then(function (response) {
+      if (response.ok) return null;
+      return response.json().catch(function () { return {}; });
+    }).then(function (payload) {
+      if (payload && payload.code === 'replaced') {
+        showReplacedOverlay();
+      }
+    }).catch(function () {});
   }
 
   function resetTimers() {
@@ -112,5 +141,6 @@
   }
 
   setInterval(updateTimerDisplay, 1000);
+  setInterval(pollSessionStatus, statusPollMs);
   resetTimers();
 })();

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -208,6 +208,15 @@
           </div>
         </div>
       </dialog>
+      <dialog id="session-replaced-overlay" class="session-modal-overlay" aria-labelledby="session-replaced-title">
+        <div class="session-modal">
+          <h2 class="session-modal-title" id="session-replaced-title">Signed Out</h2>
+          <p class="session-modal-message">You've been signed out because your account signed in from another device or browser.</p>
+          <div class="session-modal-actions">
+            <a href="{{ url_for('web.login', session_replaced=1) }}" class="button">Log In Again</a>
+          </div>
+        </div>
+      </dialog>
       {% endif %}
       {% block alerts %}
       {% with messages = get_flashed_messages(with_categories=true) %}

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -343,6 +343,8 @@ def login():
         return redirect(url_for(_DASHBOARD_ENDPOINT))
     if request.args.get("session_expired"):
         flash("Your session expired due to inactivity. Please log in again.", "warning")
+    elif request.args.get("session_replaced"):
+        flash("You were signed out because your account signed in from another device or browser.", "warning")
     return render_template(_LOGIN_TEMPLATE, form=LoginForm())
 
 

--- a/docs/security/architecture/session-management.md
+++ b/docs/security/architecture/session-management.md
@@ -154,9 +154,15 @@ Only one active customer/admin session is allowed per runtime namespace. A new
 successful login replaces previous active sessions in that namespace and moves
 them to past-session history. Old browser tabs may still display stale HTML
 until the next request, but the revoked session cannot access protected routes.
-The session-management page is for reviewing the current active session and
-recent past sessions; normal operation does not require a manual bulk-revoke
-form.
+The replaced tab does not have to navigate to find out, though:
+`session-timeout.js` polls `GET /auth/session/status` roughly every 15 seconds
+(paused while the tab is hidden) and shows a dedicated "Signed Out" dialog as
+soon as the server reports the session was replaced. The status endpoint is
+listed in `app/security/sessions.py::ACTIVITY_EXEMPT_ENDPOINTS` so polling it
+never refreshes `last_activity_at`; otherwise a background poll would silently
+defeat the inactivity timeout below. The session-management page is for
+reviewing the current active session and recent past sessions; normal
+operation does not require a manual bulk-revoke form.
 
 | Lifecycle event | Control | Evidence |
 | --- | --- | --- |
@@ -165,6 +171,7 @@ form.
 | Successful admin MFA | Uses the admin session cookie and staff account checks | `app/admin/services.py`; `tests/test_admin_staff_invites.py::test_admin_login_creates_only_admin_session_cookie` |
 | Password change | Requires TOTP step-up, changes the password, and revokes all customer sessions so the user signs in again | `app/auth/services.py::change_password()`; `tests/test_account_security_actions.py::test_password_change_succeeds_with_recent_mfa_and_revokes_other_sessions` |
 | Any successful login, MFA-verified or not | Enforces the single active customer/admin session cap and moves replaced sessions to past-session history | `app/security/sessions.py::establish_authenticated_session()` and `enforce_active_session_cap()`; `tests/test_session_management.py::test_mfa_login_enforces_single_active_session_cap` |
+| A replaced or ended session polled from its own browser tab | Reports status without requiring the (now invalid) session, without extending the inactivity window | `app/auth/routes.py::session_status()`; `app/security/sessions.py::session_replacement_reason()`; `tests/test_session_management.py::test_session_status_reports_replaced_after_new_login_elsewhere`, `tests/test_session_management.py::test_session_status_polling_does_not_extend_inactivity_window` |
 | Logout | Revokes current server-side session | `tests/test_session_management.py::test_logout_invalidates_current_session` |
 | Protected revoke-other endpoint | Preserved as a CSRF/MFA-protected backend defense-in-depth route and not linked from the session-management page | `tests/test_session_management.py::test_revoke_other_sessions_accepts_totp_stepup_and_rotates_session`; `tests/test_session_management.py::test_sessions_page_keeps_review_controls_without_bulk_revoke_action` |
 | Terminate one listed session | Uses public session references and ownership checks | `tests/test_session_management.py::test_terminate_other_session_by_public_reference_revokes_it` |

--- a/tests/js/collect-browser-coverage.mjs
+++ b/tests/js/collect-browser-coverage.mjs
@@ -448,15 +448,17 @@ async function exerciseSessionTimeout() {
   const continueButton = new MockElement({ id: "session-continue-btn" });
   const timer = new MockElement({ id: "session-timer" });
   const timerValue = new MockElement({ id: "session-timer-value" });
+  const replacedOverlay = new MockElement({ id: "session-replaced-overlay" });
   document.selectorMap.set('meta[name="session-timeout"]', meta);
   document.selectorMap.set('meta[name="csrf-token"]', csrf);
-  for (const element of [overlay, countdown, continueButton, timer, timerValue]) {
+  for (const element of [overlay, countdown, continueButton, timer, timerValue, replacedOverlay]) {
     document.idMap.set(element.id, element);
   }
   const context = createBrowserContext(document);
   runScript("app/static/js/session-timeout.js", context);
   for (const callback of context.__timeoutCallbacks) callback();
   for (const callback of [...context.__intervalCallbacks]) callback();
+  await new Promise((resolve) => setTimeout(resolve, 0));
   for (let index = 0; index < 65; index += 1) {
     for (const callback of [...context.__intervalCallbacks]) callback();
   }
@@ -467,6 +469,19 @@ async function exerciseSessionTimeout() {
   await new Promise((resolve) => setTimeout(resolve, 0));
   assert.equal(continueButton.disabled, false);
   assert.match(timerValue.textContent, /^\d+:\d{2}$/);
+  assert.equal(replacedOverlay.open, false);
+
+  document.hidden = true;
+  context.fetch = async () => ({ ok: false, async json() { return { code: "replaced" }; } });
+  for (const callback of [...context.__intervalCallbacks]) callback();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(replacedOverlay.open, false);
+
+  document.hidden = false;
+  for (const callback of [...context.__intervalCallbacks]) callback();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(replacedOverlay.open, true);
+  assert.equal(overlay.open, false);
 }
 
 async function exerciseTheme() {

--- a/tests/test_route_inventory_security.py
+++ b/tests/test_route_inventory_security.py
@@ -320,6 +320,17 @@ ROUTE_SECURITY_INVENTORY = {
         "step_up": "not_required",
         "public_justification": "",
     },
+    "auth.session_status": {
+        "endpoint": "auth.session_status",
+        "rule": "/auth/session/status",
+        "methods": {"GET"},
+        "access": "public",
+        "classification": "session",
+        "csrf": "not_applicable",
+        "rate_limit": "edge_auth",
+        "step_up": "not_required",
+        "public_justification": "Polled by the client-side session-timeout script to detect a session replaced or ended elsewhere, so it must report status without requiring a currently-valid session.",
+    },
     "auth.terminate_session": {
         "endpoint": "auth.terminate_session",
         "rule": "/auth/sessions/<session_id>",

--- a/tests/test_session_management.py
+++ b/tests/test_session_management.py
@@ -521,6 +521,87 @@ def test_session_timeout_ui_uses_explicit_extension_and_csp_safe_toggling(client
         assert passive_event not in script
 
 
+def test_session_timeout_ui_polls_status_and_declares_replaced_overlay(client):
+    register(client)
+    login(client)
+    user, _secret = enable_mfa_for_user()
+    mark_recent_mfa(client, user)
+    response = client.get("/dashboard")
+    markup = response.data.decode("utf-8")
+    script = Path("app/static/js/session-timeout.js").read_text(encoding="utf-8")
+
+    assert response.status_code == 200
+    assert '<dialog id="session-replaced-overlay"' in markup
+    assert "/auth/session/status" in script
+    assert "document.hidden" in script
+
+
+def test_session_status_reports_active_for_valid_session(client):
+    register(client)
+    login(client)
+
+    response = client.get("/auth/session/status")
+
+    assert response.status_code == 200
+    assert response.get_json() == {"status": "active"}
+
+
+def test_session_status_reports_replaced_after_new_login_elsewhere(app, client):
+    second_client = app.test_client()
+    register(client)
+    login(client)
+    login(second_client)
+
+    response = client.get("/auth/session/status")
+
+    assert response.status_code == 401
+    assert response.get_json() == {"status": "signed_out", "code": "replaced"}
+
+
+def test_session_status_reports_ended_after_logout(client):
+    register(client)
+    login(client)
+    client.post("/logout")
+
+    response = client.get("/auth/session/status")
+
+    assert response.status_code == 401
+    assert response.get_json() == {"status": "signed_out", "code": "ended"}
+
+
+def test_session_status_reports_ended_for_anonymous_client(app):
+    anon_client = app.test_client()
+
+    response = anon_client.get("/auth/session/status")
+
+    assert response.status_code == 401
+    assert response.get_json() == {"status": "signed_out", "code": "ended"}
+
+
+def test_session_status_polling_does_not_extend_inactivity_window(client):
+    register(client)
+    login(client)
+    user, _secret = enable_mfa_for_user()
+    mark_recent_mfa(client, user)
+    stale_but_valid = int(time.time()) - 60
+
+    with client.session_transaction() as sess:
+        sess["last_activity_at"] = stale_but_valid
+
+    status_response = client.get("/auth/session/status")
+    with client.session_transaction() as sess:
+        after_status_poll = sess.get("last_activity_at")
+
+    other_response = client.get("/dashboard")
+    with client.session_transaction() as sess:
+        after_normal_request = sess.get("last_activity_at")
+
+    assert status_response.status_code == 200
+    assert after_status_poll == stale_but_valid
+    assert other_response.status_code == 200
+    assert after_normal_request > stale_but_valid
+
+
 def test_security_warning_alerts_do_not_auto_dismiss():
     script = Path("app/static/js/account.js").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Summary
---

Building on the recently merged single-active-session-cap fix (#526), a session that gets replaced by a new sign-in elsewhere previously only found out on its next click or page load. This adds a short client-side poll so the older tab shows a clear "Signed Out" popup within ~15 seconds instead.

Why
---

Once a session is capped/revoked server-side, the old tab's cookie is already dead, but nothing told the browser that until it made another request. For a banking app, a silent "you're still logged in until you happen to click something" gap is confusing and not great UX for a security event the user should know about promptly.

What changed
---

* `app/security/sessions.py` - `open_session()` now stashes why a presented session was already revoked onto `flask.g` for the one request that discovers it (`session_replacement_reason()`). New `ACTIVITY_EXEMPT_ENDPOINTS` set stops the new status-poll endpoint from refreshing `last_activity_at`, so background polling can't silently defeat the existing inactivity timeout.
* `app/auth/routes.py` - new `GET /auth/session/status`: `200 {"status": "active"}` when the session is still good, `401 {"status": "signed_out", "code": "replaced"|"ended"}` otherwise. Added to the existing MFA-onboarding allowlist (discovered via a real 403 in testing - the poll must work regardless of onboarding state).
* `app/__init__.py` - same endpoint added to the forced-password-change allowlist for the same reason.
* `app/static/js/session-timeout.js` - polls the new endpoint every ~15s, paused while the tab is hidden (`document.hidden`); on `code: "replaced"` it stops the local idle-timer UI and shows a new dedicated dialog instead of the generic idle-timeout one.
* `app/templates/base.html` - new `#session-replaced-overlay` dialog, reusing the existing session-modal styling.
* `app/web/routes.py` - `session_replaced=1` login flash message, mirroring the existing `session_expired=1` pattern.
* `tests/test_route_inventory_security.py` - inventory entry for the new public, non-CSRF, GET-only endpoint.
* `tests/test_session_management.py` - 6 new tests: active/replaced/ended/anonymous status responses, and a dedicated test proving the poll does not extend the inactivity window (while a normal request does).
* `tests/js/collect-browser-coverage.mjs` - extended to exercise the new overlay element and both the hidden-tab-skips-poll and replaced-shows-popup branches.
* `docs/security/architecture/session-management.md` - documents the new polling behavior and the activity-exemption rule, plus a new lifecycle-table row.

Security impact
---

Purely additive to session handling: no existing check is loosened. The new endpoint is intentionally public (like `auth.session_extend`/`auth.csrf_token`) since it exists specifically to report status once a session is no longer valid; it reveals only a coarse `active`/`replaced`/`ended` signal, no other session's identity, IP, or location. The activity-exemption mechanism is scoped to exactly this one endpoint and is centralized in `sessions.py` rather than duplicated per call site.

Deployment impact
---

* no deployment action

No schema, config, or environment changes.

Verification
---

* `git diff --check`
* `.\.venv\Scripts\python.exe -m pytest -q -n auto` - 1691 passed, 31 skipped
* `node tests/js/collect-browser-coverage.mjs` - 89.1% browser-script line coverage (>= 80% gate)

Notes
---

Depends on #526 (single active session cap on every login) already being merged to `main`, which it is.