### PR TITLE
Detect replaced sessions faster: shorter poll plus refocus check

### DIFF
--- a/app/static/js/session-timeout.js
+++ b/app/static/js/session-timeout.js
@@ -21,7 +21,7 @@
   const timerValueEl = document.getElementById('session-timer-value');
   const csrfMeta = document.querySelector('meta[name="csrf-token"]');
   const replacedOverlayEl = document.getElementById('session-replaced-overlay');
-  const statusPollMs = 15000;
+  const statusPollMs = 5000;
   let sessionEnded = false;
 
   function formatTime(ms) {
@@ -139,6 +139,10 @@
       });
     });
   }
+
+  document.addEventListener('visibilitychange', function () {
+    if (!document.hidden) pollSessionStatus();
+  });
 
   setInterval(updateTimerDisplay, 1000);
   setInterval(pollSessionStatus, statusPollMs);

--- a/docs/security/architecture/session-management.md
+++ b/docs/security/architecture/session-management.md
@@ -155,9 +155,10 @@ successful login replaces previous active sessions in that namespace and moves
 them to past-session history. Old browser tabs may still display stale HTML
 until the next request, but the revoked session cannot access protected routes.
 The replaced tab does not have to navigate to find out, though:
-`session-timeout.js` polls `GET /auth/session/status` roughly every 15 seconds
-(paused while the tab is hidden) and shows a dedicated "Signed Out" dialog as
-soon as the server reports the session was replaced. The status endpoint is
+`session-timeout.js` polls `GET /auth/session/status` roughly every 5 seconds
+(paused while the tab is hidden, and re-checked immediately when the tab
+regains visibility) and shows a dedicated "Signed Out" dialog as soon as the
+server reports the session was replaced. The status endpoint is
 listed in `app/security/sessions.py::ACTIVITY_EXEMPT_ENDPOINTS` so polling it
 never refreshes `last_activity_at`; otherwise a background poll would silently
 defeat the inactivity timeout below. The session-management page is for

--- a/tests/js/collect-browser-coverage.mjs
+++ b/tests/js/collect-browser-coverage.mjs
@@ -471,6 +471,21 @@ async function exerciseSessionTimeout() {
   assert.match(timerValue.textContent, /^\d+:\d{2}$/);
   assert.equal(replacedOverlay.open, false);
 
+  let fetchCalls = 0;
+  context.fetch = async () => {
+    fetchCalls += 1;
+    return { ok: true, async json() { return {}; } };
+  };
+  document.hidden = true;
+  await document.emit("visibilitychange");
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(fetchCalls, 0);
+
+  document.hidden = false;
+  await document.emit("visibilitychange");
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(fetchCalls, 1);
+
   document.hidden = true;
   context.fetch = async () => ({ ok: false, async json() { return { code: "replaced" }; } });
   for (const callback of [...context.__intervalCallbacks]) callback();


### PR DESCRIPTION
Summary
---

Follow-up to #527 (the session-replaced notification popup). Shortens detection latency for the common case of stepping away from a tab and coming back.

Why
---

The status poll ran on a fixed 15-second interval only, so if another device signed into the same account while you were looking at a different tab, switching back could take up to 15 seconds to show the "Signed Out" popup.

What changed
---

* `app/static/js/session-timeout.js` - `statusPollMs` dropped from 15000 to 5000; added a `visibilitychange` listener that triggers an immediate `pollSessionStatus()` call when the tab becomes visible again (still a no-op while hidden, per the existing `document.hidden` guard inside `pollSessionStatus`).
* `tests/js/collect-browser-coverage.mjs` - new assertions proving the refocus listener does not fetch while hidden, and does fetch immediately once visible.
* `docs/security/architecture/session-management.md` - updated the polling cadence description (15s -> 5s, plus the refocus behavior).

Security impact
---

None - purely a client-side UX timing change to an already-reviewed, read-only status endpoint. No new server behavior.

Deployment impact
---

* no deployment action

Verification
---

* `git diff --check`
* `.\.venv\Scripts\python.exe -m pytest -q -n auto` - 1691 passed, 31 skipped
* `node tests/js/collect-browser-coverage.mjs` - 89.2% browser-script line coverage (>= 80% gate)

Notes
---

Depends on #527 already being merged to `main`, which it is.