### PR TITLE
Resolve main branch Sonar cleanup issues

### DIFF
--- a/app/admin/services.py
+++ b/app/admin/services.py
@@ -134,6 +134,7 @@ INVITE_FRESH_MFA_REQUIRED_ERROR = (
 )
 INVITE_CREATE_ERROR = "Invite could not be created"
 INVITE_ACCEPTANCE_ERROR = "Invite acceptance failed"
+STAFF_INVITE_NOT_FOUND_ERROR = "Invite not found"
 INVALID_WORKPLACE_EMAIL_ERROR = "Invalid workplace email"
 GENERIC_INVITE_ERROR = "Invite link is invalid or expired"
 GENERIC_WORKPLACE_VERIFICATION_ERROR = "Workplace verification failed"
@@ -2066,7 +2067,7 @@ def revoke_staff_invite(actor: User, invite_id: int, totp_code: str | None) -> d
     )
     invite = db.session.get(StaffInvite, int(invite_id))
     if invite is None or invite.status not in ACTIVE_INVITE_STATUSES:
-        raise AuthError("Invite not found", 404)
+        raise AuthError(STAFF_INVITE_NOT_FOUND_ERROR, 404)
     invite.status = "revoked"
     invite.revoked_at = _utcnow()
     invite.revoked_by_user_id = actor.id
@@ -2086,7 +2087,7 @@ def reissue_staff_invite(actor: User, invite_id: int, totp_code: str | None) -> 
     )
     invite = db.session.get(StaffInvite, int(invite_id))
     if invite is None or invite.status not in ACTIVE_INVITE_STATUSES:
-        raise AuthError("Invite not found", 404)
+        raise AuthError(STAFF_INVITE_NOT_FOUND_ERROR, 404)
 
     _reset_active_invite_acceptance_for_root_action(
         invite,
@@ -2146,7 +2147,7 @@ def reset_staff_invite_acceptance(actor: User, invite_id: int, totp_code: str | 
     )
     invite = db.session.get(StaffInvite, int(invite_id))
     if invite is None or invite.status not in ACTIVE_INVITE_STATUSES:
-        raise AuthError("Invite not found", 404)
+        raise AuthError(STAFF_INVITE_NOT_FOUND_ERROR, 404)
 
     _reset_active_invite_acceptance_for_root_action(
         invite,

--- a/app/static/js/session-timeout.js
+++ b/app/static/js/session-timeout.js
@@ -76,7 +76,9 @@
     clearTimeout(expireTimer);
     clearTimeout(warningTimer);
     hideOverlay();
-    if (replacedOverlayEl && !replacedOverlayEl.open) replacedOverlayEl.showModal();
+    if (replacedOverlayEl?.open === false) {
+      replacedOverlayEl.showModal();
+    }
   }
 
   function pollSessionStatus() {


### PR DESCRIPTION
Summary
---

Resolve the two open Sonar findings reported on the latest main analysis after PR 528 merged.

Why
---

Main branch workflows were green, but Sonar still reported one repeated staff-invite error literal and one session-timeout JavaScript optional-chaining issue. Repo rules require resolving open Sonar findings for the analyzed branch.

What changed
---

- Centralized the staff invite not-found error message in app/admin/services.py.
- Updated the replaced-session overlay guard in app/static/js/session-timeout.js to use optional chaining while preserving the closed-dialog check.

Security impact
---

No security controls, identity boundaries, secrets, permissions, or deployment protections are weakened. The staff invite error text remains unchanged, and the session replacement overlay behavior remains fail-safe for missing DOM nodes.

Deployment impact
---

No operator action, EC2 bootstrap, database migration, or secret change is required. Normal staging and production deployment workflows are sufficient.

Verification
---

- git diff --check
- .\.venv\Scripts\python.exe -m pytest -q tests/test_session_management.py tests/test_admin_staff_invites.py
- .\.venv\Scripts\python.exe -m pytest -q -n 4
- .\.venv\Scripts\python.exe -m pytest -q -n 4 --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term

Notes
---

Coverage remains 91%.