### PR TITLE
Open the mobile account menu in one tap instead of two

### DIFF
--- a/app/static/js/theme.js
+++ b/app/static/js/theme.js
@@ -88,16 +88,25 @@
       });
     }
 
+    function setNavOpen(isOpen) {
+      if (!navToggle || !navMenu) {
+        return;
+      }
+      navMenu.classList.toggle("is-open", isOpen);
+      navToggle.setAttribute("aria-expanded", isOpen ? "true" : "false");
+    }
+
     if (navToggle && navMenu) {
       navToggle.addEventListener("click", function () {
-        const isOpen = navMenu.classList.toggle("is-open");
-        navToggle.setAttribute("aria-expanded", isOpen ? "true" : "false");
+        const isOpen = !navMenu.classList.contains("is-open");
+        setNavOpen(isOpen);
+        setAccountOpen(isOpen);
       });
 
       navMenu.addEventListener("click", function (event) {
         if (event.target.tagName === "A") {
-          navMenu.classList.remove("is-open");
-          navToggle.setAttribute("aria-expanded", "false");
+          setNavOpen(false);
+          setAccountOpen(false);
         }
       });
     }
@@ -140,18 +149,24 @@
       accountPanel.addEventListener("click", function (event) {
         if (closestElement(event.target, "a")) {
           setAccountOpen(false);
+          setNavOpen(false);
         }
       });
 
       document.addEventListener("click", function (event) {
-        if (!closestElement(event.target, "[data-account-menu]")) {
+        if (
+          !closestElement(event.target, "[data-account-menu]") &&
+          !closestElement(event.target, "[data-nav-toggle]")
+        ) {
           setAccountOpen(false);
+          setNavOpen(false);
         }
       });
 
       document.addEventListener("keydown", function (event) {
         if (event.key === "Escape") {
           setAccountOpen(false);
+          setNavOpen(false);
         }
       });
     }

--- a/tests/js/collect-browser-coverage.mjs
+++ b/tests/js/collect-browser-coverage.mjs
@@ -106,6 +106,7 @@ class MockElement {
   closest(selector) {
     if (selector === ".alert") return this.alert ?? null;
     if (selector === "[data-account-menu]") return this.accountMenu ?? null;
+    if (selector === "[data-nav-toggle]") return this.navToggle ?? null;
     if (selector === "a" && this.tagName === "A") return this;
     return null;
   }
@@ -507,6 +508,7 @@ async function exerciseTheme() {
   const iconUse = new MockElement();
   icon.selectorMap.set("use", iconUse);
   const navToggle = new MockElement();
+  navToggle.navToggle = navToggle;
   const navMenu = new MockElement();
   const accountMenu = new MockElement();
   const accountTrigger = new MockElement();
@@ -532,8 +534,33 @@ async function exerciseTheme() {
   runScript("app/static/js/theme.js", context);
   for (const callback of context.__domReadyListeners) callback();
   await toggle.emit("click");
+
+  await navToggle.emit("click");
+  assert.equal(navMenu.classList.contains("is-open"), true);
+  assert.equal(accountPanel.hidden, false, "opening the hamburger must also open the account panel");
+  assert.equal(accountMenu.classList.contains("is-open"), true);
+
+  await document.emit("click", { target: navToggle });
+  assert.equal(
+    accountPanel.hidden,
+    false,
+    "clicking the hamburger button itself must not be treated as an outside click",
+  );
+
+  await document.emit("click", { target: new MockElement() });
+  assert.equal(navMenu.classList.contains("is-open"), false, "outside click must close the nav too");
+  assert.equal(accountPanel.hidden, true);
+
   await navToggle.emit("click");
   await navMenu.emit("click", { target: Object.assign(new MockElement(), { tagName: "A" }) });
+  assert.equal(navMenu.classList.contains("is-open"), false);
+  assert.equal(accountPanel.hidden, true);
+
+  await navToggle.emit("click");
+  await document.emit("keydown", { key: "Escape" });
+  assert.equal(navMenu.classList.contains("is-open"), false, "Escape must close the nav too");
+  assert.equal(accountPanel.hidden, true);
+
   await accountTrigger.emit("click");
   for (const key of ["Enter", " ", "ArrowDown"]) {
     await accountTrigger.emit("keydown", { key });


### PR DESCRIPTION
Summary
---

On the mobile dashboard header, tapping the hamburger only revealed the account trigger (avatar + username); a second tap on that was required to actually see the menu (Dashboard, Edit Profile, Security Settings, Log Out, ...). Since the hamburger's mobile nav panel has nothing else in it for a signed-in user, that second tap was pure friction with no benefit.

Why
---

User-reported UX issue: "in mobile view in user dashboard the hamburger menu reveal the username then clicking username will reveal another menu cant it be like at all once when click?" On mobile, the account trigger and account panel already sit inside the same hamburger-gated `.nav`, so gating them independently added a redundant disclosure step rather than protecting against clutter (unlike on desktop, where the trigger is the only way to reveal the dropdown at all).

What changed
---

* `app/static/js/theme.js` - the hamburger (`data-nav-toggle`) and account panel (`data-account-panel`) open/close state are now coupled: opening the nav also opens the account panel, and closing it (outside click, Escape, or clicking a menu item) closes both together. No new markup or CSS - reuses the existing `.account-panel`'s mobile layout, which already stacks correctly once expanded.
* Also fixes a latent bug found while making this change: the document-level "click outside closes the account menu" listener didn't exclude the hamburger button itself, so clicking it would open the panel and then immediately close it again in the same click (event bubbles from the button up to `document`). Now excluded via a `[data-nav-toggle]` check alongside the existing `[data-account-menu]` one.
* `tests/js/collect-browser-coverage.mjs` - new assertions: hamburger tap opens both nav and account panel together; clicking the hamburger itself isn't treated as an outside click; outside click / Escape / picking a menu item close both together.

Desktop is unaffected - the hamburger button is hidden outside the mobile breakpoint, so this coupling never fires there; the account trigger keeps its normal independent dropdown behavior.

Security impact
---

None - client-side disclosure-widget timing only, no new data exposed, no change to any auth/session control.

Deployment impact
---

* no deployment action

Verification
---

* `git diff --check`
* `.\.venv\Scripts\python.exe -m pytest -q -n auto` - 1693 passed, 31 skipped
* `node tests/js/collect-browser-coverage.mjs` - 89.1% browser-script line coverage (>= 80% gate)

Notes
---

None.