### PR TITLE
Center the mobile footer instead of leaving it flush left

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -2660,6 +2660,16 @@ th {
 
   .footer-inner {
     grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .footer-brand {
+    margin-inline: auto;
+  }
+
+  .footer-column {
+    padding-top: var(--space-6);
+    border-top: 1px solid var(--line);
   }
 
   .feature-grid,


### PR DESCRIPTION
Summary
---

On mobile, the site footer (brand blurb, Sitemap, Account Security, Security Posture) collapsed to a single column but kept its desktop left-alignment with no separation between sections, so it read as one plain left-hugging block of text.

Why
---

User-reported: "the sitemap for mobile view... currently look all aligned to the left." Confirmed visually with a before screenshot at a 390px mobile viewport - the footer really was just a wall of left-aligned headings and links with no visual structure once it dropped to one column.

What changed
---

* `app/static/css/app.css` - inside the existing `@media (max-width: 760px)` block: center-align footer text (`text-align: center` on `.footer-inner`, which cascades to headings/links/paragraphs), center the brand blurb block itself (`margin-inline: auto` on `.footer-brand`, since it has its own `max-width: 46ch`), and add a hairline top divider + extra padding above each stacked `.footer-column` (reusing the existing `--line` and `--space-6` tokens - no new colors, fonts, or markup).
* Desktop is untouched - this is scoped entirely inside the existing 760px mobile media query.

Verification
---

* `git diff --check`
* `.\.venv\Scripts\python.exe -m pytest -q -n auto` - 1693 passed, 31 skipped
* Visually verified with Playwright (installed locally: `pip install playwright==1.61.0` + `playwright install chromium`, matching the pinned dev-lock version) - took before/after screenshots of the homepage footer at a 390x844 mobile viewport confirming the fix. Before: flush-left, no separation. After: centered, clearly sectioned.

Security impact
---

None - CSS-only styling change, no markup, logic, or data changes.

Deployment impact
---

* no deployment action

Notes
---

None.