### PR TITLE
Harden staff invite acceptance controls

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -23,6 +23,7 @@ from .security.sessions import install_database_sessions, register_session_hooks
 from .security.http_errors import (
     CSRF_ERROR_MESSAGE,
     RATE_LIMIT_MESSAGE,
+    request_wants_json,
     safe_error_response,
 )
 from .security.turnstile import register_turnstile_template_helpers
@@ -173,6 +174,23 @@ def register_error_handlers(app: Flask) -> None:
 
     @app.errorhandler(CSRFError)
     def csrf_error(error):
+        if request.endpoint in {
+            "admin.invite_accept_start",
+            "admin.invite_accept_verify",
+        }:
+            from .admin.routes import invite_acceptance_csrf_error_response
+            from .security.audit import audit_event
+
+            audit_event(
+                "staff_invite_accept",
+                "failure",
+                metadata={
+                    "reason": "csrf_or_session_failed",
+                    "phase": _invite_acceptance_phase_for_endpoint(request.endpoint),
+                },
+            )
+            if not request_wants_json():
+                return invite_acceptance_csrf_error_response()
         return respond(CSRF_ERROR_MESSAGE, 400)
 
     @app.errorhandler(400)
@@ -255,8 +273,14 @@ def register_invite_acceptance_response_headers(app: Flask) -> None:
             response.headers["Cache-Control"] = "no-store, no-cache, max-age=0, private"
             response.headers["Pragma"] = "no-cache"
             response.headers["Expires"] = "0"
-            response.headers["Referrer-Policy"] = "same-origin"
+            response.headers["Referrer-Policy"] = "origin"
         return response
+
+
+def _invite_acceptance_phase_for_endpoint(endpoint: str | None) -> str:
+    if endpoint == "admin.invite_accept_verify":
+        return "verify"
+    return "start"
 
 
 def register_no_store_headers(app: Flask) -> None:

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -91,6 +91,8 @@ _ADMIN_LOGIN_TEMPLATE = "admin/login.html"
 _ADMIN_MFA_VERIFY_TEMPLATE = "admin/mfa_verify.html"
 _STAFF_INVITE_ACCEPT_TEMPLATE = "admin/invite_accept.html"
 _INVALID_REQUEST_MESSAGE = "Invalid request"
+_INVITE_START_VALIDATION_MESSAGE = "Check the setup details and try again."
+_INVITE_CSRF_MESSAGE = "Security token expired or invalid. Review the form and try again."
 _ADMIN_RATE_LIMIT_HOURLY = "10 per hour"
 _ADMIN_RATE_LIMIT_STEP_UP = "5 per 5 minutes"
 _ADMIN_MFA_COARSE_RATE_LIMIT = "30 per minute"
@@ -845,6 +847,7 @@ def _render_invite_acceptance(
     phase: str,
     status_code: int = 200,
     totp_setup: dict[str, str] | None = None,
+    start_form_data: dict[str, str] | None = None,
 ):
     return (
         render_template(
@@ -852,6 +855,7 @@ def _render_invite_acceptance(
             token=token,
             phase=phase,
             totp_setup=totp_setup,
+            start_form_data=start_form_data or {},
         ),
         status_code,
     )
@@ -863,11 +867,75 @@ def _invite_acceptance_browser_error(
     phase: str,
     message: str,
     status_code: int,
+    retry_after: int | None = None,
+    start_form_data: dict[str, str] | None = None,
 ):
     if status_code == 429:
-        return rate_limit_response()
+        return rate_limit_response(retry_after)
     flash(message, "error")
-    return _render_invite_acceptance(token, phase=phase, status_code=status_code)
+    return _render_invite_acceptance(
+        token,
+        phase=phase,
+        status_code=status_code,
+        start_form_data=start_form_data,
+    )
+
+
+def invite_acceptance_csrf_error_response():
+    token = str((request.view_args or {}).get("token") or "")
+    phase = "verify" if request.endpoint == "admin.invite_accept_verify" else "start"
+    flash(_INVITE_CSRF_MESSAGE, "error")
+    return _render_invite_acceptance(
+        token,
+        phase=phase,
+        status_code=400,
+        start_form_data=_safe_invite_start_form_data(),
+    )
+
+
+def _safe_invite_start_form_data() -> dict[str, str]:
+    if request.is_json:
+        return {}
+    return {
+        "full_name": str(request.form.get("full_name") or "")[:120],
+        "phone_number": str(request.form.get("phone_number") or "")[:32],
+    }
+
+
+def _invite_start_validation_reason() -> str:
+    payload: dict[str, Any]
+    if request.is_json:
+        loaded = request.get_json(silent=True)
+        payload = loaded if isinstance(loaded, dict) else {}
+    else:
+        payload = dict(request.form)
+    full_name = str(payload.get("full_name") or "").strip()
+    phone_number = str(payload.get("phone_number") or "").strip()
+    password = str(payload.get("password") or "")
+    confirm_password = str(payload.get("confirm_password") or "")
+    if {"role", "workplace_email", "email", "account_type", "customer_user_id", "is_admin"} & {
+        str(field).strip() for field in payload
+    }:
+        return "forged_fields"
+    if not full_name or len(full_name) > 120 or re.search(r"[\x00-\x1f\x7f<>]", full_name):
+        return "invalid_full_name"
+    if not re.fullmatch(PHONE_RE, phone_number):
+        return "invalid_phone"
+    if password and confirm_password and password != confirm_password:
+        return "password_mismatch"
+    if not (8 <= len(password) <= 256) or not (8 <= len(confirm_password) <= 256):
+        return "password_policy"
+    return "form_validation"
+
+
+def _invite_start_validation_message(reason: str) -> str:
+    messages = {
+        "invalid_full_name": "Enter a valid full name.",
+        "invalid_phone": "Enter an 8-digit Singapore mobile number starting with 8 or 9.",
+        "password_mismatch": "Passwords must match.",
+        "password_policy": "Use a password that meets the staff password policy.",
+    }
+    return messages.get(reason, _INVITE_START_VALIDATION_MESSAGE)
 
 
 @admin_bp.get("/health/live")
@@ -1550,13 +1618,16 @@ def invite_accept_start(token: str):
             request_fields=_request_fields(),
         )
     except ValidationError:
+        reason = _invite_start_validation_reason()
+        audit_event("staff_invite_accept", "failure", metadata={"reason": reason})
         if wants_json:
             raise
         return _invite_acceptance_browser_error(
             token,
             phase="start",
-            message=_INVALID_REQUEST_MESSAGE,
+            message=_invite_start_validation_message(reason),
             status_code=400,
+            start_form_data=_safe_invite_start_form_data(),
         )
     except AuthError as exc:
         if wants_json:
@@ -1566,6 +1637,8 @@ def invite_accept_start(token: str):
             phase="start",
             message=exc.message,
             status_code=exc.status_code,
+            retry_after=exc.retry_after,
+            start_form_data=_safe_invite_start_form_data(),
         )
     if wants_json:
         return jsonify(result)
@@ -1591,6 +1664,7 @@ def invite_accept_verify(token: str):
             request_fields=_request_fields(),
         )
     except ValidationError:
+        audit_event("staff_invite_accept", "failure", metadata={"reason": "verify_form_validation"})
         if wants_json:
             raise
         return _invite_acceptance_browser_error(
@@ -1607,6 +1681,7 @@ def invite_accept_verify(token: str):
             phase="verify",
             message=exc.message,
             status_code=exc.status_code,
+            retry_after=exc.retry_after,
         )
     if wants_json:
         return jsonify(result)

--- a/app/admin/services.py
+++ b/app/admin/services.py
@@ -134,6 +134,13 @@ INVITE_FRESH_MFA_REQUIRED_ERROR = (
 )
 INVITE_CREATE_ERROR = "Invite could not be created"
 INVITE_ACCEPTANCE_ERROR = "Invite acceptance failed"
+INVITE_TURNSTILE_ERROR = "Complete the security challenge before starting setup."
+INVITE_DUPLICATE_IDENTITY_ERROR = (
+    "Staff identity details could not be accepted. Ask a root admin to review the invite."
+)
+INVITE_WORKPLACE_DELIVERY_ERROR = (
+    "Setup could not send the workplace verification code. Ask a root admin to reissue the invite or retry later."
+)
 STAFF_INVITE_NOT_FOUND_ERROR = "Invite not found"
 INVALID_WORKPLACE_EMAIL_ERROR = "Invalid workplace email"
 GENERIC_INVITE_ERROR = "Invite link is invalid or expired"
@@ -3047,14 +3054,24 @@ def start_invite_acceptance(
         require_turnstile("admin_invite_accept", turnstile_token)
     except TurnstileError as exc:
         audit_event("staff_invite_accept", "failure", metadata={"reason": "turnstile_failed"})
-        raise AuthError(INVITE_ACCEPTANCE_ERROR, 400) from exc
+        raise AuthError(INVITE_TURNSTILE_ERROR, 400) from exc
 
     invite = _active_invite_by_token(token, lock=True, audit_failures=True)
     _ensure_invite_identity_policy(invite, "staff_invite_accept")
     session_hash = _invite_acceptance_session_hash(invite.id, create=True)
     _ensure_invite_acceptance_can_start(invite, session_hash)
-    name = validate_full_name(full_name)
-    phone = validate_phone_number(phone_number)
+    invite_id = int(invite.id)
+    created_setup_user_id: int | None = None
+    try:
+        name = validate_full_name(full_name)
+    except AuthError:
+        audit_event("staff_invite_accept", "failure", metadata={"reason": "invalid_full_name"})
+        raise
+    try:
+        phone = validate_phone_number(phone_number)
+    except AuthError:
+        audit_event("staff_invite_accept", "failure", metadata={"reason": "invalid_phone"})
+        raise
     if password != confirm_password:
         audit_event("staff_invite_accept", "failure", metadata={"reason": "password_mismatch"})
         raise AuthError("Passwords must match", 400)
@@ -3066,7 +3083,11 @@ def start_invite_acceptance(
 
     user = db.session.get(User, invite.setup_user_id) if invite.setup_user_id else None
     if user is None:
-        _reject_duplicate_staff_signup(invite.workplace_email_normalized, phone)
+        try:
+            _reject_duplicate_staff_signup(invite.workplace_email_normalized, phone)
+        except AuthError as exc:
+            audit_event("staff_invite_accept", "failure", metadata={"reason": "duplicate_identity"})
+            raise AuthError(INVITE_DUPLICATE_IDENTITY_ERROR, exc.status_code) from exc
         user = User(
             username=_staff_username(invite.workplace_email_normalized),
             email=invite.workplace_email_normalized,
@@ -3082,6 +3103,7 @@ def start_invite_acceptance(
         mark_password_changed(user)
         db.session.add(user)
         db.session.flush()
+        created_setup_user_id = int(user.id)
         invite.setup_user_id = user.id
     else:
         if invite.acceptance_session_hash:
@@ -3120,9 +3142,12 @@ def start_invite_acceptance(
         db.session.commit()
     except Exception as exc:
         db.session.rollback()
+        db.session.expunge_all()
+        _clear_failed_invite_acceptance_start(invite_id, created_setup_user_id)
         current_app.logger.warning("staff_workplace_verification_email_failed error=%s", type(exc).__name__)
         audit_event("staff_workplace_verification_sent", "failure", metadata={"reason": "email_delivery_failed"})
-        raise AuthError(INVITE_ACCEPTANCE_ERROR, 503) from exc
+        audit_event("staff_invite_accept", "failure", metadata={"reason": "workplace_email_delivery_failed"})
+        raise AuthError(INVITE_WORKPLACE_DELIVERY_ERROR, 503) from exc
     return {
         "message": "TOTP setup required",
         "invite": {
@@ -3290,6 +3315,22 @@ def _clear_invite_acceptance_state(invite: StaffInvite) -> None:
     invite.workplace_verification_expires_at = None
     invite.workplace_verified_at = None
     session.pop(INVITE_ACCEPTANCE_SESSION_KEY, None)
+
+
+def _clear_failed_invite_acceptance_start(invite_id: int, setup_user_id: int | None) -> None:
+    if setup_user_id is None:
+        return
+    invite = db.session.get(StaffInvite, int(invite_id))
+    if invite is None:
+        return
+    if setup_user_id is not None and invite.setup_user_id == int(setup_user_id):
+        setup_user = db.session.get(User, int(setup_user_id))
+        invite.setup_user_id = None
+        if setup_user is not None and setup_user.account_status == "setup_pending":
+            db.session.delete(setup_user)
+    invite.status = "pending"
+    _clear_invite_acceptance_state(invite)
+    db.session.flush()
 
 
 def _consume_invite_probe_limit(token: str) -> None:

--- a/app/static/js/admin-invite-accept.js
+++ b/app/static/js/admin-invite-accept.js
@@ -1,0 +1,97 @@
+(function () {
+  const managedForms = [];
+  const messages = {
+    pending: "Security challenge is verifying. Submit will unlock when it completes.",
+    ready: "Security challenge complete. You can start setup.",
+    required: "Complete the security challenge to enable setup.",
+    expired: "Security challenge expired. Complete it again before starting setup.",
+    failed: "Security challenge could not be completed. Try again or refresh the page.",
+    timeout: "Security challenge timed out. Complete it again before starting setup.",
+    submitting: "Starting setup..."
+  };
+
+  function updateForm(form, state, token) {
+    const required = form.dataset.turnstileRequired === "true";
+    const responseInput = form.querySelector("[data-turnstile-response]");
+    const submitButton = form.querySelector("[data-invite-start-submit]");
+    const status = form.querySelector("[data-turnstile-status]");
+    const hasFreshToken = state === "valid" && Boolean(token);
+
+    form.dataset.turnstileState = state;
+    if (responseInput) {
+      responseInput.value = hasFreshToken ? token : "";
+    }
+    if (status) {
+      if (hasFreshToken) status.textContent = messages.ready;
+      else if (state === "expired") status.textContent = messages.expired;
+      else if (state === "failed") status.textContent = messages.failed;
+      else if (state === "timeout") status.textContent = messages.timeout;
+      else status.textContent = required ? messages.pending : "";
+    }
+    if (submitButton) {
+      submitButton.disabled = required && !hasFreshToken;
+    }
+  }
+
+  function setTurnstileState(state, token) {
+    for (const form of managedForms) {
+      updateForm(form, state, token || "");
+    }
+  }
+
+  function prepareSubmit(event, form) {
+    const required = form.dataset.turnstileRequired === "true";
+    const responseInput = form.querySelector("[data-turnstile-response]");
+    const submitButton = form.querySelector("[data-invite-start-submit]");
+    const status = form.querySelector("[data-turnstile-status]");
+    const hasFreshToken = !required || Boolean(responseInput && responseInput.value);
+
+    if (form.dataset.submitting === "true" || !hasFreshToken) {
+      event.preventDefault();
+      if (status && !hasFreshToken) status.textContent = messages.required;
+      return;
+    }
+
+    form.dataset.submitting = "true";
+    if (submitButton) {
+      submitButton.disabled = true;
+      submitButton.textContent = messages.submitting;
+    }
+  }
+
+  function init() {
+    const forms = document.querySelectorAll("[data-invite-accept-start]");
+    for (const form of forms) {
+      managedForms.push(form);
+      form.addEventListener("submit", function (event) {
+        prepareSubmit(event, form);
+      });
+      if (form.dataset.turnstileRequired === "true") {
+        updateForm(form, "pending", "");
+      }
+    }
+  }
+
+  window.sitbankInviteTurnstileSuccess = function (token) {
+    setTurnstileState("valid", token);
+  };
+  window.sitbankInviteTurnstileExpired = function () {
+    setTurnstileState("expired", "");
+  };
+  window.sitbankInviteTurnstileError = function () {
+    setTurnstileState("failed", "");
+    return true;
+  };
+  window.sitbankInviteTurnstileTimeout = function () {
+    setTurnstileState("timeout", "");
+  };
+  window.sitbankInviteTurnstilePending = function () {
+    setTurnstileState("pending", "");
+  };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/app/templates/_turnstile.html
+++ b/app/templates/_turnstile.html
@@ -1,8 +1,21 @@
 {% set _turnstile_ns = namespace(script_loaded=False) %}
-{% macro widget(action) -%}
+{% macro widget(action, managed=false) -%}
   {% if turnstile_widget_enabled(action) %}
     <div class="turnstile-widget">
-      <div class="cf-turnstile" data-sitekey="{{ turnstile_site_key }}" data-action="{{ action }}"></div>
+      <div
+        class="cf-turnstile"
+        data-sitekey="{{ turnstile_site_key }}"
+        data-action="{{ action }}"
+        {% if managed %}
+        data-callback="sitbankInviteTurnstileSuccess"
+        data-expired-callback="sitbankInviteTurnstileExpired"
+        data-error-callback="sitbankInviteTurnstileError"
+        data-timeout-callback="sitbankInviteTurnstileTimeout"
+        data-before-interactive-callback="sitbankInviteTurnstilePending"
+        data-after-interactive-callback="sitbankInviteTurnstilePending"
+        data-unsupported-callback="sitbankInviteTurnstileError"
+        {% endif %}
+      ></div>
     </div>
     {% if not _turnstile_ns.script_loaded %}
       {% set _turnstile_ns.script_loaded = True %}

--- a/app/templates/admin/invite_accept.html
+++ b/app/templates/admin/invite_accept.html
@@ -7,17 +7,29 @@
 <section class="panel narrow">
   <p class="eyebrow">Staff onboarding</p>
   {% if phase == "start" %}
+    {% set invite_turnstile_required = turnstile_widget_enabled("admin_invite_accept") %}
     <h1>Set up your staff access</h1>
     <p class="muted">This invite does not activate an account until password setup, workplace verification, and authenticator verification all succeed.</p>
-    <form class="form-stack" method="post" action="{{ url_for('admin.invite_accept_start', token=token) }}" autocomplete="off">
+    <form
+      class="form-stack"
+      method="post"
+      action="{{ url_for('admin.invite_accept_start', token=token) }}"
+      autocomplete="off"
+      data-invite-accept-start
+      data-turnstile-required="{{ 'true' if invite_turnstile_required else 'false' }}"
+    >
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      {% if invite_turnstile_required %}
+      <input type="hidden" name="turnstile_token" value="" data-turnstile-response>
+      {% endif %}
       <div class="form-group">
         <label for="invite-full-name">Full name</label>
-        <input id="invite-full-name" name="full_name" type="text" maxlength="120" autocomplete="name" required>
+        <input id="invite-full-name" name="full_name" type="text" maxlength="120" autocomplete="name" value="{{ start_form_data.get('full_name', '') }}" required>
       </div>
       <div class="form-group">
         <label for="invite-phone-number">Singapore mobile number</label>
-        <input id="invite-phone-number" name="phone_number" type="tel" inputmode="numeric" pattern="[89][0-9]{7}" maxlength="8" autocomplete="tel" required>
+        <input id="invite-phone-number" name="phone_number" type="tel" inputmode="numeric" pattern="[89][0-9]{7}" maxlength="8" autocomplete="tel" value="{{ start_form_data.get('phone_number', '') }}" aria-describedby="invite-phone-help" required>
+        <p class="hint" id="invite-phone-help">Use exactly 8 digits starting with 8 or 9, without +65, spaces, or hyphens.</p>
       </div>
       <div class="form-group">
         <label for="invite-password">Password</label>
@@ -27,8 +39,11 @@
         <label for="invite-confirm-password">Confirm password</label>
         <input id="invite-confirm-password" name="confirm_password" type="password" minlength="8" maxlength="256" autocomplete="new-password" required>
       </div>
-      {{ turnstile.widget("admin_invite_accept") }}
-      <button class="button full" type="submit">Start secure setup</button>
+      {{ turnstile.widget("admin_invite_accept", managed=true) }}
+      {% if invite_turnstile_required %}
+      <p class="hint" id="invite-turnstile-status" data-turnstile-status aria-live="polite">Complete the security challenge to enable setup.</p>
+      {% endif %}
+      <button class="button full" type="submit" data-invite-start-submit {% if invite_turnstile_required %}disabled aria-describedby="invite-turnstile-status"{% endif %}>Start secure setup</button>
     </form>
   {% elif phase == "verify" %}
     <h1>Verify your staff access</h1>
@@ -66,6 +81,12 @@
   {% else %}
     <h1>Staff invite unavailable</h1>
     <p class="muted">This invite link is invalid or expired. Ask a root admin to review the invite and send a new link if access is still needed.</p>
-  {% endif %}
+{% endif %}
 </section>
+{% endblock %}
+
+{% block scripts %}
+  {% if phase == "start" %}
+    <script src="{{ url_for('static', filename='js/admin-invite-accept.js') }}" defer></script>
+  {% endif %}
 {% endblock %}

--- a/app/templates/admin/invites.html
+++ b/app/templates/admin/invites.html
@@ -27,7 +27,7 @@
       </select>
       <label for="invite-totp-code">Authenticator code</label>
       <input id="invite-totp-code" name="totp_code" inputmode="numeric" autocomplete="one-time-code" maxlength="6" required>
-      <p class="hint">Use a fresh authenticator code for each invite action. Delivery status reports backend handoff only, never recipient mailbox delivery.</p>
+      <p class="hint">Use a fresh authenticator code from the currently signed-in root admin for each invite action, and avoid submitting near code expiry. Delivery status reports backend handoff only, never recipient mailbox delivery.</p>
       <button type="submit">Create invite</button>
     </form>
   </section>
@@ -87,6 +87,7 @@
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <label for="reissue-totp-{{ invite.id }}">Authenticator code</label>
                     <input id="reissue-totp-{{ invite.id }}" name="totp_code" inputmode="numeric" autocomplete="one-time-code" maxlength="6" placeholder="6-digit code" required>
+                    <p class="hint">Use the current code from your own root-admin authenticator. Wait for the next code if this one is close to expiry or was used for another invite action.</p>
                     <button type="submit">Send new invite</button>
                   </form>
                 </details>

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -231,8 +231,11 @@ Deployment maps production and staging GitHub Environment variables named
 `TURNSTILE_ENABLED`, `TURNSTILE_SITE_KEY`, `TURNSTILE_VERIFY_URL`, and
 `TURNSTILE_*_ENABLED` runtime settings. Configure separate Cloudflare widgets:
 the production widget covers `sitbank.pp.ua` and `www.sitbank.pp.ua`, while the
-staging widget covers `staging-sitbank.pp.ua`. Store server credentials only as
-the `PROD_TURNSTILE_SECRET_KEY` and `STAGING_TURNSTILE_SECRET_KEY` GitHub
+staging widget covers `staging-sitbank.pp.ua`. If admin invite acceptance uses
+a private/admin hostname in that environment, add the exact recipient-facing
+hostname to the matching widget's hostname allowlist; do not use wildcard
+provider-domain coverage as a shortcut. Store server credentials only as the
+`PROD_TURNSTILE_SECRET_KEY` and `STAGING_TURNSTILE_SECRET_KEY` GitHub
 Environment secrets. The trusted deployment installs each credential as
 `/etc/sitbank*/secrets/turnstile_secret_key`; Compose mounts that
 environment-specific credential read-only into both the customer and admin

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -469,9 +469,14 @@ the onboarding form; explicit JSON clients retain the minimal API response.
 Viewing the page does not consume the invite or create an account. Setup changes
 the invite from `pending` to `totp_pending` and creates only a `setup_pending`
 identity; only successful workplace-code and TOTP verification activates the
-identity and marks the invite `accepted`. The setup flow uses `no-store` and
-same-origin referrer response headers, CSRF-protected browser forms, same-browser
-verification binding, and capped restarts that would otherwise rotate
+identity and marks the invite `accepted`. The setup form accepts exactly 8
+Singapore mobile digits starting with `8` or `9`, without `+65`, spaces, or
+hyphens. When Turnstile is enabled, the setup submit control remains disabled
+until the browser holds a fresh successful Turnstile response; expiry, timeout,
+error, or re-verification clears the response and preserves only non-sensitive
+entered values such as name and mobile number. The setup flow uses `no-store`
+and `Referrer-Policy: origin` response headers, CSRF-protected browser forms,
+same-browser verification binding, and capped restarts that would otherwise rotate
 passwords, TOTP setup secrets, or workplace verification codes. If an active
 invite becomes locked by the restart cap, a root admin should use the invite
 screen's reset action with a fresh TOTP code; do not unlock it by editing
@@ -480,8 +485,9 @@ Stale or malformed browser invite links render a generic invite-unavailable page
 instead of the private admin error page; explicit JSON clients receive only the
 minimal generic error.
 Invite creation, revoke, reset, and reissue actions use strict high-risk TOTP:
-wait for a fresh authenticator code before retrying an invite action, and do
-not reuse the same code for repeated invite operations. The invite table shows
+enter the code from the currently signed-in root admin, wait for a fresh
+authenticator code before retrying an invite action, and do not submit near code
+expiry or reuse the same code for repeated invite operations. The invite table shows
 the persisted allowlisted delivery states `unconfirmed`, `queued`, or `failed`.
 `queued` means SITBank handed the message to the configured email backend, not
 that the recipient inbox accepted it. `unconfirmed` means no reliable backend
@@ -1416,5 +1422,7 @@ secrets `PROD_TURNSTILE_SECRET_KEY` and `STAGING_TURNSTILE_SECRET_KEY`.
 Deployment installs them as separate root-managed
 `/etc/sitbank*/secrets/turnstile_secret_key` files and never writes the value
 to `container.env`. Production and staging use separate widgets for
-`sitbank.pp.ua`/`www.sitbank.pp.ua` and `staging-sitbank.pp.ua`. The admin app remains private behind Tailscale while its public-auth entry routes retain
-Turnstile defense in depth.
+`sitbank.pp.ua`/`www.sitbank.pp.ua` and `staging-sitbank.pp.ua`. If admin
+invite acceptance is enabled for a private/admin hostname, include that exact
+recipient-facing hostname in the matching Turnstile widget's hostname allowlist;
+do not broaden the widget to wildcard provider domains. The admin app remains private behind Tailscale while its public-auth entry routes retain Turnstile defense in depth.

--- a/docs/security/architecture/cryptography-and-authentication.md
+++ b/docs/security/architecture/cryptography-and-authentication.md
@@ -363,9 +363,9 @@ Staff onboarding is invite-based. Root admins create invites for `staff` or
 Privileged staff/admin/root-admin identities use only approved workplace email
 domains from `ADMIN_ALLOWED_EMAIL_DOMAINS`; staff invites are sent to the
 workplace email and do not collect a personal backup email. Invite acceptance
-validates the token, workplace email policy, password policy, optional
-Turnstile, workplace verification code, and TOTP setup before activating the
-account. A normal browser GET renders the onboarding page while an explicit JSON
+validates the token, workplace email policy, Singapore mobile format, password
+policy, optional Turnstile, workplace verification code, and TOTP setup before
+activating the account. A normal browser GET renders the onboarding page while an explicit JSON
 client receives the minimal API response. Viewing the page leaves the invite
 pending and creates no account. Starting setup creates only a `setup_pending`
 staff/admin identity and changes the invite to `totp_pending`; the invite becomes
@@ -386,8 +386,12 @@ handoff fails during invite creation, the invite is moved out of active pending
 state so it does not block safe retry.
 The public invite lookup returns only a generic valid-link message and exposes
 no acceptance metadata, setup state, workplace email, role, status, user id,
-counter, or lock timestamp. Invite acceptance responses are marked `no-store` with `Referrer-Policy: same-origin`,
-so same-origin HTTPS form posts keep Flask-WTF SSL-strict CSRF protection while cross-origin requests do not receive the invite URL. The post-start verification step uses same-browser acceptance session
+counter, or lock timestamp. Invite acceptance responses are marked `no-store`
+with `Referrer-Policy: origin`, so HTTPS form posts keep only origin-level
+evidence for Flask-WTF SSL-strict CSRF protection while avoiding token-bearing
+path disclosure in same-origin referrers. When Turnstile is enabled, the browser
+setup submit remains disabled until a fresh successful Turnstile response exists
+and is disabled again on expiry, timeout, error, or re-verification. The post-start verification step uses same-browser acceptance session
 binding and is bound to the browser session that started setup. Repeated setup restarts are capped so an invite cannot
 indefinitely reset passwords, TOTP secrets, or workplace verification codes;
 locked active invites require a root-admin TOTP reset before another setup

--- a/tests/js/collect-browser-coverage.mjs
+++ b/tests/js/collect-browser-coverage.mjs
@@ -9,6 +9,7 @@ const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url))
 const browserScripts = [
   "app/static/js/account.js",
   "app/static/js/admin-alerts.js",
+  "app/static/js/admin-invite-accept.js",
   "app/static/js/dashboard.js",
   "app/static/js/payees.js",
   "app/static/js/session-timeout.js",
@@ -440,6 +441,63 @@ async function exerciseAdminAlerts() {
   runScript("app/static/js/admin-alerts.js", emptyContext);
 }
 
+async function exerciseAdminInviteAccept() {
+  const document = new MockDocument();
+  const form = new MockElement({
+    attributes: {
+      "data-invite-accept-start": "",
+      "data-turnstile-required": "true",
+    },
+  });
+  const responseInput = new MockElement({ attributes: { "data-turnstile-response": "" } });
+  const submitButton = new MockElement({ attributes: { "data-invite-start-submit": "" } });
+  const status = new MockElement({ attributes: { "data-turnstile-status": "" } });
+  form.selectorMap.set("[data-turnstile-response]", responseInput);
+  form.selectorMap.set("[data-invite-start-submit]", submitButton);
+  form.selectorMap.set("[data-turnstile-status]", status);
+  document.selectorAllMap.set("[data-invite-accept-start]", [form]);
+
+  const context = createBrowserContext(document);
+  runScript("app/static/js/admin-invite-accept.js", context);
+
+  assert.equal(submitButton.disabled, true);
+  assert.match(status.textContent, /verifying/);
+
+  context.sitbankInviteTurnstileSuccess("fresh-token");
+  assert.equal(responseInput.value, "fresh-token");
+  assert.equal(submitButton.disabled, false);
+  assert.match(status.textContent, /complete/);
+
+  const submitted = await form.emit("submit");
+  assert.equal(submitted.defaultPrevented, undefined);
+  assert.equal(form.dataset.submitting, "true");
+  assert.equal(submitButton.disabled, true);
+
+  const duplicate = await form.emit("submit");
+  assert.equal(duplicate.defaultPrevented, true);
+  form.dataset.submitting = "";
+
+  context.sitbankInviteTurnstileExpired();
+  assert.equal(responseInput.value, "");
+  assert.equal(submitButton.disabled, true);
+  assert.match(status.textContent, /expired/);
+
+  const missingToken = await form.emit("submit");
+  assert.equal(missingToken.defaultPrevented, true);
+  assert.match(status.textContent, /Complete the security challenge/);
+
+  assert.equal(context.sitbankInviteTurnstileError(), true);
+  assert.match(status.textContent, /could not be completed/);
+  context.sitbankInviteTurnstileTimeout();
+  assert.match(status.textContent, /timed out/);
+  context.sitbankInviteTurnstilePending();
+  assert.match(status.textContent, /verifying/);
+  context.sitbankInviteTurnstileSuccess("");
+  assert.equal(responseInput.value, "");
+  assert.equal(submitButton.disabled, true);
+  assert.match(status.textContent, /verifying/);
+}
+
 async function exerciseSessionTimeout() {
   const document = new MockDocument();
   const meta = new MockElement({ attributes: { content: "120" } });
@@ -700,6 +758,7 @@ await post(session, "Profiler.startPreciseCoverage", {
 
 await exerciseAccount();
 await exerciseAdminAlerts();
+await exerciseAdminInviteAccept();
 await exerciseDashboard();
 await exercisePayees();
 await exerciseSessionTimeout();

--- a/tests/test_admin_staff_invites.py
+++ b/tests/test_admin_staff_invites.py
@@ -117,7 +117,7 @@ def _assert_invite_acceptance_security_headers(response):
     assert "no-store" in cache_control
     assert "private" in cache_control
     assert response.headers.get("Pragma") == "no-cache"
-    assert response.headers.get("Referrer-Policy") == "same-origin"
+    assert response.headers.get("Referrer-Policy") == "origin"
 
 
 def _assert_generic_invite_unavailable_page(response, token: str):
@@ -437,6 +437,8 @@ def test_invites_page_renders_actions_and_delivery_guidance(admin_client):
     assert "No backend handoff evidence is available." in unconfirmed_body
     assert "Revoke invite" in body
     assert "Reissue invite" in body
+    assert "currently signed-in root admin" in body
+    assert "Wait for the next code if this one is close to expiry" in body
     assert body.index("Revoke invite") < body.index('id="revoke-totp-')
     assert body.index("Reissue invite") < body.index('id="reissue-totp-')
 
@@ -524,6 +526,82 @@ def test_root_admin_can_reissue_pending_invite_with_new_token(admin_client, monk
     assert original_token not in json.dumps(reissue_event.event_metadata, default=str)
 
 
+def test_root_admin_reissue_mfa_step_up_outcomes_are_safe(
+    admin_app,
+    admin_client,
+    monkeypatch,
+):
+    _root_one, root_one_secret = _create_staff_identity(
+        username="root-admin",
+        email=ROOT_EMAIL,
+        account_type="root_admin",
+        phone_number="91234567",
+    )
+    _root_two, root_two_secret = _create_staff_identity(
+        username="second-root-admin",
+        email="root2@sit.singaporetech.edu.sg",
+        account_type="root_admin",
+        phone_number="91234569",
+    )
+    _root_three, root_three_secret = _create_staff_identity(
+        username="third-root-admin",
+        email="root3@sit.singaporetech.edu.sg",
+        account_type="root_admin",
+        phone_number="91234570",
+    )
+    root_two_client = admin_app.test_client()
+    root_three_client = admin_app.test_client()
+    _login_admin(admin_client, root_one_secret)
+    _login_admin(root_two_client, root_two_secret, email="root2@sit.singaporetech.edu.sg")
+    _login_admin(root_three_client, root_three_secret, email="root3@sit.singaporetech.edu.sg")
+    assert _create_invite(admin_client, root_one_secret).status_code == 201
+    invite = db.session.execute(db.select(StaffInvite)).scalar_one()
+    original_token = _latest_invite_token()
+    fresh_time = _FIXED_TOTP_TIME + 31
+    monkeypatch.setattr("app.auth.services.time.time", lambda: fresh_time)
+    valid_code = pyotp.TOTP(root_one_secret, digits=6, interval=30).at(fresh_time)
+
+    valid = admin_client.post(f"/invites/{invite.id}/reissue", json={"totp_code": valid_code})
+    new_token = _latest_invite_token()
+    replayed = admin_client.post(f"/invites/{invite.id}/reissue", json={"totp_code": valid_code})
+    adjacent_code = pyotp.TOTP(root_two_secret, digits=6, interval=30).at(fresh_time - 30)
+    adjacent = root_two_client.post(f"/invites/{invite.id}/reissue", json={"totp_code": adjacent_code})
+    malformed = root_two_client.post(f"/invites/{invite.id}/reissue", json={"totp_code": "not-a-code"})
+    wrong_account_code = valid_code
+    wrong_account = root_three_client.post(
+        f"/invites/{invite.id}/reissue",
+        json={"totp_code": wrong_account_code},
+    )
+    backed_off = root_three_client.post(
+        f"/invites/{invite.id}/reissue",
+        json={"totp_code": wrong_account_code},
+    )
+    db.session.refresh(invite)
+
+    assert valid.status_code == 200
+    assert new_token != original_token
+    assert replayed.status_code == 403
+    assert adjacent.status_code == 403
+    assert malformed.status_code == 400
+    assert wrong_account.status_code == 403
+    assert backed_off.status_code == 429
+    assert backed_off.headers["Retry-After"].isdigit()
+    assert backed_off.headers["X-Auth-Retry-After"].isdigit()
+    assert invite.status == "pending"
+    assert _invite_info_json(admin_client, original_token).status_code == 401
+    assert _invite_info_json(admin_client, new_token).status_code == 200
+    for response, submitted_code in (
+        (replayed, valid_code),
+        (adjacent, adjacent_code),
+        (malformed, "not-a-code"),
+        (wrong_account, wrong_account_code),
+        (backed_off, wrong_account_code),
+    ):
+        body = response.get_data(as_text=True)
+        assert submitted_code not in body
+        assert "Fresh MFA verification is required" in body or response.status_code in {400, 429}
+
+
 def test_reissue_delivery_failure_is_persisted_without_rotating_the_live_token(
     admin_client,
     monkeypatch,
@@ -572,6 +650,7 @@ def test_invite_acceptance_requires_turnstile_when_enabled(admin_app, admin_clie
     _login_admin(admin_client, secret)
     assert _create_invite(admin_client, secret).status_code == 201
     token = _latest_invite_token()
+    invite = db.session.execute(db.select(StaffInvite)).scalar_one()
 
     missing = admin_client.post(
         f"/invites/accept/{token}/start",
@@ -582,6 +661,19 @@ def test_invite_acceptance_requires_turnstile_when_enabled(admin_app, admin_clie
             "confirm_password": STAFF_PASSWORD,
         },
     )
+    db.session.refresh(invite)
+    missing_event = db.session.query(SecurityAuditEvent).filter_by(
+        event_type="staff_invite_accept",
+        outcome="failure",
+    ).one()
+
+    assert missing.status_code == 400
+    assert missing.get_json() == {"error": "Complete the security challenge before starting setup."}
+    assert invite.status == "pending"
+    assert invite.setup_user_id is None
+    assert db.session.query(User).count() == 1
+    assert missing_event.event_metadata == {"reason": "turnstile_failed"}
+    assert "browser-token" not in json.dumps(missing_event.event_metadata, default=str)
 
     calls = []
 
@@ -600,9 +692,44 @@ def test_invite_acceptance_requires_turnstile_when_enabled(admin_app, admin_clie
         },
     )
 
-    assert missing.status_code == 400
     assert valid.status_code == 200
     assert calls == [("admin_invite_accept", "browser-token")]
+
+
+def test_invite_setup_form_disables_submit_until_managed_turnstile_succeeds(
+    admin_app,
+    admin_client,
+):
+    admin_app.config["TURNSTILE_ENABLED"] = True
+    admin_app.config["TURNSTILE_SITE_KEY"] = "fake-site-key"
+    admin_app.config["TURNSTILE_SECRET_KEY"] = "turnstile-secret"
+    _root, secret = _create_staff_identity(
+        username="root-admin",
+        email=ROOT_EMAIL,
+        account_type="root_admin",
+        phone_number="91234567",
+    )
+    _login_admin(admin_client, secret)
+    assert _create_invite(admin_client, secret).status_code == 201
+    token = _latest_invite_token()
+
+    response = admin_client.get(f"/invites/accept/{token}")
+    body = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert 'data-invite-accept-start' in body
+    assert 'data-turnstile-required="true"' in body
+    assert 'name="turnstile_token" value="" data-turnstile-response' in body
+    assert 'data-callback="sitbankInviteTurnstileSuccess"' in body
+    assert 'data-expired-callback="sitbankInviteTurnstileExpired"' in body
+    assert 'data-error-callback="sitbankInviteTurnstileError"' in body
+    assert 'data-timeout-callback="sitbankInviteTurnstileTimeout"' in body
+    assert 'data-before-interactive-callback="sitbankInviteTurnstilePending"' in body
+    assert 'data-after-interactive-callback="sitbankInviteTurnstilePending"' in body
+    assert 'data-unsupported-callback="sitbankInviteTurnstileError"' in body
+    assert '<button class="button full" type="submit" data-invite-start-submit disabled' in body
+    assert "Complete the security challenge to enable setup." in body
+    assert 'js/admin-invite-accept.js' in body
 
 
 def test_turnstile_verifier_rejects_non_https_verify_url(admin_app):
@@ -694,8 +821,22 @@ def test_browser_invite_onboarding_requires_csrf_and_activates_only_after_both_c
             f"/invites/accept/{token}/start",
             data=_staff_invite_start_payload(),
         )
+        missing_csrf_body = missing_csrf.get_data(as_text=True)
         assert missing_csrf.status_code == 400
+        assert "Security token expired or invalid. Review the form and try again." in missing_csrf_body
+        assert "Private admin request status" not in missing_csrf_body
+        assert 'value="Staff Person"' in missing_csrf_body
+        assert 'value="91234568"' in missing_csrf_body
+        assert STAFF_PASSWORD not in missing_csrf_body
         assert invite.status == "pending"
+        csrf_event = db.session.query(SecurityAuditEvent).filter_by(
+            event_type="staff_invite_accept",
+            outcome="failure",
+        ).one()
+        assert csrf_event.event_metadata == {
+            "reason": "csrf_or_session_failed",
+            "phase": "start",
+        }
 
         start_payload = _staff_invite_start_payload(
             csrf_token=_csrf_token_from(landing),
@@ -744,7 +885,195 @@ def test_browser_invite_onboarding_requires_csrf_and_activates_only_after_both_c
     _assert_invite_acceptance_security_headers(verify)
 
 
-def test_invite_acceptance_strict_https_csrf_allows_same_origin_referrer(
+@pytest.mark.parametrize(
+    ("payload_overrides", "expected_message", "expected_reason"),
+    [
+        ({"full_name": "<Bad Name>"}, "Invalid full name", "invalid_full_name"),
+        (
+            {"phone_number": "+65 9123 4568"},
+            "Enter an 8-digit Singapore mobile number starting with 8 or 9.",
+            "invalid_phone",
+        ),
+        (
+            {"confirm_password": f"{STAFF_PASSWORD} different"},
+            "Passwords must match.",
+            "password_mismatch",
+        ),
+        (
+            {"password": "short", "confirm_password": "short"},
+            "Use a password that meets the staff password policy.",
+            "password_policy",
+        ),
+    ],
+)
+def test_browser_invite_start_validation_failures_are_safe_and_audited(
+    admin_client,
+    payload_overrides,
+    expected_message,
+    expected_reason,
+):
+    _root, root_secret = _create_staff_identity(
+        username="root-admin",
+        email=ROOT_EMAIL,
+        account_type="root_admin",
+        phone_number="91234567",
+    )
+    _login_admin(admin_client, root_secret)
+    assert _create_invite(admin_client, root_secret).status_code == 201
+    token = _latest_invite_token()
+    invite = db.session.execute(db.select(StaffInvite)).scalar_one()
+    payload = _staff_invite_start_payload(turnstile_token="browser-token", **payload_overrides)
+
+    response = admin_client.post(f"/invites/accept/{token}/start", data=payload)
+    body = response.get_data(as_text=True)
+    db.session.refresh(invite)
+    event = db.session.query(SecurityAuditEvent).filter_by(
+        event_type="staff_invite_accept",
+        outcome="failure",
+    ).one()
+
+    assert response.status_code == 400
+    assert expected_message in body
+    assert invite.status == "pending"
+    assert invite.setup_user_id is None
+    assert db.session.query(User).count() == 1
+    assert event.event_metadata["reason"] == expected_reason
+    assert STAFF_PASSWORD not in body
+    assert "browser-token" not in body
+    assert "turnstile_token" not in json.dumps(event.event_metadata, default=str)
+
+
+def test_browser_invite_turnstile_failure_preserves_only_safe_fields(
+    admin_client,
+    monkeypatch,
+):
+    from app.security.turnstile import TurnstileError
+
+    _root, root_secret = _create_staff_identity(
+        username="root-admin",
+        email=ROOT_EMAIL,
+        account_type="root_admin",
+        phone_number="91234567",
+    )
+    _login_admin(admin_client, root_secret)
+    assert _create_invite(admin_client, root_secret).status_code == 201
+    token = _latest_invite_token()
+    invite = db.session.execute(db.select(StaffInvite)).scalar_one()
+
+    def fail_turnstile(_action, _token=None):
+        raise TurnstileError("fake provider detail")
+
+    monkeypatch.setattr("app.admin.services.require_turnstile", fail_turnstile)
+
+    response = admin_client.post(
+        f"/invites/accept/{token}/start",
+        data=_staff_invite_start_payload(
+            full_name="Safe Recipient",
+            phone_number="92345678",
+            turnstile_token="fresh-browser-token",
+        ),
+    )
+    body = response.get_data(as_text=True)
+    db.session.refresh(invite)
+    event = db.session.query(SecurityAuditEvent).filter_by(
+        event_type="staff_invite_accept",
+        outcome="failure",
+    ).one()
+
+    assert response.status_code == 400
+    assert "Complete the security challenge before starting setup." in body
+    assert 'value="Safe Recipient"' in body
+    assert 'value="92345678"' in body
+    assert STAFF_PASSWORD not in body
+    assert "fresh-browser-token" not in body
+    assert "fake provider detail" not in body
+    assert invite.status == "pending"
+    assert invite.setup_user_id is None
+    assert db.session.query(User).count() == 1
+    assert event.event_metadata == {"reason": "turnstile_failed"}
+
+
+def test_invite_start_duplicate_identity_and_delivery_failures_are_safe(
+    admin_client,
+    monkeypatch,
+    caplog,
+):
+    _root, root_secret = _create_staff_identity(
+        username="root-admin",
+        email=ROOT_EMAIL,
+        account_type="root_admin",
+        phone_number="91234567",
+    )
+    existing_staff, _existing_secret = _create_staff_identity(
+        username="existing-staff",
+        email="existing.staff@sit.singaporetech.edu.sg",
+        account_type="staff",
+        phone_number="92345678",
+    )
+    _login_admin(admin_client, root_secret)
+    assert _create_invite(admin_client, root_secret).status_code == 201
+    duplicate_token = _latest_invite_token()
+    duplicate_invite = db.session.execute(db.select(StaffInvite)).scalar_one()
+
+    duplicate = admin_client.post(
+        f"/invites/accept/{duplicate_token}/start",
+        data=_staff_invite_start_payload(phone_number=existing_staff.phone_number),
+    )
+    db.session.refresh(duplicate_invite)
+    duplicate_event = db.session.query(SecurityAuditEvent).filter_by(
+        event_type="staff_invite_accept",
+        outcome="failure",
+    ).one()
+
+    assert duplicate.status_code == 400
+    assert "Staff identity details could not be accepted" in duplicate.get_data(as_text=True)
+    assert duplicate_invite.status == "pending"
+    assert duplicate_invite.setup_user_id is None
+    assert duplicate_event.event_metadata == {"reason": "duplicate_identity"}
+
+    fresh_time = _FIXED_TOTP_TIME + 31
+    monkeypatch.setattr("app.auth.services.time.time", lambda: fresh_time)
+    assert _create_invite(
+        admin_client,
+        root_secret,
+        workplace_email="delivery.fail@sit.singaporetech.edu.sg",
+        totp_code=pyotp.TOTP(root_secret, digits=6, interval=30).at(fresh_time),
+    ).status_code == 201
+    delivery_token = _latest_invite_token()
+    delivery_invite = db.session.execute(
+        db.select(StaffInvite).where(StaffInvite.workplace_email_normalized == "delivery.fail@sit.singaporetech.edu.sg")
+    ).scalar_one()
+    delivery_invite_id = delivery_invite.id
+    caplog.set_level("WARNING")
+    monkeypatch.setattr(
+        "app.admin.services.send_security_email",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("smtp down")),
+    )
+
+    delivery = admin_client.post(
+        f"/invites/accept/{delivery_token}/start",
+        data=_staff_invite_start_payload(phone_number="93456789"),
+    )
+    body = delivery.get_data(as_text=True)
+    delivery_invite = db.session.get(StaffInvite, delivery_invite_id)
+    reasons = {
+        event.event_metadata.get("reason")
+        for event in db.session.query(SecurityAuditEvent).filter_by(
+            event_type="staff_invite_accept",
+            outcome="failure",
+        )
+    }
+
+    assert delivery.status_code == 503
+    assert "Setup could not send the workplace verification code" in body
+    assert delivery_invite.status == "pending"
+    assert delivery_invite.setup_user_id is None
+    assert "workplace_email_delivery_failed" in reasons
+    assert delivery_token not in caplog.text
+    assert STAFF_PASSWORD not in caplog.text
+
+
+def test_invite_acceptance_strict_https_csrf_allows_origin_only_referrer(
     admin_app,
     admin_client,
 ):
@@ -764,8 +1093,8 @@ def test_invite_acceptance_strict_https_csrf_allows_same_origin_referrer(
     admin_app.config["WTF_CSRF_ENABLED"] = True
     admin_app.config["WTF_CSRF_SSL_STRICT"] = True
     base_url = "https://admin.example.test"
-    landing_url = f"{base_url}/invites/accept/{token}"
-    start_url = f"{base_url}/invites/accept/{token}/start"
+    origin_referrer = f"{base_url}/"
+    assert token not in origin_referrer
 
     try:
         landing = recipient.get(f"/invites/accept/{token}", base_url=base_url)
@@ -775,7 +1104,7 @@ def test_invite_acceptance_strict_https_csrf_allows_same_origin_referrer(
         missing_csrf = recipient.post(
             f"/invites/accept/{token}/start",
             base_url=base_url,
-            headers={"Referer": landing_url},
+            headers={"Referer": origin_referrer},
             data=_staff_invite_start_payload(),
         )
         db.session.refresh(invite)
@@ -787,7 +1116,7 @@ def test_invite_acceptance_strict_https_csrf_allows_same_origin_referrer(
         start = recipient.post(
             f"/invites/accept/{token}/start",
             base_url=base_url,
-            headers={"Referer": landing_url},
+            headers={"Referer": origin_referrer},
             data=_staff_invite_start_payload(csrf_token=_csrf_token_from(landing)),
         )
         start_body = start.get_data(as_text=True)
@@ -802,7 +1131,7 @@ def test_invite_acceptance_strict_https_csrf_allows_same_origin_referrer(
         missing_verify_csrf = recipient.post(
             f"/invites/accept/{token}/verify",
             base_url=base_url,
-            headers={"Referer": start_url},
+            headers={"Referer": origin_referrer},
             data={
                 "totp_code": _stable_totp(secret_match.group(1)),
                 "workplace_verification_code": _latest_workplace_code(),
@@ -815,7 +1144,7 @@ def test_invite_acceptance_strict_https_csrf_allows_same_origin_referrer(
         verify = recipient.post(
             f"/invites/accept/{token}/verify",
             base_url=base_url,
-            headers={"Referer": start_url},
+            headers={"Referer": origin_referrer},
             data={
                 "csrf_token": _csrf_token_from(start),
                 "totp_code": _stable_totp(secret_match.group(1)),

--- a/tests/test_documentation_consistency.py
+++ b/tests/test_documentation_consistency.py
@@ -87,6 +87,10 @@ def test_profile_username_and_staff_invite_docs_match_service_and_browser_contra
         "Normal browser requests render the onboarding form",
         "Viewing the page does not consume the invite or create an account",
         "only successful workplace-code and TOTP verification activates the identity",
+        "Referrer-Policy: origin",
+        "fresh successful Turnstile response",
+        "exactly 8 Singapore mobile digits starting with `8` or `9`",
+        "recipient-facing hostname in the matching Turnstile widget's hostname allowlist",
         "delivery states `unconfirmed`, `queued`, or `failed`",
     ):
         assert required in normalized

--- a/tests/test_security_docs_issue_links.py
+++ b/tests/test_security_docs_issue_links.py
@@ -281,7 +281,11 @@ def test_staff_invite_acceptance_docs_cover_minimal_metadata_and_restart_control
     for required in (
         "public invite lookup returns only a generic valid-link message",
         "exposes no acceptance metadata, setup state, workplace email, role, status, user id, counter, or lock timestamp",
-        "referrer-policy: same-origin",
+        "referrer-policy: origin",
+        "origin-level evidence for flask-wtf ssl-strict csrf protection",
+        "fresh successful turnstile response",
+        "exactly 8 singapore mobile digits starting with `8` or `9`",
+        "currently signed-in root admin",
         "bound to the browser session that started setup",
         "repeated setup restarts are capped",
         "root-admin totp reset",
@@ -305,6 +309,7 @@ def test_staff_invite_acceptance_docs_cover_minimal_metadata_and_restart_control
         "invite lookup exposes workplace email",
         "invite info returns workplace email and role",
         "restarting invite acceptance is unlimited",
+        "referrer-policy: same-origin",
     ):
         assert stale_claim not in normalized_docs
 


### PR DESCRIPTION
Summary
---
Hardens staff invite acceptance for issues #531 and #533 by using origin-only referrers, managed Turnstile browser state, safe setup failure handling, and updated operational guidance.

Why
---
Staff invite setup sits on the public and private admin boundary. The previous referrer policy leaked same-origin token-bearing paths to strict-CSRF posts, and Turnstile, setup-error, and reissue paths needed stale-state and replay hardening without weakening CSRF, MFA, audit, or invite lifecycle controls.

What changed
---
- Changed invite acceptance no-store responses to `Referrer-Policy: origin` and added CSRF-specific invite page recovery and audit behavior.
- Added managed Turnstile browser callbacks that disable setup submit until a fresh token exists, clear stale tokens on expiry, error, timeout, and pending states, and block duplicate submit.
- Sanitized invite setup browser failures, preserved only non-sensitive form fields, and hardened duplicate identity plus workplace verification delivery rollback and audit paths.
- Added root-admin MFA timing and current-account hints and documented Turnstile hostname allowlist expectations.
- Added focused Python and browser-script regressions plus stale-doc checks.

Security impact
---
Improves invite acceptance defense in depth: strict CSRF remains enabled with origin-only HTTPS referrers, failed setup paths fail closed without persisting setup users, Turnstile stale or replay states cannot submit from the browser, and audit metadata uses safe reason codes only. No secrets, tokens, TOTP codes, passwords, provider details, or invite tokens are logged or rendered in new error paths.

Deployment impact
---
No database migration, EC2 bootstrap, secret changes, or provider secret changes are required. Normal staging deployment and production deployment apply; operators should verify that each environment's Turnstile widget hostname allowlist includes the exact recipient-facing admin or private invite hostname before enabling admin invite acceptance there.

Verification
---
- `node tests/js/collect-browser-coverage.mjs` (Browser script line coverage: 90.3%).
- `.\.venv\Scripts\python.exe -m pytest -q tests/test_admin_staff_invites.py` (41 passed).
- `.\.venv\Scripts\python.exe -m pytest -q tests/test_admin_isolation.py tests/test_security_docs_issue_links.py tests/test_documentation_consistency.py tests/test_rate_limit_error_ux.py` (77 passed).
- `.\.venv\Scripts\python.exe -m pytest -q tests/test_admin_staff_invites.py tests/test_admin_isolation.py tests/test_security_docs_issue_links.py tests/test_documentation_consistency.py` (91 passed).
- `git diff --check`.
- `.\.venv\Scripts\python.exe -m pytest -q -n 4` (1696 passed, 36 skipped, 4 warnings).
- `.\.venv\Scripts\python.exe -m pytest -q -n 4 --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term` (1696 passed, 36 skipped, 74 warnings, total coverage 91%).

Notes
---
Closes #531.
Closes #533.
Full-suite warnings are existing SQLAlchemy/Alembic SQLite expression-index reflection warnings.