### PR TITLE
Restore invite Turnstile setup submit

### DIFF
--- a/app/static/js/admin-invite-accept.js
+++ b/app/static/js/admin-invite-accept.js
@@ -10,32 +10,43 @@
     submitting: "Starting setup..."
   };
 
-  function updateForm(form, state, token) {
+  function updateForm(form, state, token, options) {
     const required = form.dataset.turnstileRequired === "true";
     const responseInput = form.querySelector("[data-turnstile-response]");
     const submitButton = form.querySelector("[data-invite-start-submit]");
     const status = form.querySelector("[data-turnstile-status]");
-    const hasFreshToken = state === "valid" && Boolean(token);
+    const shouldClearToken = Boolean(options && options.clearToken);
+    const storedToken = responseInput ? responseInput.value : "";
+    const keepValidResponse =
+      state === "pending" &&
+      !shouldClearToken &&
+      form.dataset.turnstileState === "valid" &&
+      Boolean(storedToken);
+    const effectiveState = keepValidResponse ? "valid" : state;
+    const effectiveToken =
+      effectiveState === "valid" ? token || storedToken : "";
+    const hasFreshToken = effectiveState === "valid" && Boolean(effectiveToken);
 
-    form.dataset.turnstileState = state;
+    form.dataset.turnstileState = effectiveState;
     if (responseInput) {
-      responseInput.value = hasFreshToken ? token : "";
+      responseInput.value = hasFreshToken ? effectiveToken : "";
     }
     if (status) {
       if (hasFreshToken) status.textContent = messages.ready;
-      else if (state === "expired") status.textContent = messages.expired;
-      else if (state === "failed") status.textContent = messages.failed;
-      else if (state === "timeout") status.textContent = messages.timeout;
+      else if (effectiveState === "expired") status.textContent = messages.expired;
+      else if (effectiveState === "failed") status.textContent = messages.failed;
+      else if (effectiveState === "timeout") status.textContent = messages.timeout;
       else status.textContent = required ? messages.pending : "";
     }
     if (submitButton) {
-      submitButton.disabled = required && !hasFreshToken;
+      submitButton.disabled =
+        form.dataset.submitting === "true" || (required && !hasFreshToken);
     }
   }
 
-  function setTurnstileState(state, token) {
+  function setTurnstileState(state, token, options) {
     for (const form of managedForms) {
-      updateForm(form, state, token || "");
+      updateForm(form, state, token || "", options || {});
     }
   }
 
@@ -73,20 +84,30 @@
   }
 
   window.sitbankInviteTurnstileSuccess = function (token) {
-    setTurnstileState("valid", token);
+    if (token) {
+      setTurnstileState("valid", token, { clearToken: false });
+    } else {
+      setTurnstileState("pending", "", { clearToken: true });
+    }
   };
   window.sitbankInviteTurnstileExpired = function () {
-    setTurnstileState("expired", "");
+    setTurnstileState("expired", "", { clearToken: true });
   };
   window.sitbankInviteTurnstileError = function () {
-    setTurnstileState("failed", "");
+    setTurnstileState("failed", "", { clearToken: true });
     return true;
   };
   window.sitbankInviteTurnstileTimeout = function () {
-    setTurnstileState("timeout", "");
+    setTurnstileState("timeout", "", { clearToken: true });
+  };
+  window.sitbankInviteTurnstileInteractiveStart = function () {
+    setTurnstileState("pending", "", { clearToken: true });
+  };
+  window.sitbankInviteTurnstileInteractiveEnd = function () {
+    setTurnstileState("pending", "", { clearToken: false });
   };
   window.sitbankInviteTurnstilePending = function () {
-    setTurnstileState("pending", "");
+    setTurnstileState("pending", "", { clearToken: false });
   };
 
   if (document.readyState === "loading") {

--- a/app/templates/_turnstile.html
+++ b/app/templates/_turnstile.html
@@ -11,8 +11,8 @@
         data-expired-callback="sitbankInviteTurnstileExpired"
         data-error-callback="sitbankInviteTurnstileError"
         data-timeout-callback="sitbankInviteTurnstileTimeout"
-        data-before-interactive-callback="sitbankInviteTurnstilePending"
-        data-after-interactive-callback="sitbankInviteTurnstilePending"
+        data-before-interactive-callback="sitbankInviteTurnstileInteractiveStart"
+        data-after-interactive-callback="sitbankInviteTurnstileInteractiveEnd"
         data-unsupported-callback="sitbankInviteTurnstileError"
         {% endif %}
       ></div>

--- a/app/templates/admin/invite_accept.html
+++ b/app/templates/admin/invite_accept.html
@@ -8,6 +8,7 @@
   <p class="eyebrow">Staff onboarding</p>
   {% if phase == "start" %}
     {% set invite_turnstile_required = turnstile_widget_enabled("admin_invite_accept") %}
+    <script src="{{ url_for('static', filename='js/admin-invite-accept.js') }}"></script>
     <h1>Set up your staff access</h1>
     <p class="muted">This invite does not activate an account until password setup, workplace verification, and authenticator verification all succeed.</p>
     <form
@@ -83,10 +84,4 @@
     <p class="muted">This invite link is invalid or expired. Ask a root admin to review the invite and send a new link if access is still needed.</p>
 {% endif %}
 </section>
-{% endblock %}
-
-{% block scripts %}
-  {% if phase == "start" %}
-    <script src="{{ url_for('static', filename='js/admin-invite-accept.js') }}" defer></script>
-  {% endif %}
 {% endblock %}

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -471,10 +471,16 @@ the invite from `pending` to `totp_pending` and creates only a `setup_pending`
 identity; only successful workplace-code and TOTP verification activates the
 identity and marks the invite `accepted`. The setup form accepts exactly 8
 Singapore mobile digits starting with `8` or `9`, without `+65`, spaces, or
-hyphens. When Turnstile is enabled, the setup submit control remains disabled
-until the browser holds a fresh successful Turnstile response; expiry, timeout,
-error, or re-verification clears the response and preserves only non-sensitive
-entered values such as name and mobile number. The setup flow uses `no-store`
+hyphens. When Turnstile is enabled, recipients can fill the normal setup fields
+while the challenge is pending or re-verifying, but the setup submit control
+remains disabled until the browser holds a fresh successful Turnstile response.
+The success callback stores the response only in the hidden browser form field,
+marks the form state `valid`, enables `Start secure setup`, and shows that setup
+can continue. Non-invalidating pending or after-interactive callbacks must not
+downgrade that valid state. Explicit expiry, error, timeout, unsupported-widget,
+reset, or a new before-interactive challenge lifecycle clears the response,
+disables submit again, and preserves only non-sensitive entered values such as
+name and mobile number. The setup flow uses `no-store`
 and `Referrer-Policy: origin` response headers, CSRF-protected browser forms,
 same-browser verification binding, and capped restarts that would otherwise rotate
 passwords, TOTP setup secrets, or workplace verification codes. If an active
@@ -1426,3 +1432,17 @@ to `container.env`. Production and staging use separate widgets for
 invite acceptance is enabled for a private/admin hostname, include that exact
 recipient-facing hostname in the matching Turnstile widget's hostname allowlist;
 do not broaden the widget to wildcard provider domains. The admin app remains private behind Tailscale while its public-auth entry routes retain Turnstile defense in depth.
+
+For invite-acceptance troubleshooting, use only safe browser-console checks:
+inspect the form's `turnstileState`, the hidden response field length, the
+`Start secure setup` disabled flag, and whether the expected callback names are
+functions. Never ask an operator or recipient to paste a raw challenge response,
+invite URL, session value, MFA code, password, workplace verification code,
+Cloudflare provider response, cookie, or token into chat, tickets, logs, pull
+requests, screenshots, or issue comments. The expected managed-widget lifecycle
+is: SITBank callback functions are registered before the Cloudflare API can
+invoke them; pending before success keeps submit disabled; success with a fresh
+response enables submit; after-interactive or non-invalidating pending callbacks
+preserve a still-valid response; expiry, error, timeout, unsupported-widget,
+reset, or a new before-interactive challenge lifecycle clears the stored
+response and disables submit until another fresh success arrives.

--- a/tests/js/collect-browser-coverage.mjs
+++ b/tests/js/collect-browser-coverage.mjs
@@ -443,6 +443,7 @@ async function exerciseAdminAlerts() {
 
 async function exerciseAdminInviteAccept() {
   const document = new MockDocument();
+  document.readyState = "loading";
   const form = new MockElement({
     attributes: {
       "data-invite-accept-start": "",
@@ -452,25 +453,63 @@ async function exerciseAdminInviteAccept() {
   const responseInput = new MockElement({ attributes: { "data-turnstile-response": "" } });
   const submitButton = new MockElement({ attributes: { "data-invite-start-submit": "" } });
   const status = new MockElement({ attributes: { "data-turnstile-status": "" } });
+  const fullName = new MockElement();
+  const phoneNumber = new MockElement();
+  fullName.value = "Safe Recipient";
+  phoneNumber.value = "92345678";
   form.selectorMap.set("[data-turnstile-response]", responseInput);
   form.selectorMap.set("[data-invite-start-submit]", submitButton);
   form.selectorMap.set("[data-turnstile-status]", status);
-  document.selectorAllMap.set("[data-invite-accept-start]", [form]);
 
   const context = createBrowserContext(document);
   runScript("app/static/js/admin-invite-accept.js", context);
+  assert.equal(typeof context.sitbankInviteTurnstileSuccess, "function");
+  assert.equal(typeof context.sitbankInviteTurnstileInteractiveStart, "function");
+  assert.equal(typeof context.sitbankInviteTurnstileInteractiveEnd, "function");
+
+  context.sitbankInviteTurnstilePending();
+  document.selectorAllMap.set("[data-invite-accept-start]", [form]);
+  await document.emit("DOMContentLoaded");
 
   assert.equal(submitButton.disabled, true);
+  assert.equal(form.dataset.turnstileState, "pending");
   assert.match(status.textContent, /verifying/);
+
+  context.sitbankInviteTurnstilePending();
+  assert.equal(responseInput.value, "");
+  assert.equal(submitButton.disabled, true);
+  assert.equal(form.dataset.turnstileState, "pending");
 
   context.sitbankInviteTurnstileSuccess("fresh-token");
   assert.equal(responseInput.value, "fresh-token");
   assert.equal(submitButton.disabled, false);
+  assert.equal(form.dataset.turnstileState, "valid");
   assert.match(status.textContent, /complete/);
 
+  context.sitbankInviteTurnstileInteractiveEnd();
+  assert.equal(responseInput.value, "fresh-token");
+  assert.equal(submitButton.disabled, false);
+  assert.equal(form.dataset.turnstileState, "valid");
+
+  context.sitbankInviteTurnstilePending();
+  assert.equal(responseInput.value, "fresh-token");
+  assert.equal(submitButton.disabled, false);
+  assert.equal(form.dataset.turnstileState, "valid");
+
+  context.sitbankInviteTurnstileInteractiveStart();
+  assert.equal(responseInput.value, "");
+  assert.equal(submitButton.disabled, true);
+  assert.equal(form.dataset.turnstileState, "pending");
+  assert.match(status.textContent, /verifying/);
+
+  context.sitbankInviteTurnstileSuccess("fresh-token");
   const submitted = await form.emit("submit");
   assert.equal(submitted.defaultPrevented, undefined);
   assert.equal(form.dataset.submitting, "true");
+  assert.equal(submitButton.disabled, true);
+
+  context.sitbankInviteTurnstileInteractiveEnd();
+  assert.equal(responseInput.value, "fresh-token");
   assert.equal(submitButton.disabled, true);
 
   const duplicate = await form.emit("submit");
@@ -480,6 +519,8 @@ async function exerciseAdminInviteAccept() {
   context.sitbankInviteTurnstileExpired();
   assert.equal(responseInput.value, "");
   assert.equal(submitButton.disabled, true);
+  assert.equal(fullName.value, "Safe Recipient");
+  assert.equal(phoneNumber.value, "92345678");
   assert.match(status.textContent, /expired/);
 
   const missingToken = await form.emit("submit");

--- a/tests/test_admin_staff_invites.py
+++ b/tests/test_admin_staff_invites.py
@@ -696,6 +696,99 @@ def test_invite_acceptance_requires_turnstile_when_enabled(admin_app, admin_clie
     assert calls == [("admin_invite_accept", "browser-token")]
 
 
+def test_invite_acceptance_rejects_stale_turnstile_and_accepts_standard_field(
+    admin_app,
+    admin_client,
+    monkeypatch,
+    caplog,
+):
+    from app.security.turnstile import TurnstileError
+
+    admin_app.config["TURNSTILE_ENABLED"] = True
+    admin_app.config["TURNSTILE_SECRET_KEY"] = "turnstile-secret"
+    _root, secret = _create_staff_identity(
+        username="root-admin",
+        email=ROOT_EMAIL,
+        account_type="root_admin",
+        phone_number="91234567",
+    )
+    _login_admin(admin_client, secret)
+    assert _create_invite(admin_client, secret).status_code == 201
+    token = _latest_invite_token()
+    invite = db.session.execute(db.select(StaffInvite)).scalar_one()
+    calls = []
+
+    def fake_require(action, token_value=None):
+        calls.append((action, token_value))
+        if token_value != "fresh-browser-token":
+            raise TurnstileError("fake stale provider detail")
+
+    monkeypatch.setattr("app.admin.services.require_turnstile", fake_require)
+
+    missing = admin_client.post(
+        f"/invites/accept/{token}/start",
+        json=_staff_invite_start_payload(),
+    )
+    stale = admin_client.post(
+        f"/invites/accept/{token}/start",
+        data=_staff_invite_start_payload(
+            full_name="Safe Recipient",
+            phone_number="92345678",
+            turnstile_token="stale-browser-token",
+        ),
+    )
+    db.session.refresh(invite)
+
+    assert missing.status_code == 400
+    assert missing.get_json() == {"error": "Complete the security challenge before starting setup."}
+    assert stale.status_code == 400
+    stale_body = stale.get_data(as_text=True)
+    assert "Complete the security challenge before starting setup." in stale_body
+    assert 'value="Safe Recipient"' in stale_body
+    assert 'value="92345678"' in stale_body
+    assert invite.status == "pending"
+    assert invite.setup_user_id is None
+    assert db.session.query(User).count() == 1
+
+    valid = admin_client.post(
+        f"/invites/accept/{token}/start",
+        data=_staff_invite_start_payload(**{"cf-turnstile-response": "fresh-browser-token"}),
+    )
+    db.session.refresh(invite)
+    failure_metadata = [
+        event.event_metadata
+        for event in db.session.query(SecurityAuditEvent)
+        .filter_by(event_type="staff_invite_accept", outcome="failure")
+        .order_by(SecurityAuditEvent.id)
+        .all()
+    ]
+    rendered_payloads = "\n".join(
+        (
+            missing.get_data(as_text=True),
+            stale_body,
+            valid.get_data(as_text=True),
+            json.dumps(failure_metadata, default=str),
+            caplog.text,
+        )
+    )
+
+    assert valid.status_code == 200
+    assert invite.status == "totp_pending"
+    assert calls == [
+        ("admin_invite_accept", None),
+        ("admin_invite_accept", "stale-browser-token"),
+        ("admin_invite_accept", "fresh-browser-token"),
+    ]
+    assert failure_metadata == [{"reason": "turnstile_failed"}, {"reason": "turnstile_failed"}]
+    for forbidden in (
+        "stale-browser-token",
+        "fresh-browser-token",
+        "fake stale provider detail",
+        STAFF_PASSWORD,
+    ):
+        assert forbidden not in rendered_payloads
+
+
 def test_invite_setup_form_disables_submit_until_managed_turnstile_succeeds(
     admin_app,
     admin_client,
@@ -724,12 +817,16 @@ def test_invite_setup_form_disables_submit_until_managed_turnstile_succeeds(
     assert 'data-expired-callback="sitbankInviteTurnstileExpired"' in body
     assert 'data-error-callback="sitbankInviteTurnstileError"' in body
     assert 'data-timeout-callback="sitbankInviteTurnstileTimeout"' in body
-    assert 'data-before-interactive-callback="sitbankInviteTurnstilePending"' in body
-    assert 'data-after-interactive-callback="sitbankInviteTurnstilePending"' in body
+    assert 'data-before-interactive-callback="sitbankInviteTurnstileInteractiveStart"' in body
+    assert 'data-after-interactive-callback="sitbankInviteTurnstileInteractiveEnd"' in body
     assert 'data-unsupported-callback="sitbankInviteTurnstileError"' in body
     assert '<button class="button full" type="submit" data-invite-start-submit disabled' in body
     assert "Complete the security challenge to enable setup." in body
     assert 'js/admin-invite-accept.js' in body
+    assert body.index("js/admin-invite-accept.js") < body.index(
+        "https://challenges.cloudflare.com/turnstile/v0/api.js"
+    )
+    assert 'js/admin-invite-accept.js" defer' not in body
 
 
 def test_turnstile_verifier_rejects_non_https_verify_url(admin_app):

--- a/tests/test_security_docs_issue_links.py
+++ b/tests/test_security_docs_issue_links.py
@@ -141,6 +141,27 @@ def test_global_verification_runbook_is_linked_from_main_docs():
         assert "global-verification.md" in text, path
 
 
+def test_invite_turnstile_lifecycle_docs_match_fail_closed_behavior():
+    operations = Path("docs/OPERATIONS.md").read_text(encoding="utf-8")
+    normalized = " ".join(operations.split())
+
+    for required in (
+        "recipients can fill the normal setup fields while the challenge is pending or re-verifying",
+        "remains disabled until the browser holds a fresh successful Turnstile response",
+        "marks the form state `valid`",
+        "Non-invalidating pending or after-interactive callbacks must not downgrade that valid state",
+        "Explicit expiry, error, timeout, unsupported-widget, reset, or a new before-interactive challenge lifecycle clears the response",
+        "inspect the form's `turnstileState`, the hidden response field length, the `Start secure setup` disabled flag",
+        "Never ask an operator or recipient to paste a raw challenge response",
+        "success with a fresh response enables submit",
+        "after-interactive or non-invalidating pending callbacks preserve a still-valid response",
+    ):
+        assert required in normalized
+
+    assert "paste a raw challenge response" in operations
+    assert "paste the Turnstile response" not in operations
+
+
 def test_global_verification_runbook_keeps_required_contexts_and_baselines():
     runbook = GLOBAL_RUNBOOK.read_text(encoding="utf-8")
 


### PR DESCRIPTION
Summary
---
Closes #536 by restoring the staff invite acceptance Turnstile lifecycle so a visible successful challenge enables `Start secure setup` without weakening server-side verification.

Why
---
After the prior invite hardening, Cloudflare could reach the managed widget before SITBank's callback names were registered, and later pending callbacks could downgrade a valid browser response back to pending. That left recipients unable to start secure setup even after a successful challenge.

What changed
---
- Load the invite acceptance script before the managed Cloudflare Turnstile API script can invoke callbacks.
- Split before-interactive and after-interactive callbacks so new challenge lifecycles clear stale responses, while non-invalidating pending callbacks preserve a still-valid response.
- Keep duplicate submits blocked after setup begins.
- Add browser-script, Flask integration, sanitization, and documentation consistency coverage.
- Update operations guidance with safe Turnstile state diagnostics that never request raw challenge responses.

Security impact
---
Server-side Turnstile verification remains fail-closed, including stale and missing response regressions. The change does not relax invite token validation, CSRF, rate limits, same-browser setup binding, staff/admin/customer separation, MFA setup, audit logging, Cloudflare hostname guidance, or secret handling. Tests assert raw Turnstile responses, passwords, and provider details do not leak through rendered responses, audit metadata, or logs.

Deployment impact
---
Staging and production application deployments are required for the template and static JavaScript change to take effect. No database migration, EC2 bootstrap, secret change, provider setting change, or rollback behavior change is required. Validate with real Turnstile in staging/private-admin before production.

Verification
---
- `git diff --check` passed.
- `node tests/js/collect-browser-coverage.mjs` passed with browser script line coverage at 90.6%.
- `.\.venv\Scripts\python.exe -m pytest -q tests\test_admin_staff_invites.py::test_invite_acceptance_requires_turnstile_when_enabled tests\test_admin_staff_invites.py::test_invite_acceptance_rejects_stale_turnstile_and_accepts_standard_field tests\test_admin_staff_invites.py::test_invite_setup_form_disables_submit_until_managed_turnstile_succeeds tests\test_security_docs_issue_links.py::test_invite_turnstile_lifecycle_docs_match_fail_closed_behavior` passed: 4 passed.
- `.\.venv\Scripts\python.exe -m pytest -q -n 4` passed: 1698 passed, 36 skipped, 4 warnings.
- `.\.venv\Scripts\python.exe -m pytest -q -n auto --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term` passed: 1698 passed, 36 skipped, total coverage 91%; warnings were existing SQLite reflection/resource warnings.

Notes
---
No follow-up required from this PR beyond staging validation with real Cloudflare Turnstile enabled.