### PR TITLE
Fix mobile footer link layout and disclaimer spacing

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -296,6 +296,10 @@ img {
   max-width: 46ch;
 }
 
+.footer-brand p {
+  text-wrap: pretty;
+}
+
 .footer-title {
   margin: 0;
   color: var(--text);
@@ -2664,12 +2668,20 @@ th {
   }
 
   .footer-brand {
+    max-width: none;
     margin-inline: auto;
   }
 
   .footer-column {
     padding-top: var(--space-6);
     border-top: 1px solid var(--line);
+  }
+
+  .footer-links {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: var(--space-2) var(--space-4);
   }
 
   .feature-grid,
@@ -3267,7 +3279,7 @@ th {
   display: flex;
   align-items: flex-start;
   gap: var(--space-3);
-  margin: 40px 0 var(--space-8);
+  margin: 40px 0 0;
   color: var(--muted);
   font-size: 0.84rem;
   line-height: 1.6;


### PR DESCRIPTION
Summary
  ---

Fixes three mobile/responsive CSS issues in the site footer and landing page: stacked footer sublinks, inconsistent text wrapping between footer columns, and an oversized gap below the landing page disclaimer.

  Why
  ---

On mobile, the Sitemap and Account Security footer links stacked one per line instead of reading as a compact link row, the SITBank description kept a desktop-only `46ch` width cap that made it wrap noticeably narrower than the neighboring Security Posture text (inconsistent, uneven layout), and the landing page disclaimer had a doubled bottom margin (its own `margin-bottom` plus the page's bottom padding) leaving a large empty gap before the footer.

  What changed
  ---

  * `.footer-links` now lays out as a wrapped, centered row with spacing on mobile (`max-width: 760px`) instead of a vertical stack.
  * `.footer-brand` drops its `46ch` max-width on mobile so the SITBank description wraps at the same width as the other footer columns.
  * `.footer-brand p` gets `text-wrap: pretty` to avoid orphan line breaks.
  * `.lp-disclaimer` no longer has its own bottom margin, removing the doubled gap before the footer on the landing page.

  Security impact
  ---

  None. Presentation-only CSS change in `app/static/css/app.css`; no template, route, auth, or data-handling logic touched.

  Deployment impact
  ---

  * no deployment action

  Verification
  ---

  * Rendered the footer and landing page disclaimer via a local static harness and Playwright screenshots at 390px/600px/760px/900px/1280px
  widths to confirm link row wrapping, matched text-wrap behavior between footer columns, and the reduced disclaimer gap.
  * Ran the app locally via `docker compose -f compose.dev.yml up --build` and visually confirmed the same behavior against the live
  templates/CSS (bind-mounted).
  * `git diff --check` passes (whitespace-only, no conflicts).
  * Pytest suite not run — change is CSS-only with no Python/template logic touched.

  Notes
  ---

  CSS-only change; no functional/behavioral impact beyond layout.