### PR TITLE
Redesign admin dashboard for cohesive role-scoped UX

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -2167,25 +2167,183 @@ th {
   gap: var(--space-6);
 }
 
-.admin-summary-grid {
+.admin-identity-bar {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-5);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: var(--space-6) var(--space-7);
+  background: var(--surface);
+  box-shadow: var(--shadow-soft);
+}
+
+.admin-identity-main {
+  display: grid;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.admin-identity-main h1 {
+  font-size: 1.5rem;
+  overflow-wrap: anywhere;
+}
+
+.admin-identity-badges {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.admin-summary-row {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: var(--space-5);
 }
 
-.admin-nav-grid {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.admin-list {
+.admin-boundary-list {
   display: grid;
   gap: var(--space-3);
   margin: 0;
-  padding-left: 1.1rem;
+  padding: 0;
+  list-style: none;
+}
+
+.admin-boundary-list li {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
   color: var(--muted-strong);
 }
 
-.admin-notice-list {
+.admin-boundary-list .icon {
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+  margin-top: 2px;
+  color: var(--success);
+}
+
+.admin-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: var(--space-4);
+  margin: 0;
+}
+
+.admin-stat-grid div {
+  display: grid;
+  gap: var(--space-1);
+  border-top: 1px solid var(--line);
+  padding-top: var(--space-3);
+}
+
+.admin-stat-grid dt {
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.admin-stat-grid dd {
+  margin: 0;
+  color: var(--text);
+  font-size: 1.4rem;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+}
+
+.admin-access-map {
+  display: grid;
+  gap: var(--space-6);
+  margin-top: var(--space-5);
+}
+
+.admin-access-tier-label {
+  margin: 0 0 var(--space-3);
+  color: var(--muted-strong);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.admin-op-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: var(--space-3);
+}
+
+.admin-op-card {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: var(--space-4);
+  background: var(--surface);
+  color: var(--text);
+  font-weight: 650;
+  text-decoration: none;
+  box-shadow: var(--shadow-soft);
+  transition:
+    border-color 150ms ease,
+    background-color 150ms ease,
+    color 150ms ease,
+    transform 150ms ease;
+}
+
+.admin-op-card:hover {
+  border-color: var(--primary);
+  background: var(--primary-soft);
+  color: var(--primary-hover);
+  transform: translateY(-2px);
+}
+
+.admin-op-card[aria-current="page"] {
+  border-color: var(--primary);
+  background: var(--primary-soft);
+  color: var(--primary-hover);
+}
+
+.admin-op-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  flex: 0 0 auto;
+  border-radius: var(--radius);
+  background: var(--primary-soft);
+  color: var(--primary);
+}
+
+.admin-op-icon .icon {
+  width: 20px;
+  height: 20px;
+}
+
+.admin-placeholder-list {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.admin-placeholder-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: var(--space-4);
+  background: var(--surface-raised);
+}
+
+.admin-notice-stack {
   display: grid;
   gap: var(--space-3);
 }
@@ -2528,9 +2686,8 @@ th {
     min-height: 0;
   }
 
-  .admin-summary-grid,
-  .admin-metadata-grid,
-  .admin-nav-grid {
+  .admin-summary-row,
+  .admin-metadata-grid {
     grid-template-columns: 1fr;
   }
 
@@ -2562,6 +2719,14 @@ th {
   }
 
   .balance-amount {
+    justify-content: flex-start;
+  }
+
+  .admin-identity-bar {
+    align-items: stretch;
+  }
+
+  .admin-identity-badges {
     justify-content: flex-start;
   }
 

--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -3,57 +3,74 @@
 {% block title %}Admin Dashboard | SITBank{% endblock %}
 
 {% block content %}
+{% set workspace_labels = {
+  "root_admin": "Root admin control center",
+  "admin": "Security & audit console",
+  "staff": "Business operations workspace",
+} %}
+{% set has_stats = summary.pending_invites is not none or summary.staff_accounts is not none %}
 <section class="dashboard admin-dashboard">
-  <div class="bank-account-card admin-identity-card">
-    <div class="bank-account-card-inner">
-      <div class="bank-account-identity">
-        <p class="bank-card-eyebrow">Staff/Admin Identity</p>
-        <h1 class="bank-card-name">{{ user.email }}</h1>
-        <p class="bank-card-number">{{ role_label }} &middot; {{ user.account_status }}</p>
-      </div>
-      <div class="bank-account-balance">
-        <p class="bank-card-eyebrow">Session Control</p>
-        <p class="balance-amount">TOTP {% if user.mfa_enabled %}enrolled{% else %}pending{% endif %}</p>
-      </div>
+
+  <div class="admin-identity-bar">
+    <div class="admin-identity-main">
+      <p class="eyebrow">{{ workspace_labels.get(user.account_type, "Staff workspace") }}</p>
+      <h1>{{ user.email }}</h1>
+      <p class="muted">{{ role_label }} &middot; {{ user.account_status }}</p>
+    </div>
+    <div class="admin-identity-badges">
+      <span class="badge{% if not user.mfa_enabled %} warning{% endif %}">TOTP {% if user.mfa_enabled %}enrolled{% else %}pending{% endif %}</span>
+      <span class="badge{% if not user.workplace_email_verified %} warning{% endif %}">Workplace email {% if user.workplace_email_verified %}verified{% else %}pending{% endif %}</span>
     </div>
   </div>
 
-  <div class="admin-summary-grid">
+  <div{% if has_stats %} class="admin-summary-row"{% endif %}>
     <section class="panel">
       <div class="section-header">
         <h2>Role Boundary</h2>
       </div>
-      <ul class="admin-list">
+      <ul class="admin-boundary-list">
         {% for item in responsibilities %}
-        <li>{{ item }}</li>
+        <li>
+          <svg class="icon" focusable="false" aria-hidden="true"><use href="#icon-check-circle"></use></svg>
+          <span>{{ item }}</span>
+        </li>
         {% endfor %}
       </ul>
     </section>
 
+    {% if has_stats %}
     <section class="panel">
       <div class="section-header">
-        <h2>Security Status</h2>
+        <h2>Access Summary</h2>
       </div>
-      <dl class="admin-metadata-grid">
-        <div>
-          <dt>Workplace email</dt>
-          <dd>{% if summary.workplace_email_verified %}Verified{% else %}Pending{% endif %}</dd>
-        </div>
-        <div>
-          <dt>Authenticator MFA</dt>
-          <dd>{% if summary.totp_enrolled %}Enabled{% else %}Required{% endif %}</dd>
-        </div>
+      <dl class="admin-stat-grid">
         <div>
           <dt>Role rank</dt>
           <dd>{{ summary.current_role_rank }}</dd>
         </div>
+        {% if summary.pending_invites is not none %}
+        <div>
+          <dt>Pending invites</dt>
+          <dd>{{ summary.pending_invites }}</dd>
+        </div>
+        {% endif %}
+        {% if summary.staff_accounts is not none %}
+        {% for group in summary.staff_accounts %}
+        <div>
+          <dt>{{ group.role }} &middot; {{ group.status }}</dt>
+          <dd>{{ group.count }}</dd>
+        </div>
+        {% endfor %}
+        {% endif %}
       </dl>
     </section>
+    {% endif %}
   </div>
 
   <section class="panel">
     <div class="section-header">
-      <h2>Allowed Operations</h2>
+      <h2>Access Map</h2>
+      <p class="muted">Tools are grouped by trust tier and scoped to your role server-side.</p>
     </div>
     {% set nav_icons = {
       "Dashboard": "icon-controls",
@@ -67,16 +84,49 @@
       "Customer locks": "icon-lock",
       "Approvals": "icon-check-circle",
     } %}
-    <div class="bank-quick-grid admin-nav-grid">
-      {% for item in navigation %}
-      <a class="bank-quick-btn" href="{{ item.href }}">
-        <span class="bank-quick-icon" aria-hidden="true">
-          <svg class="icon" focusable="false"><use href="#{{ nav_icons.get(item.label, 'icon-controls') }}"></use></svg>
-        </span>
-        <span>{{ item.label }}</span>
-        <span class="badge neutral">{{ item.group }}</span>
-      </a>
+    {% set tier_order = ["overview", "business", "security", "admin", "root"] %}
+    {% set tier_labels = {
+      "overview": "Overview",
+      "business": "Business",
+      "security": "Security & audit",
+      "admin": "Staff & admin management",
+      "root": "Root admin controls",
+    } %}
+    <div class="admin-access-map">
+      {% for tier in tier_order %}
+      {% set tier_items = navigation|selectattr("group", "equalto", tier)|list %}
+      {% if tier_items %}
+      <div class="admin-access-tier">
+        <p class="admin-access-tier-label">{{ tier_labels[tier] }}</p>
+        <div class="admin-op-grid">
+          {% for item in tier_items %}
+          <a class="admin-op-card" href="{{ item.href }}"{% if request.endpoint == item.endpoint %} aria-current="page"{% endif %}>
+            <span class="admin-op-icon" aria-hidden="true">
+              <svg class="icon" focusable="false"><use href="#{{ nav_icons.get(item.label, 'icon-controls') }}"></use></svg>
+            </span>
+            <span>{{ item.label }}</span>
+          </a>
+          {% endfor %}
+        </div>
+      </div>
+      {% endif %}
       {% endfor %}
+      {% set other_items = navigation|rejectattr("group", "in", tier_order)|list %}
+      {% if other_items %}
+      <div class="admin-access-tier">
+        <p class="admin-access-tier-label">Other</p>
+        <div class="admin-op-grid">
+          {% for item in other_items %}
+          <a class="admin-op-card" href="{{ item.href }}"{% if request.endpoint == item.endpoint %} aria-current="page"{% endif %}>
+            <span class="admin-op-icon" aria-hidden="true">
+              <svg class="icon" focusable="false"><use href="#{{ nav_icons.get(item.label, 'icon-controls') }}"></use></svg>
+            </span>
+            <span>{{ item.label }}</span>
+          </a>
+          {% endfor %}
+        </div>
+      </div>
+      {% endif %}
     </div>
   </section>
 
@@ -85,13 +135,15 @@
     <div class="section-header">
       <h2>Business Operations</h2>
     </div>
-    <div class="bank-quick-grid admin-nav-grid">
+    <div class="admin-placeholder-list">
       {% for item in business_operations %}
-      <span class="bank-quick-btn is-disabled" aria-disabled="true">
-        <span>{{ item.label }}</span>
+      <div class="admin-placeholder-card">
+        <div>
+          <p><strong>{{ item.label }}</strong></p>
+          <p class="muted">{{ item.description }}</p>
+        </div>
         <span class="badge neutral">{{ item.status }}</span>
-        <span class="muted">{{ item.description }}</span>
-      </span>
+      </div>
       {% endfor %}
     </div>
   </section>
@@ -101,14 +153,18 @@
     <div class="section-header">
       <h2>Security Notices</h2>
     </div>
-    <div class="admin-notice-list">
+    {% set notice_icons = {"danger": "icon-alert", "warning": "icon-lock", "info": "icon-info"} %}
+    <div class="admin-notice-stack">
       {% for notice in security_notices %}
-      <article class="notice {{ notice.severity }}">
+      <div class="notice {{ notice.severity }}">
+        <span class="notice-icon" aria-hidden="true">
+          <svg class="icon" focusable="false"><use href="#{{ notice_icons.get(notice.severity, 'icon-info') }}"></use></svg>
+        </span>
         <div>
           <p><strong>{{ notice.title }}</strong></p>
-          <p>{{ notice.message }}</p>
+          <p class="muted">{{ notice.message }}</p>
         </div>
-      </article>
+      </div>
       {% endfor %}
     </div>
   </section>


### PR DESCRIPTION
Summary
---

Redesigns the admin landing page (`/admin` dashboard) so it reads as one coherent console instead of a mix of customer-style banking card, quick-action grid, and plain panels.

Why
---

The dashboard reused the customer `bank-account-card`/`bank-quick-grid` components (a red gradient "balance card" showing TOTP status like a currency figure, and quick-link tiles carrying a redundant group badge on every item) alongside plain `panel`/table sections used by every other admin page. The result looked inconsistent, and staff, admin, and root admin all saw the identical visual shell with no cue for which role's console they were in.

What changed
---

* Replaced the identity "balance card" with a compact identity bar showing role-specific framing: "Root admin control center" / "Security & audit console" / "Business operations workspace".
* Role Boundary and Access Summary now sit side by side only when there is real stat data to show (staff no longer get a half-empty summary panel).
* Replaced the flat 3-column nav grid with an Access Map that groups tools by trust tier (Overview → Business → Security & Audit → Staff Management → Root Controls), matching the app's existing separation-of-duties model instead of a flat badge-per-tile grid.
* Security notices now show a severity-appropriate icon, matching the `.notice`/`.notice-icon` pattern already used elsewhere in the app.
* Business Operations placeholder (staff-only) is now a readable row card instead of a squeezed fixed-height grid tile.
* Added the corresponding CSS; removed the old `admin-summary-grid` / `admin-nav-grid` / `admin-list` / `admin-notice-list` classes after confirming they were unused by any other template.

No backend, route, or service changes.

Security impact
---

None — templates and CSS only. All server-side role scoping (which nav items, stats, and sections render) is unchanged; this only restyles what was already being sent to the browser.

Deployment impact
---

* no deployment action

Verification
---

* `.\.venv\Scripts\python.exe -m pytest -q tests/test_admin_dashboard_operations.py tests/test_admin_dashboard_role_separation.py tests/test_dashboard.py -n auto` — 60 passed
* `.\.venv\Scripts\python.exe -m pytest -q tests/ -k admin -n auto` — 340 passed, 3 skipped
* Grepped templates for the removed CSS classes to confirm no other page referenced them before deleting

Notes
---

Follow-up (not in this PR): a live-browser visual pass once a preview environment is available; this PR was verified via the test suite and manual template/CSS review only.