### PR TITLE
Add email notifications for Payup and Local Transfer

### DIFF
--- a/app/banking/routes.py
+++ b/app/banking/routes.py
@@ -54,6 +54,8 @@ from app.banking.services import (
     payup_transfer_token_verifier,
     resolve_local_transfer_limit_choice,
     resolve_transfer_limit_choice,
+    send_transfer_limit_change_notification,
+    send_transfer_notification,
     statement_for_period,
 )
 from app.banking.topup_tokens import (
@@ -1165,6 +1167,12 @@ def payup_confirm_submit():
             user=g.current_user,
             metadata={"reason": "execution_policy"},
         )
+        send_transfer_notification(
+            g.current_user,
+            direction="withdrawal",
+            outcome="failure",
+            channel="PayUp",
+        )
         flash(exc.message, "error")
         return redirect(url_for(_PAYUP_ENDPOINT))
 
@@ -1339,6 +1347,7 @@ def transfer_limits():
 def transfer_limits_submit():
     form = TransferLimitsForm()
     if not form.validate_on_submit():
+        send_transfer_limit_change_notification(g.current_user, outcome="failure")
         return render_template(_TRANSFER_LIMITS_TEMPLATE, form=form), 400
 
     try:
@@ -1347,6 +1356,7 @@ def transfer_limits_submit():
             form.local_transfer_limit.data, form.local_transfer_limit_custom.data
         )
     except AuthError as exc:
+        send_transfer_limit_change_notification(g.current_user, outcome="failure")
         flash(exc.message, "error")
         return render_template(_TRANSFER_LIMITS_TEMPLATE, form=form), exc.status_code
 
@@ -1357,6 +1367,7 @@ def transfer_limits_submit():
             "transfer_limits_change",
         )
     except AuthError as exc:
+        send_transfer_limit_change_notification(g.current_user, outcome="failure")
         flash(exc.message, "error")
         return render_template(_TRANSFER_LIMITS_TEMPLATE, form=form), exc.status_code
 
@@ -1372,6 +1383,12 @@ def transfer_limits_submit():
             "payup_daily_limit": str(payup_limit),
             "local_transfer_daily_limit": str(local_transfer_limit),
         },
+    )
+    send_transfer_limit_change_notification(
+        g.current_user,
+        outcome="success",
+        payup_limit=payup_limit,
+        local_transfer_limit=local_transfer_limit,
     )
     flash("Daily transfer limits updated.", "success")
     return redirect(url_for(_TRANSFER_LIMITS_ENDPOINT))

--- a/app/banking/services.py
+++ b/app/banking/services.py
@@ -37,6 +37,7 @@ from app.models import (
     User,
 )
 from app.security.audit import AuditWriteError, audit_event, audit_event_required, audit_reference
+from app.security.email import send_security_email
 from app.security.session_hmac import active_hmac_hex
 from app.security.sessions import (
     authenticated_session_age_seconds,
@@ -81,6 +82,7 @@ _PAYUP_SENSITIVE_EVENT_TYPES = frozenset(
         "recovery_codes_regenerate",
     }
 )
+_DAILY_LIMIT_WARNING_RATIO = Decimal("0.80")
 
 
 @dataclass(frozen=True)
@@ -120,6 +122,144 @@ def _amount_audit_band(amount: Decimal) -> str:
     if normalized < Decimal("10000"):
         return "1000_to_9999"
     return "10000_or_more"
+
+
+def _format_money(amount: Decimal | object) -> str:
+    return str(Decimal(str(amount)).quantize(Decimal("0.01")))
+
+
+def send_transfer_notification(
+    user: User,
+    *,
+    direction: str,
+    outcome: str,
+    channel: str,
+    amount: Decimal | None = None,
+    transaction_reference: str | None = None,
+    counterparty_label: str | None = None,
+) -> None:
+    normalized_direction = str(direction or "").strip().casefold()
+    normalized_outcome = str(outcome or "").strip().casefold()
+    if normalized_direction not in {"withdrawal", "deposit"}:
+        raise ValueError("Unsupported transfer notification direction")
+    if normalized_outcome not in {"success", "failure"}:
+        raise ValueError("Unsupported transfer notification outcome")
+
+    direction_label = normalized_direction.title()
+    status_label = "successful" if normalized_outcome == "success" else "unsuccessful"
+    subject = f"SITBank {direction_label} {status_label}"
+    lines = [
+        f"A {direction_label.lower()} {channel} transaction was {status_label}.",
+    ]
+    if amount is not None:
+        lines.append(f"Amount: SGD {_format_money(amount)}")
+    if counterparty_label:
+        lines.append(f"Counterparty: {counterparty_label}")
+    if transaction_reference:
+        lines.append(f"Reference: {transaction_reference[:8].upper()}")
+    lines.append(
+        "If you did not request or expect this activity, contact SITBank support through the approved recovery path."
+    )
+    _send_banking_email(
+        user,
+        subject,
+        "\n".join(lines),
+        event_type="banking_transfer_notification",
+        metadata={
+            "direction": normalized_direction,
+            "outcome": normalized_outcome,
+            "channel": channel,
+        },
+    )
+
+
+def maybe_send_daily_limit_warning(
+    user: User,
+    *,
+    channel: str,
+    used_before: Decimal,
+    amount: Decimal,
+    daily_limit: Decimal,
+) -> None:
+    limit = Decimal(str(daily_limit))
+    if limit <= 0:
+        return
+    before_ratio = Decimal(str(used_before)) / limit
+    after_amount = Decimal(str(used_before)) + Decimal(str(amount))
+    after_ratio = after_amount / limit
+    if before_ratio >= _DAILY_LIMIT_WARNING_RATIO or after_ratio < _DAILY_LIMIT_WARNING_RATIO:
+        return
+
+    percent_used = (after_ratio * Decimal("100")).quantize(Decimal("0.01"))
+    body = "\n".join(
+        [
+            f"Your {channel} daily transfer usage has reached {percent_used}% of your limit.",
+            f"Used today: SGD {_format_money(after_amount)}",
+            f"Daily limit: SGD {_format_money(limit)}",
+            "If this activity was not yours, contact SITBank support through the approved recovery path.",
+        ]
+    )
+    _send_banking_email(
+        user,
+        f"SITBank {channel} daily limit 80% alert",
+        body,
+        event_type="banking_daily_limit_notification",
+        metadata={"channel": channel, "threshold": "80_percent"},
+    )
+
+
+def send_transfer_limit_change_notification(
+    user: User,
+    *,
+    outcome: str,
+    payup_limit: Decimal | None = None,
+    local_transfer_limit: Decimal | None = None,
+) -> None:
+    normalized_outcome = str(outcome or "").strip().casefold()
+    if normalized_outcome not in {"success", "failure"}:
+        raise ValueError("Unsupported transfer limit notification outcome")
+
+    status_label = "successful" if normalized_outcome == "success" else "unsuccessful"
+    lines = [f"Your daily transfer limit change was {status_label}."]
+    if normalized_outcome == "success" and payup_limit is not None and local_transfer_limit is not None:
+        lines.append(f"PayUp daily limit: SGD {_format_money(payup_limit)}")
+        lines.append(f"Local Transfer daily limit: SGD {_format_money(local_transfer_limit)}")
+    lines.append(
+        "If you did not request this change, contact SITBank support through the approved recovery path."
+    )
+    _send_banking_email(
+        user,
+        f"SITBank transfer limit change {status_label}",
+        "\n".join(lines),
+        event_type="banking_transfer_limit_notification",
+        metadata={"outcome": normalized_outcome},
+    )
+
+
+def _send_banking_email(
+    user: User,
+    subject: str,
+    body: str,
+    *,
+    event_type: str,
+    metadata: Mapping[str, object] | None = None,
+) -> None:
+    try:
+        send_security_email(user.email, subject, body)
+    except Exception as exc:
+        current_app.logger.warning(
+            "%s_failed error=%s",
+            event_type,
+            type(exc).__name__,
+        )
+        audit_event(
+            event_type,
+            "failure",
+            user=user,
+            metadata={"reason": "email_delivery_failed", **dict(metadata or {})},
+        )
+        return
+    audit_event(event_type, "queued", user=user, metadata=dict(metadata or {}))
 
 
 def ensure_outbound_transfer_allowed(user: User) -> None:
@@ -672,6 +812,12 @@ def _reject_local_transfer(
         payee_account=payee_account,
     )
     db.session.commit()
+    send_transfer_notification(
+        sender,
+        direction="withdrawal",
+        outcome="failure",
+        channel="Local Transfer",
+    )
     raise AuthError(message, status_code)
 
 
@@ -860,7 +1006,12 @@ def _ensure_local_transfer_balance(sender: User, payee: Payee, locked_sender: Us
         )
 
 
-def _ensure_local_transfer_daily_limit(sender: User, payee: Payee, locked_sender: User, amount: Decimal) -> None:
+def _ensure_local_transfer_daily_limit(
+    sender: User,
+    payee: Payee,
+    locked_sender: User,
+    amount: Decimal,
+) -> tuple[Decimal, Decimal]:
     daily_limit = Decimal(str(locked_sender.local_transfer_daily_limit))
     used_today = local_transfer_amount_used_today(locked_sender)
     if used_today + amount > daily_limit:
@@ -871,6 +1022,7 @@ def _ensure_local_transfer_daily_limit(sender: User, payee: Payee, locked_sender
             metadata={"reason": "daily_limit_exceeded", "amount_band": _amount_audit_band(amount)},
             payee_account=payee.account_number,
         )
+    return used_today, daily_limit
 
 
 def execute_local_transfer(
@@ -902,7 +1054,12 @@ def execute_local_transfer(
     # Recompute usage under the sender's row lock (acquired above), which serializes
     # concurrent Local Transfers from the same sender and makes this check-then-insert
     # sequence atomic, matching the equivalent PayUp daily-limit recheck.
-    _ensure_local_transfer_daily_limit(sender, payee, locked_sender, amount)
+    used_today, daily_limit = _ensure_local_transfer_daily_limit(
+        sender,
+        payee,
+        locked_sender,
+        amount,
+    )
 
     txn_ref = str(uuid.uuid4())
     txn_created_at = datetime.now(timezone.utc)
@@ -944,6 +1101,31 @@ def execute_local_transfer(
     pending_tfr.consumed_transaction_ref = txn_ref
 
     _audit_local_transfer_success(sender, payee, amount, reference, txn_ref)
+    send_transfer_notification(
+        sender,
+        direction="withdrawal",
+        outcome="success",
+        amount=amount,
+        channel="Local Transfer",
+        transaction_reference=txn_ref,
+        counterparty_label=payee.recipient_name,
+    )
+    send_transfer_notification(
+        locked_recipient,
+        direction="deposit",
+        outcome="success",
+        amount=amount,
+        channel="Local Transfer",
+        transaction_reference=txn_ref,
+        counterparty_label=sender.full_name or sender.username,
+    )
+    maybe_send_daily_limit_warning(
+        sender,
+        channel="Local Transfer",
+        used_before=used_today,
+        amount=amount,
+        daily_limit=daily_limit,
+    )
     return txn_ref
 
 
@@ -1441,6 +1623,7 @@ def execute_payup_transfer(
     # which serializes concurrent PayUp transfers from the same sender and makes
     # this check-then-insert sequence effectively atomic for that sender.
     used_today = payup_amount_used_today(locked_sender)
+    daily_limit = Decimal(str(locked_sender.payup_daily_limit))
     risk = evaluate_payup_risk(
         locked_sender,
         amount,
@@ -1543,7 +1726,36 @@ def execute_payup_transfer(
     except AuditWriteError:
         db.session.rollback()
         raise
+    send_transfer_notification(
+        sender,
+        direction="withdrawal",
+        outcome="success",
+        amount=amount,
+        channel="PayUp",
+        transaction_reference=txn_ref,
+        counterparty_label=_payup_notification_label(locked_recipient),
+    )
+    send_transfer_notification(
+        locked_recipient,
+        direction="deposit",
+        outcome="success",
+        amount=amount,
+        channel="PayUp",
+        transaction_reference=txn_ref,
+        counterparty_label=_payup_notification_label(locked_sender),
+    )
+    maybe_send_daily_limit_warning(
+        sender,
+        channel="PayUp",
+        used_before=used_today,
+        amount=amount,
+        daily_limit=daily_limit,
+    )
     return txn_ref
+
+
+def _payup_notification_label(user: User) -> str:
+    return str(getattr(user, "payup_nickname", "") or "").strip() or user.full_name or user.username
 
 
 def _requires_durable_audit(action: str, outcome: str) -> bool:

--- a/tests/test_local_transfer.py
+++ b/tests/test_local_transfer.py
@@ -799,3 +799,54 @@ def test_transfer_submit_route_blocks_when_exceeding_daily_limit(client, transfe
     assert response.status_code == 400
     assert b"daily Local Transfer limit" in response.data
     assert PendingTransfer.query.count() == 0
+
+
+def test_unsuccessful_local_transfer_sends_withdrawal_failure_email(app, transfer_context):
+    from app.security.email import password_reset_outbox
+
+    alice = transfer_context["alice"]
+    payee = transfer_context["payee"]
+
+    alice.balance = Decimal("1.00")
+    db.session.commit()
+
+    token = _make_pending_transfer(alice, payee, Decimal("999.00"))
+
+    with app.test_request_context("/banking/transfer/confirm", method="POST"):
+        with pytest.raises(AuthError):
+            execute_local_transfer(sender=alice, payee=payee, confirmation_token=token)
+
+    delivery = password_reset_outbox()[-1]
+    assert delivery["to"] == "alice@example.com"
+    assert delivery["subject"] == "SITBank Withdrawal unsuccessful"
+    assert "withdrawal Local Transfer transaction was unsuccessful" in delivery["body"]
+
+
+def test_successful_local_transfer_sends_withdrawal_deposit_and_limit_warning(
+    app,
+    transfer_context,
+):
+    from app.security.email import password_reset_outbox
+
+    alice = transfer_context["alice"]
+    bob = transfer_context["bob"]
+    payee = transfer_context["payee"]
+
+    _make_local_transfer_transaction(alice, bob, Decimal("350.00"))
+    token = _make_pending_transfer(alice, payee, Decimal("50.00"))
+
+    with app.test_request_context("/banking/transfer/confirm", method="POST"):
+        execute_local_transfer(sender=alice, payee=payee, confirmation_token=token)
+
+    deliveries = password_reset_outbox()
+    assert [item["subject"] for item in deliveries[-3:]] == [
+        "SITBank Withdrawal successful",
+        "SITBank Deposit successful",
+        "SITBank Local Transfer daily limit 80% alert",
+    ]
+    assert deliveries[-3]["to"] == "alice@example.com"
+    assert "withdrawal Local Transfer transaction was successful" in deliveries[-3]["body"]
+    assert deliveries[-2]["to"] == "bob@example.com"
+    assert "deposit Local Transfer transaction was successful" in deliveries[-2]["body"]
+    assert deliveries[-1]["to"] == "alice@example.com"
+    assert "80.00% of your limit" in deliveries[-1]["body"]

--- a/tests/test_payup.py
+++ b/tests/test_payup.py
@@ -367,6 +367,31 @@ def test_execute_payup_transfer_debits_sender_and_credits_recipient(app, payup_c
     assert transaction_hash_matches(txn)
 
 
+def test_successful_payup_sends_withdrawal_deposit_and_limit_warning(app, payup_context):
+    from app.security.email import password_reset_outbox
+
+    alice = payup_context["alice"]
+    bob = payup_context["bob"]
+    _make_payup_transaction(alice, bob, Decimal("350.00"))
+    token = _make_payup_pending(alice, bob, Decimal("50.00"))
+
+    with _payup_service_context(app, alice):
+        execute_payup_transfer(sender=alice, confirmation_token=token, authorized=True)
+
+    deliveries = password_reset_outbox()
+    assert [item["subject"] for item in deliveries[-3:]] == [
+        "SITBank Withdrawal successful",
+        "SITBank Deposit successful",
+        "SITBank PayUp daily limit 80% alert",
+    ]
+    assert deliveries[-3]["to"] == "alice@example.com"
+    assert "withdrawal PayUp transaction was successful" in deliveries[-3]["body"]
+    assert deliveries[-2]["to"] == "bob@example.com"
+    assert "deposit PayUp transaction was successful" in deliveries[-2]["body"]
+    assert deliveries[-1]["to"] == "alice@example.com"
+    assert "80.00% of your limit" in deliveries[-1]["body"]
+
+
 def test_execute_payup_transfer_self_transfer_blocked(app, payup_context):
     alice = payup_context["alice"]
     token = _make_payup_pending(alice, alice, Decimal("10.00"))

--- a/tests/test_transfer_limits.py
+++ b/tests/test_transfer_limits.py
@@ -74,6 +74,8 @@ def test_transfer_limits_get_preselects_custom_for_nonpreset_local_transfer_valu
 
 
 def test_transfer_limits_post_updates_with_valid_preset_and_totp(client, limits_context, monkeypatch):
+    from app.security.email import password_reset_outbox
+
     alice_secret = limits_context["alice_secret"]
     code = _fresh_totp(alice_secret, monkeypatch)
 
@@ -86,6 +88,10 @@ def test_transfer_limits_post_updates_with_valid_preset_and_totp(client, limits_
     db.session.expire_all()
     alice = db.session.execute(db.select(User).where(User.username == "alice01")).scalar_one()
     assert Decimal(str(alice.payup_daily_limit)) == Decimal("1000")
+    delivery = password_reset_outbox()[-1]
+    assert delivery["to"] == "alice@example.com"
+    assert delivery["subject"] == "SITBank transfer limit change successful"
+    assert "PayUp daily limit: SGD 1000.00" in delivery["body"]
 
 
 def test_transfer_limits_post_custom_amount_above_100_succeeds(client, limits_context, monkeypatch):
@@ -246,6 +252,8 @@ def test_transfer_limits_post_missing_totp_fails_closed(client, limits_context):
 
 
 def test_transfer_limits_post_wrong_totp_fails_closed(client, limits_context):
+    from app.security.email import password_reset_outbox
+
     response = client.post(
         "/banking/settings/transfer-limits",
         data={"payup_limit": "1000", "local_transfer_limit": "1000", "totp_code": "000000"},
@@ -256,6 +264,9 @@ def test_transfer_limits_post_wrong_totp_fails_closed(client, limits_context):
     alice = db.session.execute(db.select(User).where(User.username == "alice01")).scalar_one()
     assert Decimal(str(alice.payup_daily_limit)) == Decimal("500.00")
     assert Decimal(str(alice.local_transfer_daily_limit)) == Decimal("500.00")
+    delivery = password_reset_outbox()[-1]
+    assert delivery["to"] == "alice@example.com"
+    assert delivery["subject"] == "SITBank transfer limit change unsuccessful"
 
 
 def test_transfer_limits_post_updates_local_transfer_limit_with_valid_preset_and_totp(


### PR DESCRIPTION
## Summary
Adds customer email notifications for key banking events: outgoing transfers, incoming funds, daily-limit threshold alerts, and transfer-limit change outcomes.

## Why
Customers currently do not receive email alerts when money movement or transfer-limit changes occur. This weakens account visibility and makes it harder for customers to notice unauthorized or unexpected activity quickly.

## What changed
Sends withdrawal email notifications for successful and unsuccessful Local Transfer and PayUp outgoing transfers.
Sends deposit email notifications to recipients when incoming Local Transfer or PayUp funds are received.
Sends an email alert when a customer’s daily transfer usage crosses the 80% threshold.
Sends successful or unsuccessful email notifications when daily transfer limit changes are attempted.
Adds regression tests covering withdrawal, deposit, 80% threshold, and transfer-limit change notifications.

## Security impact
This improves customer account monitoring and supports faster detection of suspicious money movement or unauthorized transfer-limit changes. Email delivery failures are handled without rolling back completed banking transactions, and notification audit events avoid exposing raw sensitive banking values.

## Deployment impact
No database migration or secret change is required for the feature itself.
Existing email configuration must be working for real delivery. Development/test environments continue to use the configured test/console email backend.

## Verification
Added focused regression tests for Local Transfer notifications.
Added focused regression tests for PayUp notifications.
Added focused regression tests for transfer-limit change notifications.
Ran syntax/compile checks for touched Python files.
Ran git diff --check.

## Notes
Local real-email testing depends on valid SMTP configuration. Test/dev fake email backends can confirm notification generation without sending real email.