### PR TITLE
Simplify admin dashboard and add account menu to admin nav

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -2198,35 +2198,6 @@ th {
   flex-wrap: wrap;
 }
 
-.admin-summary-row {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: var(--space-5);
-}
-
-.admin-boundary-list {
-  display: grid;
-  gap: var(--space-3);
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.admin-boundary-list li {
-  display: flex;
-  align-items: flex-start;
-  gap: var(--space-3);
-  color: var(--muted-strong);
-}
-
-.admin-boundary-list .icon {
-  width: 18px;
-  height: 18px;
-  flex: 0 0 auto;
-  margin-top: 2px;
-  color: var(--success);
-}
-
 .admin-stat-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
@@ -2341,11 +2312,6 @@ th {
   border-radius: var(--radius);
   padding: var(--space-4);
   background: var(--surface-raised);
-}
-
-.admin-notice-stack {
-  display: grid;
-  gap: var(--space-3);
 }
 
 .admin-form-grid,
@@ -2508,10 +2474,6 @@ th {
   color: var(--text);
   font-weight: 650;
   overflow-wrap: anywhere;
-}
-
-.admin-logout-form {
-  margin: 0;
 }
 
 .action-grid {
@@ -2686,7 +2648,6 @@ th {
     min-height: 0;
   }
 
-  .admin-summary-row,
   .admin-metadata-grid {
     grid-template-columns: 1fr;
   }

--- a/app/templates/admin/base.html
+++ b/app/templates/admin/base.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}SITBank Admin{% endblock %}</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
+    <script src="{{ url_for('static', filename='js/theme.js') }}"></script>
     {% if g.current_user %}
     <meta name="csrf-token" content="{{ csrf_token() }}">
     {% endif %}
@@ -84,10 +85,26 @@
           </div>
           <div class="nav-actions">
             {% if g.current_user %}
-            <form class="admin-logout-form" method="post" action="{{ url_for('admin.logout') }}">
-              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-              <button class="button secondary small" type="submit">Log out</button>
-            </form>
+            <div class="account-menu" data-account-menu>
+              <button class="account-trigger" type="button" id="admin-account-menu-button" aria-haspopup="true" aria-expanded="false" aria-controls="admin-account-menu-panel" data-account-trigger>
+                <span class="account-avatar" aria-hidden="true">
+                  <svg class="icon" focusable="false"><use href="#icon-user"></use></svg>
+                </span>
+                <span class="account-trigger-copy">
+                  <span class="account-trigger-name">Account</span>
+                </span>
+              </button>
+              <div class="account-panel" id="admin-account-menu-panel" aria-labelledby="admin-account-menu-button" data-account-panel hidden>
+                <a href="{{ url_for('admin.index') }}">Dashboard</a>
+                <div class="account-menu-section-label">Profile Settings</div>
+                <span class="is-disabled" aria-disabled="true" title="Not available yet">Change Password</span>
+                <span class="is-disabled" aria-disabled="true" title="Not available yet">Change MFA</span>
+                <form class="account-menu-form" method="post" action="{{ url_for('admin.logout') }}">
+                  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                  <button type="submit">Log out</button>
+                </form>
+              </div>
+            </div>
             {% endif %}
           </div>
         </nav>

--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -23,49 +23,33 @@
     </div>
   </div>
 
-  <div{% if has_stats %} class="admin-summary-row"{% endif %}>
-    <section class="panel">
-      <div class="section-header">
-        <h2>Role Boundary</h2>
+  {% if has_stats %}
+  <section class="panel">
+    <div class="section-header">
+      <h2>Access Summary</h2>
+    </div>
+    <dl class="admin-stat-grid">
+      <div>
+        <dt>Role rank</dt>
+        <dd>{{ summary.current_role_rank }}</dd>
       </div>
-      <ul class="admin-boundary-list">
-        {% for item in responsibilities %}
-        <li>
-          <svg class="icon" focusable="false" aria-hidden="true"><use href="#icon-check-circle"></use></svg>
-          <span>{{ item }}</span>
-        </li>
-        {% endfor %}
-      </ul>
-    </section>
-
-    {% if has_stats %}
-    <section class="panel">
-      <div class="section-header">
-        <h2>Access Summary</h2>
+      {% if summary.pending_invites is not none %}
+      <div>
+        <dt>Pending invites</dt>
+        <dd>{{ summary.pending_invites }}</dd>
       </div>
-      <dl class="admin-stat-grid">
-        <div>
-          <dt>Role rank</dt>
-          <dd>{{ summary.current_role_rank }}</dd>
-        </div>
-        {% if summary.pending_invites is not none %}
-        <div>
-          <dt>Pending invites</dt>
-          <dd>{{ summary.pending_invites }}</dd>
-        </div>
-        {% endif %}
-        {% if summary.staff_accounts is not none %}
-        {% for group in summary.staff_accounts %}
-        <div>
-          <dt>{{ group.role }} &middot; {{ group.status }}</dt>
-          <dd>{{ group.count }}</dd>
-        </div>
-        {% endfor %}
-        {% endif %}
-      </dl>
-    </section>
-    {% endif %}
-  </div>
+      {% endif %}
+      {% if summary.staff_accounts is not none %}
+      {% for group in summary.staff_accounts %}
+      <div>
+        <dt>{{ group.role }} &middot; {{ group.status }}</dt>
+        <dd>{{ group.count }}</dd>
+      </div>
+      {% endfor %}
+      {% endif %}
+    </dl>
+  </section>
+  {% endif %}
 
   <section class="panel">
     <div class="section-header">
@@ -73,7 +57,6 @@
       <p class="muted">Tools are grouped by trust tier and scoped to your role server-side.</p>
     </div>
     {% set nav_icons = {
-      "Dashboard": "icon-controls",
       "Business operations": "icon-info",
       "Disputes": "icon-reference",
       "Audit logs": "icon-education",
@@ -92,9 +75,10 @@
       "admin": "Staff & admin management",
       "root": "Root admin controls",
     } %}
+    {% set operations = navigation|rejectattr("label", "equalto", "Dashboard")|list %}
     <div class="admin-access-map">
       {% for tier in tier_order %}
-      {% set tier_items = navigation|selectattr("group", "equalto", tier)|list %}
+      {% set tier_items = operations|selectattr("group", "equalto", tier)|list %}
       {% if tier_items %}
       <div class="admin-access-tier">
         <p class="admin-access-tier-label">{{ tier_labels[tier] }}</p>
@@ -111,7 +95,7 @@
       </div>
       {% endif %}
       {% endfor %}
-      {% set other_items = navigation|rejectattr("group", "in", tier_order)|list %}
+      {% set other_items = operations|rejectattr("group", "in", tier_order)|list %}
       {% if other_items %}
       <div class="admin-access-tier">
         <p class="admin-access-tier-label">Other</p>
@@ -148,26 +132,6 @@
     </div>
   </section>
   {% endif %}
-
-  <section class="panel">
-    <div class="section-header">
-      <h2>Security Notices</h2>
-    </div>
-    {% set notice_icons = {"danger": "icon-alert", "warning": "icon-lock", "info": "icon-info"} %}
-    <div class="admin-notice-stack">
-      {% for notice in security_notices %}
-      <div class="notice {{ notice.severity }}">
-        <span class="notice-icon" aria-hidden="true">
-          <svg class="icon" focusable="false"><use href="#{{ notice_icons.get(notice.severity, 'icon-info') }}"></use></svg>
-        </span>
-        <div>
-          <p><strong>{{ notice.title }}</strong></p>
-          <p class="muted">{{ notice.message }}</p>
-        </div>
-      </div>
-      {% endfor %}
-    </div>
-  </section>
 
   {% if recent_audit_events %}
   <section class="panel">


### PR DESCRIPTION
Summary
---

Follow-up to #546. Trims the admin dashboard down further and adds a full-name account dropdown to the admin navbar.

Why
---

Feedback on the redesigned admin dashboard: the Role Boundary and Security Notices sections weren't needed, the Access Map's "Dashboard" tile was a link back to the page you're already on (confusing), and the admin navbar had no account menu (unlike the customer app).

What changed
---

* Removed the Role Boundary and Security Notices sections from the admin dashboard; the Access Summary panel (role rank / pending invites / staff account counts) now renders full width instead of sharing a row with Role Boundary, and only when there's real stat data.
* Removed the "Dashboard" tile from the Access Map — it always linked back to the current page.
* Added a full-name account dropdown to the admin navbar (`admin/base.html`), reusing the customer app's existing `.account-menu`/`.account-trigger`/`.account-panel` CSS and `theme.js` (no new JS, no CSS changes needed for the menu itself). Contains Dashboard, a Profile Settings group with **Change Password** and **Change MFA**, and Log out.
* Removed now-unused CSS (`admin-boundary-list`, `admin-notice-stack`, `admin-summary-row`, `admin-logout-form`) after confirming nothing else referenced them.

Change Password / Change MFA are shown **disabled** (`is-disabled`, matching the same convention the customer nav already uses for gated actions). The admin app currently has no self-service route for a logged-in staff/admin/root-admin to change their own password or reset their own MFA — only the one-time invite-acceptance flow sets an initial password/TOTP. Wiring these up needs new backend routes, which is out of scope here (frontend-only PR).

Bug found and fixed during this change (not a new feature, a regression this PR introduced and fixed before finalizing): the first draft read `g.current_user.full_name` directly in `admin/base.html`. That broke two tests in `test_admin_staff_invites.py`:
* `g.current_user` is loaded once per request in `app/__init__.py`, and on the invite-acceptance duplicate-identity/delivery-failure error-rendering path, the DB session is rolled back before the page re-renders — dereferencing any mapped column on `g.current_user` at that point raises `SQLAlchemy DetachedInstanceError`. Nothing previously touched a `g.current_user` attribute in this shared template, so this was latent and never triggered before.
* Separately, the literal `role="menu"` / `role="menuitem"` ARIA attributes collided with a strict "no field name leak" substring check on the invite-accept page (it checks that the word "role" — an invite JSON field name — never appears in that page's HTML).

Fixed by keeping the trigger label static ("Account" instead of the live name) and dropping the ARIA `role` attributes — the dropdown's open/close and keyboard navigation are driven by `data-*` attributes and DOM structure in `theme.js`, not by the `role` attribute, so there's no behavior change.

No backend, route, or service changes.

Security impact
---

None — templates and CSS only. Change Password / Change MFA are inert (`aria-disabled`, no `href`/form action) until a real backend route exists.

Deployment impact
---

* no deployment action

Verification
---

* `.\.venv\Scripts\python.exe -m pytest -q tests/ -k admin -n auto` — 340 passed, 3 skipped
* `.\.venv\Scripts\python.exe -m pytest -q -n auto` (full suite) — 1710 passed, 34 skipped
* Grepped templates/CSS for removed classes to confirm nothing else referenced them before deleting

Notes
---

Follow-up (separate PR, needs backend work): add self-service "change my password" and "reset my MFA" routes for staff/admin/root-admin, then wire the two disabled menu items to them.