### PR TITLE
Add dismissible top-up success toast and log top-ups in history

### DIFF
--- a/app/banking/services.py
+++ b/app/banking/services.py
@@ -823,6 +823,22 @@ def credit_account_topup(user: User, amount: Decimal) -> TopUpCredit:
         status="completed",
         created_at=created_at,
     )
+    (
+        txn_hash,
+        txn_integrity_key_id,
+        txn_integrity_algorithm,
+        txn_integrity_version,
+    ) = sign_transaction_integrity(
+        transaction_ref=credit_ref,
+        sender_id=locked_user.id,
+        recipient_id=locked_user.id,
+        payee_id=None,
+        amount=amount,
+        reference="",
+        status="completed",
+        transaction_type="topup",
+        created_at=created_at,
+    )
     locked_user.balance = Decimal(str(locked_user.balance)) + amount
     credit = TopUpCredit(
         credit_ref=credit_ref,
@@ -836,6 +852,23 @@ def credit_account_topup(user: User, amount: Decimal) -> TopUpCredit:
         created_at=created_at,
     )
     db.session.add(credit)
+    db.session.add(
+        Transaction(
+            transaction_ref=credit_ref,
+            transaction_hash=txn_hash,
+            transaction_integrity_key_id=txn_integrity_key_id,
+            transaction_integrity_algorithm=txn_integrity_algorithm,
+            transaction_integrity_version=txn_integrity_version,
+            sender_id=locked_user.id,
+            recipient_id=locked_user.id,
+            payee_id=None,
+            amount=amount,
+            reference="",
+            status="completed",
+            transaction_type="topup",
+            created_at=created_at,
+        )
+    )
     db.session.commit()
     audit_event(
         "account_topup",

--- a/app/models.py
+++ b/app/models.py
@@ -750,7 +750,7 @@ class Transaction(db.Model):
         ),
         db.CheckConstraint("amount > 0", name="ck_transactions_amount_positive"),
         db.CheckConstraint(
-            "transaction_type IN ('local_transfer', 'payup')",
+            "transaction_type IN ('local_transfer', 'payup', 'topup')",
             name="ck_transactions_transaction_type",
         ),
         db.CheckConstraint(

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1086,17 +1086,34 @@ select:focus {
   box-shadow: var(--shadow-soft);
 }
 
-.alert span {
+.alert-message {
   flex: 1 1 auto;
 }
 
-.alert::before {
-  width: 14px;
-  height: 14px;
-  flex: 0 0 14px;
-  border-radius: 50%;
-  background: currentColor;
-  content: "";
+.alert-icon {
+  display: inline-flex;
+  flex: 0 0 auto;
+  color: currentColor;
+}
+
+.alert-icon .icon {
+  width: 20px;
+  height: 20px;
+}
+
+.alert-close {
+  flex: 0 0 auto;
+  border: none;
+  background: none;
+  padding: 0 var(--space-1);
+  color: currentColor;
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.alert-close:hover {
+  opacity: 0.7;
 }
 
 

--- a/app/static/js/account.js
+++ b/app/static/js/account.js
@@ -121,7 +121,8 @@
   }
 
   function scheduleBannerDismissal(banner) {
-    setTimeout(fadeOutBanner.bind(null, banner), 3000);
+    const timerId = setTimeout(fadeOutBanner.bind(null, banner), 3000);
+    banner.dataset.dismissTimer = String(timerId);
   }
 
   function dismissTransientFlashBanners() {
@@ -130,8 +131,24 @@
     document.querySelectorAll(".alerts .alert-success, .alerts .alert-info").forEach(scheduleBannerDismissal);
   }
 
+  function wireManualBannerDismissal() {
+    document.querySelectorAll(".alerts [data-alert-close]").forEach(function (button) {
+      button.addEventListener("click", function () {
+        const banner = button.closest(".alert");
+        if (!banner) {
+          return;
+        }
+        if (banner.dataset.dismissTimer) {
+          clearTimeout(Number(banner.dataset.dismissTimer));
+        }
+        fadeOutBanner(banner);
+      });
+    });
+  }
+
   globalThis.addEventListener("DOMContentLoaded", function () {
     dismissTransientFlashBanners();
+    wireManualBannerDismissal();
 
     document.querySelectorAll("[data-otp-resend-countdown]").forEach(function (button) {
       const seconds = Number.parseInt(button.dataset.otpResendCountdown, 10);

--- a/app/static/js/topup_pending.js
+++ b/app/static/js/topup_pending.js
@@ -31,7 +31,8 @@
         .then(function (data) {
           if (data.status === "completed") {
             statusMessage.textContent = "Approved. Redirecting…";
-            globalThis.location.href = dashboardUrl;
+            const separator = dashboardUrl.includes("?") ? "&" : "?";
+            globalThis.location.href = dashboardUrl + separator + "topup=success";
             return;
           }
           if (data.status === "expired" || data.status === "failed") {

--- a/app/templates/_transaction_party.html
+++ b/app/templates/_transaction_party.html
@@ -1,5 +1,7 @@
 {% macro transaction_party(txn, user) -%}
-{% if txn.transaction_type == "payup" %}
+{% if txn.transaction_type == "topup" %}
+  Self top-up
+{% elif txn.transaction_type == "payup" %}
   {% if txn.sender_id == user.id %}
     {% set recipient_label = (txn.recipient.payup_nickname if txn.recipient else "") or (txn.recipient.phone_number if txn.recipient else "") or "PayUp recipient" %}
     To: {{ recipient_label }}

--- a/app/templates/_transaction_row.html
+++ b/app/templates/_transaction_row.html
@@ -3,7 +3,9 @@
 {% macro transaction_row(txn, user, show_actions=False) -%}
 <tr>
   <td data-label="Type">
-    {% if txn.sender_id == user.id %}
+    {% if txn.transaction_type == 'topup' %}
+    <span class="badge">Top Up</span>
+    {% elif txn.sender_id == user.id %}
     <span class="badge neutral">Sent</span>
     {% else %}
     <span class="badge">Received</span>
@@ -16,13 +18,17 @@
   <td data-label="Method">
     {% if txn.transaction_type == 'payup' %}
     PayUp
+    {% elif txn.transaction_type == 'topup' %}
+    Top Up
     {% else %}
     Local Transfer
     {% endif %}
   </td>
   <td data-label="Reference">{{ txn.reference or "—" }}</td>
   <td data-label="Amount (SGD)" class="cell-amount">
-    {% if txn.sender_id == user.id %}
+    {% if txn.transaction_type == 'topup' %}
+    +{{ txn.amount }}
+    {% elif txn.sender_id == user.id %}
     <span class="muted">−{{ txn.amount }}</span>
     {% else %}
     +{{ txn.amount }}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -228,8 +228,13 @@
         {% if messages %}
           <section class="alerts" aria-label="Status messages">
             {% for category, message in messages %}
+              {% set icon_name = "check-circle" if category == "success" else ("alert" if category in ("warning", "error") else "info") %}
               <div class="alert alert-{{ category }}">
-                <span>{{ message }}</span>
+                <span class="alert-icon" aria-hidden="true">
+                  <svg class="icon" focusable="false"><use href="#icon-{{ icon_name }}"></use></svg>
+                </span>
+                <span class="alert-message">{{ message }}</span>
+                <button type="button" class="alert-close" data-alert-close aria-label="Dismiss message">&times;</button>
               </div>
             {% endfor %}
           </section>

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -115,7 +115,7 @@
       {% if messages %}
         {% for category, message in messages %}
           <div class="alert alert-{{ category }} alert-inline">
-            <span>{{ message }}</span>
+            <span class="alert-message">{{ message }}</span>
           </div>
         {% endfor %}
       {% endif %}
@@ -143,7 +143,7 @@
       {% if messages %}
         {% for category, message in messages %}
           <div class="alert alert-{{ category }} alert-inline">
-            <span>{{ message }}</span>
+            <span class="alert-message">{{ message }}</span>
           </div>
         {% endfor %}
       {% endif %}

--- a/app/templates/transaction_detail.html
+++ b/app/templates/transaction_detail.html
@@ -20,7 +20,9 @@
       <div>
         <dt>Type</dt>
         <dd>
-          {% if transaction.sender_id == user.id %}
+          {% if transaction.transaction_type == "topup" %}
+          <span class="badge">Top Up</span>
+          {% elif transaction.sender_id == user.id %}
           <span class="badge neutral">Sent</span>
           {% else %}
           <span class="badge">Received</span>
@@ -28,14 +30,14 @@
         </dd>
       </div>
       <div>
-        <dt>{{ "Parties" if transaction.transaction_type == "payup" else ("Recipient" if transaction.sender_id == user.id else "Sender") }}</dt>
+        <dt>{{ "Parties" if transaction.transaction_type == "payup" else ("Recipient" if transaction.transaction_type != "topup" and transaction.sender_id == user.id else "Sender") }}</dt>
         <dd>
           {{ transaction_party(transaction, user) }}
         </dd>
       </div>
       <div>
         <dt>Method</dt>
-        <dd>{{ "PayUp" if transaction.transaction_type == "payup" else "Local Transfer" }}</dd>
+        <dd>{{ "PayUp" if transaction.transaction_type == "payup" else ("Top Up" if transaction.transaction_type == "topup" else "Local Transfer") }}</dd>
       </div>
       <div>
         <dt>Reference</dt>
@@ -44,7 +46,9 @@
       <div>
         <dt>Amount (SGD)</dt>
         <dd>
-          {% if transaction.sender_id == user.id %}
+          {% if transaction.transaction_type == "topup" %}
+          +{{ transaction.amount }}
+          {% elif transaction.sender_id == user.id %}
           <span class="muted">−{{ transaction.amount }}</span>
           {% else %}
           +{{ transaction.amount }}

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -627,6 +627,8 @@ def mfa_verify_submit():
 @web_bp.get("/dashboard")
 @web_login_required
 def dashboard():
+    if request.args.get("topup") == "success":
+        flash("Your top-up was added to your account.", "success")
     recent_txns = (
         db.session.execute(
             db.select(Transaction)

--- a/migrations/versions/20260708_0034_allow_topup_transaction_type.py
+++ b/migrations/versions/20260708_0034_allow_topup_transaction_type.py
@@ -1,0 +1,43 @@
+"""Allow 'topup' in transactions.transaction_type so top-ups appear in history.
+
+Revision ID: 20260708_0034
+Revises: 20260708_0033
+Create Date: 2026-07-08 00:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260708_0034"
+down_revision = "20260708_0033"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # See 20260703_0022_add_payup_support.py for why this is Postgres-only:
+    # SQLite cannot ALTER an existing CHECK constraint, and the application
+    # layer only ever writes a validated transaction_type value.
+    if op.get_context().dialect.name == "postgresql":
+        op.execute(sa.text(
+            "ALTER TABLE transactions DROP CONSTRAINT ck_transactions_transaction_type"
+        ))
+        op.execute(sa.text(
+            "ALTER TABLE transactions ADD CONSTRAINT ck_transactions_transaction_type"
+            " CHECK (transaction_type IN ('local_transfer', 'payup', 'topup'))"
+        ))
+
+
+def downgrade() -> None:
+    # Lossy if any 'topup' rows exist: re-adding the narrower constraint will
+    # fail until those rows are removed or recategorized. Matches the
+    # best-effort precedent in 20260703_0022_add_payup_support.py.
+    if op.get_context().dialect.name == "postgresql":
+        op.execute(sa.text(
+            "ALTER TABLE transactions DROP CONSTRAINT ck_transactions_transaction_type"
+        ))
+        op.execute(sa.text(
+            "ALTER TABLE transactions ADD CONSTRAINT ck_transactions_transaction_type"
+            " CHECK (transaction_type IN ('local_transfer', 'payup'))"
+        ))

--- a/tests/test_authenticated_portal_ui.py
+++ b/tests/test_authenticated_portal_ui.py
@@ -59,7 +59,7 @@ def test_theme_assets_are_csp_compatible_and_store_only_theme_preference(client)
     assert ".profile-status-copy" in stylesheet
     assert ".alert {" in stylesheet
     assert "display: flex;" in stylesheet
-    assert "flex: 0 0 14px;" in stylesheet
+    assert ".alert-icon {" in stylesheet
     assert ".mfa-step.is-complete .step-number" in stylesheet
     assert "background: var(--success);" not in stylesheet
     assert "#0f766e" not in logo
@@ -203,7 +203,7 @@ def test_flash_messages_are_dismissible(client):
 
     assert response.status_code == 200
     assert "alert-success" in response.data.decode("utf-8")
-    assert "data-alert-dismiss" not in response.data.decode("utf-8")
+    assert "data-alert-close" in response.data.decode("utf-8")
 
 def test_landing_route_public_for_anonymous_and_dashboard_for_authenticated(client):
     public_response = client.get("/")

--- a/tests/test_banking_topup.py
+++ b/tests/test_banking_topup.py
@@ -8,7 +8,7 @@ import pyotp
 from _auth_flow_helpers import enable_mfa_for_user, login, register
 from app.banking.topup_tokens import generate_topup_token
 from app.extensions import db
-from app.models import SecurityAuditEvent, TopUpApprovalRequest, TopUpCredit, User
+from app.models import SecurityAuditEvent, Transaction, TopUpApprovalRequest, TopUpCredit, User
 
 
 def _topup_approve_url(raw_token: str) -> str:
@@ -77,6 +77,20 @@ def test_topup_happy_path_credits_balance_and_records_ledger(client):
         == 1
     )
 
+    txn = db.session.execute(
+        db.select(Transaction).where(Transaction.transaction_type == "topup", Transaction.sender_id == user.id)
+    ).scalar_one()
+    assert txn.recipient_id == user.id
+    assert Decimal(str(txn.amount)) == Decimal("50.00")
+    assert txn.status == "completed"
+    assert txn.transaction_ref == credit.credit_ref
+
+    history_response = client.get("/transactions")
+    assert history_response.status_code == 200
+    history_html = history_response.data.decode("utf-8")
+    assert "Top Up" in history_html
+    assert "+50.00" in history_html
+
 
 def test_topup_wrong_totp_rejected_without_crediting(client):
     register(client)
@@ -96,6 +110,19 @@ def test_topup_wrong_totp_rejected_without_crediting(client):
     assert request_row.failure_count == 1
     assert request_row.status == "pending"
     assert db.session.query(TopUpCredit).filter_by(user_id=user.id).count() == 0
+    assert db.session.query(Transaction).filter_by(sender_id=user.id, transaction_type="topup").count() == 0
+
+
+def test_topup_success_flash_shown_on_dashboard(client):
+    register(client)
+    login(client)
+    enable_mfa_for_user()
+
+    response = client.get("/dashboard?topup=success", follow_redirects=True)
+    assert response.status_code == 200
+    assert "Your top-up was added to your account." in response.data.decode("utf-8")
+    assert "alert-success" in response.data.decode("utf-8")
+    assert "data-alert-close" in response.data.decode("utf-8")
 
 
 def test_topup_approval_locks_after_max_failures(client):


### PR DESCRIPTION
Summary
  ---

  Adds a dismissible success toast when a top-up completes, and makes top-ups appear in transaction history alongside transfers.

  Why
  ---

  Top-up completion previously showed no confirmation on the dashboard and never appeared in transaction history, since it only wrote a TopUpCredit ledger row rather than a Transaction row.

  What changed
  ---

  * Extended the existing flash-alert system (app/templates/base.html, app/static/css/app.css) with a success/info/warning icon and a manual close button, alongside the existing 3-second auto-dismiss for success/info banners
  * app/static/js/account.js — wired up manual dismissal (clears the pending auto-dismiss timer)
  * app/static/js/topup_pending.js — redirects to the dashboard with ?topup=success on completion
  * app/web/routes.py — dashboard route flashes "Your top-up was added to your account." when that query param is present
  * app/banking/services.py — credit_account_topup now also writes a self-credit Transaction row (transaction_type="topup") alongside the existing TopUpCredit row
  * app/models.py — widened the transactions.transaction_type check constraint to allow "topup"
  * migrations/versions/20260708_0034_allow_topup_transaction_type.py — new migration for the widened constraint (Postgres-only ALTER, matching the existing payup-support migration's dialect-guard pattern)
  * app/templates/_transaction_row.html, _transaction_party.html, transaction_detail.html — added a "Top Up" badge/label and +amount display for the new transaction type
  * app/templates/register.html — updated its own inline flash markup to the new alert-message class for consistency
  * tests/test_banking_topup.py — asserts the Transaction row and its appearance in /transactions, plus a new test for the dashboard success flash
  * tests/test_authenticated_portal_ui.py — updated an assertion that had locked in the old icon-less alert markup

  Security impact
  ---

  No new trust boundary. The dashboard's ?topup=success flash is a plain string comparison against a literal, not reflected into the page, so no injection surface. The new Transaction row reuses the same sign_transaction_integrity signing path as transfers, with sender_id == recipient_id == the authenticated user (self-credit), so existing IDOR/ownership checks on /transactions and /transactions/<id> apply unchanged.

  Deployment impact
  ---

  * database migration (20260708_0034_allow_topup_transaction_type)
  * staging deployment
  * no secret changes
  * no EC2 bootstrap required

  Verification
  ---

  * pytest, full suite: 1713 passed, 31 skipped (one pre-existing, environment-specific network test deselected — unrelated to this change)
  * Manual smoke test locally via compose.dev.yml: top-up flow shows the green success toast on the dashboard with working auto-dismiss and manual close, and the top-up appears in Recent Transactions / Transaction History

  Notes
  ---

  Branch topup-success-popup-and-history, rebased on current main (includes PR #544 and #546). No follow-up work identified.