### PR TITLE
Added toggle for email notifications for withdrawal/deposit

### DIFF
--- a/app/auth/forms.py
+++ b/app/auth/forms.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from flask_wtf import FlaskForm
-from wtforms import PasswordField, StringField
+from wtforms import BooleanField, PasswordField, StringField
 from wtforms.validators import Email, EqualTo, InputRequired, Length, Optional, Regexp, ValidationError
 
 from app.security.passwords import password_max_chars, password_min_length
@@ -166,6 +166,12 @@ class ProfileForm(FlaskForm):
             Optional(),
             Regexp(TOTP_RE, message=_MFA_CODE_ERROR),
         ],
+    )
+
+
+class ProfileNotificationPreferencesForm(FlaskForm):
+    transfer_activity_email_enabled = BooleanField(
+        "Email notifications for withdrawal and deposit"
     )
 
 

--- a/app/banking/services.py
+++ b/app/banking/services.py
@@ -144,6 +144,8 @@ def send_transfer_notification(
         raise ValueError("Unsupported transfer notification direction")
     if normalized_outcome not in {"success", "failure"}:
         raise ValueError("Unsupported transfer notification outcome")
+    if not _transfer_activity_email_enabled(user):
+        return
 
     direction_label = normalized_direction.title()
     status_label = "successful" if normalized_outcome == "success" else "unsuccessful"
@@ -154,7 +156,7 @@ def send_transfer_notification(
     if amount is not None:
         lines.append(f"Amount: SGD {_format_money(amount)}")
     if counterparty_label:
-        lines.append(f"Counterparty: {counterparty_label}")
+        lines.append(f"Recipient: {counterparty_label}")
     if transaction_reference:
         lines.append(f"Reference: {transaction_reference[:8].upper()}")
     lines.append(
@@ -260,6 +262,10 @@ def _send_banking_email(
         )
         return
     audit_event(event_type, "queued", user=user, metadata=dict(metadata or {}))
+
+
+def _transfer_activity_email_enabled(user: User) -> bool:
+    return getattr(user, "transfer_activity_email_enabled", True) is not False
 
 
 def ensure_outbound_transfer_allowed(user: User) -> None:

--- a/app/models.py
+++ b/app/models.py
@@ -69,6 +69,12 @@ class User(db.Model):
         default=True,
         server_default=db.true(),
     )
+    transfer_activity_email_enabled = db.Column(
+        db.Boolean,
+        nullable=False,
+        default=True,
+        server_default=db.true(),
+    )
     local_transfer_daily_limit = db.Column(
         db.Numeric(10, 2),
         nullable=False,

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -940,6 +940,18 @@ form {
   display: none;
 }
 
+.checkbox-group label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-weight: 600;
+}
+
+.checkbox-group input {
+  width: 1rem;
+  height: 1rem;
+}
+
 input[data-limit-custom]::-webkit-outer-spin-button,
 input[data-limit-custom]::-webkit-inner-spin-button {
   margin: 0;
@@ -1171,6 +1183,11 @@ select:focus {
 .profile-grid {
   grid-template-columns: minmax(280px, 0.9fr) minmax(0, 1.1fr);
   align-items: stretch;
+}
+
+.profile-stack {
+  display: grid;
+  gap: var(--space-4);
 }
 
 .profile-grid.is-single-column {

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -64,59 +64,80 @@
       </dl>
     </article>
 
-    <article class="profile-panel profile-card">
-      <div class="profile-panel-title">
-        <p class="eyebrow">Editable field</p>
-        <h2>Update profile details</h2>
-      </div>
-      <p class="muted">Changes to your sign-in details are securely recorded and require MFA verification.</p>
-      {% if g.mfa_ready %}
-        <form method="post" action="{{ url_for('web.profile_submit') }}" novalidate>
-          {{ form.hidden_tag() }}
-          <div class="form-group">
-            <label for="{{ form.email.id }}">Email address</label>
-            {{ form.email(autocomplete="email", maxlength="255") }}
-            {% for error in form.email.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
+    <div class="profile-stack">
+      <article class="profile-panel profile-card">
+        <div class="profile-panel-title">
+          <p class="eyebrow">Notification preference</p>
+          <h2>Email notifications for withdrawal and deposit</h2>
+        </div>
+        <p class="muted">All other account, security, transfer-limit, and daily-limit notifications are mandatory.</p>
+        <form method="post" action="{{ url_for('web.profile_notification_preferences_submit') }}" novalidate>
+          {{ notification_form.hidden_tag() }}
+          <div class="form-group checkbox-group">
+            <label for="{{ notification_form.transfer_activity_email_enabled.id }}">
+              {{ notification_form.transfer_activity_email_enabled(role="switch") }}
+              <span>Send emails for withdrawal and deposit activity</span>
+            </label>
+            {% for error in notification_form.transfer_activity_email_enabled.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
           </div>
-          <div class="form-group">
-            <label for="{{ form.phone_number.id }}">Phone number</label>
-            {{ form.phone_number(autocomplete="tel", inputmode="numeric", maxlength="8") }}
-            {% for error in form.phone_number.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
-          </div>
-          {% if pending_email_change %}
-            <div class="notice">
-              <span class="notice-icon" aria-hidden="true">
-                <svg class="icon" focusable="false"><use href="#icon-info"></use></svg>
-              </span>
-              <p class="muted">Enter the verification code sent to {{ pending_email_change.email }}.</p>
+          <button class="button full" type="submit">Save notification preference</button>
+        </form>
+      </article>
+
+      <article class="profile-panel profile-card">
+        <div class="profile-panel-title">
+          <p class="eyebrow">Editable field</p>
+          <h2>Update profile details</h2>
+        </div>
+        <p class="muted">Changes to your sign-in details are securely recorded and require MFA verification.</p>
+        {% if g.mfa_ready %}
+          <form method="post" action="{{ url_for('web.profile_submit') }}" novalidate>
+            {{ form.hidden_tag() }}
+            <div class="form-group">
+              <label for="{{ form.email.id }}">Email address</label>
+              {{ form.email(autocomplete="email", maxlength="255") }}
+              {% for error in form.email.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
             </div>
             <div class="form-group">
-              <label for="{{ form.email_verification_code.id }}">Email verification code</label>
-              {{ form.email_verification_code(inputmode="numeric", autocomplete="one-time-code", maxlength="6", placeholder="6-digit code") }}
-              {% for error in form.email_verification_code.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
+              <label for="{{ form.phone_number.id }}">Phone number</label>
+              {{ form.phone_number(autocomplete="tel", inputmode="numeric", maxlength="8") }}
+              {% for error in form.phone_number.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
             </div>
-          {% endif %}
-          <div class="form-group">
-            <label for="{{ form.totp_code.id }}">Authenticator code</label>
-            {{ form.totp_code(inputmode="numeric", autocomplete="one-time-code", maxlength="6", placeholder="6-digit code") }}
-            {% for error in form.totp_code.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
-            <p class="hint">Enter the current 6-digit code from your authenticator app.</p>
+            {% if pending_email_change %}
+              <div class="notice">
+                <span class="notice-icon" aria-hidden="true">
+                  <svg class="icon" focusable="false"><use href="#icon-info"></use></svg>
+                </span>
+                <p class="muted">Enter the verification code sent to {{ pending_email_change.email }}.</p>
+              </div>
+              <div class="form-group">
+                <label for="{{ form.email_verification_code.id }}">Email verification code</label>
+                {{ form.email_verification_code(inputmode="numeric", autocomplete="one-time-code", maxlength="6", placeholder="6-digit code") }}
+                {% for error in form.email_verification_code.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
+              </div>
+            {% endif %}
+            <div class="form-group">
+              <label for="{{ form.totp_code.id }}">Authenticator code</label>
+              {{ form.totp_code(inputmode="numeric", autocomplete="one-time-code", maxlength="6", placeholder="6-digit code") }}
+              {% for error in form.totp_code.errors %}<p class="field-error">{{ error }}</p>{% endfor %}
+              <p class="hint">Enter the current 6-digit code from your authenticator app.</p>
+            </div>
+            <button class="button full" type="submit">Verify and save</button>
+          </form>
+        {% else %}
+          <div class="notice warning">
+            <span class="notice-icon" aria-hidden="true">
+              <svg class="icon" focusable="false"><use href="#icon-shield-check"></use></svg>
+            </span>
+            <div>
+              <h3>MFA required</h3>
+              <p class="muted">Profile updates stay locked until an authenticator app is enrolled.</p>
+            </div>
           </div>
-          <button class="button full" type="submit">Verify and save</button>
-        </form>
-      {% else %}
-        <div class="notice warning">
-          <span class="notice-icon" aria-hidden="true">
-            <svg class="icon" focusable="false"><use href="#icon-shield-check"></use></svg>
-          </span>
-          <div>
-            <h3>MFA required</h3>
-            <p class="muted">Profile updates stay locked until an authenticator app is enrolled.</p>
-          </div>
-        </div>
-        <a class="button secondary" href="{{ url_for('web.mfa_setup') }}">Manage MFA</a>
-      {% endif %}
-    </article>
+          <a class="button secondary" href="{{ url_for('web.mfa_setup') }}">Manage MFA</a>
+        {% endif %}
+      </article>
+    </div>
   </div>
 </section>
 {% endblock %}

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -25,6 +25,7 @@ from app.auth.forms import (
     PasswordChangeForm,
     PasswordResetForm,
     ProfileForm,
+    ProfileNotificationPreferencesForm,
     RegisterDetailsForm,
     RegistrationOtpCodeForm,
     RegistrationOtpRequestForm,
@@ -850,6 +851,32 @@ def my_disputes():
     return render_template("my_disputes.html", disputes=disputes)
 
 
+def _profile_notification_preferences_form(user) -> ProfileNotificationPreferencesForm:
+    form = ProfileNotificationPreferencesForm()
+    form.transfer_activity_email_enabled.data = (
+        getattr(user, "transfer_activity_email_enabled", True) is not False
+    )
+    return form
+
+
+def _render_profile_page(
+    *,
+    form: ProfileForm,
+    notification_form: ProfileNotificationPreferencesForm | None = None,
+    status_code: int = 200,
+):
+    pending_email_change = pending_profile_email_change()
+    return render_template(
+        _PROFILE_TEMPLATE,
+        user=g.current_user,
+        form=form,
+        notification_form=notification_form
+        or _profile_notification_preferences_form(g.current_user),
+        recent_mfa=has_recent_fresh_mfa(),
+        pending_email_change=pending_email_change,
+    ), status_code
+
+
 @web_bp.get("/profile")
 @web_login_required
 @web_not_frozen_required
@@ -858,13 +885,7 @@ def profile():
     pending_email_change = pending_profile_email_change()
     form.email.data = pending_email_change["email"] if pending_email_change else g.current_user.email
     form.phone_number.data = g.current_user.phone_number
-    return render_template(
-        _PROFILE_TEMPLATE,
-        user=g.current_user,
-        form=form,
-        recent_mfa=has_recent_fresh_mfa(),
-        pending_email_change=pending_email_change,
-    )
+    return _render_profile_page(form=form)[0]
 
 
 @web_bp.post("/profile")
@@ -872,16 +893,8 @@ def profile():
 @web_not_frozen_required
 def profile_submit():
     form = ProfileForm()
-    recent_mfa = has_recent_fresh_mfa()
-    pending_email_change = pending_profile_email_change()
     if not form.validate_on_submit():
-        return render_template(
-            _PROFILE_TEMPLATE,
-            user=g.current_user,
-            form=form,
-            recent_mfa=recent_mfa,
-            pending_email_change=pending_email_change,
-        ), 400
+        return _render_profile_page(form=form, status_code=400)
 
     try:
         result = update_profile_details(
@@ -895,24 +908,45 @@ def profile_submit():
         if exc.status_code == 429:
             return rate_limit_response()
         flash(exc.message, "error")
-        return render_template(
-            _PROFILE_TEMPLATE,
-            user=g.current_user,
-            form=form,
-            recent_mfa=recent_mfa,
-            pending_email_change=pending_profile_email_change(),
-        ), exc.status_code
+        return _render_profile_page(form=form, status_code=exc.status_code)
 
     if result.get("email_verification_pending"):
         flash("Verification code sent to the new email address.", "info")
-        return render_template(
-            _PROFILE_TEMPLATE,
-            user=g.current_user,
-            form=form,
-            recent_mfa=has_recent_fresh_mfa(),
-            pending_email_change=pending_profile_email_change(),
-        )
+        return _render_profile_page(form=form)[0]
     flash("Profile updated." if result.get("updated") else "No profile changes were needed.", "success")
+    return redirect(url_for("web.profile"))
+
+
+@web_bp.post("/profile/notification-preferences")
+@web_login_required
+@web_not_frozen_required
+def profile_notification_preferences_submit():
+    notification_form = ProfileNotificationPreferencesForm()
+    profile_form = ProfileForm()
+    pending_email_change = pending_profile_email_change()
+    profile_form.email.data = pending_email_change["email"] if pending_email_change else g.current_user.email
+    profile_form.phone_number.data = g.current_user.phone_number
+
+    if not notification_form.validate_on_submit():
+        return _render_profile_page(
+            form=profile_form,
+            notification_form=notification_form,
+            status_code=400,
+        )
+
+    enabled = bool(notification_form.transfer_activity_email_enabled.data)
+    if g.current_user.transfer_activity_email_enabled != enabled:
+        g.current_user.transfer_activity_email_enabled = enabled
+        db.session.commit()
+        audit_event(
+            "notification_preferences_update",
+            "success",
+            user=g.current_user,
+            metadata={"transfer_activity_email_enabled": enabled},
+        )
+        flash("Notification preference updated.", "success")
+    else:
+        flash("Notification preference already up to date.", "info")
     return redirect(url_for("web.profile"))
 
 

--- a/migrations/versions/20260708_0035_add_transfer_activity_email_preference.py
+++ b/migrations/versions/20260708_0035_add_transfer_activity_email_preference.py
@@ -1,0 +1,30 @@
+"""Add transfer activity email preference.
+
+Revision ID: 20260708_0035
+Revises: 20260708_0034
+Create Date: 2026-07-08 00:35:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20260708_0035"
+down_revision = "20260708_0034"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "transfer_activity_email_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "transfer_activity_email_enabled")

--- a/tests/test_account_security_actions.py
+++ b/tests/test_account_security_actions.py
@@ -146,6 +146,9 @@ def test_authenticated_user_can_open_own_edit_profile_page(client):
     assert 'name="email"' in markup
     assert 'name="phone_number"' in markup
     assert "Update profile details" in markup
+    assert "Email notifications for withdrawal and deposit" in markup
+    assert "All other account, security, transfer-limit, and daily-limit notifications are mandatory." in markup
+    assert 'action="/profile/notification-preferences"' in markup
     assert "Verify and save" in markup
     assert "Authenticator MFA required" not in markup
     assert "Manage MFA" in markup
@@ -156,6 +159,30 @@ def test_authenticated_user_can_open_own_edit_profile_page(client):
     assert "Use an authenticator app for login MFA." in markup
     assert 'class="badge warning"' not in markup
     assert "Preferred verification" not in markup
+
+
+def test_profile_notification_preference_updates_without_totp(client):
+    register(client)
+    login(client)
+    user, _secret = enable_mfa_for_user()
+    mark_recent_mfa(client, user)
+    assert user.transfer_activity_email_enabled is True
+
+    response = client.post(
+        "/profile/notification-preferences",
+        data={},
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/profile")
+    db.session.refresh(user)
+    assert user.transfer_activity_email_enabled is False
+    assert db.session.query(SecurityAuditEvent).filter_by(
+        event_type="notification_preferences_update",
+        outcome="success",
+        user_id=user.id,
+    ).count() == 1
+
 
 def test_profile_enables_change_password_action_after_mfa_setup(client):
     register(client)

--- a/tests/test_local_transfer.py
+++ b/tests/test_local_transfer.py
@@ -850,3 +850,26 @@ def test_successful_local_transfer_sends_withdrawal_deposit_and_limit_warning(
     assert "deposit Local Transfer transaction was successful" in deliveries[-2]["body"]
     assert deliveries[-1]["to"] == "alice@example.com"
     assert "80.00% of your limit" in deliveries[-1]["body"]
+
+
+def test_disabled_transfer_activity_email_preference_skips_withdrawal_and_deposit_email(
+    app,
+    transfer_context,
+):
+    from app.security.email import password_reset_outbox
+
+    alice = transfer_context["alice"]
+    bob = transfer_context["bob"]
+    payee = transfer_context["payee"]
+    alice.transfer_activity_email_enabled = False
+    bob.transfer_activity_email_enabled = False
+    db.session.commit()
+    before_count = len(password_reset_outbox())
+
+    token = _make_pending_transfer(alice, payee, Decimal("50.00"))
+
+    with app.test_request_context("/banking/transfer/confirm", method="POST"):
+        txn_ref = execute_local_transfer(sender=alice, payee=payee, confirmation_token=token)
+
+    assert Transaction.query.filter_by(transaction_ref=txn_ref).count() == 1
+    assert len(password_reset_outbox()) == before_count

--- a/tests/test_route_inventory_security.py
+++ b/tests/test_route_inventory_security.py
@@ -628,6 +628,17 @@ ROUTE_SECURITY_INVENTORY = {
         "step_up": "required",
         "public_justification": "",
     },
+    "web.profile_notification_preferences_submit": {
+        "endpoint": "web.profile_notification_preferences_submit",
+        "rule": "/profile/notification-preferences",
+        "methods": {"POST"},
+        "access": "authenticated",
+        "classification": "profile",
+        "csrf": "required",
+        "rate_limit": "edge_app",
+        "step_up": "not_required",
+        "public_justification": "",
+    },
     "web.mfa_setup": {
         "endpoint": "web.mfa_setup",
         "rule": "/mfa/setup",


### PR DESCRIPTION
## Summary

Adds a customer profile preference for withdrawal and deposit email notifications while keeping required security and limit notifications mandatory.

## Why

Customers need control over routine transfer activity emails, but security-sensitive notifications such as account, transfer-limit, and daily-limit alerts must remain enforced.

This change separates optional withdrawal/deposit notifications from mandatory operational and security notifications.

## What Changed

* Added a notification preference box on the profile page above the existing profile details form.
* Added a `transfer_activity_email_enabled` user preference and database migration.
* Updated transfer notification delivery so withdrawal/deposit emails respect the customer preference.
* Kept limit-change and daily-limit notifications mandatory.
* Added tests for:

  * Profile preference route behavior.
  * Profile preference UI rendering.
  * Withdrawal/deposit notification suppression.
  * Mandatory notification delivery behavior.

## Security Impact

This does not change authentication, MFA, CSRF, session handling, secret handling, or authorization requirements.

The new preference update is scoped only to withdrawal/deposit notification opt-in or opt-out behavior and does not require authenticator step-up.

Mandatory account, security, transfer-limit, and daily-limit notifications remain enforced and are not user-disableable.

## Deployment Impact

Requires:

* Staging deployment.
* Production deployment.
* Database migration.

Does not require:

* EC2 bootstrap.
* Secret changes.

## Verification

Ran targeted tests successfully for:

* Profile notification preferences.
* Transfer notifications.
* PayUp flows.
* Transfer-limit behavior.
* Route inventory.

Ran deployment/documentation consistency and route-inventory tests successfully.

Ran:

```powershell
git diff --check
```

Recommended full validation before merge/deployment:

```powershell
.\.venv\Scripts\python.exe -m pytest -q -n auto
```

## Notes

Run database migrations during deployment so the new user preference column is added before the updated code handles profile notification settings.
