### PR TITLE
Centralize customer unfreeze endpoint name

### DIFF
--- a/app/admin/services.py
+++ b/app/admin/services.py
@@ -111,6 +111,7 @@ MANUAL_RECOVERY_ADMIN_TRANSITION_STATUSES = frozenset(
 )
 ADMIN_ACTION_REQUEST_TTL_SECONDS = 24 * 60 * 60
 ADMIN_ACTION_PENDING_STATUS = "pending"
+CUSTOMER_UNFREEZE_REQUESTS_ENDPOINT = "admin.customer_unfreeze_requests"
 STAFF_ACTION_OPERATION_TYPES = {
     "deactivate": "staff_deactivate",
     "reactivate": "staff_reactivate",
@@ -877,8 +878,8 @@ def admin_navigation_for(user: User) -> list[dict[str, str]]:
         items.append(
             {
                 "label": "Customer support",
-                "href": url_for("admin.customer_unfreeze_requests"),
-                "endpoint": "admin.customer_unfreeze_requests",
+                "href": url_for(CUSTOMER_UNFREEZE_REQUESTS_ENDPOINT),
+                "endpoint": CUSTOMER_UNFREEZE_REQUESTS_ENDPOINT,
                 "group": "business",
             }
         )
@@ -1518,7 +1519,7 @@ def _staff_business_operations(actor: User) -> list[dict[str, str]]:
             "label": "Unfreeze customer accounts",
             "status": "Available",
             "description": "Review customers who froze their own account and unfreeze them with a documented reason.",
-            "href": url_for("admin.customer_unfreeze_requests"),
+            "href": url_for(CUSTOMER_UNFREEZE_REQUESTS_ENDPOINT),
         }
     ]
 


### PR DESCRIPTION
Summary
---

Centralize the customer unfreeze requests endpoint name used by admin service helpers.

Why
---

Sonar on main reported a duplicate-literal finding for the customer unfreeze requests endpoint after PR #559 merged.

What changed
---

- Added a shared `CUSTOMER_UNFREEZE_REQUESTS_ENDPOINT` constant.
- Reused the constant for admin navigation and staff business operations links.

Security impact
---

No auth, authorization, session, secret, deployment, or runtime behavior changes. This preserves the existing customer support route boundary while removing duplicated policy-adjacent endpoint text.

Deployment impact
---

No deployment action, database migration, EC2 bootstrap, or secret changes are required.

Verification
---

- `git diff --check`
- `pytest -q tests/test_admin_self_service_account.py tests/test_admin_dashboard_role_separation.py tests/test_admin_route_inventory_security.py tests/test_admin_rbac_matrix.py`
- `pytest -q -n 4`
- `pytest -q -n 4 --cov=. --cov-config=.coveragerc --cov-report=xml:coverage.xml --cov-report=term`

Notes
---

Follow-up to the issue #557 Sonar/main-branch cleanup after PR #559.