### PR TITLE
Fix counterparty labels in deposit notification emails

### DIFF
--- a/app/banking/services.py
+++ b/app/banking/services.py
@@ -158,7 +158,8 @@ def send_transfer_notification(
     if amount is not None:
         lines.append(f"Amount: SGD {_format_money(amount)}")
     if counterparty_label:
-        lines.append(f"Recipient: {counterparty_label}")
+        counterparty_field = "Sender" if normalized_direction == "deposit" else "Recipient"
+        lines.append(f"{counterparty_field}: {counterparty_label}")
     if transaction_reference:
         lines.append(f"Reference: {transaction_reference[:8].upper()}")
     lines.append(

--- a/tests/test_local_transfer.py
+++ b/tests/test_local_transfer.py
@@ -900,8 +900,11 @@ def test_successful_local_transfer_sends_withdrawal_deposit_and_limit_warning(
     ]
     assert deliveries[-3]["to"] == "alice@example.com"
     assert "withdrawal Local Transfer transaction was successful" in deliveries[-3]["body"]
+    assert "Recipient: Bob Recipient" in deliveries[-3]["body"]
     assert deliveries[-2]["to"] == "bob@example.com"
     assert "deposit Local Transfer transaction was successful" in deliveries[-2]["body"]
+    assert "Sender: Alice Sender" in deliveries[-2]["body"]
+    assert "Recipient:" not in deliveries[-2]["body"]
     assert deliveries[-1]["to"] == "alice@example.com"
     assert "80.00% of your limit" in deliveries[-1]["body"]
 

--- a/tests/test_payup.py
+++ b/tests/test_payup.py
@@ -386,8 +386,11 @@ def test_successful_payup_sends_withdrawal_deposit_and_limit_warning(app, payup_
     ]
     assert deliveries[-3]["to"] == "alice@example.com"
     assert "withdrawal PayUp transaction was successful" in deliveries[-3]["body"]
+    assert "Recipient: Bob PayUp" in deliveries[-3]["body"]
     assert deliveries[-2]["to"] == "bob@example.com"
     assert "deposit PayUp transaction was successful" in deliveries[-2]["body"]
+    assert "Sender: Alice PayUp" in deliveries[-2]["body"]
+    assert "Recipient:" not in deliveries[-2]["body"]
     assert deliveries[-1]["to"] == "alice@example.com"
     assert "80.00% of your limit" in deliveries[-1]["body"]
 


### PR DESCRIPTION
Summary
---

Fixes issue #581: deposit notification emails reused the withdrawal-side "Recipient:" label even though the counterparty passed in for a deposit is actually the sender, so a deposit email could misleadingly read "Recipient: Alice" when Alice sent the money.

Why
---

`send_transfer_notification()` always rendered `Recipient: {counterparty_label}` regardless of direction, but Local Transfer and PayUp both pass the sender as the counterparty for the recipient-side deposit email. That makes deposit notifications harder to interpret correctly during fraud review, since the label implies the named party received the money rather than sent it.

What changed
---

* `send_transfer_notification()` now labels the counterparty by direction: "Sender" for deposit notifications, "Recipient" for withdrawal notifications.
* Updated the existing Local Transfer and PayUp notification tests to assert the correct label on both the withdrawal and deposit emails, and that "Recipient:" does not appear in a deposit email.

Security impact
---

No change to the notification preference model, delivery, or audit metadata. Top-up deposit notifications don't pass a counterparty label at all (self-deposit) and are unaffected.

Deployment impact
---

* no EC2 bootstrap, staging/prod deploy, database migration, secret change, or provider setting change expected

Verification
---

* `git diff --check`
* `.\.venv\Scripts\python.exe -m pytest -q tests/test_local_transfer.py tests/test_payup.py` (all passed)
* `.\.venv\Scripts\python.exe -m pytest -q -n auto` (1808 passed, 34 skipped)

Notes
---

None.