### PR TITLE
Align top-up deposit emails with notification preference wording

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -897,7 +897,8 @@ do not retain an older MFA-principal route limit that can undercut the
 configured PayUp policy.
 
 The customer transfer activity email preference controls only routine
-withdrawal and deposit emails for Local Transfer and PayUp. Daily-limit,
+withdrawal and deposit emails for Local Transfer and PayUp, and deposit
+emails for Top Up. Daily-limit,
 transfer-limit, account, security, MFA, recovery, password, session,
 staff/admin, and other high-risk notifications remain mandatory and cannot be
 disabled through this setting. `POST /profile/notification-preferences`

--- a/tests/test_documentation_consistency.py
+++ b/tests/test_documentation_consistency.py
@@ -184,6 +184,7 @@ def test_notification_preference_docs_match_optional_activity_boundary():
 
     for required in (
         "transfer activity email preference controls only routine withdrawal and deposit emails",
+        "deposit emails for Top Up",
         "Daily-limit, transfer-limit, account, security, MFA, recovery, password, session, staff/admin, and other high-risk notifications remain mandatory",
         "`POST /profile/notification-preferences` intentionally does not require TOTP",
         "authenticated, CSRF-protected, current-user-scoped, frozen-account-blocked",
@@ -199,6 +200,7 @@ def test_notification_preference_docs_match_optional_activity_boundary():
         "transfer-limit notifications can be disabled",
         "general successful-transfer notification channel to reuse",
         "future email or push channel requires a separate reviewed delivery",
+        "deposit emails for Local Transfer and PayUp. Daily-limit",
     ):
         assert stale not in docs
 


### PR DESCRIPTION
Summary
---

Fixes issue #587: operations documentation said the transfer activity email preference controls only routine withdrawal and deposit emails for Local Transfer and PayUp, but top-up deposit emails are already gated on the same preference, leaving customers and reviewers with conflicting expectations.

Why
---

PR #566 added top-up deposit notification emails through the existing `send_transfer_notification()` path, which already checks `transfer_activity_email_enabled`. The operations documentation was never updated to reflect that top-up deposit receipts are covered by the same optional preference, so the documented scope no longer matched the implemented behavior.

What changed
---

* Updated `docs/OPERATIONS.md` to state the preference also controls Top Up deposit emails.
* Extended `test_notification_preference_docs_match_optional_activity_boundary` to require the new wording and to fail if the stale, narrower phrasing (ending right before the mandatory-notifications sentence with no Top Up mention) ever returns.

Security impact
---

Documentation-only change; the existing opt-out behavior for top-up deposit emails is preserved as-is, and mandatory notifications (daily-limit, transfer-limit, security, MFA, recovery, password, session, staff/admin) remain unaffected and undocumented as optional.

Deployment impact
---

* no EC2 bootstrap, staging/prod deploy, database migration, secret change, or provider setting change expected

Verification
---

* `git diff --check`
* `.\.venv\Scripts\python.exe -m pytest -q tests/test_documentation_consistency.py tests/test_banking_topup.py tests/test_security_governance_docs.py` (all passed)
* `.\.venv\Scripts\python.exe -m pytest -q -n auto` (1807 passed, 34 skipped)

Notes
---

None.